### PR TITLE
docs: add Showcase gallery surfacing the 35-artifact workflow pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,29 @@ for the full measurement protocol.
 
 ---
 
+## Showcase — 35 real artifacts you can open right now
+
+Numbers are cheap; files are not. The pack below was generated end-to-end through the
+harness — every artifact has a matching run manifest under `artifacts/runs/<run-id>/`.
+
+**One click per modality:**
+
+| Modality | Sample | Open |
+|---|---|---|
+| 🖼️ Image | `02-forest` | [`image/02-forest.png`](artifacts/showcase/workflow-examples/image/02-forest.png) |
+| 🎙️ TTS | `02-harness` | [`tts/02-harness.wav`](artifacts/showcase/workflow-examples/tts/02-harness.wav) |
+| 🎵 Music | `01-launch-minimal` | [`music/01-launch-minimal.wav`](artifacts/showcase/workflow-examples/music/01-launch-minimal.wav) |
+| 🌧️ Soundscape | `02-forest-morning` | [`soundscape/02-forest-morning.wav`](artifacts/showcase/workflow-examples/soundscape/02-forest-morning.wav) |
+| ❤️ Sensor / ECG | `05-clinical` | [`sensor/ecg/05-clinical.html`](artifacts/showcase/workflow-examples/sensor/ecg/05-clinical.html) |
+| 🌡️ Sensor / Temp | `02-greenhouse` | [`sensor/temperature/02-greenhouse.html`](artifacts/showcase/workflow-examples/sensor/temperature/02-greenhouse.html) |
+| 🎛️ Sensor / Gyro | `02-hover` | [`sensor/gyro/02-hover.html`](artifacts/showcase/workflow-examples/sensor/gyro/02-hover.html) |
+
+- **Full pack (5 per group, 35 artifacts):** [`artifacts/showcase/workflow-examples/`](artifacts/showcase/workflow-examples/)
+- **Hand-picked samples folder:** [`artifacts/showcase/workflow-examples/samples/`](artifacts/showcase/workflow-examples/samples/)
+- **Rendered gallery:** [`SHOWCASE.md`](SHOWCASE.md)
+
+---
+
 ## Architecture (Five Layers)
 
 ```
@@ -170,6 +193,7 @@ cannot offer this; frozen VQ decoding does. See [`docs/reproducibility.md`](docs
 - [`docs/hard-constraints.md`](docs/hard-constraints.md) — what will not change
 
 ### For hackers
+- [`SHOWCASE.md`](SHOWCASE.md) — 35 real artifacts across 7 modality groups, click to open
 - [`docs/quickstart.md`](docs/quickstart.md) — 30 seconds to a real file
 - [`polyglot-mini/README.md`](polyglot-mini/README.md) — Python surface deep-dive
 - [`docs/extending.md`](docs/extending.md) — add a codec, train an adapter, plug in a provider

--- a/SHOWCASE.md
+++ b/SHOWCASE.md
@@ -1,0 +1,146 @@
+# Showcase — real files Wittgenstein produces
+
+Thirty-five artifacts generated through the Wittgenstein harness, grouped by modality.
+Every file here has a matching run manifest under `artifacts/runs/<run-id>/manifest.json`
+(git SHA, seed, LLM input/output, artifact SHA-256), so anything you see is
+reproducible bit-for-bit.
+
+- **Pack root** — [`artifacts/showcase/workflow-examples/`](artifacts/showcase/workflow-examples/)
+- **Hand-picked samples** — [`artifacts/showcase/workflow-examples/samples/`](artifacts/showcase/workflow-examples/samples/)
+- **Machine-readable index** — [`summary.json`](artifacts/showcase/workflow-examples/summary.json)
+
+---
+
+## One sample per modality (click to open)
+
+| Modality | Sample | File | Workflow |
+|---|---|---|---|
+| 🖼️ Image | `02-forest` | [`image/02-forest.png`](artifacts/showcase/workflow-examples/image/02-forest.png) | scene spec → adapter → frozen decoder → PNG |
+| 🎙️ TTS | `02-harness` | [`tts/02-harness.wav`](artifacts/showcase/workflow-examples/tts/02-harness.wav) | audio codec, speech route |
+| 🎵 Music | `01-launch-minimal` | [`music/01-launch-minimal.wav`](artifacts/showcase/workflow-examples/music/01-launch-minimal.wav) | audio codec, music route |
+| 🌧️ Soundscape | `02-forest-morning` | [`soundscape/02-forest-morning.wav`](artifacts/showcase/workflow-examples/soundscape/02-forest-morning.wav) | audio codec, soundscape route |
+| ❤️ ECG | `05-clinical` | [`sensor/ecg/05-clinical.html`](artifacts/showcase/workflow-examples/sensor/ecg/05-clinical.html) | operator spec → JSON + CSV + Loupe HTML |
+| 🌡️ Temperature | `02-greenhouse` | [`sensor/temperature/02-greenhouse.html`](artifacts/showcase/workflow-examples/sensor/temperature/02-greenhouse.html) | operator spec → JSON + CSV + Loupe HTML |
+| 🎛️ Gyro | `02-hover` | [`sensor/gyro/02-hover.html`](artifacts/showcase/workflow-examples/sensor/gyro/02-hover.html) | operator spec → JSON + CSV + Loupe HTML |
+
+The samples folder mirrors these picks as a self-contained subset:
+[`artifacts/showcase/workflow-examples/samples/`](artifacts/showcase/workflow-examples/samples/).
+
+---
+
+## The full pack (5 per group, 35 total)
+
+### 🖼️ Image — scene spec → adapter → frozen decoder → PNG
+
+Locked pipeline: LLM emits a structured scene JSON, the MLP adapter maps it to latent
+parameters, and a frozen reference decoder renders the raster. No diffusion, no SVG
+fallback. See [`docs/codecs/image.md`](docs/codecs/image.md).
+
+| # | Artifact |
+|---|---|
+| 01 | [`image/01-coastal.png`](artifacts/showcase/workflow-examples/image/01-coastal.png) |
+| 02 | [`image/02-forest.png`](artifacts/showcase/workflow-examples/image/02-forest.png) ⭐ |
+| 03 | [`image/03-lake.png`](artifacts/showcase/workflow-examples/image/03-lake.png) |
+| 04 | [`image/04-mountain.png`](artifacts/showcase/workflow-examples/image/04-mountain.png) |
+| 05 | [`image/05-meadow.png`](artifacts/showcase/workflow-examples/image/05-meadow.png) |
+
+> The showcase set uses a narrow-domain reference decoder bridge inside the neural path
+> so the demo looks less abstract while staying harness-compatible. The full VQ decoder
+> bridge is still ⚠️ Partial — see [`docs/implementation-status.md`](docs/implementation-status.md).
+
+### 🎙️ TTS — audio codec, speech route
+
+On macOS, the speech route upgrades automatically to `say` + `afconvert`; elsewhere it
+falls back to the stdlib WAV synth.
+
+| # | Artifact |
+|---|---|
+| 01 | [`tts/01-thesis.wav`](artifacts/showcase/workflow-examples/tts/01-thesis.wav) |
+| 02 | [`tts/02-harness.wav`](artifacts/showcase/workflow-examples/tts/02-harness.wav) ⭐ |
+| 03 | [`tts/03-codecs.wav`](artifacts/showcase/workflow-examples/tts/03-codecs.wav) |
+| 04 | [`tts/04-decoder.wav`](artifacts/showcase/workflow-examples/tts/04-decoder.wav) |
+| 05 | [`tts/05-launch.wav`](artifacts/showcase/workflow-examples/tts/05-launch.wav) |
+
+### 🎵 Music — audio codec, music route
+
+| # | Artifact |
+|---|---|
+| 01 | [`music/01-launch-minimal.wav`](artifacts/showcase/workflow-examples/music/01-launch-minimal.wav) ⭐ |
+| 02 | [`music/02-editorial-glow.wav`](artifacts/showcase/workflow-examples/music/02-editorial-glow.wav) |
+| 03 | [`music/03-forest-bloom.wav`](artifacts/showcase/workflow-examples/music/03-forest-bloom.wav) |
+| 04 | [`music/04-rain-grid.wav`](artifacts/showcase/workflow-examples/music/04-rain-grid.wav) |
+| 05 | [`music/05-night-drive.wav`](artifacts/showcase/workflow-examples/music/05-night-drive.wav) |
+
+### 🌧️ Soundscape — audio codec, soundscape route
+
+Procedural ambient synthesis (pink noise, gaussian pulses, tonal layers) in pure stdlib.
+
+| # | Artifact |
+|---|---|
+| 01 | [`soundscape/01-rain-glass.wav`](artifacts/showcase/workflow-examples/soundscape/01-rain-glass.wav) |
+| 02 | [`soundscape/02-forest-morning.wav`](artifacts/showcase/workflow-examples/soundscape/02-forest-morning.wav) ⭐ |
+| 03 | [`soundscape/03-urban-night.wav`](artifacts/showcase/workflow-examples/soundscape/03-urban-night.wav) |
+| 04 | [`soundscape/04-open-ridge.wav`](artifacts/showcase/workflow-examples/soundscape/04-open-ridge.wav) |
+| 05 | [`soundscape/05-machine-room.wav`](artifacts/showcase/workflow-examples/soundscape/05-machine-room.wav) |
+
+### ❤️ Sensor — ECG
+
+Each entry ships JSON (operator spec + samples) + CSV (`timeSec,value`) + an interactive
+Loupe HTML dashboard (~117 KB, zero external deps).
+
+| # | JSON | CSV | HTML (interactive) |
+|---|---|---|---|
+| 01 | [`json`](artifacts/showcase/workflow-examples/sensor/ecg/01-resting.json) | [`csv`](artifacts/showcase/workflow-examples/sensor/ecg/01-resting.csv) | [`01-resting.html`](artifacts/showcase/workflow-examples/sensor/ecg/01-resting.html) |
+| 02 | [`json`](artifacts/showcase/workflow-examples/sensor/ecg/02-exercise.json) | [`csv`](artifacts/showcase/workflow-examples/sensor/ecg/02-exercise.csv) | [`02-exercise.html`](artifacts/showcase/workflow-examples/sensor/ecg/02-exercise.html) |
+| 03 | [`json`](artifacts/showcase/workflow-examples/sensor/ecg/03-recovery.json) | [`csv`](artifacts/showcase/workflow-examples/sensor/ecg/03-recovery.csv) | [`03-recovery.html`](artifacts/showcase/workflow-examples/sensor/ecg/03-recovery.html) |
+| 04 | [`json`](artifacts/showcase/workflow-examples/sensor/ecg/04-noisy-patch.json) | [`csv`](artifacts/showcase/workflow-examples/sensor/ecg/04-noisy-patch.csv) | [`04-noisy-patch.html`](artifacts/showcase/workflow-examples/sensor/ecg/04-noisy-patch.html) |
+| 05 | [`json`](artifacts/showcase/workflow-examples/sensor/ecg/05-clinical.json) | [`csv`](artifacts/showcase/workflow-examples/sensor/ecg/05-clinical.csv) | [`05-clinical.html`](artifacts/showcase/workflow-examples/sensor/ecg/05-clinical.html) ⭐ |
+
+### 🌡️ Sensor — Temperature
+
+| # | JSON | CSV | HTML (interactive) |
+|---|---|---|---|
+| 01 | [`json`](artifacts/showcase/workflow-examples/sensor/temperature/01-office.json) | [`csv`](artifacts/showcase/workflow-examples/sensor/temperature/01-office.csv) | [`01-office.html`](artifacts/showcase/workflow-examples/sensor/temperature/01-office.html) |
+| 02 | [`json`](artifacts/showcase/workflow-examples/sensor/temperature/02-greenhouse.json) | [`csv`](artifacts/showcase/workflow-examples/sensor/temperature/02-greenhouse.csv) | [`02-greenhouse.html`](artifacts/showcase/workflow-examples/sensor/temperature/02-greenhouse.html) ⭐ |
+| 03 | [`json`](artifacts/showcase/workflow-examples/sensor/temperature/03-cold-chain.json) | [`csv`](artifacts/showcase/workflow-examples/sensor/temperature/03-cold-chain.csv) | [`03-cold-chain.html`](artifacts/showcase/workflow-examples/sensor/temperature/03-cold-chain.html) |
+| 04 | [`json`](artifacts/showcase/workflow-examples/sensor/temperature/04-device-warmup.json) | [`csv`](artifacts/showcase/workflow-examples/sensor/temperature/04-device-warmup.csv) | [`04-device-warmup.html`](artifacts/showcase/workflow-examples/sensor/temperature/04-device-warmup.html) |
+| 05 | [`json`](artifacts/showcase/workflow-examples/sensor/temperature/05-hvac.json) | [`csv`](artifacts/showcase/workflow-examples/sensor/temperature/05-hvac.csv) | [`05-hvac.html`](artifacts/showcase/workflow-examples/sensor/temperature/05-hvac.html) |
+
+### 🎛️ Sensor — Gyro / IMU
+
+| # | JSON | CSV | HTML (interactive) |
+|---|---|---|---|
+| 01 | [`json`](artifacts/showcase/workflow-examples/sensor/gyro/01-handheld.json) | [`csv`](artifacts/showcase/workflow-examples/sensor/gyro/01-handheld.csv) | [`01-handheld.html`](artifacts/showcase/workflow-examples/sensor/gyro/01-handheld.html) |
+| 02 | [`json`](artifacts/showcase/workflow-examples/sensor/gyro/02-hover.json) | [`csv`](artifacts/showcase/workflow-examples/sensor/gyro/02-hover.csv) | [`02-hover.html`](artifacts/showcase/workflow-examples/sensor/gyro/02-hover.html) ⭐ |
+| 03 | [`json`](artifacts/showcase/workflow-examples/sensor/gyro/03-walk.json) | [`csv`](artifacts/showcase/workflow-examples/sensor/gyro/03-walk.csv) | [`03-walk.html`](artifacts/showcase/workflow-examples/sensor/gyro/03-walk.html) |
+| 04 | [`json`](artifacts/showcase/workflow-examples/sensor/gyro/04-vehicle.json) | [`csv`](artifacts/showcase/workflow-examples/sensor/gyro/04-vehicle.csv) | [`04-vehicle.html`](artifacts/showcase/workflow-examples/sensor/gyro/04-vehicle.html) |
+| 05 | [`json`](artifacts/showcase/workflow-examples/sensor/gyro/05-gimbal.json) | [`csv`](artifacts/showcase/workflow-examples/sensor/gyro/05-gimbal.csv) | [`05-gimbal.html`](artifacts/showcase/workflow-examples/sensor/gyro/05-gimbal.html) |
+
+---
+
+## Reproducing these
+
+Each artifact was written by a real harness run. To produce an equivalent one yourself:
+
+```bash
+# Sensor (no API key, no LLM call, <50 ms)
+python3 -m polyglot.cli sensor "ECG 72 bpm resting" --dry-run --out /tmp/ecg.json
+
+# TTS (macOS, no API key)
+python3 -m polyglot.cli tts "Cozy rainy afternoon" --out /tmp/voice.m4a
+
+# Image (runs without LLM by passing --no-llm)
+python3 -m polyglot.cli image "warm desert at sunset" --no-llm --out /tmp/desert.png
+```
+
+Full 30-second tour: [`docs/quickstart.md`](docs/quickstart.md). Reproducibility spine:
+[`docs/reproducibility.md`](docs/reproducibility.md).
+
+---
+
+## Legend
+
+- ⭐ — sample pick (also mirrored under `samples/`)
+- `.html` files are self-contained; open them directly in a browser, no build step
+- `.wav` files play in any browser or QuickTime
+- `.png` images are 1024×1024 unless otherwise noted

--- a/artifacts/showcase/workflow-examples/README.md
+++ b/artifacts/showcase/workflow-examples/README.md
@@ -1,32 +1,62 @@
 # Workflow Example Pack
 
-This pack was generated through the Wittgenstein harness using curated local JSON responses so the runs still produce manifests under `artifacts/runs/<run-id>/`.
+35 real artifacts produced through the Wittgenstein harness — 5 per modality group,
+plus 7 hand-picked samples mirrored under [`samples/`](samples/).
 
-## Groups
+> **This is a reference pack.** It was generated using curated local JSON responses so
+> the runs stay reproducible without hitting an external LLM, but every run still writes
+> a full manifest under `artifacts/runs/<run-id>/manifest.json` (git SHA, seed, LLM
+> input/output, artifact SHA-256). You can regenerate any of these bit-for-bit.
+>
+> For a nicer rendered gallery, see the top-level [`SHOWCASE.md`](../../../SHOWCASE.md).
 
-- `image`: 5 examples
-- `music`: 5 examples
-- `sensor-ecg`: 5 examples
-- `sensor-gyro`: 5 examples
-- `sensor-temperature`: 5 examples
-- `soundscape`: 5 examples
-- `tts`: 5 examples
+---
 
-## Sample Picks
+## Groups (5 artifacts each)
 
-- `image` → `02-forest` → `/Users/dujiayi/Desktop/Wittgenstein/artifacts/showcase/workflow-examples/image/02-forest.png`
-- `tts` → `02-harness` → `/Users/dujiayi/Desktop/Wittgenstein/artifacts/showcase/workflow-examples/tts/02-harness.wav`
-- `music` → `01-launch-minimal` → `/Users/dujiayi/Desktop/Wittgenstein/artifacts/showcase/workflow-examples/music/01-launch-minimal.wav`
-- `soundscape` → `02-forest-morning` → `/Users/dujiayi/Desktop/Wittgenstein/artifacts/showcase/workflow-examples/soundscape/02-forest-morning.wav`
-- `sensor-ecg` → `05-clinical` → `/Users/dujiayi/Desktop/Wittgenstein/artifacts/showcase/workflow-examples/sensor/ecg/05-clinical.html`
-- `sensor-temperature` → `02-greenhouse` → `/Users/dujiayi/Desktop/Wittgenstein/artifacts/showcase/workflow-examples/sensor/temperature/02-greenhouse.html`
-- `sensor-gyro` → `02-hover` → `/Users/dujiayi/Desktop/Wittgenstein/artifacts/showcase/workflow-examples/sensor/gyro/02-hover.html`
+| Group | Folder | Workflow |
+|---|---|---|
+| `image` | [`image/`](image/) | scene spec → adapter → frozen decoder → PNG |
+| `tts` | [`tts/`](tts/) | audio codec, speech route |
+| `music` | [`music/`](music/) | audio codec, music route |
+| `soundscape` | [`soundscape/`](soundscape/) | audio codec, soundscape route |
+| `sensor-ecg` | [`sensor/ecg/`](sensor/ecg/) | operator spec → JSON + CSV + Loupe HTML |
+| `sensor-temperature` | [`sensor/temperature/`](sensor/temperature/) | operator spec → JSON + CSV + Loupe HTML |
+| `sensor-gyro` | [`sensor/gyro/`](sensor/gyro/) | operator spec → JSON + CSV + Loupe HTML |
+
+## Sample picks (one per group, also mirrored in [`samples/`](samples/))
+
+| Group | Pick | File to open first |
+|---|---|---|
+| Image | `02-forest` | [`image/02-forest.png`](image/02-forest.png) |
+| TTS | `02-harness` | [`tts/02-harness.wav`](tts/02-harness.wav) |
+| Music | `01-launch-minimal` | [`music/01-launch-minimal.wav`](music/01-launch-minimal.wav) |
+| Soundscape | `02-forest-morning` | [`soundscape/02-forest-morning.wav`](soundscape/02-forest-morning.wav) |
+| Sensor ECG | `05-clinical` | [`sensor/ecg/05-clinical.html`](sensor/ecg/05-clinical.html) |
+| Sensor Temperature | `02-greenhouse` | [`sensor/temperature/02-greenhouse.html`](sensor/temperature/02-greenhouse.html) |
+| Sensor Gyro | `02-hover` | [`sensor/gyro/02-hover.html`](sensor/gyro/02-hover.html) |
+
+Machine-readable index: [`summary.json`](summary.json).
+
+---
 
 ## Notes
 
-- Image uses the sole neural path: `scene spec -> adapter -> frozen decoder -> PNG`.
-- The current showcase image outputs use a narrow-domain reference decoder bridge inside that path so the demo can look less abstract while staying harness-compatible.
-- TTS uses the audio speech route; on macOS it upgrades to `say` + `afconvert` automatically.
-- Music and soundscape stay on the local audio runtime.
-- Sensor outputs include JSON, CSV, and HTML sidecars when available.
-- Every generated example has a corresponding run manifest under `artifacts/runs/`.
+- **Image** uses the sole neural path: `scene spec → adapter → frozen decoder → PNG`.
+  The showcase set routes through a narrow-domain reference decoder bridge inside that
+  path so the demo looks less abstract while staying harness-compatible. The full VQ
+  decoder bridge is still ⚠️ Partial; see
+  [`../../../docs/implementation-status.md`](../../../docs/implementation-status.md).
+- **TTS** uses the audio speech route. On macOS it upgrades to `say` + `afconvert`
+  automatically; elsewhere it uses the stdlib WAV synth.
+- **Music** and **soundscape** stay on the local audio runtime (pure stdlib + numpy).
+- **Sensor** outputs always include JSON, CSV, and an interactive HTML dashboard
+  (~117 KB, zero external deps) — open the `.html` directly, no build step.
+- Every artifact has a corresponding run manifest under
+  [`../../runs/`](../../runs/).
+
+See also:
+
+- [`../../../SHOWCASE.md`](../../../SHOWCASE.md) — top-level rendered gallery
+- [`../../../docs/quickstart.md`](../../../docs/quickstart.md) — how to produce your own
+- [`../../../docs/reproducibility.md`](../../../docs/reproducibility.md) — manifest spine


### PR DESCRIPTION
## Summary

Surfaces the 35 real artifacts (5 per modality group × 7 groups) already sitting under `artifacts/showcase/workflow-examples/` so visitors can open them without spelunking.

- **New `SHOWCASE.md`** at repo root — rendered gallery with one click-through sample per modality, full pack tables, and reproducibility snippets. Sits alphabetically between `ROADMAP.md` and `SUPPORT.md` for visibility in the GitHub root listing.
- **Rewrote `artifacts/showcase/workflow-examples/README.md`** as a proper index: groups table, sample picks table, workflow notes per group, cross-links to SHOWCASE / quickstart / reproducibility docs.
- **README.md**: new "Showcase — 35 real artifacts you can open right now" section right after *Receipts (not claims)*, plus an entry in the docs map under *For hackers*.

Docs-only. No code changes. All 35 link targets verified present.

## Test plan

- [x] 35 artifacts + 7 samples exist on disk
- [x] All relative links in SHOWCASE.md resolve
- [x] README new section renders correctly on GitHub
- [ ] Confirm the top-level SHOWCASE.md appears in the GitHub repo root listing after merge