### PR TITLE
ci: rebalance dependabot signal and scope

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 4
+    labels:
+      - "dependencies"
+      - "npm"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
     groups:
       npm-dev:
         dependency-type: "development"
@@ -16,25 +22,36 @@ updates:
         update-types:
           - "minor"
           - "patch"
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-major"
 
   - package-ecosystem: "pip"
     directory: "/polyglot-mini"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 1
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      pip-runtime:
+        update-types:
+          - "minor"
+          - "patch"
     ignore:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
-          - "version-update:semver-minor"
-          - "version-update:semver-patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 2
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"


### PR DESCRIPTION
## Why
We do not want Dependabot to be overly restricted, but we also want the repo to get useful maintenance signals instead of noisy PR floods.

## What changed
- `npm`
  - keep grouped `minor` / `patch` updates
  - allow `major` updates to open again for visibility
  - raise the open PR limit slightly
  - add `dependencies` / `npm` labels
  - standardize commit message prefix
- `pip` for `polyglot-mini`
  - re-enable `minor` / `patch` updates
  - keep `major` updates ignored
  - group the runtime updates
  - add `dependencies` / `python` labels
- `github-actions`
  - keep weekly updates enabled
  - add `dependencies` / `github-actions` labels
  - standardize commit message prefix

## Effect
Dependabot becomes more helpful again, while the information it provides is easier for maintainers to triage.
