### PR TITLE
docs(research): P2b briefs — CLI conventions, benchmarks v2, site reconciliation

### DIFF
--- a/docs/research/briefs/D_cli_and_sdk_conventions.md
+++ b/docs/research/briefs/D_cli_and_sdk_conventions.md
@@ -1,16 +1,172 @@
 # Brief D — CLI / SDK / harness conventions
 
 **Date:** 2026-04-23
-**Status:** Not started (placeholder)
-**Author:** —
-**Summary:** Survey how modern AI CLIs and SDKs look (shape of commands, config, auth, output contracts), then decide what Wittgenstein should match versus intentionally diverge from.
+**Author:** research (max.zhuang.yan@gmail.com)
+**Status:** Draft v0.1
+**Summary:** Surveys what a modern AI CLI / SDK looks like in April 2026 — subcommand taxonomy, flag vocabulary, config resolution order, auth, pipe discipline, doctor patterns, one-liner install — and audits where `wittgenstein`'s current CLI is on the industry grid and where it is off. Verdict: the shape is mostly right (noun-first subcommands, `--seed`, `--dry-run`, a `doctor`), but the output contract, config precedence, and install story are under-specified; RFC-0002 should adopt a small set of hard conventions (`--json`/NDJSON on stdout, stderr for logs, `flag > env > project file > user file > defaults`, a single `npx @wittgenstein/cli` one-liner) and deliberately diverge from the "LLM-chat CLI" pattern — Wittgenstein is a harness, not a chatbot, and its CLI is first a pipeline tool, second a demo.
 
 ---
 
+## Context
+
+Three pieces of 2024–2026 work make CLI conventions load-bearing for Wittgenstein rather than a style question.
+
+First, Anthropic's _Scaling Managed Agents: Decoupling the brain from the hands_ (Anthropic, April 2026) formalised the split between the reasoning component ("brain"), the execution environment ("hands" / sandbox), and an append-only session log. Managed Agents is explicitly a _meta-harness_: unopinionated about the concrete harness layered around Claude, but committed to the shape of the interface between them. The observation that matters for Brief D is that the boundary between brain, harness, and sandbox is an API boundary — and the CLI is one projection of that API. If the CLI does not enforce clean stdout/stderr discipline, structured output, and explicit config precedence, the harness layer is lying to itself when it claims those boundaries exist.
+
+Second, METR's 2024 evaluation work (METR, 2024) repeatedly showed that _scaffolding changes are comparable in magnitude to a major model upgrade_ on their autonomy suite — and that the scaffolding-vs-model interaction is a live experimental variable, not a fixed factor. A useful harness therefore needs to be A/B-testable: runs need to carry the full manifest of what scaffolding was used, which means the CLI (a) must emit structured artifacts deterministically, (b) must accept the same run configuration as env / file / flag, and (c) must support `--dry-run` and fixed-seed runs cheaply. These are not polish features. They are the minimum surface area required to credibly claim a run is reproducible.
+
+Third, HumanLayer's _12-Factor Agents_ (Horthy, 2025) distilled a set of principles that directly constrain CLI shape: _own your prompts, own your control flow, stateless agent design, separate business state from execution state, manage context explicitly_. Several of these have direct CLI projections — stateless by default (no global mutable state in `~/.wittgenstein/`), separation between business config (what the LLM is told) and execution config (which provider, which sandbox), and an explicit, inspectable event log (the `RunManifest` spine already exists in Wittgenstein for this).
+
+So: the question for RFC-0002 is not "what color should the flags be." It is "what does the CLI have to look like so that the harness claims above are actually true when someone runs `wittgenstein image 'X' --seed 7`."
+
 ## Steelman
+
+State the industry convention as its proponents would.
+
+There is now a recognisable _2025-class AI CLI_ template, converged on across at least six reference implementations: Claude Code, Codex CLI (OpenAI), Gemini CLI (Google), Cursor CLI, Kimi CLI (Moonshot), and — as the non-AI reference standard — `gh` from GitHub. The template has seven load-bearing components.
+
+**1. One binary, noun-first subcommands.** `gh pr list`, `gh issue view`, `claude /status`, `kimi mcp`, `gemini /agents`. The pattern is `<tool> <resource> <verb>` or `<tool> <verb>`. The verb is never the first positional. This makes shell history greppable, tab-completion discoverable, and help pages chunkable.
+
+**2. A small, shared flag vocabulary.** Every serious CLI in 2026 supports a roughly-equivalent core set: `--model` / `-m` (which LLM), `--stream` (token streaming), `--seed` (determinism), `--json` or `-o json` (machine output contract), `--dry-run` (no side effects, no billable calls), `-q`/`--quiet`, `-v`/`--verbose`, `--config <path>`. Gemini CLI uses `--model` / `-m` (Google, 2025). `gh` uses `--json <fields>` with `--jq` and `--template` as post-filters (GitHub, 2025). These flags mean the same thing everywhere.
+
+**3. A strict config resolution order.** The canonical order, inherited from npm and 12-Factor App, is `CLI flag > env var > project-local config > user config > global/system config > built-in defaults` (npm, 2024). This is universal and it is not up for debate: tools that invert it (env overrides flag, project overrides flag) are considered broken.
+
+**4. Auth that decouples from config.** `gh auth login`, `kimi login`, Claude Code's OAuth bootstrap, `codex login` all follow the same shape: a subcommand whose only job is to obtain or refresh credentials, store them in a platform-appropriate keychain or a well-documented file, and exit. The credential is never a flag and never a field in the main config file. `gh auth status --json hosts` is the canonical inspection command (GitHub, 2025).
+
+**5. Structured output on stdout, logs on stderr.** This is the Unix discipline, re-enforced by the LLM-era. `gh` supports `--json <fields>` output on any subcommand (GitHub, 2025). `jq` pipelines downstream assume NDJSON or canonical JSON. Interactive pretty-printing happens when stdout is a TTY; it silently switches to machine format when piped. Logs, progress bars, warnings all go to stderr.
+
+**6. A `doctor` subcommand.** Claude Code has `/doctor` (environment diagnostics, distinct from `/status` which reads current session config — Anthropic, 2026). `gh` has `gh auth status`. `brew doctor`, `npm doctor`, `flutter doctor` are the pre-LLM precedents. The pattern is: one subcommand, no side effects, emits a structured health report with actionable error messages. On success exits 0; on failure exits nonzero with a list of what to fix.
+
+**7. A one-line install.** `curl https://cursor.com/install -fsSL | bash` (Cursor, 2025). `npm install -g @openai/codex` (OpenAI, 2025). `brew install gh`. The user acquires the binary in a single command that does not require cloning a repo or managing a Python env.
+
+The steelman version of the 2025-class AI CLI is: if your tool does not implement all seven of these, it is below the bar set by every mainstream AI developer tool shipped in the last eighteen months. Matching them is table stakes. Deviating from them is a deliberate choice that must be defended.
+
+## Survey
+
+Nine reference tools, read for the seven components above. Facts verified against current 2025–2026 documentation.
+
+**OpenAI Codex CLI (OpenAI, 2025).** Subcommand taxonomy: `codex`, `codex exec`, `codex features`, `codex login`. Flags: `--model`, `--sandbox`, `--approval-mode`, `--config`, `--cd`. Config resolution: env > `~/.codex/config.toml` > built-in defaults; CLI flags override all. Auth: `codex login` (browser OAuth flow), stored in `~/.codex/`. Output contract: pretty on TTY, JSON when `--json` is set; session transcripts written to disk in a structured format. Doctor: no dedicated `doctor`, but `codex features` inspects and persists capability flags. Install: `npm install -g @openai/codex`. Notes: the Agents SDK _itself_ is a Python library (`pip install openai-agents`) — there is no `agents` CLI, which is the first important observation. The CLI surface is for the coding agent; the SDK surface is for building agents. This is a deliberate split that Wittgenstein should mirror.
+
+**Anthropic SDK + Claude Managed Agents (Anthropic, 2026).** The SDK is `anthropic` (Python) / `@anthropic-ai/sdk` (TypeScript); there is no general-purpose `anthropic` CLI. Managed Agents exposes a REST surface for session lifecycle (create session, post event, fetch session log), not a CLI. The brain-hands-session split _does_ imply a CLI shape for harness builders: the CLI's job is to drive a session, and the session log is the authoritative artifact. This is exactly the `RunManifest` pattern Wittgenstein already has.
+
+**Claude Code CLI (Anthropic, 2026).** Subcommands: the REPL is the primary interface; slash-commands inside the REPL provide structure — `/doctor`, `/status`, `/config`, `/model`, `/agents`, `/mcp`. Non-REPL invocation: `claude config list | set | reset`, `claude --print <prompt>`. Flags: `--model`, `--print` (one-shot), `--dangerously-skip-permissions`, `--config`. Config: `.claude/settings.json` (project) layered over `~/.claude/settings.json` (user); env vars with `CLAUDE_CODE_*` prefix override file. Auth: OAuth via `claude login`, stored in platform keychain. Doctor pattern: `/doctor` actively _tests_ the environment (Node version, MCP servers reachable, credentials valid) and reports failures with actionable errors; `/status` is a separate read-only settings dump. Install: `npm install -g @anthropic-ai/claude-code` or `curl -fsSL claude.ai/install.sh | sh`. The doctor / status split is the single most copyable convention from Claude Code.
+
+**Gemini CLI (Google, 2025).** Open-source (`google-gemini/gemini-cli`). Subcommands: slash-prefix inside REPL (`/agents`, `/mcp list`, `/model`, `/include-directories`), `@path` for file inclusion, `!cmd` for shell. Flags: `--model` / `-m` with aliases, `--include-directories`, `--yolo` (auto-approve), `-o <format>`. Config: `.gemini/config.json` project > user > env `GEMINI_*`. Auth: Google OAuth via `gemini auth login`; API-key mode for programmatic use. Output: pretty in TTY; JSON mode via flag. Doctor: no `doctor`, but `/mcp list` and `/about` cover health-check-shaped queries. Install: `npm install -g @google/gemini-cli`.
+
+**`gh` (GitHub, 2015–2025).** The non-AI reference standard. Subcommands: `gh <resource> <verb>` — `gh pr list`, `gh issue view`, `gh run watch`. Flags: `--json <fields>` on basically every command, `--jq`, `--template`, `-R <owner/repo>`, `--web`. Config: `~/.config/gh/config.yml`, `GH_TOKEN` / `GITHUB_TOKEN` env overrides. Auth: `gh auth login` / `gh auth status --json hosts --show-token` / `gh auth refresh` / `gh auth logout`. Output: `--json` gives canonical JSON on stdout; everything else is pretty-printed with TTY detection. Doctor-equivalent: `gh auth status`. Install: `brew install gh`, `winget install --id GitHub.cli`, or apt repo. `gh` is the cleanest implementation of the seven-point template and the one Wittgenstein's CLI should most closely resemble in shape.
+
+**`npm` (npm Inc., 2010–2025).** Config resolution is the canonical implementation of the precedence order (npm, 2024): `--foo bar` on CLI > `npm_config_foo=bar` in env (case-insensitive) > project `.npmrc` > user `~/.npmrc` > global `.npmrc` > built-in defaults. Any new CLI that wants to ship in 2026 without justifying itself should copy this order verbatim.
+
+**Cursor CLI (Cursor, 2025–2026).** Single binary `cursor-agent`. Subcommands / modes: `--mode=plan|ask|agent`, slash-commands in REPL (`/plan`, `/ask`, `/model`, `/usage`, `/about`, `/resume`). Flags: `--mode`, `--model`. Config: `.cursor/mcp.json` for MCP, environment for API keys. Auth: session tokens managed by Cursor account. Output: pretty TTY; structured mode for pipe. Doctor: `/about` is the health-check. Install: `curl https://cursor.com/install -fsSL | bash`. The mode flag (`--mode=plan|ask|agent`) is interesting — it's a dimension we don't have today and may not need.
+
+**Kimi CLI (Moonshot, 2025).** `kimi` is the main binary. Subcommands: `kimi` (interactive), `kimi login`, `kimi mcp <subcmd>`, `kimi export`, plus a Web UI server and an agent trace visualizer. Flags: `--model`, `--port`, `--host` (for Web UI). Config: `~/.kimi/` with `context.jsonl`, `wire.jsonl`, `state.json` exported on demand. Auth: browser OAuth via `kimi login`, auto-configures available models. Doctor: not by that name, but the "Ralph Loop" mode and tracing visualizer cover inspection. Install: via pip / uvx. Kimi's export format (`context.jsonl` + `wire.jsonl` + `state.json`) is _exactly_ the shape a harness-side run manifest should take and is a cleaner version of what Wittgenstein currently writes under `artifacts/runs/`.
+
+**Lark CLI / LangChain CLI (LangChain, 2024–2025).** `langchain` CLI exists primarily as a project scaffolder — `langchain app new`, `langchain serve`. It is _not_ an interactive agent runner. The relevant lesson for Wittgenstein is the LangChain CLI's narrow scope: it sets up a LangServe app and stops there. It does not try to be a chat client. Wittgenstein's CLI has a similar opportunity to stay narrow: generate artifacts and emit manifests; do not try to become a chat REPL.
+
+**12-Factor Agents (Horthy / HumanLayer, 2025).** Not a CLI, a manifesto. Directly relevant principles: _own your prompts_ (prompts live as files in the repo, not hard-coded in the binary — Wittgenstein already does this), _own your control flow_ (the harness drives the loop, not the LLM — Wittgenstein already does this), _stateless agent design_ (no hidden `~/.wittgenstein/` mutable state — Wittgenstein mostly does this but has implicit workspace resolution that should be documented), _separate business state from execution state_ (the `RunManifest` records business state; execution state lives in provider SDKs and should not leak into manifests). The 12-factor framing converts roughly into these CLI rules: (a) everything reproducible from `CLI invocation + git SHA + manifest`, (b) no mutable global state the CLI depends on, (c) config is layered and explicit, (d) the session log is the single source of truth.
+
+## Wittgenstein's current CLI — audit
+
+Source: `packages/cli/src/commands/*.ts`, `packages/cli/README.md`, `docs/quickstart.md`.
+
+Current surface:
+
+```
+wittgenstein image   <prompt> [--out <path>] [--seed <n>] [--dry-run]
+wittgenstein tts     <prompt> [--out <path>] [--seed <n>] [--dry-run]
+wittgenstein audio   <prompt> [--route speech|soundscape|music] [--out] [--seed] [--dry-run]
+wittgenstein sensor  <prompt> [--out] [--seed] [--dry-run]
+wittgenstein video   <prompt> [--out] [--seed] [--dry-run]
+wittgenstein svg     <prompt> [--out] [--seed] [--dry-run]
+wittgenstein asciipng <prompt> [--out] [--seed] [--dry-run]
+wittgenstein animate-html --out <path>
+wittgenstein doctor  [--config <path>]
+wittgenstein init
+wittgenstein minimax-key
+```
+
+Seven modality groups (image, tts/audio, sensor, video, svg, asciipng, animate-html) plus three infra commands (`doctor`, `init`, `minimax-key`). `RunManifest` is the spine: every invocation writes `artifacts/runs/<id>/manifest.json` with git SHA, lockfile hash, seed, prompt, IR, LLM output, and artifact SHA-256.
+
+**Where it's on the grid.**
+
+- _Noun-first subcommands._ `wittgenstein <modality>` follows the `gh <resource>` pattern, not the `cli run --modality=X` anti-pattern. Good.
+- _`--seed` everywhere._ Determinism is a first-class flag on every modality command. Matches the steelman.
+- _`--dry-run` everywhere._ Matches the steelman and the METR "scaffolding is a variable" constraint.
+- _`doctor` subcommand._ Already emits JSON with structured fields (`ok`, `nodeVersion`, `hasApiKey`, `llmProvider`, `llmModel`, `artifactsDir`). This is closer to Claude Code's `/doctor` than to the average Python CLI's "print stuff and hope" pattern.
+- _Manifest-per-run._ Kimi-shaped, 12-factor-aligned. This is genuinely ahead of the median CLI.
+- _`--out` relative-path resolution._ `--out` relative paths resolve from the workspace root, which is the Claude Code / gh convention (project-local semantics by default).
+
+**Where it's off the grid.**
+
+- _No `--json` / NDJSON output contract._ Every modality command currently writes its primary artifact to disk (`--out`) and prints human-readable logs. There is no canonical way to pipe `wittgenstein image ... | jq '.manifest_path'`. `doctor` happens to emit JSON but that is a local convention, not a contract. _This is the single biggest gap._
+- _No documented config resolution order._ `@wittgenstein/core`'s `loadWittgensteinConfig` reads a config file, but the precedence of flag vs env vs project vs user is not stated in the CLI docs. Users don't know whether `MOONSHOT_API_KEY` in the env beats a `provider.apiKey` entry in `wittgenstein.config.json`, or the reverse.
+- _No `auth` subcommand._ API keys are read from env vars directly (`MOONSHOT_API_KEY`, `MINIMAX_API_KEY`, etc.). There is a `minimax-key` command, which is provider-specific rather than a uniform `wittgenstein auth <provider>` surface. The `gh auth` pattern is cleaner.
+- _No `--model` flag._ The model is resolved via config. This is defensible — Wittgenstein is a harness, not a chat CLI, and the user often shouldn't care — but there is no escape hatch for A/B-testing models at the CLI level, which is exactly the METR use case.
+- _No `--stream`._ Irrelevant for most modality runs (they produce a single artifact, not a token stream), but likely relevant for a future `wittgenstein chat` or `wittgenstein plan` surface.
+- _Stdout vs stderr discipline is ad hoc._ Progress output, warnings, and the final manifest path all go to stdout today. For pipe-ability, logs must move to stderr.
+- _Two install paths, no canonical one-liner._ The quickstart documents both `pnpm --filter @wittgenstein/cli exec wittgenstein ...` (workspace-internal) and `python3 -m polyglot.cli ...` (the Python twin). `npm install -g @wittgenstein/cli` exists but `npx @wittgenstein/cli doctor` is not highlighted as the canonical try-it-out command. Cursor's `curl | bash` and Claude Code's `npm install -g` have set the bar at one command.
+- _`init` and `minimax-key` leak implementation._ `minimax-key` is a one-off for a specific provider; it should be `wittgenstein auth minimax` or removed. `init` is fine but should be documented.
+- _No `wittgenstein run` universal entrypoint._ For scripted use, a single `wittgenstein run --modality=image --prompt=... --seed=...` would be more ergonomic than seven modality-specific commands. But see the Red Team below — this is a live trade-off, not an obvious win.
 
 ## Red team
 
+Three plausible pushbacks, answered inline.
+
+**Pushback A: "Why not just match `openai` / `codex` 1:1?"** Because those tools are shaped around a different job. The OpenAI Agents SDK is a Python framework for building agents; the Codex CLI is a coding agent for a terminal user. Neither is optimised for "driver of a deterministic multimodal artifact pipeline." If Wittgenstein adopted Codex's shape verbatim it would gain a REPL and a sandbox mode it doesn't need, and would lose the noun-first modality taxonomy that is actually its clearest win. The right reference is `gh`, not `codex` — a CLI whose job is to drive well-defined resources through well-defined verbs. Match `gh`'s surface discipline, not Codex's surface features.
+
+**Pushback B: "CLI ergonomics is bikeshedding before codec v2 lands."** Partly fair, partly wrong. It would be bikeshedding if this were about colours and help-text wording. It isn't. The items on the critical path are (i) `--json` / NDJSON output contract, (ii) documented config precedence, and (iii) stderr discipline. Items (i) and (iii) are prerequisites for A/B-testing codecs at all — if you can't `wittgenstein image ... --json | jq '.metrics.fid'`, you can't run an overnight sweep. Item (ii) is a prerequisite for reproducibility claims to be real. Codec v2 will land faster with these in place, not slower. The rest (install one-liner, `auth` subcommand, `--model` flag) can wait behind a post-v2 milestone.
+
+**Pushback C: "Users run the CLI once then use the SDK. The CLI doesn't matter."** True for chat CLIs like Codex and Cursor. False for Wittgenstein, because the CLI _is_ the reproducibility surface. The `RunManifest` is produced by the CLI path. A user who drops to the SDK and skips the CLI loses the manifest spine, loses the `artifacts/runs/<id>/` layout, and loses the git-SHA + lockfile-hash provenance that makes a run citeable. In Wittgenstein's world, the CLI is not a demo — it is the canonical way to produce an artifact you can put in a paper. Making it pipe-friendly is making the science-grade artifact stream pipe-friendly. That matters.
+
 ## Kill criteria
 
+Concrete things that would invalidate this brief's recommendations.
+
+1. **By Q2 2027, if the dominant developer-tool UX has shifted from CLI → TUI → MCP-native clients,** such that new AI tools ship primarily as MCP servers consumed by hosts (Claude Code, Cursor, Gemini CLI's `/mcp`), the CLI-shape recommendations here are stale and RFC-0002 should pivot to "Wittgenstein is an MCP server first, a CLI second." Probability: moderate. Gemini CLI, Claude Code, Cursor all converged on MCP in 2025; the direction of travel is real. Mitigation: ship an MCP adapter in parallel with the CLI hardening so neither path is a dead end.
+
+2. **If NDJSON-on-stdout turns out to conflict with how users actually pipe binary artifacts.** Most Wittgenstein outputs are binary (PNG, WAV, MP4). `--json` is a manifest-and-metadata contract, not an artifact-on-stdout contract. If, in practice, users want to pipe the artifact itself (`wittgenstein image ... | convert - out.jpg`), a stdout-binary mode conflicts with a stdout-JSON mode. Resolution: `--out -` writes the artifact to stdout; `--json` writes the manifest to stdout; the two are mutually exclusive and the CLI errors loudly if both are set. This is the ffmpeg convention and it works.
+
+3. **If the config precedence order we pick conflicts with an upstream tool (`pnpm`, `pip`, `uvx`) that wraps us.** If `pnpm --filter @wittgenstein/cli exec wittgenstein` injects env vars that we treat as higher-precedence than flags, we have a bug. Mitigation: enforce `flag > env > file > defaults` in `loadWittgensteinConfig` with tests.
+
+4. **If a future `wittgenstein chat` or `wittgenstein plan` surface needs streaming, tools, and state that don't fit the "one-shot artifact" pattern.** This is not a kill but a forcing function: the current CLI shape will need a second command family (streaming, interactive) that lives next to the modality commands. The recommendations below should not foreclose that.
+
+5. **If Anthropic's Managed Agents pricing model (Anthropic charges 8 US cents per session hour for active runtime, per their April 2026 post) becomes the dominant cost structure for agent workloads,** then "a CLI that drives local sessions" becomes the minority case and we should design for "a CLI that drives remote Managed Agents sessions" — which has different config and auth shape. Probability: low in the next year; agents are still mostly local-driven.
+
 ## Verdict
+
+RFC-0002 should propose the following six decisions. Four track the industry convention; two deliberately diverge because Wittgenstein is a harness, not an LLM-chat CLI.
+
+1. **Adopt `--json` as the canonical machine-output flag on every modality command and on `doctor`.** When `--json` is set, stdout is a single canonical JSON object (or NDJSON for multi-phase runs) containing `{manifest_path, artifact_path, artifact_sha256, run_id, seed, git_sha, duration_ms, ...}`; everything else (progress, warnings, model chatter) goes to stderr. Without `--json`, stdout auto-detects TTY and pretty-prints. This is the `gh` contract (GitHub, 2025) and it is non-negotiable if A/B sweeps are to work.
+
+2. **Document and enforce the config resolution order: `CLI flag > env var > project config (./wittgenstein.config.ts or .json) > user config (~/.wittgenstein/config.json) > built-in defaults`.** Copy npm's order verbatim (npm, 2024); add a test that inverts each pair and asserts the correct one wins. `doctor` should print which layer each effective value came from.
+
+3. **Keep `wittgenstein <modality> <prompt>` as the primary shape; do _not_ collapse to `wittgenstein run --modality=...`.** The noun-first pattern is the clearest part of today's CLI and matches `gh`. Do add a power-user `wittgenstein run --manifest <path>` that replays a previous RunManifest byte-for-byte — this is the A/B-sweep primitive.
+
+4. **Ship a `wittgenstein doctor` that tests, a separate read-only `wittgenstein config show` that inspects.** Copy the Claude Code `/doctor` vs `/status` split (Anthropic, 2026). `doctor` exits nonzero on failure with a list of actionable fixes; `config show` prints effective config with provenance.
+
+5. **Add a uniform `wittgenstein auth <provider> [login|status|logout]` surface and deprecate `minimax-key`.** Model it on `gh auth` (GitHub, 2025) and `kimi login` (Moonshot, 2025). Keep env-var fallback for CI (`MOONSHOT_API_KEY`, etc.), but make `wittgenstein auth status --json` the canonical inspection path. The current `minimax-key` command should be a thin alias that prints a deprecation warning.
+
+6. **Make the install one-liner `npx @wittgenstein/cli doctor`, and make that command do something useful with zero config.** `npx @wittgenstein/cli doctor` should, with no API key and no config file, report which codecs are usable in dry-run mode, which need a provider key, and which need system tools (ffmpeg, afconvert). Cursor's `curl | bash` (Cursor, 2025) is the speed benchmark; `npx` gets us most of the way there without a custom install script.
+
+Two deliberate divergences from the 2025-class AI CLI template.
+
+- **No interactive REPL as the primary interface, and no slash-commands.** Claude Code, Cursor, Gemini, Kimi all centre a REPL. Wittgenstein should not. The harness thesis is that the LLM is one stage in a pipeline, not the user-facing surface; a REPL pulls towards chat-app framing and away from pipeline framing. Keep `wittgenstein` as a one-shot command with structured output. If an interactive surface is ever needed, it should be a separate binary (`wittgenstein-repl`) with an explicit "this is the toy version" label.
+
+- **No `--model` override on modality commands by default.** The chat CLIs all expose `--model` because their primary job is LLM-as-service. Wittgenstein's primary job is a specific codec producing a specific artifact; the model is an internal implementation detail of the harness, and exposing it at the CLI invites users to swap it in ways that invalidate the codec's guarantees. Instead, expose `--provider <name>` (choose which configured provider) and let the provider's config pin the model. Power users who need fine-grained model control can set `WITTGENSTEIN_LLM_MODEL=...` in env; the precedence rule from (2) means that still works. This is a divergence from Gemini / Claude Code / Kimi and it is defensible because we are a harness, not a chat service.
+
+Net: six decisions to write into RFC-0002, two of which are industry-standard, two of which are industry-standard-with-Wittgenstein-shape (config order with provenance-aware `doctor`, noun-first with `--manifest` replay), and two of which are deliberate divergences from chat-CLI framing. The current CLI is about 70% of the way to the bar the 2025-class AI CLIs have set; the remaining 30% is mostly the output contract and the config precedence, and both are cheap to fix. — research, 2026-04-23.
+
+## References
+
+- Anthropic (April 2026). "Scaling Managed Agents: Decoupling the brain from the hands." https://www.anthropic.com/engineering/managed-agents
+- Anthropic (2026). "Claude Code CLI Reference." https://code.claude.com/docs/en/cli-reference
+- Cursor (2025–2026). "Cursor CLI." https://cursor.com/cli and https://cursor.com/docs/cli/overview
+- GitHub (2025). "gh Manual." https://cli.github.com/manual/ ; `gh auth status` https://cli.github.com/manual/gh_auth_status
+- Google (2025). "Gemini CLI Reference." https://geminicli.com/docs/reference/commands/ ; repo https://github.com/google-gemini/gemini-cli
+- Horthy, D. / HumanLayer (2025). "12-Factor Agents." https://github.com/humanlayer/12-factor-agents and https://www.humanlayer.dev/12-factor-agents
+- LangChain (2024–2025). "LangChain CLI." https://python.langchain.com/docs/langserve/
+- METR (2024). "An update on our general capability evaluations." https://metr.org/blog/2024-08-06-update-on-evaluations/
+- Moonshot AI (2025). "Kimi Code CLI." https://github.com/MoonshotAI/kimi-cli and https://moonshotai.github.io/kimi-cli/en/reference/kimi-command.html
+- npm / npm Inc. (2024). "npm-config." https://docs.npmjs.com/cli/v11/using-npm/config/
+- OpenAI (2025). "Codex CLI Reference." https://developers.openai.com/codex/cli/reference ; "Agents SDK." https://openai.github.io/openai-agents-python/
+- Wittgenstein repo (2026). `packages/cli/src/commands/*.ts`, `packages/cli/README.md`, `docs/quickstart.md`.

--- a/docs/research/briefs/E_benchmarks_v2.md
+++ b/docs/research/briefs/E_benchmarks_v2.md
@@ -1,16 +1,187 @@
 # Brief E — Per-modality quality benchmarks (v2)
 
 **Date:** 2026-04-23
-**Status:** Not started (placeholder)
-**Author:** —
-**Summary:** Define the smallest set of _standard_ quality metrics per modality (image/audio/video/sensor) that Wittgenstein can run locally, reproducibly, without turning the repo into a benchmark zoo.
+**Author:** research (max.zhuang.yan@gmail.com)
+**Status:** Draft v0.1
+**Summary:** Picks the smallest set of real (non-structural) quality metrics per modality that Wittgenstein can actually run locally and reproducibly without breaking the Latency / Price / Quality contract — one default-tier metric per modality, one heavy-tier fallback, composite lifted off the structural floor. Verdict tease: VQAScore for image, UTMOS for speech, librosa-BPM + key for music, CLAP for soundscape, NeuroKit2 rule-set for ECG, derivative-bound rules for gyro/temperature, CLIP-temporal for video, and a single `[0,1] → mean` composite with a hard "API-break-is-a-fail" rule.
 
 ---
 
+## Context
+
+The current state of the Wittgenstein benchmark harness is honest and narrow. The README at `benchmarks/README.md` admits it outright: "Today's quality numbers are **structural proxies**, not research-grade metrics." The four cases that run in CI (`image-editorial`, `tts-launch`, `audio-music`, `sensor-ecg`) each produce a 0.0–1.0 score that decomposes into three things: does the artifact exist and parse, are the container-level dimensions right (width × height for PNG, duration for WAV, sample count for sensor JSON), and does a trivial signal-level sanity check pass (pixel variance > 100, RMS in a loudness window, signal mean in a physiological range). That is a file-format smoke test wearing a quality badge.
+
+This is not nothing. The 35-artifact showcase that the gallery branch just landed (`docs/showcase-gallery`, commit 7897062) leans hard on those structural checks to prove that every modality at least _renders_ deterministically across SVG, ASCII-PNG, raster PNG, WAV (speech / music / soundscape), JSON+CSV (ECG, gyro, temperature), and eventually MP4. If any of those checks regresses, we know instantly that the codec broke. But none of those checks can distinguish "the adapter produced a plausible 440 Hz A4 sine wave" from "the adapter produced a plausible violin tone", because both decode, both land in the loudness window, and both are within 30% of the expected duration. The quality axis has almost no dynamic range below the ceiling.
+
+The driving question for this brief is: what is the _smallest_ set of real metrics — one per modality — that lifts Quality off the structural floor without (a) requiring a paid API (violates the Price ≈ 0 dry-run contract), (b) requiring a GPU to run every pre-commit hook (violates Latency), or (c) adding so many dependencies that the repo turns into a metric zoo? Every pick below has to clear that bar.
+
 ## Steelman
+
+The structural-proxy floor was the right first move, and this brief should not pretend otherwise. Three reasons.
+
+First, reproducibility beats perceptual score when the stack is still settling. A CLIPScore number is only meaningful relative to a specific CLIP checkpoint, a specific prompt-normalization scheme, a specific batch size, and a specific numerical precision. If any of those five drift between the author's laptop and the CI runner, the number drifts with them, and you have a benchmark that no-one outside the author's machine can reproduce. The structural checks have none of that attack surface: a PNG either has dimensions 1024 × 1024 or it does not. That property is the reason the harness's Latency and Cost columns are already trustworthy, and it is the reason the team decided Quality could wait.
+
+Second, the METR 2024 harness-gains result is directly on point. METR's "update on our general capability evaluations" (August 2024) and the follow-up "Measuring AI Ability to Complete Long Tasks" (March 2025) both show that a large fraction of reported capability improvement on agent benchmarks comes from the scaffolding around the model — the harness — rather than the model weights themselves. Philschmid's April 2026 follow-up essay argues the same point: harness is load-bearing in 2026. The Wittgenstein corollary is: if you bolt a flaky perceptual-score harness onto an honest structural-proxy harness, the composite score will move because the harness moved, not because the model moved, and you will spend six months debugging a benchmark rather than shipping a codec. The structural floor was deliberately the cheapest harness that could not lie.
+
+Third, the reproducibility premium compounds. Every artifact Wittgenstein ships lives in a `RunManifest` with a fixed seed and a deterministic route. That manifest is the primary scientific asset of the repo; the artifact is secondary. Any quality metric we add has to be a _function_ of the manifest plus the artifact, runnable offline, with no hidden state. If we cannot meet that bar, we do not add the metric. This brief therefore asks a narrower question than "what is the best metric per modality": it asks "what is the best metric per modality that is also a pure function of (manifest, artifact) and fits in a laptop."
+
+## Per-modality picks
+
+One subsection per modality the 35-artifact showcase covers. Each pick names one default-tier metric (must run in CI on a laptop with no GPU, under ~5 s per artifact) and, where relevant, one heavy-tier metric (gated behind `--quality=heavy`). Candidates are discussed; the pick is in bold.
+
+### Image (SVG + ASCII-PNG + raster)
+
+Candidates: CLIPScore (Hessel et al., 2021, arXiv:2104.08718), VQAScore (Lin et al., 2024, arXiv:2404.01291), ImageReward (Xu et al., 2023, arXiv:2304.05977), HPSv2 (Wu et al., 2023, arXiv:2306.09341).
+
+CLIPScore is the obvious default — reference-free, widely cited, cheap to run against an OpenCLIP ViT-B/32 checkpoint (~150 MB). But the 2023–2024 literature has documented, in detail, that CLIPScore rewards prompt-rephrasing and treats text encoders as bags of words (Hessel et al. acknowledge this themselves; the 2023 robustness paper arXiv:2305.14998 quantifies it; VQAScore's opening argument is essentially "CLIPScore conflates 'the horse is eating the grass' with 'the grass is eating the horse'"). For a showcase that explicitly includes compositional prompts (editorial product shots, multi-object scenes), CLIPScore as the default metric would be a trap.
+
+ImageReward and HPSv2 are better correlated with human preference than CLIPScore, but both are human-preference reward models trained specifically on diffusion outputs at typical web-art styles. They will misbehave on Wittgenstein's SVG and ASCII-PNG artifacts, neither of which looks like Midjourney training data, and both ship as ~1–2 GB checkpoints.
+
+**Pick: VQAScore (default tier), CLIPScore as the cheap fallback when VQAScore is unavailable.** VQAScore (arXiv:2404.01291, ECCV 2024) reframes image-text alignment as a VQA probability — "Does this figure show '{text}'?" P(yes) — using an off-the-shelf VLM. The reference implementation (`t2v_metrics` on GitHub, `linzhiqiu/t2v_metrics`) runs with CLIP-FlanT5-XL (~3 GB) and reports state-of-the-art correlation with human judgement on eight image-text alignment benchmarks. Crucially, it beats CLIPScore on compositional prompts, which is exactly what Wittgenstein's editorial cases are. Rationale for default tier: the authors publish a smaller variant that fits in the GPU-less budget for a single-shot evaluation (~10 s per artifact on CPU with int8), and the score is bounded in [0, 1] by construction, which the composite wants. Rationale for CLIPScore fallback: if the VQAScore model download fails in CI, CLIPScore still runs in < 1 s and produces a score that is wrong-but-present, which matters for the composite's "no silent drops" rule.
+
+For SVG specifically, we rasterize at 512² before scoring. For ASCII-PNG, we score both the text form (VQAScore between the caption and the rendered raster) and we keep the structural check (does the glyph grid parse) as a gating pre-condition.
+
+### Speech / voice
+
+Candidates: Whisper WER via ASR round-trip (Radford et al., 2022, arXiv:2212.04356), UTMOS (Saeki et al., 2022, arXiv:2204.02152), DNSMOS P.835 (Reddy et al., 2021, arXiv:2110.01763).
+
+Whisper WER is tempting because Whisper-base is 140 MB and runs on CPU, and "does the generated speech say the words we asked it to say" is a real property. But WER is only meaningful when the reference transcript is known exactly, and it measures _intelligibility_, not _naturalness_ — a robotic monotone that happens to hit every phoneme scores perfectly. For Wittgenstein's speech route, intelligibility is already close to saturated because the underlying TTS is not experimental; the variance we care about is naturalness and prosody.
+
+DNSMOS P.835 (arXiv:2110.01763) predicts three ITU-T P.835 scores — speech quality (SIG), background noise (BAK), overall (OVRL) — and the reported correlation with human ratings is very high (PCC 0.94 / 0.98 / 0.98). But DNSMOS was specifically built to evaluate _noise suppressors_; its signal of interest is "did the denoiser remove noise without hurting the speech", not "is this synthetic voice convincing." Wrong target for our use case.
+
+**Pick: UTMOS (default tier), Whisper-WER as a gating pre-condition, DNSMOS as a heavy-tier diagnostic.** UTMOS (arXiv:2204.02152, the winner of VoiceMOS 2022) is an SSL-feature ensemble that predicts MOS for synthetic speech specifically. The `speechmos` and `utmos` Python packages wrap it into a single `predict(wav)` call; the underlying wav2vec2 feature extractor is ~360 MB and runs on CPU at about 2× realtime. Output is a single [1, 5] MOS score, trivially normalizable to [0, 1]. This is the right default because (a) MOS is what speech synthesis papers report, (b) the model was trained on the right distribution (Blizzard Challenge / VCC outputs, not denoised clean speech), and (c) it is small enough for CI.
+
+Whisper-WER sits _before_ UTMOS as a gate: if the ASR round-trip has WER > 0.5, we report "unintelligible" and do not trust the UTMOS number. This prevents the harness from praising a beautiful-sounding but content-free noise. DNSMOS ships behind `--quality=heavy` because its SIG / BAK / OVRL breakdown is genuinely useful when debugging a route regression, but running three models instead of one is not the default.
+
+### Music
+
+Candidates: BPM estimation accuracy (librosa / essentia), key estimation accuracy (librosa / essentia), CLAP similarity (LAION-CLAP, arXiv:2211.06687).
+
+Music is the modality where structural proxies bite hardest: "WAV decodes, duration in window, RMS in loudness band" is true of literally any signal we produce. The Wittgenstein music route currently claims 1.00 quality, which is correct under the structural definition and false under any musical definition.
+
+**Pick: librosa BPM accuracy + key estimation accuracy (default tier), CLAP similarity (heavy tier).** The default metric is a pair of deterministic DSP routines: `librosa.beat.beat_track` returns a tempo estimate, and the route manifest already names the target BPM (every music case is generated from a prompt that fixes tempo either explicitly or implicitly through a genre tag). The quality score is `1 − min(|BPM_estimated − BPM_target| / BPM_target, 1)`, clipped to [0, 1]. Key estimation follows the same pattern using the Krumhansl-Schmuckler profile available in `librosa.feature.chroma_cqt` + `librosa.key`. Rationale: both routines run in < 1 s on CPU, both are deterministic, and both measure something a listener actually cares about. They are lossy — neither catches "this track is tonally correct but musically boring" — but they remove the ceiling effect at the structural floor and they cost effectively zero.
+
+CLAP (LAION-CLAP, arXiv:2211.06687) is the heavy-tier upgrade. The `laion/clap-htsat-unfused` checkpoint (~600 MB) embeds audio and text into a shared space; cosine similarity between the prompt and the artifact is a reasonable proxy for "does this sound like what was asked for." Behind `--quality=heavy` because the checkpoint is six times larger than everything else in the default tier combined.
+
+### Soundscape
+
+Candidates: spectral centroid match to a reference bank, PANNs tag retrieval (Kong et al., 2020, arXiv:1912.10211), CLAP similarity.
+
+Soundscape is the trickiest modality because there is usually no reference recording to compare against — the prompt says "rain on a tin roof at night" and the artifact is one of infinitely many plausible realizations. Spectral centroid match is cheap but too blunt (rain and static white noise both have high centroids). PANNs tagging produces 527 AudioSet tag probabilities; you can compute "does the top-k tag list overlap the prompt tags" as a score. This works but requires a prompt → AudioSet-tag mapping step, which is an adapter we do not have.
+
+**Pick: CLAP similarity (default tier), PANNs tag retrieval (heavy tier).** CLAP wins here as the default because it takes the prompt string natively — no tag mapping — and produces a scalar cosine that normalizes cleanly to [0, 1]. The same `laion/clap-htsat-unfused` checkpoint covers both music (heavy) and soundscape (default), so we pay the 600 MB download once. This is the one place in the brief where a heavier model is the right default: spectral centroid is too noisy to be useful, and PANNs without a tag-mapping adapter is not actionable. Running CLAP on a single 6-second soundscape is ~3 s on CPU, inside the budget.
+
+PANNs retrieval stays available under `--quality=heavy` as a diagnostic. The 527-tag breakdown is useful for "why did this score so low" investigations in a way CLAP's single cosine is not.
+
+### Sensor / ECG
+
+Candidates: clinical plausibility rule sets (QRS width, PR interval, heart rate range), open ECG quality indices.
+
+**Pick: NeuroKit2 rule set (default tier).** NeuroKit2 (neuropsychology/NeuroKit on GitHub) is an open-source Python toolbox for neurophysiological signal processing with a mature ECG module. The relevant functions are `ecg_peaks`, `ecg_delineate`, and `ecg_quality`. The plausibility check we run is an explicit, reviewed rule list rather than a single opaque score:
+
+1. Heart rate in [40, 180] BPM. (Covers resting bradycardia through exercise; below 40 or above 180 in a "stable ECG" prompt is a route bug.)
+2. QRS width in [60, 120] ms. Anything wider on a "normal" prompt signals reconstruction failure.
+3. PR interval in [120, 220] ms. Outside this window is either a prompt-specified arrhythmia (allowed if the prompt asked for it) or a route bug.
+4. R-R interval coefficient of variation consistent with the prompt's `stability` tag.
+5. Signal quality index (`ecg_quality`, Zhao 2018 method) above a floor of 0.5.
+
+Score = fraction of rules passed, in [0, 1]. Rationale: ECG is the one modality where "plausibility" has a textbook answer, and an opaque learned metric would be strictly worse than an explicit rule list that a clinician could review. Open ECG plausibility checkers with a published 2024–2026 paper (e.g., the Ho et al. 2025 telehealth RR-interval extraction work at medRxiv 2025.03.10.25323655) exist but are narrower in scope than the NeuroKit2 module and do not supersede it as a default. NeuroKit2 runs entirely on CPU in milliseconds per 30-second trace.
+
+### Sensor / gyro + temperature
+
+No pretrained model makes sense here — these are physical signals with strong prior structure, and a learned metric would be over-engineered.
+
+**Pick: physical-plausibility rule set (default tier).** Explicit rules per sensor type:
+
+- **Gyroscope (rad/s or deg/s):** magnitude bounded by the declared range (default ±2000 deg/s for consumer IMUs); first derivative bounded by `ω̇_max ≈ 10⁴ deg/s²` for hand motion; no NaN / Inf; unit declared in manifest matches unit of data column; sample count matches `floor(sample_rate × duration)` (already in the structural tier, retained).
+- **Temperature (°C):** values in the prompt-declared envelope (e.g., "ambient room" → [15, 30]; "ice bath" → [-5, 10]); first derivative bounded by declared thermal time constant (default 1 °C/s for ambient sensors, stricter for thermocouples in well-mixed environments); no monotonic drift inconsistent with the declared scenario (stable-room data that ramps 10 °C over a minute is a route bug).
+
+Score = fraction of rules passed, in [0, 1]. Both rule sets are ~15 lines of NumPy. Zero extra dependencies. This is deliberately the same shape as the ECG rule set for consistency — the composite treats them identically.
+
+### Video
+
+Candidates: structural pass (does the MP4 demux, are the frames the right resolution, is duration within tolerance) + CLIP-based temporal coherence via VideoCLIP / InternVideo2.
+
+Video is the least mature modality in the repo — the MP4 renderer is still pending per `benchmarks/README.md` — so the v2 metric here is a target, not a measurement we can run today.
+
+**Pick: structural pass gate + per-frame CLIP similarity mean/std (default tier), InternVideo2 similarity (heavy tier).** The default is: demux, sample N=8 frames uniformly, compute CLIPScore of each frame against the prompt, report `mean − std` as the score. The `mean` rewards prompt alignment; the `− std` term penalizes frame-to-frame drift, which is the cheapest available proxy for temporal coherence without loading a video model. Runs in ~5 s on CPU for an 8-frame, 512² video.
+
+Heavy tier is InternVideo2 (arXiv:2403.15377) similarity between the prompt and the clip. InternVideo2 is the current public best on text-to-video retrieval, with strong video-language semantic alignment; it is also ~1 GB and wants a GPU for sensible latency, so it stays behind `--quality=heavy`. VideoCLIP-XL is a reasonable alternative at a similar size. Between these two, default is InternVideo2 because its zero-shot retrieval numbers are better and its API is simpler.
+
+Note: "CLIP-temporal" is not a published metric; it is a construction. We should name it `clip-frame-drift` in the codebase to avoid implying a citation that does not exist.
+
+## Composite Quality score
+
+One normalization rule, one hard invariant.
+
+Rule: each per-modality metric is normalized to [0, 1] by a documented transform (UTMOS `(x − 1) / 4`, VQAScore already in [0, 1], librosa-BPM accuracy clipped to [0, 1], NeuroKit2 rule fraction already in [0, 1], etc.). The composite for a run is the unweighted arithmetic mean of the per-modality [0, 1] scores, computed only over modalities the run actually produced. The `RunManifest` records which modalities contributed and each modality's raw + normalized score.
+
+Invariant: **no modality can silently drop because its API broke.** If a metric fails to compute — model download failed, import error, OOM, whatever — the harness emits an explicit `null` score for that modality, marks the run as `quality_partial`, and the composite is _not_ computed. A run with missing quality data does not get a quality number. The CLI surface is:
+
+```
+pnpm benchmark --quality=off         # structural only (today's behavior, default for CI pre-commit)
+pnpm benchmark --quality              # default-tier metrics from this brief
+pnpm benchmark --quality=heavy        # adds VQAScore-large, DNSMOS, CLAP-music, InternVideo2
+```
+
+The default-tier models together are under ~1.5 GB (UTMOS wav2vec2 ~360 MB + VQAScore small ~500 MB + CLAP ~600 MB + librosa/NeuroKit2 zero). The heavy tier adds ~3 GB. Both sit under an explicit `benchmarks/tools/` directory with pinned checksums.
 
 ## Red team
 
+Three pushbacks, answered inline.
+
+**"The proxies already work, don't overfit to BLEU-style metrics."** The structural proxies work as regression guards, not as quality measurements. The 35-artifact showcase needs a quality axis that can distinguish "the image adapter shipped" from "the image adapter produces coherent compositions", and structural checks cannot do that. This brief is not proposing BLEU-per-modality; it is proposing one metric per modality that at least has a published correlation with human judgement (VQAScore, UTMOS, CLAP) or with a clinical reference (NeuroKit2 rule list). Crucially, the structural proxies stay — they become gating pre-conditions. A run that fails the structural check does not compute the perceptual metric, because "beautiful but malformed" is not a state we want to reward. This is the opposite of overfitting: the composite is explicitly multi-tier.
+
+**"CLIPScore is a trap — it rewards prompt-rephrasing."** Correct, which is why CLIPScore is the fallback, not the default. The default image metric is VQAScore, precisely because the VQAScore paper spends its first three pages documenting CLIPScore's bag-of-words failure mode on compositional prompts. For video, `clip-frame-drift` uses CLIPScore across frames, which inherits the same weakness; that is acceptable because the load-bearing quantity there is the _drift_ (frame-to-frame std), not the absolute similarity. If the adapter learns to rephrase prompts in its latent to game the CLIP score, the drift term will not change and the absolute mean will move uniformly across the default set. We should still track the VQAScore-video variant (the `t2v_metrics` repo supports it) as the eventual replacement.
+
+**"Perceptual metrics are expensive / require GPUs — breaks the local-first bet."** This is the strongest pushback and the brief is designed around it. The default tier is calibrated to run on CPU under ~5 s per artifact, total ~1.5 GB of model weights, no paid APIs. That is achievable today: UTMOS wav2vec2 is 360 MB and runs at 2× realtime on CPU; NeuroKit2 is pure NumPy; librosa BPM is DSP; VQAScore has a small-model path; CLAP on CPU is the slowest piece and still fits. The _heavy_ tier is explicitly GPU-preferred and explicitly behind a flag. If the default tier cannot hit the per-artifact budget on a 2024-class laptop in CI, we drop to the cheap fallback per modality (CLIPScore for image, Whisper-WER for speech, spectral-centroid for soundscape) before we drop the quality axis entirely. The local-first bet survives; the ceiling on Quality moves up without the floor on Latency moving.
+
 ## Kill criteria
 
+Three concrete triggers.
+
+1. **If, on the 35-artifact showcase, any two default-tier metrics for the _same_ modality disagree by more than 0.3 on normalized [0, 1] scale,** the composite is noise and we stop reporting a composite until the disagreement is diagnosed. Example: VQAScore says 0.8 on an editorial image, CLIPScore-fallback says 0.4 — that is either a genuine compositional-prompt failure VQAScore is catching and CLIPScore is missing (keep VQAScore as primary) or a VQAScore model-load bug (mark run as `quality_partial`). We cannot know without investigation; we will not publish a mean.
+
+2. **If any default-tier metric requires a paid API,** the metric fails the Price ≈ 0 constraint and is rejected. This applies retroactively: if LAION-CLAP's weights move behind a license wall, we fall back to PANNs (Apache 2.0) or drop soundscape to the cheap tier. No metric in the default set should have a billing dependency.
+
+3. **If any default-tier metric requires more than 4 GB of model download,** it is not default-tier; it moves to `--quality=heavy`. The 4 GB ceiling is the point where a clean `pnpm install && pnpm benchmark --quality` on a GitHub-Actions-sized runner starts timing out. The current default set totals ~1.5 GB, leaving headroom, but this is the ceiling.
+
+A softer kill: **if the composite never moves** across a month of adapter iteration on the same showcase, either the metrics are saturated or the adapter is not improving. Either way we re-examine; metrics that never move are a waste of Latency budget.
+
 ## Verdict
+
+| Modality | Current proxy | v2 metric | Library / source | Model size | Upgrade tier |
+|---|---|---|---|---|---|
+| Image (SVG / ASCII-PNG / raster) | PNG valid + dims + pixel variance > 100 | VQAScore (P(yes) on "Does this figure show '{text}'?") | `linzhiqiu/t2v_metrics` (arXiv:2404.01291) | ~500 MB (small) / ~3 GB (CLIP-FlanT5-XL) | default / heavy |
+| Image cheap fallback | — | CLIPScore | `jmhessel/clipscore` (arXiv:2104.08718) | ~150 MB (OpenCLIP ViT-B/32) | default fallback |
+| Speech / voice | WAV valid + duration + RMS | UTMOS | `speechmos` / `sarulab-speech/UTMOSv2` (arXiv:2204.02152) | ~360 MB | default |
+| Speech gate | — | Whisper-WER round-trip | `openai-whisper` (arXiv:2212.04356) | ~140 MB (base) | default gate |
+| Speech diagnostic | — | DNSMOS P.835 (SIG / BAK / OVRL) | `microsoft/DNS-Challenge` (arXiv:2110.01763) | ~80 MB | heavy |
+| Music | WAV valid + duration + RMS | librosa BPM accuracy + key accuracy | `librosa` (DSP, no model) | 0 | default |
+| Music heavy | — | CLAP text-audio cosine | `laion/clap-htsat-unfused` (arXiv:2211.06687) | ~600 MB | heavy |
+| Soundscape | WAV valid + duration + RMS | CLAP text-audio cosine | `laion/clap-htsat-unfused` | ~600 MB | default |
+| Soundscape diagnostic | — | PANNs top-k tag retrieval | `qiuqiangkong/audioset_tagging_cnn` (arXiv:1912.10211) | ~320 MB (CNN14) | heavy |
+| Sensor / ECG | JSON+CSV + sample count + mean-in-range | HR / QRS / PR / SQI rule set | `NeuroKit2` ecg module | 0 | default |
+| Sensor / gyro | JSON+CSV + sample count | range + derivative + unit rules | NumPy | 0 | default |
+| Sensor / temperature | JSON+CSV + sample count | envelope + derivative rules | NumPy | 0 | default |
+| Video | (pending MP4) structural only | `clip-frame-drift` (frame-wise CLIPScore mean − std) | `open_clip_torch` | ~150 MB | default |
+| Video heavy | — | InternVideo2 text-video similarity | `InternVideo2` (arXiv:2403.15377) | ~1 GB | heavy |
+
+Upgrade order, cheapest-to-land first. Ship the NumPy-only metrics first: NeuroKit2 for ECG, gyro rules, temperature rules, librosa BPM + key for music. These are four PRs totalling maybe 200 lines of code, zero new model downloads, and they immediately lift four modalities off the structural floor. Second, add CLAP for soundscape; it is the one place where the heavy model pays its weight as a default. Third, add UTMOS + Whisper-WER for speech; this is where the speech route quality number becomes meaningful for the first time. Fourth, add VQAScore for image with CLIPScore as the documented fallback; this is the highest-stakes metric in the set because image is the highest-variance modality in the showcase. Fifth, wire `clip-frame-drift` for video once the MP4 renderer lands. Finally, gate DNSMOS, PANNs, CLAP-music, VQAScore-XL, and InternVideo2 behind `--quality=heavy` and document them in `docs/benchmark-standards.md`. Everything lands in the default tier under ~1.5 GB of model weights and under ~5 s per artifact on CPU. — research, 2026-04-23.
+
+## References
+
+- CLIPScore: Hessel, Holtzman, Forbes, Le Bras, Choi (2021). "CLIPScore: A Reference-free Evaluation Metric for Image Captioning." arXiv:2104.08718. https://arxiv.org/abs/2104.08718
+- VQAScore: Lin, Pathak, et al. (2024). "Evaluating Text-to-Visual Generation with Image-to-Text Generation." arXiv:2404.01291. https://arxiv.org/abs/2404.01291
+- ImageReward: Xu et al. (2023). "ImageReward: Learning and Evaluating Human Preferences for Text-to-Image Generation." arXiv:2304.05977. https://arxiv.org/abs/2304.05977
+- HPSv2: Wu et al. (2023). "Human Preference Score v2: A Solid Benchmark for Evaluating Human Preferences of Text-to-Image Synthesis." arXiv:2306.09341. https://arxiv.org/abs/2306.09341
+- Whisper: Radford et al. (2022). "Robust Speech Recognition via Large-Scale Weak Supervision." arXiv:2212.04356. https://arxiv.org/abs/2212.04356
+- UTMOS: Saeki, Xin, et al. (2022). "UTMOS: UTokyo-SaruLab System for VoiceMOS Challenge 2022." arXiv:2204.02152. https://arxiv.org/abs/2204.02152
+- DNSMOS P.835: Reddy, Gopal, Cutler (2021). "DNSMOS P.835: A Non-Intrusive Perceptual Objective Speech Quality Metric to Evaluate Noise Suppressors." arXiv:2110.01763. https://arxiv.org/abs/2110.01763
+- CLAP (LAION): Wu et al. (2022). "Large-scale Contrastive Language-Audio Pretraining with Feature Fusion and Keyword-to-Caption Augmentation." arXiv:2211.06687. https://arxiv.org/abs/2211.06687
+- PANNs: Kong, Cao, Iqbal, Wang, Wang, Plumbley (2020). "PANNs: Large-Scale Pretrained Audio Neural Networks for Audio Pattern Recognition." arXiv:1912.10211. https://arxiv.org/abs/1912.10211
+- NeuroKit2: Makowski et al. (2021). "NeuroKit2: A Python toolbox for neurophysiological signal processing." Behavior Research Methods. https://github.com/neuropsychology/NeuroKit
+- InternVideo2: Wang et al. (2024). "InternVideo2: Scaling Foundation Models for Multimodal Video Understanding." arXiv:2403.15377. https://arxiv.org/abs/2403.15377
+- METR (2024). "An update on our general capability evaluations." https://metr.org/blog/2024-08-06-update-on-evaluations/
+- METR (2025). "Measuring AI Ability to Complete Long Tasks." https://metr.org/blog/2025-03-19-measuring-ai-ability-to-complete-long-tasks/
+- Wittgenstein benchmarks README: `benchmarks/README.md` at commit 7897062.

--- a/docs/research/briefs/F_site_reconciliation.md
+++ b/docs/research/briefs/F_site_reconciliation.md
@@ -1,16 +1,118 @@
 # Brief F — Site ↔ repo reconciliation
 
 **Date:** 2026-04-23
-**Status:** Not started (placeholder)
-**Author:** —
-**Summary:** Diff `wittgenstein.wtf` claims against the repo truth (v0.1.0-alpha.2+) and produce a patch list so public narrative stops drifting from code and docs.
+**Author:** research (max.zhuang.yan@gmail.com)
+**Status:** Draft v0.1
+**Summary:** `https://wittgenstein.wtf` resolves, but the page returns nothing more than the tagline *"Wittgenstein — The modality harness for text-first models."* There is no architecture section, no showcase, no CLI, no CTA to contradict — which means the public narrative is not drifting from the repo, it is simply absent. The correct move is not reconciliation; it is to stand up a minimal v0.1 site straight out of `docs/THESIS.md` and `SHOWCASE.md`, then treat Brief F as dormant until there is actually prose on the page to diff.
 
 ---
 
-## Steelman
+## Context
+
+The public domain `wittgenstein.wtf` predates the April 2026 doc wave — specifically it predates PR #6, which landed `docs/THESIS.md` (the locked master statement), `docs/inheritance-audit.md` (the V/R/N ledger), and `docs/SYNTHESIS_v0.2.md` (branch-level merge brief). Between hackathon-era content and v0.1.0-alpha.2+, a repo owner would normally assume drift: the pitch on the marketing surface lags the engineering surface by weeks, the weeks include at least one naming debate and one path rejection, and whoever wrote the hero copy is not the same person who wrote ADR-0005.
+
+The `inheritance-audit.md` ledger formalizes this worry as **V-3** (verbal inheritance: "`wittgenstein.wtf` content — Unknown staleness vs repo — Which claims on site contradict v0.1.0-alpha.2?") and blocks **N-3** (the rewrite) behind "RFC-0004 driven by R6," i.e. behind the output of this very brief. `SYNTHESIS_v0.2.md` lists the reconciliation as P2 priority: *"website should stop drifting from code/doc state."* And `THESIS.md` §"What is explicitly open" names *"Public website ↔ repo reconciliation"* as an RFC-deferred open question.
+
+This brief's job is to produce the diff. If the diff is empty because the site is empty, that is still data, and the verdict adjusts accordingly.
+
+## Method
+
+Three steps, in order:
+
+1. **WebFetch the live site** at `https://wittgenstein.wtf`. Capture whatever text actually renders — tagline, architecture copy, showcase gallery, CLI instructions, footer, license, contact, roadmap. Treat HTTP 2xx with thin content as distinct from 404 / 5xx / DNS failure; each case maps to a different verdict.
+2. **Grep the repo** for internal references to `wittgenstein.wtf` so we know what the code and docs *think* the site says. Candidate files: `README.md`, `SHOWCASE.md`, `docs/`.
+3. **Construct the reconciliation table** from whatever overlap exists between (1) the observed site surface and (2) the locked repo statements in `docs/THESIS.md`. Where the site has no content on a row, record `no-site-yet` rather than inventing a site claim.
+
+If WebFetch returns nothing usable (DNS fail, 404, blank body, placeholder page, "Coming soon"), the brief still runs, but the reconciliation table collapses to rows whose only action is "update site" — there is nothing to update the repo from, and nothing to retire.
+
+A repo grep for `wittgenstein.wtf` returns exactly three substantive hits: `docs/inheritance-audit.md` (the V-3 / N-3 parking lot), `docs/SYNTHESIS_v0.2.md` (the P2 reconciliation line item), and `docs/research/briefs/README.md` (the index row pointing to this file). Neither `README.md` nor `SHOWCASE.md` links to the site. The repo, in other words, has already stopped treating the site as canonical — all outbound traffic goes to GitHub, not to `.wtf`. That is a useful signal before we even look at the page.
+
+## Site snapshot (as of 2026-04-23)
+
+WebFetch on `https://wittgenstein.wtf` resolves (HTTPS 2xx) but returns a document whose only meaningful text is the page title / hero line:
+
+> **Wittgenstein — The modality harness for text-first models.**
+
+Two rounds of WebFetch, one asking for "all visible text, link text, and headings," confirm there is nothing else on the page the content-processing model can see: no architecture section, no "Why this exists," no receipts table, no showcase gallery, no CLI snippet, no install instructions, no reproducibility narrative, no roadmap, no contact block, no license footer, no research lineage, no mention of "Parasoid," no mention of L1–L5, no mention of RunManifest. The word "harness" appears once, in the tagline. The word "text-first" appears once, in the tagline. That is the entire corpus.
+
+This is consistent with a single-`<h1>` static placeholder — the kind of landing page you register a domain and deploy in twenty minutes so the URL in a Show HN post is not a 404. It is *not* a marketing site. It is a domain squat with a one-line epitaph.
+
+Two caveats on this reading. First, WebFetch summarizes and does not execute JavaScript, so it is at least theoretically possible the page contains client-rendered content the fetch model cannot see. Given the current repo has no web package and no deploy artifact that would produce such content, this is unlikely but not excluded. Second, the page title exactly matches the locked master statement from `docs/THESIS.md` line 9 (modulo the "LLMs" vs "models" suffix — more on that in the table), which is evidence that whoever deployed the placeholder had at least read the thesis. So the site is not stale content; it is thin content.
+
+The practical consequence is that rows in the reconciliation table below are mostly of the form "site claim: no-site-yet | repo truth: *locked statement* | drift: absence | action: update site." There is only one live contradiction, and it is on the tagline itself.
+
+## Repo truth (v0.1.0-alpha.2+)
+
+What the repo, as of this commit, *would like* the site to say — drawn from `docs/THESIS.md` (locked master + extension + architectural bet + Path-C rejection + RunManifest spine) and cross-checked against `README.md` (showcase counts, CLI surface, install story, receipts table) and `docs/modality-launch-surface.md` / `SHOWCASE.md` (modality group count).
+
+- **Master statement (locked, `THESIS.md` §Master):** *"Wittgenstein is the modality harness for text-first models. It assumes the frontier model is, and will remain, a text-native planner. Modality capability — image, audio, video, sensor, … — is added outside the model, through a portable harness layer that the model does not need to be retrained to use."*
+- **Extension form (locked wording, `THESIS.md` §Extension):** *"Harness as multi-modal middleware. Defer modality training to the portability layer. Use small post-training (adapters) plus rule-based codecs to give text-only LLMs multimodal output capability. The LLM plans in symbols; the codec turns symbols into files; the manifest makes every file replayable."*
+- **Architectural bet (locked, five layers):** L1 Harness / runtime — routing, retry, seed, budget, telemetry. L2 IR / codec — typed schemas, prompt contracts. L3 Renderer / decoder — IR to bytes; **frozen decoders in-bounds, general generators not the default path.** L4 Optional adapter — small learned translators, shipped beside codecs, not inside the base model. L5 Packaging — CLI, install, docs, agent primers.
+- **Reproducibility bet (locked):** every artifact ships with a `RunManifest` (git SHA, lockfile hash, seed, LLM input/output, artifact SHA-256, cost, latency, error taxonomy). *"If a run cannot be replayed bit-for-bit, it did not happen."*
+- **Path rejections (locked):** **Path C — Chameleon / LlamaGen-style full multimodal retrain — is not pursued.** Diffusion in the core image path is out (see `docs/hard-constraints.md`, ADR-0005). No silent fallbacks. Cloud-API dependence is not the default.
+- **Showcase (as of `README.md` and `SHOWCASE.md`):** **35 real artifacts across 7 modality groups**: image, TTS, music, soundscape, sensor-ECG, sensor-temperature, sensor-gyro. Full pack under `artifacts/showcase/workflow-examples/`. Every artifact has a matching run manifest in `artifacts/runs/<run-id>/`.
+- **CLI surface:** two shipping surfaces — Python (`python3 -m polyglot.cli <modality>`) and TypeScript (`pnpm --filter @wittgenstein/cli exec wittgenstein <modality>`). `doctor` command exists. Install: Node ≥ 20.11, pnpm ≥ 9.0, Python ≥ 3.10.
+- **Open (not yet locked):** naming of the middleware layer (`"Parasoid"` is informal, not binding — `THESIS.md` §"What is explicitly open" and inheritance-audit R-9). Pipeline shape (one LLM round vs two). Per-modality quality benchmarks beyond structural proxies. CLI ergonomics. Website ↔ repo reconciliation.
+- **License:** Apache 2.0 (`LICENSE`, README badge).
+- **Release:** `v0.1.0-alpha.2`, early-stage, breaking changes possible before `0.1.0`.
+
+## Reconciliation table
+
+Columns: **site claim** | **repo truth** | **drift** | **action**. Rows cover the surfaces a reasonable visitor would expect; `no-site-yet` is recorded where the site is silent.
+
+| # | Site claim | Repo truth | Drift | Action |
+|---|---|---|---|---|
+| 1 | *"The modality harness for text-first models"* (tagline, present) | *"The modality harness for text-first LLMs"* (README line 5) / *"…for text-first models"* (THESIS.md §Master) | Mismatched noun: site says *models*, README says *LLMs*, THESIS says *models*. THESIS is the locked source. | **update README** to say *models* to match THESIS; leave site alone. This is the one real contradiction. |
+| 2 | Modality count — no-site-yet | 7 modality groups (image, TTS, music, soundscape, sensor-ECG, sensor-temp, sensor-gyro) | Absence | **update site** — add a single line naming the seven groups. |
+| 3 | Modality list — no-site-yet | Same as above; *video* is 🔴 stub per README §Experimental | Absence | **update site** — list seven groups, explicitly mark video as stub to match `docs/implementation-status.md`. |
+| 4 | Architecture diagram — no-site-yet | L1–L5 locked in THESIS §Architectural bet; full ASCII diagram in README lines 92–112 | Absence | **update site** — port README ASCII block or render an SVG of the same. |
+| 5 | Showcase count — no-site-yet | 35 artifacts, curated samples for 8 hero tiles (README lines 75–82); `SHOWCASE.md` canonical | Absence | **update site** — embed the 8-tile curated grid linking to raw artifacts, or iframe `SHOWCASE.md`. |
+| 6 | CLI install instructions — no-site-yet | Two surfaces; README §Install + §CLI; requirements Node ≥ 20.11, pnpm ≥ 9.0, Python ≥ 3.10 | Absence | **update site** — include the 30-second quickstart block verbatim from README lines 121–126. |
+| 7 | Reproducibility story — no-site-yet | RunManifest spine locked in THESIS §Reproducibility; artifact trail example in README lines 174–180 | Absence | **update site** — one paragraph + the `artifacts/runs/…` tree snippet. |
+| 8 | Research lineage / citations — no-site-yet | `docs/research/neural-codec-references.md`; Brief A on VQ/VLM lineage; `docs/research/briefs/README.md` index | Absence | **update site** — link out to `/docs/research/briefs/`, no inline citations needed. |
+| 9 | Naming — does site say "Parasoid"? | No. Site has no body copy. Repo says "Parasoid" is informal and not binding (THESIS §Open; inheritance-audit R-9). | No drift; informal name is not escaping the repo. | **no action.** If site adds body copy before ADR-0010 lands, do not use "Parasoid." |
+| 10 | Roadmap claims — no-site-yet | `ROADMAP.md` + `docs/implementation-status.md` Ships / Partial / Stub matrix | Absence | **update site** — link to `ROADMAP.md`, do not inline a roadmap that will drift. |
+| 11 | Contact / license footer — no-site-yet | Apache 2.0; GitHub Issues is the support surface (`SUPPORT.md`) | Absence | **update site** — add footer: `Apache 2.0 · github.com/Moapacha/wittgenstein · issues`. |
+| 12 | Benchmarks claims — no-site-yet | README §Receipts table (6 rows, real numbers, measurement protocol in `docs/benchmark-standards.md`). Quality scores (CLIPScore/WER/UTMOS) flagged as ⚠️ Proxy in experimental matrix. | Absence | **update site** — either embed the Receipts table verbatim or omit benchmarks entirely; do not paraphrase and create new drift. |
+| 13 | Path rejections (diffusion, Path C) — no-site-yet | Locked in THESIS §Path rejections and `docs/hard-constraints.md` | Absence | **update site** — one line: *"No diffusion in the core image path. No full multimodal retrain."* Helps readers who arrive from Chameleon / Emu3. |
+| 14 | Release / status banner — no-site-yet | `v0.1.0-alpha.2`, early-stage, breaking changes possible before 0.1.0 (README lines 25–29) | Absence | **update site** — include the exact status banner. Reduces expectation mismatch for first-time visitors. |
+| 15 | Call-to-action — no-site-yet | README §"How to help" — three paths, quickstart first | Absence | **update site** — one CTA: *"Open a real artifact in 30 seconds →"* linking to `SHOWCASE.md`. |
+
+Net: fourteen of fifteen rows resolve to **update site**, one resolves to **update repo** (row 1, change README tagline noun from *LLMs* to *models* to match THESIS), zero resolve to **retire site section** because there are no site sections. Calling this a "reconciliation" is generous — it is a content brief for a site that does not yet exist.
 
 ## Red team
 
+Three pushbacks worth taking seriously.
+
+**"Site is marketing, repo is engineering, drift is expected and healthy — stop trying to reconcile them."** Partially fair. For mature projects, the marketing surface legitimately runs ahead of the engineering surface (to set direction) and behind it (to avoid shipping vapor). The objection fails here for two reasons. First, there is no marketing surface to diverge. The site is one line. One line cannot drift in the useful sense; it can only be silent or wrong, and today it is silent. Second, the specific drift that was feared — hackathon copy still saying "diffusion" or "Parasoid" or a stale modality count — does not exist to be defended. Reconciliation is premature because there is nothing to reconcile, not because drift is healthy.
+
+**"Reconciliation before RFC-0001 lands is premature — naming and protocol will shift again; you will write this brief twice."** Strong objection. The inheritance-audit explicitly parks naming (R-9, V-2) at ADR-0010 and the public-site rewrite (N-3) at "RFC-0004 driven by R6." If Brief F's output drives RFC-0004, and RFC-0004 lands after RFC-0001 (CLI) and the naming pass, then any site copy written today gets rewritten when the middleware layer stops being "Parasoid" and starts being whatever-it-becomes. The mitigation is deliberate: write site copy that only references locked statements (THESIS §Master, §Extension, §Architectural bet, §Reproducibility, §Path rejections). Every one of those is ADR-gated; none of them is expected to move before v0.2. Avoid the open-question surfaces (layer naming, CLI ergonomics, benchmark protocol beyond structural proxies), and the site survives the next three RFC-landings unchanged.
+
+**"Just retire the site until v0.2 ships."** Also reasonable, and arguably the lowest-risk path. The case against retirement is that `wittgenstein.wtf` is the canonical URL people paste into Slack, HN comments, and tweets; if it 404s, the default reader assumption is "this project died between the hackathon and now." A one-line placeholder is not better than a 404 — it is a 404 with extra steps. Either retire the domain (redirect to the GitHub README) or fill it. The middle state we are currently in is the worst of both worlds: the URL resolves, so readers don't get the *"search GitHub instead"* bounce, but nothing on the page justifies the visit.
+
 ## Kill criteria
 
+Concrete conditions under which Brief F should be archived rather than extended.
+
+1. **If the site remains a one-page placeholder for more than a reconciliation cycle, the correct move is retire-and-replace, not patch.** A reconciliation table makes sense only when there is a site with content to diff. If the action count on a real content site ever exceeds 20 rows with "update site" outnumbering "update repo" by more than 10:1 (current ratio: 14:1 against one mostly-empty row), the brief has drifted from reconciliation into a roadmap for a site that does not exist — wrong tool.
+2. **If RFC-0004 (public-site rewrite) lands before RFC-0001 (CLI) and ADR-0010 (naming pass)**, Brief F's premise is invalidated: the site will be written against the repo's unlocked surfaces and will immediately re-drift when those surfaces lock. Archive Brief F and replace it with a "site content freeze" brief keyed to locked statements only.
+3. **If the site migrates to a framework that renders from `docs/THESIS.md` directly** (a trivial Astro / Eleventy config over the markdown in-repo), reconciliation becomes structural rather than editorial — the site cannot drift from the thesis because it *is* the thesis. Brief F collapses to a one-liner and the file should be deleted rather than maintained.
+4. **If the domain is allowed to lapse or redirected to `github.com/Moapacha/wittgenstein`,** Brief F is moot. The canonical URL becomes the README, the README is already the source of truth, and the reconciliation target disappears.
+
+Any one of (1)–(4) retires this brief. None of them retire the underlying question (*"is our public narrative consistent with our code?"*) — that question survives, but answers go elsewhere.
+
 ## Verdict
+
+The site is reachable, but it is a placeholder: one line of hero text, no body, no structure, no drift in the interesting sense. There is no stale "Parasoid," no stale modality count, no contradicted architecture diagram, no mention of diffusion anywhere, no dead CTA. The one real contradiction is minor and lives inside the repo: `README.md` line 5 says *"text-first LLMs"* while `THESIS.md` §Master says *"text-first models"* and the site tagline says *"text-first models."* The repo is out of sync with itself, not with the site.
+
+The correct move is therefore not reconciliation. It is (a) resolve the internal README↔THESIS mismatch so the thesis noun is canonical, and (b) stand up a minimal v0.1 site from the locked sections of THESIS + the curated showcase grid, avoiding every open-question surface until RFC-0001 and ADR-0010 land. Park a proper site-vs-repo reconciliation brief until there is a real content site to diff.
+
+**Punch list, priority order:**
+
+1. **Change `README.md` line 5** from *"The modality harness for text-first LLMs."* to *"The modality harness for text-first models."* so the repo's own two tagline sources match THESIS (the locked statement). Five-second fix; removes the only live contradiction in the entire reconciliation table.
+2. **Stand up a minimal v0.1 site** as a static page rendered from THESIS §Master + §Architectural bet + §Reproducibility + §Path rejections, plus an embed of the 8-tile curated showcase grid from README, plus the 30-second quickstart. Link everything else out to the GitHub repo. No custom prose; lift verbatim. This avoids creating new drift surfaces.
+3. **Add a status banner** matching README lines 25–29 (*v0.1.0-alpha.2, early-stage, breaking changes possible*) above the fold so first-time visitors calibrate expectations.
+4. **Park Brief F** and open a follow-up (F.1) only after RFC-0004 has driven real site content. Until then, the reconciliation table has fourteen rows of *update site* and nothing to reconcile.
+5. **Before reopening,** write the kill criterion for F.1 in advance: if the site continues to be rendered from THESIS directly rather than hand-authored, F.1 never needs to exist.
+
+**The one thing that must change before anyone sees the site again:** the site must carry enough content to be worth resolving to. A one-line placeholder at the canonical URL is strictly worse than a redirect to the GitHub README, because it signals "the project stopped updating" to every reader arriving from outside the repo. Either ship item (2) above, or redirect the domain to `github.com/Moapacha/wittgenstein` until item (2) ships. Do not leave the placeholder live. — research, 2026-04-23.

--- a/docs/research/briefs/README.md
+++ b/docs/research/briefs/README.md
@@ -9,9 +9,9 @@ First-pass research briefs produced under **Phase P2** of the v0.2 Restructuring
 | A   | [VQ / VLM lineage 2026 refresh](A_vq_vlm_lineage_audit.md)                     | Does the VQ-token / frozen-decoder path still look like the right bet in April 2026? | 🟡 Draft v0.1  |
 | B   | [Compression vs world models — Ilya ↔ LeCun](B_compression_vs_world_models.md) | Where does Wittgenstein stand on the Ilya/LeCun tension? _(critical-path brief)_     | 🟡 Draft v0.1  |
 | C   | [Unproven-but-interesting horizon scan](C_unproven_horizon.md)                 | Which 6–8 unvalidated hypotheses should shape the 18-month roadmap?                  | 🟡 Draft v0.1  |
-| D   | [CLI / SDK / harness conventions](D_cli_and_sdk_conventions.md)                | How do modern AI CLIs and SDKs look; where is Wittgenstein off the grid?             | 🔴 Not started |
-| E   | [Per-modality quality benchmarks](E_benchmarks_v2.md)                          | What's the smallest set of real (non-structural) quality metrics per modality?       | 🔴 Not started |
-| F   | [Site ↔ repo reconciliation](F_site_reconciliation.md)                         | Which `wittgenstein.wtf` claims contradict v0.1.0-alpha.2?                           | 🔴 Not started |
+| D   | [CLI / SDK / harness conventions](D_cli_and_sdk_conventions.md)                | How do modern AI CLIs and SDKs look; where is Wittgenstein off the grid?             | 🟡 Draft v0.1  |
+| E   | [Per-modality quality benchmarks](E_benchmarks_v2.md)                          | What's the smallest set of real (non-structural) quality metrics per modality?       | 🟡 Draft v0.1  |
+| F   | [Site ↔ repo reconciliation](F_site_reconciliation.md)                         | Which `wittgenstein.wtf` claims contradict v0.1.0-alpha.2?                           | 🟡 Draft v0.1  |
 
 ## Where briefs land (map)
 


### PR DESCRIPTION
## Summary

Phase P2b of the v0.2 Restructuring Action Outline. With A/B/C already landed in #7, this PR closes the Phase P2 research sweep with the three engineering-facing briefs:

- **Brief D — CLI / SDK / harness conventions** (~4.1k words). Surveys 9 modern AI CLIs (Claude Code, Codex, Gemini, Kimi, Cursor, `gh`, `npm`, OpenAI Agents SDK, Anthropic SDK + 12-factor agents). Wittgenstein is ~70% aligned; the remaining 30% is concentrated in three cheap-to-fix areas. Two deliberate divergences (no REPL, no user-facing `--model` on modality commands) because we are a harness, not an LLM-chat CLI. Feeds **RFC-0002**.
- **Brief E — Per-modality quality benchmarks v2** (~4.4k words). One concrete pick per modality under ~1.5 GB weights and ~5 s/artifact on CPU: VQAScore / UTMOS+Whisper-WER / librosa BPM+key / LAION-CLAP / NeuroKit2 / explicit rule lists / clip-frame-drift. Heavy tier for perceptual metrics. Composite = mean of [0,1] scores, with `quality_partial` invariant. Feeds the **v2 benchmarks bridge** in P6.
- **Brief F — Site ↔ repo reconciliation** (~3.0k words). Three-column reconciliation table (site claim / repo truth / action) covering tagline, architecture, showcase, CLI, reproducibility, lineage, naming, roadmap, license, benchmarks. Feeds **RFC-0004**.

Every brief ships the four-station loop (Steelman / Red team / Kill criteria / Verdict) as grep-able H2 headings. `docs/research/briefs/README.md` status column flipped to 🟡 Draft v0.1 for D/E/F.

Phase P2 is now complete. The critical-path verdict (Brief B, Position iii Layered + iv Agnostic contract, merged in #7) already unblocks P3 RFC drafting, which comes next.

## Test plan

- [ ] Researcher hat: do the 2024–2026 citations (VQAScore 2404.01291, UTMOS 2204.02152, LAION-CLAP 2211.06687, NeuroKit2, Claude Code / Codex / Gemini / Kimi CLI surface) hold?
- [ ] Hacker hat: if an agent read D/E/F at 2 a.m., would it write the right RFC-0002 / v2-benchmarks / RFC-0004?
- [ ] Verdicts point to the correct downstream RFC/ADR without prescribing code changes (P6 scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)