### PR TITLE
ci: disable pip dependabot noise for polyglot-mini

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,11 +25,13 @@ updates:
     directory: "/polyglot-mini"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 1
     ignore:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Why
`polyglot-mini` pip Dependabot PRs are currently low-value for this repo. They bump minimum requirement floors in `requirements.txt`, which increases compatibility pressure without giving us the kind of low-risk auto-merge signal we want.

## What changed
- keep the pip Dependabot entry in place for future revisiting
- effectively disable automatic pip version bump PRs for `polyglot-mini` by ignoring major, minor, and patch version updates
- reduce the open PR limit for that entry to 1

## Effect
GitHub Actions and npm updates still flow through Dependabot, but `polyglot-mini` will stop opening noisy lower-bound PRs.
