### PR TITLE
ci: tune dependabot for low-risk updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,14 +8,28 @@ updates:
     groups:
       npm-dev:
         dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
       npm-prod:
         dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "pip"
     directory: "/polyglot-mini"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Why
The current Dependabot policy is producing a mix of very safe upgrades and very large semver-major bundles. That creates noise and review burden, especially for production/runtime packages where the repo is still stabilizing.

## What changed
- keep weekly Dependabot coverage in place
- keep GitHub Actions updates enabled
- allow npm grouped updates only for `minor` and `patch`
- ignore npm `semver-major` updates by default
- ignore pip `semver-major` updates for `polyglot-mini`

## Effect
This preserves the useful low-risk automation while avoiding giant React/Next/Zod/TypeScript-style jump PRs that are not good candidates for auto-merge.
