### PR TITLE
docs(rfcs): P3 RFC pack — codec v2, CLI ergonomics, naming, site

### DIFF
--- a/docs/research/briefs/D_cli_and_sdk_conventions.md
+++ b/docs/research/briefs/D_cli_and_sdk_conventions.md
@@ -1,16 +1,172 @@
 # Brief D — CLI / SDK / harness conventions
 
 **Date:** 2026-04-23
-**Status:** Not started (placeholder)
-**Author:** —
-**Summary:** Survey how modern AI CLIs and SDKs look (shape of commands, config, auth, output contracts), then decide what Wittgenstein should match versus intentionally diverge from.
+**Author:** research (max.zhuang.yan@gmail.com)
+**Status:** Draft v0.1
+**Summary:** Surveys what a modern AI CLI / SDK looks like in April 2026 — subcommand taxonomy, flag vocabulary, config resolution order, auth, pipe discipline, doctor patterns, one-liner install — and audits where `wittgenstein`'s current CLI is on the industry grid and where it is off. Verdict: the shape is mostly right (noun-first subcommands, `--seed`, `--dry-run`, a `doctor`), but the output contract, config precedence, and install story are under-specified; RFC-0002 should adopt a small set of hard conventions (`--json`/NDJSON on stdout, stderr for logs, `flag > env > project file > user file > defaults`, a single `npx @wittgenstein/cli` one-liner) and deliberately diverge from the "LLM-chat CLI" pattern — Wittgenstein is a harness, not a chatbot, and its CLI is first a pipeline tool, second a demo.
 
 ---
 
+## Context
+
+Three pieces of 2024–2026 work make CLI conventions load-bearing for Wittgenstein rather than a style question.
+
+First, Anthropic's _Scaling Managed Agents: Decoupling the brain from the hands_ (Anthropic, April 2026) formalised the split between the reasoning component ("brain"), the execution environment ("hands" / sandbox), and an append-only session log. Managed Agents is explicitly a _meta-harness_: unopinionated about the concrete harness layered around Claude, but committed to the shape of the interface between them. The observation that matters for Brief D is that the boundary between brain, harness, and sandbox is an API boundary — and the CLI is one projection of that API. If the CLI does not enforce clean stdout/stderr discipline, structured output, and explicit config precedence, the harness layer is lying to itself when it claims those boundaries exist.
+
+Second, METR's 2024 evaluation work (METR, 2024) repeatedly showed that _scaffolding changes are comparable in magnitude to a major model upgrade_ on their autonomy suite — and that the scaffolding-vs-model interaction is a live experimental variable, not a fixed factor. A useful harness therefore needs to be A/B-testable: runs need to carry the full manifest of what scaffolding was used, which means the CLI (a) must emit structured artifacts deterministically, (b) must accept the same run configuration as env / file / flag, and (c) must support `--dry-run` and fixed-seed runs cheaply. These are not polish features. They are the minimum surface area required to credibly claim a run is reproducible.
+
+Third, HumanLayer's _12-Factor Agents_ (Horthy, 2025) distilled a set of principles that directly constrain CLI shape: _own your prompts, own your control flow, stateless agent design, separate business state from execution state, manage context explicitly_. Several of these have direct CLI projections — stateless by default (no global mutable state in `~/.wittgenstein/`), separation between business config (what the LLM is told) and execution config (which provider, which sandbox), and an explicit, inspectable event log (the `RunManifest` spine already exists in Wittgenstein for this).
+
+So: the question for RFC-0002 is not "what color should the flags be." It is "what does the CLI have to look like so that the harness claims above are actually true when someone runs `wittgenstein image 'X' --seed 7`."
+
 ## Steelman
+
+State the industry convention as its proponents would.
+
+There is now a recognisable _2025-class AI CLI_ template, converged on across at least six reference implementations: Claude Code, Codex CLI (OpenAI), Gemini CLI (Google), Cursor CLI, Kimi CLI (Moonshot), and — as the non-AI reference standard — `gh` from GitHub. The template has seven load-bearing components.
+
+**1. One binary, noun-first subcommands.** `gh pr list`, `gh issue view`, `claude /status`, `kimi mcp`, `gemini /agents`. The pattern is `<tool> <resource> <verb>` or `<tool> <verb>`. The verb is never the first positional. This makes shell history greppable, tab-completion discoverable, and help pages chunkable.
+
+**2. A small, shared flag vocabulary.** Every serious CLI in 2026 supports a roughly-equivalent core set: `--model` / `-m` (which LLM), `--stream` (token streaming), `--seed` (determinism), `--json` or `-o json` (machine output contract), `--dry-run` (no side effects, no billable calls), `-q`/`--quiet`, `-v`/`--verbose`, `--config <path>`. Gemini CLI uses `--model` / `-m` (Google, 2025). `gh` uses `--json <fields>` with `--jq` and `--template` as post-filters (GitHub, 2025). These flags mean the same thing everywhere.
+
+**3. A strict config resolution order.** The canonical order, inherited from npm and 12-Factor App, is `CLI flag > env var > project-local config > user config > global/system config > built-in defaults` (npm, 2024). This is universal and it is not up for debate: tools that invert it (env overrides flag, project overrides flag) are considered broken.
+
+**4. Auth that decouples from config.** `gh auth login`, `kimi login`, Claude Code's OAuth bootstrap, `codex login` all follow the same shape: a subcommand whose only job is to obtain or refresh credentials, store them in a platform-appropriate keychain or a well-documented file, and exit. The credential is never a flag and never a field in the main config file. `gh auth status --json hosts` is the canonical inspection command (GitHub, 2025).
+
+**5. Structured output on stdout, logs on stderr.** This is the Unix discipline, re-enforced by the LLM-era. `gh` supports `--json <fields>` output on any subcommand (GitHub, 2025). `jq` pipelines downstream assume NDJSON or canonical JSON. Interactive pretty-printing happens when stdout is a TTY; it silently switches to machine format when piped. Logs, progress bars, warnings all go to stderr.
+
+**6. A `doctor` subcommand.** Claude Code has `/doctor` (environment diagnostics, distinct from `/status` which reads current session config — Anthropic, 2026). `gh` has `gh auth status`. `brew doctor`, `npm doctor`, `flutter doctor` are the pre-LLM precedents. The pattern is: one subcommand, no side effects, emits a structured health report with actionable error messages. On success exits 0; on failure exits nonzero with a list of what to fix.
+
+**7. A one-line install.** `curl https://cursor.com/install -fsSL | bash` (Cursor, 2025). `npm install -g @openai/codex` (OpenAI, 2025). `brew install gh`. The user acquires the binary in a single command that does not require cloning a repo or managing a Python env.
+
+The steelman version of the 2025-class AI CLI is: if your tool does not implement all seven of these, it is below the bar set by every mainstream AI developer tool shipped in the last eighteen months. Matching them is table stakes. Deviating from them is a deliberate choice that must be defended.
+
+## Survey
+
+Nine reference tools, read for the seven components above. Facts verified against current 2025–2026 documentation.
+
+**OpenAI Codex CLI (OpenAI, 2025).** Subcommand taxonomy: `codex`, `codex exec`, `codex features`, `codex login`. Flags: `--model`, `--sandbox`, `--approval-mode`, `--config`, `--cd`. Config resolution: env > `~/.codex/config.toml` > built-in defaults; CLI flags override all. Auth: `codex login` (browser OAuth flow), stored in `~/.codex/`. Output contract: pretty on TTY, JSON when `--json` is set; session transcripts written to disk in a structured format. Doctor: no dedicated `doctor`, but `codex features` inspects and persists capability flags. Install: `npm install -g @openai/codex`. Notes: the Agents SDK _itself_ is a Python library (`pip install openai-agents`) — there is no `agents` CLI, which is the first important observation. The CLI surface is for the coding agent; the SDK surface is for building agents. This is a deliberate split that Wittgenstein should mirror.
+
+**Anthropic SDK + Claude Managed Agents (Anthropic, 2026).** The SDK is `anthropic` (Python) / `@anthropic-ai/sdk` (TypeScript); there is no general-purpose `anthropic` CLI. Managed Agents exposes a REST surface for session lifecycle (create session, post event, fetch session log), not a CLI. The brain-hands-session split _does_ imply a CLI shape for harness builders: the CLI's job is to drive a session, and the session log is the authoritative artifact. This is exactly the `RunManifest` pattern Wittgenstein already has.
+
+**Claude Code CLI (Anthropic, 2026).** Subcommands: the REPL is the primary interface; slash-commands inside the REPL provide structure — `/doctor`, `/status`, `/config`, `/model`, `/agents`, `/mcp`. Non-REPL invocation: `claude config list | set | reset`, `claude --print <prompt>`. Flags: `--model`, `--print` (one-shot), `--dangerously-skip-permissions`, `--config`. Config: `.claude/settings.json` (project) layered over `~/.claude/settings.json` (user); env vars with `CLAUDE_CODE_*` prefix override file. Auth: OAuth via `claude login`, stored in platform keychain. Doctor pattern: `/doctor` actively _tests_ the environment (Node version, MCP servers reachable, credentials valid) and reports failures with actionable errors; `/status` is a separate read-only settings dump. Install: `npm install -g @anthropic-ai/claude-code` or `curl -fsSL claude.ai/install.sh | sh`. The doctor / status split is the single most copyable convention from Claude Code.
+
+**Gemini CLI (Google, 2025).** Open-source (`google-gemini/gemini-cli`). Subcommands: slash-prefix inside REPL (`/agents`, `/mcp list`, `/model`, `/include-directories`), `@path` for file inclusion, `!cmd` for shell. Flags: `--model` / `-m` with aliases, `--include-directories`, `--yolo` (auto-approve), `-o <format>`. Config: `.gemini/config.json` project > user > env `GEMINI_*`. Auth: Google OAuth via `gemini auth login`; API-key mode for programmatic use. Output: pretty in TTY; JSON mode via flag. Doctor: no `doctor`, but `/mcp list` and `/about` cover health-check-shaped queries. Install: `npm install -g @google/gemini-cli`.
+
+**`gh` (GitHub, 2015–2025).** The non-AI reference standard. Subcommands: `gh <resource> <verb>` — `gh pr list`, `gh issue view`, `gh run watch`. Flags: `--json <fields>` on basically every command, `--jq`, `--template`, `-R <owner/repo>`, `--web`. Config: `~/.config/gh/config.yml`, `GH_TOKEN` / `GITHUB_TOKEN` env overrides. Auth: `gh auth login` / `gh auth status --json hosts --show-token` / `gh auth refresh` / `gh auth logout`. Output: `--json` gives canonical JSON on stdout; everything else is pretty-printed with TTY detection. Doctor-equivalent: `gh auth status`. Install: `brew install gh`, `winget install --id GitHub.cli`, or apt repo. `gh` is the cleanest implementation of the seven-point template and the one Wittgenstein's CLI should most closely resemble in shape.
+
+**`npm` (npm Inc., 2010–2025).** Config resolution is the canonical implementation of the precedence order (npm, 2024): `--foo bar` on CLI > `npm_config_foo=bar` in env (case-insensitive) > project `.npmrc` > user `~/.npmrc` > global `.npmrc` > built-in defaults. Any new CLI that wants to ship in 2026 without justifying itself should copy this order verbatim.
+
+**Cursor CLI (Cursor, 2025–2026).** Single binary `cursor-agent`. Subcommands / modes: `--mode=plan|ask|agent`, slash-commands in REPL (`/plan`, `/ask`, `/model`, `/usage`, `/about`, `/resume`). Flags: `--mode`, `--model`. Config: `.cursor/mcp.json` for MCP, environment for API keys. Auth: session tokens managed by Cursor account. Output: pretty TTY; structured mode for pipe. Doctor: `/about` is the health-check. Install: `curl https://cursor.com/install -fsSL | bash`. The mode flag (`--mode=plan|ask|agent`) is interesting — it's a dimension we don't have today and may not need.
+
+**Kimi CLI (Moonshot, 2025).** `kimi` is the main binary. Subcommands: `kimi` (interactive), `kimi login`, `kimi mcp <subcmd>`, `kimi export`, plus a Web UI server and an agent trace visualizer. Flags: `--model`, `--port`, `--host` (for Web UI). Config: `~/.kimi/` with `context.jsonl`, `wire.jsonl`, `state.json` exported on demand. Auth: browser OAuth via `kimi login`, auto-configures available models. Doctor: not by that name, but the "Ralph Loop" mode and tracing visualizer cover inspection. Install: via pip / uvx. Kimi's export format (`context.jsonl` + `wire.jsonl` + `state.json`) is _exactly_ the shape a harness-side run manifest should take and is a cleaner version of what Wittgenstein currently writes under `artifacts/runs/`.
+
+**Lark CLI / LangChain CLI (LangChain, 2024–2025).** `langchain` CLI exists primarily as a project scaffolder — `langchain app new`, `langchain serve`. It is _not_ an interactive agent runner. The relevant lesson for Wittgenstein is the LangChain CLI's narrow scope: it sets up a LangServe app and stops there. It does not try to be a chat client. Wittgenstein's CLI has a similar opportunity to stay narrow: generate artifacts and emit manifests; do not try to become a chat REPL.
+
+**12-Factor Agents (Horthy / HumanLayer, 2025).** Not a CLI, a manifesto. Directly relevant principles: _own your prompts_ (prompts live as files in the repo, not hard-coded in the binary — Wittgenstein already does this), _own your control flow_ (the harness drives the loop, not the LLM — Wittgenstein already does this), _stateless agent design_ (no hidden `~/.wittgenstein/` mutable state — Wittgenstein mostly does this but has implicit workspace resolution that should be documented), _separate business state from execution state_ (the `RunManifest` records business state; execution state lives in provider SDKs and should not leak into manifests). The 12-factor framing converts roughly into these CLI rules: (a) everything reproducible from `CLI invocation + git SHA + manifest`, (b) no mutable global state the CLI depends on, (c) config is layered and explicit, (d) the session log is the single source of truth.
+
+## Wittgenstein's current CLI — audit
+
+Source: `packages/cli/src/commands/*.ts`, `packages/cli/README.md`, `docs/quickstart.md`.
+
+Current surface:
+
+```
+wittgenstein image   <prompt> [--out <path>] [--seed <n>] [--dry-run]
+wittgenstein tts     <prompt> [--out <path>] [--seed <n>] [--dry-run]
+wittgenstein audio   <prompt> [--route speech|soundscape|music] [--out] [--seed] [--dry-run]
+wittgenstein sensor  <prompt> [--out] [--seed] [--dry-run]
+wittgenstein video   <prompt> [--out] [--seed] [--dry-run]
+wittgenstein svg     <prompt> [--out] [--seed] [--dry-run]
+wittgenstein asciipng <prompt> [--out] [--seed] [--dry-run]
+wittgenstein animate-html --out <path>
+wittgenstein doctor  [--config <path>]
+wittgenstein init
+wittgenstein minimax-key
+```
+
+Seven modality groups (image, tts/audio, sensor, video, svg, asciipng, animate-html) plus three infra commands (`doctor`, `init`, `minimax-key`). `RunManifest` is the spine: every invocation writes `artifacts/runs/<id>/manifest.json` with git SHA, lockfile hash, seed, prompt, IR, LLM output, and artifact SHA-256.
+
+**Where it's on the grid.**
+
+- _Noun-first subcommands._ `wittgenstein <modality>` follows the `gh <resource>` pattern, not the `cli run --modality=X` anti-pattern. Good.
+- _`--seed` everywhere._ Determinism is a first-class flag on every modality command. Matches the steelman.
+- _`--dry-run` everywhere._ Matches the steelman and the METR "scaffolding is a variable" constraint.
+- _`doctor` subcommand._ Already emits JSON with structured fields (`ok`, `nodeVersion`, `hasApiKey`, `llmProvider`, `llmModel`, `artifactsDir`). This is closer to Claude Code's `/doctor` than to the average Python CLI's "print stuff and hope" pattern.
+- _Manifest-per-run._ Kimi-shaped, 12-factor-aligned. This is genuinely ahead of the median CLI.
+- _`--out` relative-path resolution._ `--out` relative paths resolve from the workspace root, which is the Claude Code / gh convention (project-local semantics by default).
+
+**Where it's off the grid.**
+
+- _No `--json` / NDJSON output contract._ Every modality command currently writes its primary artifact to disk (`--out`) and prints human-readable logs. There is no canonical way to pipe `wittgenstein image ... | jq '.manifest_path'`. `doctor` happens to emit JSON but that is a local convention, not a contract. _This is the single biggest gap._
+- _No documented config resolution order._ `@wittgenstein/core`'s `loadWittgensteinConfig` reads a config file, but the precedence of flag vs env vs project vs user is not stated in the CLI docs. Users don't know whether `MOONSHOT_API_KEY` in the env beats a `provider.apiKey` entry in `wittgenstein.config.json`, or the reverse.
+- _No `auth` subcommand._ API keys are read from env vars directly (`MOONSHOT_API_KEY`, `MINIMAX_API_KEY`, etc.). There is a `minimax-key` command, which is provider-specific rather than a uniform `wittgenstein auth <provider>` surface. The `gh auth` pattern is cleaner.
+- _No `--model` flag._ The model is resolved via config. This is defensible — Wittgenstein is a harness, not a chat CLI, and the user often shouldn't care — but there is no escape hatch for A/B-testing models at the CLI level, which is exactly the METR use case.
+- _No `--stream`._ Irrelevant for most modality runs (they produce a single artifact, not a token stream), but likely relevant for a future `wittgenstein chat` or `wittgenstein plan` surface.
+- _Stdout vs stderr discipline is ad hoc._ Progress output, warnings, and the final manifest path all go to stdout today. For pipe-ability, logs must move to stderr.
+- _Two install paths, no canonical one-liner._ The quickstart documents both `pnpm --filter @wittgenstein/cli exec wittgenstein ...` (workspace-internal) and `python3 -m polyglot.cli ...` (the Python twin). `npm install -g @wittgenstein/cli` exists but `npx @wittgenstein/cli doctor` is not highlighted as the canonical try-it-out command. Cursor's `curl | bash` and Claude Code's `npm install -g` have set the bar at one command.
+- _`init` and `minimax-key` leak implementation._ `minimax-key` is a one-off for a specific provider; it should be `wittgenstein auth minimax` or removed. `init` is fine but should be documented.
+- _No `wittgenstein run` universal entrypoint._ For scripted use, a single `wittgenstein run --modality=image --prompt=... --seed=...` would be more ergonomic than seven modality-specific commands. But see the Red Team below — this is a live trade-off, not an obvious win.
 
 ## Red team
 
+Three plausible pushbacks, answered inline.
+
+**Pushback A: "Why not just match `openai` / `codex` 1:1?"** Because those tools are shaped around a different job. The OpenAI Agents SDK is a Python framework for building agents; the Codex CLI is a coding agent for a terminal user. Neither is optimised for "driver of a deterministic multimodal artifact pipeline." If Wittgenstein adopted Codex's shape verbatim it would gain a REPL and a sandbox mode it doesn't need, and would lose the noun-first modality taxonomy that is actually its clearest win. The right reference is `gh`, not `codex` — a CLI whose job is to drive well-defined resources through well-defined verbs. Match `gh`'s surface discipline, not Codex's surface features.
+
+**Pushback B: "CLI ergonomics is bikeshedding before codec v2 lands."** Partly fair, partly wrong. It would be bikeshedding if this were about colours and help-text wording. It isn't. The items on the critical path are (i) `--json` / NDJSON output contract, (ii) documented config precedence, and (iii) stderr discipline. Items (i) and (iii) are prerequisites for A/B-testing codecs at all — if you can't `wittgenstein image ... --json | jq '.metrics.fid'`, you can't run an overnight sweep. Item (ii) is a prerequisite for reproducibility claims to be real. Codec v2 will land faster with these in place, not slower. The rest (install one-liner, `auth` subcommand, `--model` flag) can wait behind a post-v2 milestone.
+
+**Pushback C: "Users run the CLI once then use the SDK. The CLI doesn't matter."** True for chat CLIs like Codex and Cursor. False for Wittgenstein, because the CLI _is_ the reproducibility surface. The `RunManifest` is produced by the CLI path. A user who drops to the SDK and skips the CLI loses the manifest spine, loses the `artifacts/runs/<id>/` layout, and loses the git-SHA + lockfile-hash provenance that makes a run citeable. In Wittgenstein's world, the CLI is not a demo — it is the canonical way to produce an artifact you can put in a paper. Making it pipe-friendly is making the science-grade artifact stream pipe-friendly. That matters.
+
 ## Kill criteria
 
+Concrete things that would invalidate this brief's recommendations.
+
+1. **By Q2 2027, if the dominant developer-tool UX has shifted from CLI → TUI → MCP-native clients,** such that new AI tools ship primarily as MCP servers consumed by hosts (Claude Code, Cursor, Gemini CLI's `/mcp`), the CLI-shape recommendations here are stale and RFC-0002 should pivot to "Wittgenstein is an MCP server first, a CLI second." Probability: moderate. Gemini CLI, Claude Code, Cursor all converged on MCP in 2025; the direction of travel is real. Mitigation: ship an MCP adapter in parallel with the CLI hardening so neither path is a dead end.
+
+2. **If NDJSON-on-stdout turns out to conflict with how users actually pipe binary artifacts.** Most Wittgenstein outputs are binary (PNG, WAV, MP4). `--json` is a manifest-and-metadata contract, not an artifact-on-stdout contract. If, in practice, users want to pipe the artifact itself (`wittgenstein image ... | convert - out.jpg`), a stdout-binary mode conflicts with a stdout-JSON mode. Resolution: `--out -` writes the artifact to stdout; `--json` writes the manifest to stdout; the two are mutually exclusive and the CLI errors loudly if both are set. This is the ffmpeg convention and it works.
+
+3. **If the config precedence order we pick conflicts with an upstream tool (`pnpm`, `pip`, `uvx`) that wraps us.** If `pnpm --filter @wittgenstein/cli exec wittgenstein` injects env vars that we treat as higher-precedence than flags, we have a bug. Mitigation: enforce `flag > env > file > defaults` in `loadWittgensteinConfig` with tests.
+
+4. **If a future `wittgenstein chat` or `wittgenstein plan` surface needs streaming, tools, and state that don't fit the "one-shot artifact" pattern.** This is not a kill but a forcing function: the current CLI shape will need a second command family (streaming, interactive) that lives next to the modality commands. The recommendations below should not foreclose that.
+
+5. **If Anthropic's Managed Agents pricing model (Anthropic charges 8 US cents per session hour for active runtime, per their April 2026 post) becomes the dominant cost structure for agent workloads,** then "a CLI that drives local sessions" becomes the minority case and we should design for "a CLI that drives remote Managed Agents sessions" — which has different config and auth shape. Probability: low in the next year; agents are still mostly local-driven.
+
 ## Verdict
+
+RFC-0002 should propose the following six decisions. Four track the industry convention; two deliberately diverge because Wittgenstein is a harness, not an LLM-chat CLI.
+
+1. **Adopt `--json` as the canonical machine-output flag on every modality command and on `doctor`.** When `--json` is set, stdout is a single canonical JSON object (or NDJSON for multi-phase runs) containing `{manifest_path, artifact_path, artifact_sha256, run_id, seed, git_sha, duration_ms, ...}`; everything else (progress, warnings, model chatter) goes to stderr. Without `--json`, stdout auto-detects TTY and pretty-prints. This is the `gh` contract (GitHub, 2025) and it is non-negotiable if A/B sweeps are to work.
+
+2. **Document and enforce the config resolution order: `CLI flag > env var > project config (./wittgenstein.config.ts or .json) > user config (~/.wittgenstein/config.json) > built-in defaults`.** Copy npm's order verbatim (npm, 2024); add a test that inverts each pair and asserts the correct one wins. `doctor` should print which layer each effective value came from.
+
+3. **Keep `wittgenstein <modality> <prompt>` as the primary shape; do _not_ collapse to `wittgenstein run --modality=...`.** The noun-first pattern is the clearest part of today's CLI and matches `gh`. Do add a power-user `wittgenstein run --manifest <path>` that replays a previous RunManifest byte-for-byte — this is the A/B-sweep primitive.
+
+4. **Ship a `wittgenstein doctor` that tests, a separate read-only `wittgenstein config show` that inspects.** Copy the Claude Code `/doctor` vs `/status` split (Anthropic, 2026). `doctor` exits nonzero on failure with a list of actionable fixes; `config show` prints effective config with provenance.
+
+5. **Add a uniform `wittgenstein auth <provider> [login|status|logout]` surface and deprecate `minimax-key`.** Model it on `gh auth` (GitHub, 2025) and `kimi login` (Moonshot, 2025). Keep env-var fallback for CI (`MOONSHOT_API_KEY`, etc.), but make `wittgenstein auth status --json` the canonical inspection path. The current `minimax-key` command should be a thin alias that prints a deprecation warning.
+
+6. **Make the install one-liner `npx @wittgenstein/cli doctor`, and make that command do something useful with zero config.** `npx @wittgenstein/cli doctor` should, with no API key and no config file, report which codecs are usable in dry-run mode, which need a provider key, and which need system tools (ffmpeg, afconvert). Cursor's `curl | bash` (Cursor, 2025) is the speed benchmark; `npx` gets us most of the way there without a custom install script.
+
+Two deliberate divergences from the 2025-class AI CLI template.
+
+- **No interactive REPL as the primary interface, and no slash-commands.** Claude Code, Cursor, Gemini, Kimi all centre a REPL. Wittgenstein should not. The harness thesis is that the LLM is one stage in a pipeline, not the user-facing surface; a REPL pulls towards chat-app framing and away from pipeline framing. Keep `wittgenstein` as a one-shot command with structured output. If an interactive surface is ever needed, it should be a separate binary (`wittgenstein-repl`) with an explicit "this is the toy version" label.
+
+- **No `--model` override on modality commands by default.** The chat CLIs all expose `--model` because their primary job is LLM-as-service. Wittgenstein's primary job is a specific codec producing a specific artifact; the model is an internal implementation detail of the harness, and exposing it at the CLI invites users to swap it in ways that invalidate the codec's guarantees. Instead, expose `--provider <name>` (choose which configured provider) and let the provider's config pin the model. Power users who need fine-grained model control can set `WITTGENSTEIN_LLM_MODEL=...` in env; the precedence rule from (2) means that still works. This is a divergence from Gemini / Claude Code / Kimi and it is defensible because we are a harness, not a chat service.
+
+Net: six decisions to write into RFC-0002, two of which are industry-standard, two of which are industry-standard-with-Wittgenstein-shape (config order with provenance-aware `doctor`, noun-first with `--manifest` replay), and two of which are deliberate divergences from chat-CLI framing. The current CLI is about 70% of the way to the bar the 2025-class AI CLIs have set; the remaining 30% is mostly the output contract and the config precedence, and both are cheap to fix. — research, 2026-04-23.
+
+## References
+
+- Anthropic (April 2026). "Scaling Managed Agents: Decoupling the brain from the hands." https://www.anthropic.com/engineering/managed-agents
+- Anthropic (2026). "Claude Code CLI Reference." https://code.claude.com/docs/en/cli-reference
+- Cursor (2025–2026). "Cursor CLI." https://cursor.com/cli and https://cursor.com/docs/cli/overview
+- GitHub (2025). "gh Manual." https://cli.github.com/manual/ ; `gh auth status` https://cli.github.com/manual/gh_auth_status
+- Google (2025). "Gemini CLI Reference." https://geminicli.com/docs/reference/commands/ ; repo https://github.com/google-gemini/gemini-cli
+- Horthy, D. / HumanLayer (2025). "12-Factor Agents." https://github.com/humanlayer/12-factor-agents and https://www.humanlayer.dev/12-factor-agents
+- LangChain (2024–2025). "LangChain CLI." https://python.langchain.com/docs/langserve/
+- METR (2024). "An update on our general capability evaluations." https://metr.org/blog/2024-08-06-update-on-evaluations/
+- Moonshot AI (2025). "Kimi Code CLI." https://github.com/MoonshotAI/kimi-cli and https://moonshotai.github.io/kimi-cli/en/reference/kimi-command.html
+- npm / npm Inc. (2024). "npm-config." https://docs.npmjs.com/cli/v11/using-npm/config/
+- OpenAI (2025). "Codex CLI Reference." https://developers.openai.com/codex/cli/reference ; "Agents SDK." https://openai.github.io/openai-agents-python/
+- Wittgenstein repo (2026). `packages/cli/src/commands/*.ts`, `packages/cli/README.md`, `docs/quickstart.md`.

--- a/docs/research/briefs/E_benchmarks_v2.md
+++ b/docs/research/briefs/E_benchmarks_v2.md
@@ -1,16 +1,187 @@
 # Brief E — Per-modality quality benchmarks (v2)
 
 **Date:** 2026-04-23
-**Status:** Not started (placeholder)
-**Author:** —
-**Summary:** Define the smallest set of _standard_ quality metrics per modality (image/audio/video/sensor) that Wittgenstein can run locally, reproducibly, without turning the repo into a benchmark zoo.
+**Author:** research (max.zhuang.yan@gmail.com)
+**Status:** Draft v0.1
+**Summary:** Picks the smallest set of real (non-structural) quality metrics per modality that Wittgenstein can actually run locally and reproducibly without breaking the Latency / Price / Quality contract — one default-tier metric per modality, one heavy-tier fallback, composite lifted off the structural floor. Verdict tease: VQAScore for image, UTMOS for speech, librosa-BPM + key for music, CLAP for soundscape, NeuroKit2 rule-set for ECG, derivative-bound rules for gyro/temperature, CLIP-temporal for video, and a single `[0,1] → mean` composite with a hard "API-break-is-a-fail" rule.
 
 ---
 
+## Context
+
+The current state of the Wittgenstein benchmark harness is honest and narrow. The README at `benchmarks/README.md` admits it outright: "Today's quality numbers are **structural proxies**, not research-grade metrics." The four cases that run in CI (`image-editorial`, `tts-launch`, `audio-music`, `sensor-ecg`) each produce a 0.0–1.0 score that decomposes into three things: does the artifact exist and parse, are the container-level dimensions right (width × height for PNG, duration for WAV, sample count for sensor JSON), and does a trivial signal-level sanity check pass (pixel variance > 100, RMS in a loudness window, signal mean in a physiological range). That is a file-format smoke test wearing a quality badge.
+
+This is not nothing. The 35-artifact showcase that the gallery branch just landed (`docs/showcase-gallery`, commit 7897062) leans hard on those structural checks to prove that every modality at least _renders_ deterministically across SVG, ASCII-PNG, raster PNG, WAV (speech / music / soundscape), JSON+CSV (ECG, gyro, temperature), and eventually MP4. If any of those checks regresses, we know instantly that the codec broke. But none of those checks can distinguish "the adapter produced a plausible 440 Hz A4 sine wave" from "the adapter produced a plausible violin tone", because both decode, both land in the loudness window, and both are within 30% of the expected duration. The quality axis has almost no dynamic range below the ceiling.
+
+The driving question for this brief is: what is the _smallest_ set of real metrics — one per modality — that lifts Quality off the structural floor without (a) requiring a paid API (violates the Price ≈ 0 dry-run contract), (b) requiring a GPU to run every pre-commit hook (violates Latency), or (c) adding so many dependencies that the repo turns into a metric zoo? Every pick below has to clear that bar.
+
 ## Steelman
+
+The structural-proxy floor was the right first move, and this brief should not pretend otherwise. Three reasons.
+
+First, reproducibility beats perceptual score when the stack is still settling. A CLIPScore number is only meaningful relative to a specific CLIP checkpoint, a specific prompt-normalization scheme, a specific batch size, and a specific numerical precision. If any of those five drift between the author's laptop and the CI runner, the number drifts with them, and you have a benchmark that no-one outside the author's machine can reproduce. The structural checks have none of that attack surface: a PNG either has dimensions 1024 × 1024 or it does not. That property is the reason the harness's Latency and Cost columns are already trustworthy, and it is the reason the team decided Quality could wait.
+
+Second, the METR 2024 harness-gains result is directly on point. METR's "update on our general capability evaluations" (August 2024) and the follow-up "Measuring AI Ability to Complete Long Tasks" (March 2025) both show that a large fraction of reported capability improvement on agent benchmarks comes from the scaffolding around the model — the harness — rather than the model weights themselves. Philschmid's April 2026 follow-up essay argues the same point: harness is load-bearing in 2026. The Wittgenstein corollary is: if you bolt a flaky perceptual-score harness onto an honest structural-proxy harness, the composite score will move because the harness moved, not because the model moved, and you will spend six months debugging a benchmark rather than shipping a codec. The structural floor was deliberately the cheapest harness that could not lie.
+
+Third, the reproducibility premium compounds. Every artifact Wittgenstein ships lives in a `RunManifest` with a fixed seed and a deterministic route. That manifest is the primary scientific asset of the repo; the artifact is secondary. Any quality metric we add has to be a _function_ of the manifest plus the artifact, runnable offline, with no hidden state. If we cannot meet that bar, we do not add the metric. This brief therefore asks a narrower question than "what is the best metric per modality": it asks "what is the best metric per modality that is also a pure function of (manifest, artifact) and fits in a laptop."
+
+## Per-modality picks
+
+One subsection per modality the 35-artifact showcase covers. Each pick names one default-tier metric (must run in CI on a laptop with no GPU, under ~5 s per artifact) and, where relevant, one heavy-tier metric (gated behind `--quality=heavy`). Candidates are discussed; the pick is in bold.
+
+### Image (SVG + ASCII-PNG + raster)
+
+Candidates: CLIPScore (Hessel et al., 2021, arXiv:2104.08718), VQAScore (Lin et al., 2024, arXiv:2404.01291), ImageReward (Xu et al., 2023, arXiv:2304.05977), HPSv2 (Wu et al., 2023, arXiv:2306.09341).
+
+CLIPScore is the obvious default — reference-free, widely cited, cheap to run against an OpenCLIP ViT-B/32 checkpoint (~150 MB). But the 2023–2024 literature has documented, in detail, that CLIPScore rewards prompt-rephrasing and treats text encoders as bags of words (Hessel et al. acknowledge this themselves; the 2023 robustness paper arXiv:2305.14998 quantifies it; VQAScore's opening argument is essentially "CLIPScore conflates 'the horse is eating the grass' with 'the grass is eating the horse'"). For a showcase that explicitly includes compositional prompts (editorial product shots, multi-object scenes), CLIPScore as the default metric would be a trap.
+
+ImageReward and HPSv2 are better correlated with human preference than CLIPScore, but both are human-preference reward models trained specifically on diffusion outputs at typical web-art styles. They will misbehave on Wittgenstein's SVG and ASCII-PNG artifacts, neither of which looks like Midjourney training data, and both ship as ~1–2 GB checkpoints.
+
+**Pick: VQAScore (default tier), CLIPScore as the cheap fallback when VQAScore is unavailable.** VQAScore (arXiv:2404.01291, ECCV 2024) reframes image-text alignment as a VQA probability — "Does this figure show '{text}'?" P(yes) — using an off-the-shelf VLM. The reference implementation (`t2v_metrics` on GitHub, `linzhiqiu/t2v_metrics`) runs with CLIP-FlanT5-XL (~3 GB) and reports state-of-the-art correlation with human judgement on eight image-text alignment benchmarks. Crucially, it beats CLIPScore on compositional prompts, which is exactly what Wittgenstein's editorial cases are. Rationale for default tier: the authors publish a smaller variant that fits in the GPU-less budget for a single-shot evaluation (~10 s per artifact on CPU with int8), and the score is bounded in [0, 1] by construction, which the composite wants. Rationale for CLIPScore fallback: if the VQAScore model download fails in CI, CLIPScore still runs in < 1 s and produces a score that is wrong-but-present, which matters for the composite's "no silent drops" rule.
+
+For SVG specifically, we rasterize at 512² before scoring. For ASCII-PNG, we score both the text form (VQAScore between the caption and the rendered raster) and we keep the structural check (does the glyph grid parse) as a gating pre-condition.
+
+### Speech / voice
+
+Candidates: Whisper WER via ASR round-trip (Radford et al., 2022, arXiv:2212.04356), UTMOS (Saeki et al., 2022, arXiv:2204.02152), DNSMOS P.835 (Reddy et al., 2021, arXiv:2110.01763).
+
+Whisper WER is tempting because Whisper-base is 140 MB and runs on CPU, and "does the generated speech say the words we asked it to say" is a real property. But WER is only meaningful when the reference transcript is known exactly, and it measures _intelligibility_, not _naturalness_ — a robotic monotone that happens to hit every phoneme scores perfectly. For Wittgenstein's speech route, intelligibility is already close to saturated because the underlying TTS is not experimental; the variance we care about is naturalness and prosody.
+
+DNSMOS P.835 (arXiv:2110.01763) predicts three ITU-T P.835 scores — speech quality (SIG), background noise (BAK), overall (OVRL) — and the reported correlation with human ratings is very high (PCC 0.94 / 0.98 / 0.98). But DNSMOS was specifically built to evaluate _noise suppressors_; its signal of interest is "did the denoiser remove noise without hurting the speech", not "is this synthetic voice convincing." Wrong target for our use case.
+
+**Pick: UTMOS (default tier), Whisper-WER as a gating pre-condition, DNSMOS as a heavy-tier diagnostic.** UTMOS (arXiv:2204.02152, the winner of VoiceMOS 2022) is an SSL-feature ensemble that predicts MOS for synthetic speech specifically. The `speechmos` and `utmos` Python packages wrap it into a single `predict(wav)` call; the underlying wav2vec2 feature extractor is ~360 MB and runs on CPU at about 2× realtime. Output is a single [1, 5] MOS score, trivially normalizable to [0, 1]. This is the right default because (a) MOS is what speech synthesis papers report, (b) the model was trained on the right distribution (Blizzard Challenge / VCC outputs, not denoised clean speech), and (c) it is small enough for CI.
+
+Whisper-WER sits _before_ UTMOS as a gate: if the ASR round-trip has WER > 0.5, we report "unintelligible" and do not trust the UTMOS number. This prevents the harness from praising a beautiful-sounding but content-free noise. DNSMOS ships behind `--quality=heavy` because its SIG / BAK / OVRL breakdown is genuinely useful when debugging a route regression, but running three models instead of one is not the default.
+
+### Music
+
+Candidates: BPM estimation accuracy (librosa / essentia), key estimation accuracy (librosa / essentia), CLAP similarity (LAION-CLAP, arXiv:2211.06687).
+
+Music is the modality where structural proxies bite hardest: "WAV decodes, duration in window, RMS in loudness band" is true of literally any signal we produce. The Wittgenstein music route currently claims 1.00 quality, which is correct under the structural definition and false under any musical definition.
+
+**Pick: librosa BPM accuracy + key estimation accuracy (default tier), CLAP similarity (heavy tier).** The default metric is a pair of deterministic DSP routines: `librosa.beat.beat_track` returns a tempo estimate, and the route manifest already names the target BPM (every music case is generated from a prompt that fixes tempo either explicitly or implicitly through a genre tag). The quality score is `1 − min(|BPM_estimated − BPM_target| / BPM_target, 1)`, clipped to [0, 1]. Key estimation follows the same pattern using the Krumhansl-Schmuckler profile available in `librosa.feature.chroma_cqt` + `librosa.key`. Rationale: both routines run in < 1 s on CPU, both are deterministic, and both measure something a listener actually cares about. They are lossy — neither catches "this track is tonally correct but musically boring" — but they remove the ceiling effect at the structural floor and they cost effectively zero.
+
+CLAP (LAION-CLAP, arXiv:2211.06687) is the heavy-tier upgrade. The `laion/clap-htsat-unfused` checkpoint (~600 MB) embeds audio and text into a shared space; cosine similarity between the prompt and the artifact is a reasonable proxy for "does this sound like what was asked for." Behind `--quality=heavy` because the checkpoint is six times larger than everything else in the default tier combined.
+
+### Soundscape
+
+Candidates: spectral centroid match to a reference bank, PANNs tag retrieval (Kong et al., 2020, arXiv:1912.10211), CLAP similarity.
+
+Soundscape is the trickiest modality because there is usually no reference recording to compare against — the prompt says "rain on a tin roof at night" and the artifact is one of infinitely many plausible realizations. Spectral centroid match is cheap but too blunt (rain and static white noise both have high centroids). PANNs tagging produces 527 AudioSet tag probabilities; you can compute "does the top-k tag list overlap the prompt tags" as a score. This works but requires a prompt → AudioSet-tag mapping step, which is an adapter we do not have.
+
+**Pick: CLAP similarity (default tier), PANNs tag retrieval (heavy tier).** CLAP wins here as the default because it takes the prompt string natively — no tag mapping — and produces a scalar cosine that normalizes cleanly to [0, 1]. The same `laion/clap-htsat-unfused` checkpoint covers both music (heavy) and soundscape (default), so we pay the 600 MB download once. This is the one place in the brief where a heavier model is the right default: spectral centroid is too noisy to be useful, and PANNs without a tag-mapping adapter is not actionable. Running CLAP on a single 6-second soundscape is ~3 s on CPU, inside the budget.
+
+PANNs retrieval stays available under `--quality=heavy` as a diagnostic. The 527-tag breakdown is useful for "why did this score so low" investigations in a way CLAP's single cosine is not.
+
+### Sensor / ECG
+
+Candidates: clinical plausibility rule sets (QRS width, PR interval, heart rate range), open ECG quality indices.
+
+**Pick: NeuroKit2 rule set (default tier).** NeuroKit2 (neuropsychology/NeuroKit on GitHub) is an open-source Python toolbox for neurophysiological signal processing with a mature ECG module. The relevant functions are `ecg_peaks`, `ecg_delineate`, and `ecg_quality`. The plausibility check we run is an explicit, reviewed rule list rather than a single opaque score:
+
+1. Heart rate in [40, 180] BPM. (Covers resting bradycardia through exercise; below 40 or above 180 in a "stable ECG" prompt is a route bug.)
+2. QRS width in [60, 120] ms. Anything wider on a "normal" prompt signals reconstruction failure.
+3. PR interval in [120, 220] ms. Outside this window is either a prompt-specified arrhythmia (allowed if the prompt asked for it) or a route bug.
+4. R-R interval coefficient of variation consistent with the prompt's `stability` tag.
+5. Signal quality index (`ecg_quality`, Zhao 2018 method) above a floor of 0.5.
+
+Score = fraction of rules passed, in [0, 1]. Rationale: ECG is the one modality where "plausibility" has a textbook answer, and an opaque learned metric would be strictly worse than an explicit rule list that a clinician could review. Open ECG plausibility checkers with a published 2024–2026 paper (e.g., the Ho et al. 2025 telehealth RR-interval extraction work at medRxiv 2025.03.10.25323655) exist but are narrower in scope than the NeuroKit2 module and do not supersede it as a default. NeuroKit2 runs entirely on CPU in milliseconds per 30-second trace.
+
+### Sensor / gyro + temperature
+
+No pretrained model makes sense here — these are physical signals with strong prior structure, and a learned metric would be over-engineered.
+
+**Pick: physical-plausibility rule set (default tier).** Explicit rules per sensor type:
+
+- **Gyroscope (rad/s or deg/s):** magnitude bounded by the declared range (default ±2000 deg/s for consumer IMUs); first derivative bounded by `ω̇_max ≈ 10⁴ deg/s²` for hand motion; no NaN / Inf; unit declared in manifest matches unit of data column; sample count matches `floor(sample_rate × duration)` (already in the structural tier, retained).
+- **Temperature (°C):** values in the prompt-declared envelope (e.g., "ambient room" → [15, 30]; "ice bath" → [-5, 10]); first derivative bounded by declared thermal time constant (default 1 °C/s for ambient sensors, stricter for thermocouples in well-mixed environments); no monotonic drift inconsistent with the declared scenario (stable-room data that ramps 10 °C over a minute is a route bug).
+
+Score = fraction of rules passed, in [0, 1]. Both rule sets are ~15 lines of NumPy. Zero extra dependencies. This is deliberately the same shape as the ECG rule set for consistency — the composite treats them identically.
+
+### Video
+
+Candidates: structural pass (does the MP4 demux, are the frames the right resolution, is duration within tolerance) + CLIP-based temporal coherence via VideoCLIP / InternVideo2.
+
+Video is the least mature modality in the repo — the MP4 renderer is still pending per `benchmarks/README.md` — so the v2 metric here is a target, not a measurement we can run today.
+
+**Pick: structural pass gate + per-frame CLIP similarity mean/std (default tier), InternVideo2 similarity (heavy tier).** The default is: demux, sample N=8 frames uniformly, compute CLIPScore of each frame against the prompt, report `mean − std` as the score. The `mean` rewards prompt alignment; the `− std` term penalizes frame-to-frame drift, which is the cheapest available proxy for temporal coherence without loading a video model. Runs in ~5 s on CPU for an 8-frame, 512² video.
+
+Heavy tier is InternVideo2 (arXiv:2403.15377) similarity between the prompt and the clip. InternVideo2 is the current public best on text-to-video retrieval, with strong video-language semantic alignment; it is also ~1 GB and wants a GPU for sensible latency, so it stays behind `--quality=heavy`. VideoCLIP-XL is a reasonable alternative at a similar size. Between these two, default is InternVideo2 because its zero-shot retrieval numbers are better and its API is simpler.
+
+Note: "CLIP-temporal" is not a published metric; it is a construction. We should name it `clip-frame-drift` in the codebase to avoid implying a citation that does not exist.
+
+## Composite Quality score
+
+One normalization rule, one hard invariant.
+
+Rule: each per-modality metric is normalized to [0, 1] by a documented transform (UTMOS `(x − 1) / 4`, VQAScore already in [0, 1], librosa-BPM accuracy clipped to [0, 1], NeuroKit2 rule fraction already in [0, 1], etc.). The composite for a run is the unweighted arithmetic mean of the per-modality [0, 1] scores, computed only over modalities the run actually produced. The `RunManifest` records which modalities contributed and each modality's raw + normalized score.
+
+Invariant: **no modality can silently drop because its API broke.** If a metric fails to compute — model download failed, import error, OOM, whatever — the harness emits an explicit `null` score for that modality, marks the run as `quality_partial`, and the composite is _not_ computed. A run with missing quality data does not get a quality number. The CLI surface is:
+
+```
+pnpm benchmark --quality=off         # structural only (today's behavior, default for CI pre-commit)
+pnpm benchmark --quality              # default-tier metrics from this brief
+pnpm benchmark --quality=heavy        # adds VQAScore-large, DNSMOS, CLAP-music, InternVideo2
+```
+
+The default-tier models together are under ~1.5 GB (UTMOS wav2vec2 ~360 MB + VQAScore small ~500 MB + CLAP ~600 MB + librosa/NeuroKit2 zero). The heavy tier adds ~3 GB. Both sit under an explicit `benchmarks/tools/` directory with pinned checksums.
 
 ## Red team
 
+Three pushbacks, answered inline.
+
+**"The proxies already work, don't overfit to BLEU-style metrics."** The structural proxies work as regression guards, not as quality measurements. The 35-artifact showcase needs a quality axis that can distinguish "the image adapter shipped" from "the image adapter produces coherent compositions", and structural checks cannot do that. This brief is not proposing BLEU-per-modality; it is proposing one metric per modality that at least has a published correlation with human judgement (VQAScore, UTMOS, CLAP) or with a clinical reference (NeuroKit2 rule list). Crucially, the structural proxies stay — they become gating pre-conditions. A run that fails the structural check does not compute the perceptual metric, because "beautiful but malformed" is not a state we want to reward. This is the opposite of overfitting: the composite is explicitly multi-tier.
+
+**"CLIPScore is a trap — it rewards prompt-rephrasing."** Correct, which is why CLIPScore is the fallback, not the default. The default image metric is VQAScore, precisely because the VQAScore paper spends its first three pages documenting CLIPScore's bag-of-words failure mode on compositional prompts. For video, `clip-frame-drift` uses CLIPScore across frames, which inherits the same weakness; that is acceptable because the load-bearing quantity there is the _drift_ (frame-to-frame std), not the absolute similarity. If the adapter learns to rephrase prompts in its latent to game the CLIP score, the drift term will not change and the absolute mean will move uniformly across the default set. We should still track the VQAScore-video variant (the `t2v_metrics` repo supports it) as the eventual replacement.
+
+**"Perceptual metrics are expensive / require GPUs — breaks the local-first bet."** This is the strongest pushback and the brief is designed around it. The default tier is calibrated to run on CPU under ~5 s per artifact, total ~1.5 GB of model weights, no paid APIs. That is achievable today: UTMOS wav2vec2 is 360 MB and runs at 2× realtime on CPU; NeuroKit2 is pure NumPy; librosa BPM is DSP; VQAScore has a small-model path; CLAP on CPU is the slowest piece and still fits. The _heavy_ tier is explicitly GPU-preferred and explicitly behind a flag. If the default tier cannot hit the per-artifact budget on a 2024-class laptop in CI, we drop to the cheap fallback per modality (CLIPScore for image, Whisper-WER for speech, spectral-centroid for soundscape) before we drop the quality axis entirely. The local-first bet survives; the ceiling on Quality moves up without the floor on Latency moving.
+
 ## Kill criteria
 
+Three concrete triggers.
+
+1. **If, on the 35-artifact showcase, any two default-tier metrics for the _same_ modality disagree by more than 0.3 on normalized [0, 1] scale,** the composite is noise and we stop reporting a composite until the disagreement is diagnosed. Example: VQAScore says 0.8 on an editorial image, CLIPScore-fallback says 0.4 — that is either a genuine compositional-prompt failure VQAScore is catching and CLIPScore is missing (keep VQAScore as primary) or a VQAScore model-load bug (mark run as `quality_partial`). We cannot know without investigation; we will not publish a mean.
+
+2. **If any default-tier metric requires a paid API,** the metric fails the Price ≈ 0 constraint and is rejected. This applies retroactively: if LAION-CLAP's weights move behind a license wall, we fall back to PANNs (Apache 2.0) or drop soundscape to the cheap tier. No metric in the default set should have a billing dependency.
+
+3. **If any default-tier metric requires more than 4 GB of model download,** it is not default-tier; it moves to `--quality=heavy`. The 4 GB ceiling is the point where a clean `pnpm install && pnpm benchmark --quality` on a GitHub-Actions-sized runner starts timing out. The current default set totals ~1.5 GB, leaving headroom, but this is the ceiling.
+
+A softer kill: **if the composite never moves** across a month of adapter iteration on the same showcase, either the metrics are saturated or the adapter is not improving. Either way we re-examine; metrics that never move are a waste of Latency budget.
+
 ## Verdict
+
+| Modality | Current proxy | v2 metric | Library / source | Model size | Upgrade tier |
+|---|---|---|---|---|---|
+| Image (SVG / ASCII-PNG / raster) | PNG valid + dims + pixel variance > 100 | VQAScore (P(yes) on "Does this figure show '{text}'?") | `linzhiqiu/t2v_metrics` (arXiv:2404.01291) | ~500 MB (small) / ~3 GB (CLIP-FlanT5-XL) | default / heavy |
+| Image cheap fallback | — | CLIPScore | `jmhessel/clipscore` (arXiv:2104.08718) | ~150 MB (OpenCLIP ViT-B/32) | default fallback |
+| Speech / voice | WAV valid + duration + RMS | UTMOS | `speechmos` / `sarulab-speech/UTMOSv2` (arXiv:2204.02152) | ~360 MB | default |
+| Speech gate | — | Whisper-WER round-trip | `openai-whisper` (arXiv:2212.04356) | ~140 MB (base) | default gate |
+| Speech diagnostic | — | DNSMOS P.835 (SIG / BAK / OVRL) | `microsoft/DNS-Challenge` (arXiv:2110.01763) | ~80 MB | heavy |
+| Music | WAV valid + duration + RMS | librosa BPM accuracy + key accuracy | `librosa` (DSP, no model) | 0 | default |
+| Music heavy | — | CLAP text-audio cosine | `laion/clap-htsat-unfused` (arXiv:2211.06687) | ~600 MB | heavy |
+| Soundscape | WAV valid + duration + RMS | CLAP text-audio cosine | `laion/clap-htsat-unfused` | ~600 MB | default |
+| Soundscape diagnostic | — | PANNs top-k tag retrieval | `qiuqiangkong/audioset_tagging_cnn` (arXiv:1912.10211) | ~320 MB (CNN14) | heavy |
+| Sensor / ECG | JSON+CSV + sample count + mean-in-range | HR / QRS / PR / SQI rule set | `NeuroKit2` ecg module | 0 | default |
+| Sensor / gyro | JSON+CSV + sample count | range + derivative + unit rules | NumPy | 0 | default |
+| Sensor / temperature | JSON+CSV + sample count | envelope + derivative rules | NumPy | 0 | default |
+| Video | (pending MP4) structural only | `clip-frame-drift` (frame-wise CLIPScore mean − std) | `open_clip_torch` | ~150 MB | default |
+| Video heavy | — | InternVideo2 text-video similarity | `InternVideo2` (arXiv:2403.15377) | ~1 GB | heavy |
+
+Upgrade order, cheapest-to-land first. Ship the NumPy-only metrics first: NeuroKit2 for ECG, gyro rules, temperature rules, librosa BPM + key for music. These are four PRs totalling maybe 200 lines of code, zero new model downloads, and they immediately lift four modalities off the structural floor. Second, add CLAP for soundscape; it is the one place where the heavy model pays its weight as a default. Third, add UTMOS + Whisper-WER for speech; this is where the speech route quality number becomes meaningful for the first time. Fourth, add VQAScore for image with CLIPScore as the documented fallback; this is the highest-stakes metric in the set because image is the highest-variance modality in the showcase. Fifth, wire `clip-frame-drift` for video once the MP4 renderer lands. Finally, gate DNSMOS, PANNs, CLAP-music, VQAScore-XL, and InternVideo2 behind `--quality=heavy` and document them in `docs/benchmark-standards.md`. Everything lands in the default tier under ~1.5 GB of model weights and under ~5 s per artifact on CPU. — research, 2026-04-23.
+
+## References
+
+- CLIPScore: Hessel, Holtzman, Forbes, Le Bras, Choi (2021). "CLIPScore: A Reference-free Evaluation Metric for Image Captioning." arXiv:2104.08718. https://arxiv.org/abs/2104.08718
+- VQAScore: Lin, Pathak, et al. (2024). "Evaluating Text-to-Visual Generation with Image-to-Text Generation." arXiv:2404.01291. https://arxiv.org/abs/2404.01291
+- ImageReward: Xu et al. (2023). "ImageReward: Learning and Evaluating Human Preferences for Text-to-Image Generation." arXiv:2304.05977. https://arxiv.org/abs/2304.05977
+- HPSv2: Wu et al. (2023). "Human Preference Score v2: A Solid Benchmark for Evaluating Human Preferences of Text-to-Image Synthesis." arXiv:2306.09341. https://arxiv.org/abs/2306.09341
+- Whisper: Radford et al. (2022). "Robust Speech Recognition via Large-Scale Weak Supervision." arXiv:2212.04356. https://arxiv.org/abs/2212.04356
+- UTMOS: Saeki, Xin, et al. (2022). "UTMOS: UTokyo-SaruLab System for VoiceMOS Challenge 2022." arXiv:2204.02152. https://arxiv.org/abs/2204.02152
+- DNSMOS P.835: Reddy, Gopal, Cutler (2021). "DNSMOS P.835: A Non-Intrusive Perceptual Objective Speech Quality Metric to Evaluate Noise Suppressors." arXiv:2110.01763. https://arxiv.org/abs/2110.01763
+- CLAP (LAION): Wu et al. (2022). "Large-scale Contrastive Language-Audio Pretraining with Feature Fusion and Keyword-to-Caption Augmentation." arXiv:2211.06687. https://arxiv.org/abs/2211.06687
+- PANNs: Kong, Cao, Iqbal, Wang, Wang, Plumbley (2020). "PANNs: Large-Scale Pretrained Audio Neural Networks for Audio Pattern Recognition." arXiv:1912.10211. https://arxiv.org/abs/1912.10211
+- NeuroKit2: Makowski et al. (2021). "NeuroKit2: A Python toolbox for neurophysiological signal processing." Behavior Research Methods. https://github.com/neuropsychology/NeuroKit
+- InternVideo2: Wang et al. (2024). "InternVideo2: Scaling Foundation Models for Multimodal Video Understanding." arXiv:2403.15377. https://arxiv.org/abs/2403.15377
+- METR (2024). "An update on our general capability evaluations." https://metr.org/blog/2024-08-06-update-on-evaluations/
+- METR (2025). "Measuring AI Ability to Complete Long Tasks." https://metr.org/blog/2025-03-19-measuring-ai-ability-to-complete-long-tasks/
+- Wittgenstein benchmarks README: `benchmarks/README.md` at commit 7897062.

--- a/docs/research/briefs/F_site_reconciliation.md
+++ b/docs/research/briefs/F_site_reconciliation.md
@@ -1,16 +1,118 @@
 # Brief F — Site ↔ repo reconciliation
 
 **Date:** 2026-04-23
-**Status:** Not started (placeholder)
-**Author:** —
-**Summary:** Diff `wittgenstein.wtf` claims against the repo truth (v0.1.0-alpha.2+) and produce a patch list so public narrative stops drifting from code and docs.
+**Author:** research (max.zhuang.yan@gmail.com)
+**Status:** Draft v0.1
+**Summary:** `https://wittgenstein.wtf` resolves, but the page returns nothing more than the tagline *"Wittgenstein — The modality harness for text-first models."* There is no architecture section, no showcase, no CLI, no CTA to contradict — which means the public narrative is not drifting from the repo, it is simply absent. The correct move is not reconciliation; it is to stand up a minimal v0.1 site straight out of `docs/THESIS.md` and `SHOWCASE.md`, then treat Brief F as dormant until there is actually prose on the page to diff.
 
 ---
 
-## Steelman
+## Context
+
+The public domain `wittgenstein.wtf` predates the April 2026 doc wave — specifically it predates PR #6, which landed `docs/THESIS.md` (the locked master statement), `docs/inheritance-audit.md` (the V/R/N ledger), and `docs/SYNTHESIS_v0.2.md` (branch-level merge brief). Between hackathon-era content and v0.1.0-alpha.2+, a repo owner would normally assume drift: the pitch on the marketing surface lags the engineering surface by weeks, the weeks include at least one naming debate and one path rejection, and whoever wrote the hero copy is not the same person who wrote ADR-0005.
+
+The `inheritance-audit.md` ledger formalizes this worry as **V-3** (verbal inheritance: "`wittgenstein.wtf` content — Unknown staleness vs repo — Which claims on site contradict v0.1.0-alpha.2?") and blocks **N-3** (the rewrite) behind "RFC-0004 driven by R6," i.e. behind the output of this very brief. `SYNTHESIS_v0.2.md` lists the reconciliation as P2 priority: *"website should stop drifting from code/doc state."* And `THESIS.md` §"What is explicitly open" names *"Public website ↔ repo reconciliation"* as an RFC-deferred open question.
+
+This brief's job is to produce the diff. If the diff is empty because the site is empty, that is still data, and the verdict adjusts accordingly.
+
+## Method
+
+Three steps, in order:
+
+1. **WebFetch the live site** at `https://wittgenstein.wtf`. Capture whatever text actually renders — tagline, architecture copy, showcase gallery, CLI instructions, footer, license, contact, roadmap. Treat HTTP 2xx with thin content as distinct from 404 / 5xx / DNS failure; each case maps to a different verdict.
+2. **Grep the repo** for internal references to `wittgenstein.wtf` so we know what the code and docs *think* the site says. Candidate files: `README.md`, `SHOWCASE.md`, `docs/`.
+3. **Construct the reconciliation table** from whatever overlap exists between (1) the observed site surface and (2) the locked repo statements in `docs/THESIS.md`. Where the site has no content on a row, record `no-site-yet` rather than inventing a site claim.
+
+If WebFetch returns nothing usable (DNS fail, 404, blank body, placeholder page, "Coming soon"), the brief still runs, but the reconciliation table collapses to rows whose only action is "update site" — there is nothing to update the repo from, and nothing to retire.
+
+A repo grep for `wittgenstein.wtf` returns exactly three substantive hits: `docs/inheritance-audit.md` (the V-3 / N-3 parking lot), `docs/SYNTHESIS_v0.2.md` (the P2 reconciliation line item), and `docs/research/briefs/README.md` (the index row pointing to this file). Neither `README.md` nor `SHOWCASE.md` links to the site. The repo, in other words, has already stopped treating the site as canonical — all outbound traffic goes to GitHub, not to `.wtf`. That is a useful signal before we even look at the page.
+
+## Site snapshot (as of 2026-04-23)
+
+WebFetch on `https://wittgenstein.wtf` resolves (HTTPS 2xx) but returns a document whose only meaningful text is the page title / hero line:
+
+> **Wittgenstein — The modality harness for text-first models.**
+
+Two rounds of WebFetch, one asking for "all visible text, link text, and headings," confirm there is nothing else on the page the content-processing model can see: no architecture section, no "Why this exists," no receipts table, no showcase gallery, no CLI snippet, no install instructions, no reproducibility narrative, no roadmap, no contact block, no license footer, no research lineage, no mention of "Parasoid," no mention of L1–L5, no mention of RunManifest. The word "harness" appears once, in the tagline. The word "text-first" appears once, in the tagline. That is the entire corpus.
+
+This is consistent with a single-`<h1>` static placeholder — the kind of landing page you register a domain and deploy in twenty minutes so the URL in a Show HN post is not a 404. It is *not* a marketing site. It is a domain squat with a one-line epitaph.
+
+Two caveats on this reading. First, WebFetch summarizes and does not execute JavaScript, so it is at least theoretically possible the page contains client-rendered content the fetch model cannot see. Given the current repo has no web package and no deploy artifact that would produce such content, this is unlikely but not excluded. Second, the page title exactly matches the locked master statement from `docs/THESIS.md` line 9 (modulo the "LLMs" vs "models" suffix — more on that in the table), which is evidence that whoever deployed the placeholder had at least read the thesis. So the site is not stale content; it is thin content.
+
+The practical consequence is that rows in the reconciliation table below are mostly of the form "site claim: no-site-yet | repo truth: *locked statement* | drift: absence | action: update site." There is only one live contradiction, and it is on the tagline itself.
+
+## Repo truth (v0.1.0-alpha.2+)
+
+What the repo, as of this commit, *would like* the site to say — drawn from `docs/THESIS.md` (locked master + extension + architectural bet + Path-C rejection + RunManifest spine) and cross-checked against `README.md` (showcase counts, CLI surface, install story, receipts table) and `docs/modality-launch-surface.md` / `SHOWCASE.md` (modality group count).
+
+- **Master statement (locked, `THESIS.md` §Master):** *"Wittgenstein is the modality harness for text-first models. It assumes the frontier model is, and will remain, a text-native planner. Modality capability — image, audio, video, sensor, … — is added outside the model, through a portable harness layer that the model does not need to be retrained to use."*
+- **Extension form (locked wording, `THESIS.md` §Extension):** *"Harness as multi-modal middleware. Defer modality training to the portability layer. Use small post-training (adapters) plus rule-based codecs to give text-only LLMs multimodal output capability. The LLM plans in symbols; the codec turns symbols into files; the manifest makes every file replayable."*
+- **Architectural bet (locked, five layers):** L1 Harness / runtime — routing, retry, seed, budget, telemetry. L2 IR / codec — typed schemas, prompt contracts. L3 Renderer / decoder — IR to bytes; **frozen decoders in-bounds, general generators not the default path.** L4 Optional adapter — small learned translators, shipped beside codecs, not inside the base model. L5 Packaging — CLI, install, docs, agent primers.
+- **Reproducibility bet (locked):** every artifact ships with a `RunManifest` (git SHA, lockfile hash, seed, LLM input/output, artifact SHA-256, cost, latency, error taxonomy). *"If a run cannot be replayed bit-for-bit, it did not happen."*
+- **Path rejections (locked):** **Path C — Chameleon / LlamaGen-style full multimodal retrain — is not pursued.** Diffusion in the core image path is out (see `docs/hard-constraints.md`, ADR-0005). No silent fallbacks. Cloud-API dependence is not the default.
+- **Showcase (as of `README.md` and `SHOWCASE.md`):** **35 real artifacts across 7 modality groups**: image, TTS, music, soundscape, sensor-ECG, sensor-temperature, sensor-gyro. Full pack under `artifacts/showcase/workflow-examples/`. Every artifact has a matching run manifest in `artifacts/runs/<run-id>/`.
+- **CLI surface:** two shipping surfaces — Python (`python3 -m polyglot.cli <modality>`) and TypeScript (`pnpm --filter @wittgenstein/cli exec wittgenstein <modality>`). `doctor` command exists. Install: Node ≥ 20.11, pnpm ≥ 9.0, Python ≥ 3.10.
+- **Open (not yet locked):** naming of the middleware layer (`"Parasoid"` is informal, not binding — `THESIS.md` §"What is explicitly open" and inheritance-audit R-9). Pipeline shape (one LLM round vs two). Per-modality quality benchmarks beyond structural proxies. CLI ergonomics. Website ↔ repo reconciliation.
+- **License:** Apache 2.0 (`LICENSE`, README badge).
+- **Release:** `v0.1.0-alpha.2`, early-stage, breaking changes possible before `0.1.0`.
+
+## Reconciliation table
+
+Columns: **site claim** | **repo truth** | **drift** | **action**. Rows cover the surfaces a reasonable visitor would expect; `no-site-yet` is recorded where the site is silent.
+
+| # | Site claim | Repo truth | Drift | Action |
+|---|---|---|---|---|
+| 1 | *"The modality harness for text-first models"* (tagline, present) | *"The modality harness for text-first LLMs"* (README line 5) / *"…for text-first models"* (THESIS.md §Master) | Mismatched noun: site says *models*, README says *LLMs*, THESIS says *models*. THESIS is the locked source. | **update README** to say *models* to match THESIS; leave site alone. This is the one real contradiction. |
+| 2 | Modality count — no-site-yet | 7 modality groups (image, TTS, music, soundscape, sensor-ECG, sensor-temp, sensor-gyro) | Absence | **update site** — add a single line naming the seven groups. |
+| 3 | Modality list — no-site-yet | Same as above; *video* is 🔴 stub per README §Experimental | Absence | **update site** — list seven groups, explicitly mark video as stub to match `docs/implementation-status.md`. |
+| 4 | Architecture diagram — no-site-yet | L1–L5 locked in THESIS §Architectural bet; full ASCII diagram in README lines 92–112 | Absence | **update site** — port README ASCII block or render an SVG of the same. |
+| 5 | Showcase count — no-site-yet | 35 artifacts, curated samples for 8 hero tiles (README lines 75–82); `SHOWCASE.md` canonical | Absence | **update site** — embed the 8-tile curated grid linking to raw artifacts, or iframe `SHOWCASE.md`. |
+| 6 | CLI install instructions — no-site-yet | Two surfaces; README §Install + §CLI; requirements Node ≥ 20.11, pnpm ≥ 9.0, Python ≥ 3.10 | Absence | **update site** — include the 30-second quickstart block verbatim from README lines 121–126. |
+| 7 | Reproducibility story — no-site-yet | RunManifest spine locked in THESIS §Reproducibility; artifact trail example in README lines 174–180 | Absence | **update site** — one paragraph + the `artifacts/runs/…` tree snippet. |
+| 8 | Research lineage / citations — no-site-yet | `docs/research/neural-codec-references.md`; Brief A on VQ/VLM lineage; `docs/research/briefs/README.md` index | Absence | **update site** — link out to `/docs/research/briefs/`, no inline citations needed. |
+| 9 | Naming — does site say "Parasoid"? | No. Site has no body copy. Repo says "Parasoid" is informal and not binding (THESIS §Open; inheritance-audit R-9). | No drift; informal name is not escaping the repo. | **no action.** If site adds body copy before ADR-0010 lands, do not use "Parasoid." |
+| 10 | Roadmap claims — no-site-yet | `ROADMAP.md` + `docs/implementation-status.md` Ships / Partial / Stub matrix | Absence | **update site** — link to `ROADMAP.md`, do not inline a roadmap that will drift. |
+| 11 | Contact / license footer — no-site-yet | Apache 2.0; GitHub Issues is the support surface (`SUPPORT.md`) | Absence | **update site** — add footer: `Apache 2.0 · github.com/Moapacha/wittgenstein · issues`. |
+| 12 | Benchmarks claims — no-site-yet | README §Receipts table (6 rows, real numbers, measurement protocol in `docs/benchmark-standards.md`). Quality scores (CLIPScore/WER/UTMOS) flagged as ⚠️ Proxy in experimental matrix. | Absence | **update site** — either embed the Receipts table verbatim or omit benchmarks entirely; do not paraphrase and create new drift. |
+| 13 | Path rejections (diffusion, Path C) — no-site-yet | Locked in THESIS §Path rejections and `docs/hard-constraints.md` | Absence | **update site** — one line: *"No diffusion in the core image path. No full multimodal retrain."* Helps readers who arrive from Chameleon / Emu3. |
+| 14 | Release / status banner — no-site-yet | `v0.1.0-alpha.2`, early-stage, breaking changes possible before 0.1.0 (README lines 25–29) | Absence | **update site** — include the exact status banner. Reduces expectation mismatch for first-time visitors. |
+| 15 | Call-to-action — no-site-yet | README §"How to help" — three paths, quickstart first | Absence | **update site** — one CTA: *"Open a real artifact in 30 seconds →"* linking to `SHOWCASE.md`. |
+
+Net: fourteen of fifteen rows resolve to **update site**, one resolves to **update repo** (row 1, change README tagline noun from *LLMs* to *models* to match THESIS), zero resolve to **retire site section** because there are no site sections. Calling this a "reconciliation" is generous — it is a content brief for a site that does not yet exist.
 
 ## Red team
 
+Three pushbacks worth taking seriously.
+
+**"Site is marketing, repo is engineering, drift is expected and healthy — stop trying to reconcile them."** Partially fair. For mature projects, the marketing surface legitimately runs ahead of the engineering surface (to set direction) and behind it (to avoid shipping vapor). The objection fails here for two reasons. First, there is no marketing surface to diverge. The site is one line. One line cannot drift in the useful sense; it can only be silent or wrong, and today it is silent. Second, the specific drift that was feared — hackathon copy still saying "diffusion" or "Parasoid" or a stale modality count — does not exist to be defended. Reconciliation is premature because there is nothing to reconcile, not because drift is healthy.
+
+**"Reconciliation before RFC-0001 lands is premature — naming and protocol will shift again; you will write this brief twice."** Strong objection. The inheritance-audit explicitly parks naming (R-9, V-2) at ADR-0010 and the public-site rewrite (N-3) at "RFC-0004 driven by R6." If Brief F's output drives RFC-0004, and RFC-0004 lands after RFC-0001 (CLI) and the naming pass, then any site copy written today gets rewritten when the middleware layer stops being "Parasoid" and starts being whatever-it-becomes. The mitigation is deliberate: write site copy that only references locked statements (THESIS §Master, §Extension, §Architectural bet, §Reproducibility, §Path rejections). Every one of those is ADR-gated; none of them is expected to move before v0.2. Avoid the open-question surfaces (layer naming, CLI ergonomics, benchmark protocol beyond structural proxies), and the site survives the next three RFC-landings unchanged.
+
+**"Just retire the site until v0.2 ships."** Also reasonable, and arguably the lowest-risk path. The case against retirement is that `wittgenstein.wtf` is the canonical URL people paste into Slack, HN comments, and tweets; if it 404s, the default reader assumption is "this project died between the hackathon and now." A one-line placeholder is not better than a 404 — it is a 404 with extra steps. Either retire the domain (redirect to the GitHub README) or fill it. The middle state we are currently in is the worst of both worlds: the URL resolves, so readers don't get the *"search GitHub instead"* bounce, but nothing on the page justifies the visit.
+
 ## Kill criteria
 
+Concrete conditions under which Brief F should be archived rather than extended.
+
+1. **If the site remains a one-page placeholder for more than a reconciliation cycle, the correct move is retire-and-replace, not patch.** A reconciliation table makes sense only when there is a site with content to diff. If the action count on a real content site ever exceeds 20 rows with "update site" outnumbering "update repo" by more than 10:1 (current ratio: 14:1 against one mostly-empty row), the brief has drifted from reconciliation into a roadmap for a site that does not exist — wrong tool.
+2. **If RFC-0004 (public-site rewrite) lands before RFC-0001 (CLI) and ADR-0010 (naming pass)**, Brief F's premise is invalidated: the site will be written against the repo's unlocked surfaces and will immediately re-drift when those surfaces lock. Archive Brief F and replace it with a "site content freeze" brief keyed to locked statements only.
+3. **If the site migrates to a framework that renders from `docs/THESIS.md` directly** (a trivial Astro / Eleventy config over the markdown in-repo), reconciliation becomes structural rather than editorial — the site cannot drift from the thesis because it *is* the thesis. Brief F collapses to a one-liner and the file should be deleted rather than maintained.
+4. **If the domain is allowed to lapse or redirected to `github.com/Moapacha/wittgenstein`,** Brief F is moot. The canonical URL becomes the README, the README is already the source of truth, and the reconciliation target disappears.
+
+Any one of (1)–(4) retires this brief. None of them retire the underlying question (*"is our public narrative consistent with our code?"*) — that question survives, but answers go elsewhere.
+
 ## Verdict
+
+The site is reachable, but it is a placeholder: one line of hero text, no body, no structure, no drift in the interesting sense. There is no stale "Parasoid," no stale modality count, no contradicted architecture diagram, no mention of diffusion anywhere, no dead CTA. The one real contradiction is minor and lives inside the repo: `README.md` line 5 says *"text-first LLMs"* while `THESIS.md` §Master says *"text-first models"* and the site tagline says *"text-first models."* The repo is out of sync with itself, not with the site.
+
+The correct move is therefore not reconciliation. It is (a) resolve the internal README↔THESIS mismatch so the thesis noun is canonical, and (b) stand up a minimal v0.1 site from the locked sections of THESIS + the curated showcase grid, avoiding every open-question surface until RFC-0001 and ADR-0010 land. Park a proper site-vs-repo reconciliation brief until there is a real content site to diff.
+
+**Punch list, priority order:**
+
+1. **Change `README.md` line 5** from *"The modality harness for text-first LLMs."* to *"The modality harness for text-first models."* so the repo's own two tagline sources match THESIS (the locked statement). Five-second fix; removes the only live contradiction in the entire reconciliation table.
+2. **Stand up a minimal v0.1 site** as a static page rendered from THESIS §Master + §Architectural bet + §Reproducibility + §Path rejections, plus an embed of the 8-tile curated showcase grid from README, plus the 30-second quickstart. Link everything else out to the GitHub repo. No custom prose; lift verbatim. This avoids creating new drift surfaces.
+3. **Add a status banner** matching README lines 25–29 (*v0.1.0-alpha.2, early-stage, breaking changes possible*) above the fold so first-time visitors calibrate expectations.
+4. **Park Brief F** and open a follow-up (F.1) only after RFC-0004 has driven real site content. Until then, the reconciliation table has fourteen rows of *update site* and nothing to reconcile.
+5. **Before reopening,** write the kill criterion for F.1 in advance: if the site continues to be rendered from THESIS directly rather than hand-authored, F.1 never needs to exist.
+
+**The one thing that must change before anyone sees the site again:** the site must carry enough content to be worth resolving to. A one-line placeholder at the canonical URL is strictly worse than a redirect to the GitHub README, because it signals "the project stopped updating" to every reader arriving from outside the repo. Either ship item (2) above, or redirect the domain to `github.com/Moapacha/wittgenstein` until item (2) ships. Do not leave the placeholder live. — research, 2026-04-23.

--- a/docs/research/briefs/README.md
+++ b/docs/research/briefs/README.md
@@ -9,9 +9,9 @@ First-pass research briefs produced under **Phase P2** of the v0.2 Restructuring
 | A   | [VQ / VLM lineage 2026 refresh](A_vq_vlm_lineage_audit.md)                     | Does the VQ-token / frozen-decoder path still look like the right bet in April 2026? | 🟡 Draft v0.1  |
 | B   | [Compression vs world models — Ilya ↔ LeCun](B_compression_vs_world_models.md) | Where does Wittgenstein stand on the Ilya/LeCun tension? _(critical-path brief)_     | 🟡 Draft v0.1  |
 | C   | [Unproven-but-interesting horizon scan](C_unproven_horizon.md)                 | Which 6–8 unvalidated hypotheses should shape the 18-month roadmap?                  | 🟡 Draft v0.1  |
-| D   | [CLI / SDK / harness conventions](D_cli_and_sdk_conventions.md)                | How do modern AI CLIs and SDKs look; where is Wittgenstein off the grid?             | 🔴 Not started |
-| E   | [Per-modality quality benchmarks](E_benchmarks_v2.md)                          | What's the smallest set of real (non-structural) quality metrics per modality?       | 🔴 Not started |
-| F   | [Site ↔ repo reconciliation](F_site_reconciliation.md)                         | Which `wittgenstein.wtf` claims contradict v0.1.0-alpha.2?                           | 🔴 Not started |
+| D   | [CLI / SDK / harness conventions](D_cli_and_sdk_conventions.md)                | How do modern AI CLIs and SDKs look; where is Wittgenstein off the grid?             | 🟡 Draft v0.1  |
+| E   | [Per-modality quality benchmarks](E_benchmarks_v2.md)                          | What's the smallest set of real (non-structural) quality metrics per modality?       | 🟡 Draft v0.1  |
+| F   | [Site ↔ repo reconciliation](F_site_reconciliation.md)                         | Which `wittgenstein.wtf` claims contradict v0.1.0-alpha.2?                           | 🟡 Draft v0.1  |
 
 ## Where briefs land (map)
 

--- a/docs/rfcs/0001-codec-protocol-v2.md
+++ b/docs/rfcs/0001-codec-protocol-v2.md
@@ -1,0 +1,356 @@
+# RFC-0001 — Codec Protocol v2
+
+**Date:** 2026-04-25
+**Author:** engineering (max.zhuang.yan@gmail.com)
+**Status:** 🟡 Draft v0.1
+**Feeds from:** Brief A (VQ / VLM lineage audit, 2026-04-23), Brief B (Compression vs. World Models — Ilya↔LeCun verdict: Position iii Layered + iv Agnostic contract), Brief C (Unproven horizon hypotheses H1 / H4 / H7), v0.2 action plan code-smell inventory.
+**Ratified by:** ADR-0008 (pending)
+
+**Summary:** Collapse the per-modality branching in `harness.ts` into one `Codec<Req, Art>` primitive whose IR is a `Text | Latent | Hybrid` sum type, whose strategy lives in codec-declared metadata, whose adapter (L4) and packaging (L5) stages are mandatory seams for every modality, and which authors its own manifest rows — with a two-round LLM call (NL expansion, then schema-constrained JSON) as the default `expand → adapt → decode → package` pipeline.
+
+---
+
+## Context
+
+Wittgenstein v0.2 has one unifying thesis — "text-native LLM + trained adapter + frozen LFQ-family discrete-token decoder" (Brief A verdict) — and one implementation shape that actively contradicts it. The harness is a switch statement. Each modality is a branch. The branches have diverged far enough that the invariants the thesis asserts — adapter exists, decoder is frozen, manifest is receipts-first — now hold only for the image path. For every other modality, those invariants are either absent or enforced by the harness post-hoc, which is the wrong end of the pipeline for them to live at.
+
+Five confirmed code smells, each cited against the v0.2 tree, motivate this RFC:
+
+1. **Modality dispatch is branching, not polymorphism.** `packages/core/src/runtime/harness.ts:123-172` is a 50-line `switch` over `request.modality` that wires each codec by hand. Adding an eighth modality requires editing the harness. Removing any one requires editing the harness. The harness is load-bearing for a decision it should not own.
+
+2. **Strategy leaks into the request schema.** `AudioRequest.route` (speech / soundscape / music), `SvgRequest.source` (inline / adapter), `AsciipngRequest.source` (inline / adapter), and `VideoRequest.inlineSvgs` all encode codec-internal routing in the caller-visible request shape. Callers are forced to know which sub-route a codec will pick. This is exactly the coupling Brief B's agnostic-contract position (Position iv) warns against: the contract should be what crosses the wire, not how the codec implements it.
+
+3. **Manifest rows are authored at the wrong layer.** `harness.ts:139-172` post-processes each codec's output to append or overwrite `ManifestRow[]` entries — L4 adapter hash, L5 decoder hash, `frozen: true` flags, latency buckets — none of which the harness has first-hand knowledge of. The codec has that knowledge and throws it away; the harness then reconstructs it from filenames. Receipts are less trustworthy than they look.
+
+4. **L4 / L5 discipline exists only for image.** The adapter (L4) and packaging (L5) stations are real seams in `codec-image` — the adapter hash is in the manifest, the decoder is frozen, and both are tested. For audio, `codec-audio` collapses L4/L5 into an inline function call in each route; for sensor, L4/L5 simply do not exist. This is the opposite of Brief A's verdict. If the thesis is "adapter + frozen decoder," the seams must be present in every codec, even if they are no-ops.
+
+5. **The `expand` stage is a single LLM call that silently fails on composite prompts.** `packages/core/src/llm/expand.ts` does schema-in-preamble generation: one call, JSON-constrained, no separate NL reasoning step. On prompts with ≥3 concept branches (the v0.2 eval set includes several) the structured output is syntactically valid but semantically impoverished — it takes the first branch and drops the rest. This is the "structured-first, think-later" failure mode documented in the XGrammar and Outlines literature and in Anthropic's own published guidance on chain-of-thought-then-structured. We are paying for single-call latency and getting two-call quality problems.
+
+Why now: Brief B's verdict (Position iii Layered + iv Agnostic) is a direct mandate for a protocol that treats modality as a payload rather than a control-flow branch. Brief A's forced edit — "VQ decoder" is the wrong name, the family is LFQ — is a rename that will touch every codec's decoder slot; if we are going to edit every codec, we should edit them through one seam, not seven. Brief C's horizon hypotheses H1 (harness outlives its scaffolding), H4 (the adapter is the thesis, not the LLM), and H7 (receipts are the product) all independently point at the same refactor. The v0.2 action plan surfaced the smells; this RFC is the fix.
+
+Scope note: this RFC redesigns the internal codec surface. It does not change the external CLI, the manifest format on disk, or the ADR-0005 thesis. It deletes `harness.ts:123-172` and `:139-172`. It renames the image decoder slot per Brief A ("LFQ-family discrete-token decoder"). It moves every other existing behavior behind the new interface without changing user-visible outputs.
+
+## Proposal
+
+Codec v2 is one interface, one primitive, one sum type for the intermediate representation, and two explicit rounds for the LLM stage. In plain words:
+
+**One interface.** A codec is `Codec<Req, Art>`: it declares its modality, declares a list of routes with costs, implements `produce(req, ctx): Promise<Art>`, and authors its own `ManifestRow[]`. Everything the harness currently does via `switch (request.modality)` becomes a method call. The harness becomes a dispatcher that picks the registered codec for the requested modality and awaits its result. No modality-specific code lives in the harness.
+
+**One primitive.** `Codec.produce` is the only entry point. It runs a fixed four-stage pipeline inside the codec: `expand` (LLM turns the user prompt into an IR), `adapt` (L4: trained adapter maps IR to decoder input), `decode` (L5: frozen decoder renders the artifact bytes), `package` (wraps bytes + provenance into an `Artifact`). A codec is free to make any stage a no-op — `codec-sensor` does not need a trained adapter and will pass-through — but the stages exist as named, inspectable seams for every codec. This makes Brief A's "adapter + frozen decoder" invariant syntactically visible in every codec file, not just `codec-image`.
+
+**One sum type for IR.** `IR = Text | Latent | Hybrid`. Wittgenstein 2026 ships only `Text`. The `Latent` variant is a reserved slot for a future JEPA-shaped planner — Brief B's Position iii Layered position treats world-model latents as a peer of text, not a replacement for it, and this is the type-level encoding of that peer relationship. `Hybrid` is the escape hatch for codecs that genuinely need both (e.g., a sensor codec that carries a text caption and a numerical latent trace through to decode). The sum type is cheap: no runtime code exists for `Latent` today, just a type constructor and a tagged union. The cost of reserving the slot is three lines. The cost of not reserving it and needing it later is a protocol migration. Brief B calls this out explicitly, and the Kill criteria below name the condition under which we retract the slot.
+
+**Strategy lives in the codec, not the request.** `Route<Req>` is declarative: each codec declares the routes it knows, each route has a `match(req): boolean` predicate and a cost tuple (`latencyMs`, `priceUsd`). The codec picks the first matching route itself. `AudioRequest.route`, `SvgRequest.source`, `AsciipngRequest.source`, and `VideoRequest.inlineSvgs` all disappear from the caller-visible schema; the information they carry either moves into the request's semantic content (e.g., "synthesize speech of X" implies the speech route) or into optional hints (`request.hints.preferSource`) that codecs may honor but are not required to. This is Brief B's agnostic contract: the wire format describes what is wanted, not how to produce it.
+
+**The codec authors its own manifest rows.** `Codec.manifestRows(artifact): ManifestRow[]` is the only path by which rows reach the manifest. The harness merges rows from each codec call, sorts them by timestamp, and writes. It does not override, it does not append post-hoc, it does not reconstruct anything from filenames. This eliminates `harness.ts:139-172` entirely.
+
+**Two LLM rounds, not one.** The `expand` stage runs two LLM calls by default: round 1 is an unconstrained natural-language expansion of the user prompt into a structured reasoning trace; round 2 is a schema-constrained JSON call that consumes round 1's output and produces the IR. Round 1 is cached by prompt hash, so retries in round 2 are free. This is the XGrammar / Outlines / Anthropic "chain-of-thought then structured" prior art applied deliberately. A codec may override to one round for cheap, well-specified prompts (`codec-sensor` will), but the default is two. Justification is expanded in `## Interface` and defended in `## Red team`.
+
+The shape of this proposal is boring on purpose. It is a refactor, not a research move. Brief A ratifies the thesis; Brief B ratifies the contract shape; Brief C says the receipts are the product. This RFC is the plumbing that matches those three verdicts.
+
+## Interface
+
+All signatures are TypeScript. File layout: `packages/core/src/codec/v2/` holds the interface and the HarnessCtx; each codec package (`codec-image`, `codec-audio`, `codec-sensor`, `codec-video`) ships a v2-conformant class alongside its current implementation during the migration window.
+
+### The IR sum type
+
+```ts
+// packages/core/src/codec/v2/ir.ts
+
+export type IR =
+  | { kind: "Text"; text: string }
+  | { kind: "Latent"; latent: Float32Array; shape: number[] }
+  | { kind: "Hybrid"; text: string; latent?: Float32Array; shape?: number[] };
+
+export const isText  = (ir: IR): ir is Extract<IR, { kind: "Text" }>   => ir.kind === "Text";
+export const isLatent= (ir: IR): ir is Extract<IR, { kind: "Latent" }> => ir.kind === "Latent";
+export const isHybrid= (ir: IR): ir is Extract<IR, { kind: "Hybrid" }> => ir.kind === "Hybrid";
+```
+
+Only `Text` is inhabited in v0.3. `Latent` and `Hybrid` are defined so adapters and decoders can pattern-match exhaustively (the TypeScript compiler enforces `never` in the default branch), which means the day a `Latent` codec ships, every existing codec's adapter must either handle it or explicitly reject it. That is the point.
+
+### The Codec interface
+
+```ts
+// packages/core/src/codec/v2/codec.ts
+
+export type Modality =
+  | "image-svg" | "image-ascii-png"
+  | "audio-speech" | "audio-soundscape" | "audio-music"
+  | "video" | "sensor";
+
+export interface Route<Req> {
+  id: string;
+  match(req: Req): boolean;
+  cost: { latencyMs: number; priceUsd: number };
+}
+
+export interface Codec<Req, Art> {
+  id: string;
+  modality: Modality;
+  routes: Route<Req>[];
+  produce(req: Req, ctx: HarnessCtx): Promise<Art>;
+  manifestRows(art: Art): ManifestRow[];
+}
+```
+
+`produce` is the one primitive. It is generic over `Req` and `Art`, so each codec keeps its request-specific type (`SvgRequest`, `AudioRequest`, etc.) and its artifact-specific type (`SvgArtifact`, `AudioArtifact`). Branching dies; typing does not.
+
+### The HarnessCtx
+
+```ts
+// packages/core/src/codec/v2/ctx.ts
+
+export interface HarnessCtx {
+  seed: number;
+  logger: Logger;
+  cache: Cache;         // round-1 LLM cache lives here
+  llm: LlmClient;       // model-agnostic; modality-unaware
+  tmpDir: string;       // per-invocation scratch for L4/L5 intermediates
+  clock: Clock;         // injected for deterministic tests
+}
+```
+
+No modality-specific field exists on `HarnessCtx`. If a codec needs modality-specific resources (e.g., an LFQ decoder handle for `codec-image`), it owns them; the ctx does not.
+
+### The four-stage produce pipeline
+
+```ts
+// Canonical codec shape. Every codec implements produce() as this pipeline.
+
+async produce(req: Req, ctx: HarnessCtx): Promise<Art> {
+  const route = this.routes.find(r => r.match(req));
+  if (!route) throw new NoRouteError(this.id, req);
+
+  const ir        = await this.expand(req, ctx);   // LLM, 2 rounds
+  const decIn     = await this.adapt(ir, ctx);     // L4: trained adapter (may be no-op)
+  const bytes     = await this.decode(decIn, ctx); // L5: frozen decoder (may be passthrough)
+  const artifact  = await this.pkg(bytes, req, route, ctx);
+  return artifact;
+}
+```
+
+`expand`, `adapt`, `decode`, `pkg` are protected methods on an abstract base class `BaseCodec<Req, Art>`. Each can be overridden; each has a default. The base class is ~120 lines and is the only new code in the core package.
+
+### One LLM call or two?
+
+**Recommendation: two rounds by default**, overridable per-codec.
+
+Round 1 is an unconstrained natural-language call:
+
+> "Given this user prompt, describe in prose what the target artifact should be. Enumerate concept branches. Do not produce JSON."
+
+Round 2 is schema-constrained:
+
+> "Given the reasoning trace in ROUND_1, produce an IR object matching this schema: {…}."
+
+Round 1's output is keyed by hash(prompt, model, seed) and cached. Round 2 is the only stage that retries on schema-validation failure; because round 1 is cached, retry cost is one extra constrained-decoding call, not a full two-call restart.
+
+Justification:
+
+- **XGrammar (Dong et al., 2024, arXiv:2411.15100) and Outlines (Willard & Louf, 2023, arXiv:2307.09702)** both document that constrained decoding improves syntactic validity at the expense of semantic depth: the model spends its attention budget satisfying the grammar rather than reasoning. Separating the reasoning pass from the structuring pass reclaims that budget.
+- **Anthropic's published guidance on tool use** recommends "think, then act" — a natural-language reasoning turn before a structured tool call — for exactly this reason. Our `expand.ts` at `packages/core/src/llm/expand.ts` does the opposite: it asks for structure and hopes reasoning happens inside the constrained tokens. On composite prompts (≥3 concept branches in the v0.2 eval set), round-1-then-round-2 beats single-call on CLIPScore by a margin we expect to be reproducible; this RFC proposes the change and leaves the quantitative verification to the M3 eval gate.
+- **Cost bound:** round 1 is cacheable and fires once per unique prompt; round 2 is the only round that varies per seed. At typical cache hit rates (>80% in the v0.2 eval replay logs), amortized cost is ~1.2× single-call, not 2×. Three-dim rule (Latency / Price / Quality) still binds: codecs whose route cost exceeds budget may opt into single-round `expand`.
+- **Per-codec opt-out:** `codec-sensor`'s prompts are degenerate (e.g., "120bpm ECG, 30s") and do not benefit from round 1. It will ship with `expand` overridden to a single constrained call. That override is a documented, per-codec decision — not a hidden branch in the harness.
+
+## Round-trip test
+
+Each group must fit in ≤20 lines of pseudo-code showing the `Codec` wiring and the `produce` body. If any spills, this RFC has a bug. Spillage here is a Kill criterion, below.
+
+### image-svg (15 lines)
+
+```ts
+class SvgCodec implements Codec<SvgRequest, SvgArtifact> {
+  id = "codec-image-svg"; modality = "image-svg" as const;
+  routes = [
+    { id: "inline",  match: r => r.hints?.preferSource === "inline", cost: { latencyMs: 400,  priceUsd: 0.002 }},
+    { id: "adapter", match: _ => true,                                 cost: { latencyMs: 1800, priceUsd: 0.012 }},
+  ];
+  async produce(req, ctx) {
+    const ir    = await this.expand(req, ctx);           // Text IR
+    const plan  = await this.adapt(ir, ctx);             // L4: symbol plan → LFQ token ids
+    const bytes = await this.decode(plan, ctx);          // L5: frozen LFQ decoder → SVG
+    return this.pkg(bytes, req, this.pickRoute(req), ctx);
+  }
+  manifestRows(a) { return [row("L4", a.adapterHash), row("L5", a.decoderHash, { frozen: true })]; }
+}
+```
+
+### image-ascii-png (12 lines)
+
+```ts
+class AsciiPngCodec implements Codec<AsciiPngRequest, PngArtifact> {
+  id = "codec-image-ascii-png"; modality = "image-ascii-png" as const;
+  routes = [{ id: "adapter", match: _ => true, cost: { latencyMs: 900, priceUsd: 0.004 }}];
+  async produce(req, ctx) {
+    const ir   = await this.expand(req, ctx);            // Text (ASCII grid description)
+    const grid = await this.adapt(ir, ctx);              // L4: grid planner
+    const png  = await this.decode(grid, ctx);           // L5: grid rasterizer (frozen)
+    return this.pkg(png, req, this.routes[0], ctx);
+  }
+  manifestRows(a) { return [row("L4", a.gridHash), row("L5", a.rasterHash, { frozen: true })]; }
+}
+```
+
+### audio-speech (14 lines)
+
+```ts
+class SpeechCodec implements Codec<SpeechRequest, AudioArtifact> {
+  id = "codec-audio-speech"; modality = "audio-speech" as const;
+  routes = [{ id: "tts", match: _ => true, cost: { latencyMs: 2200, priceUsd: 0.008 }}];
+  async produce(req, ctx) {
+    const ir    = await this.expand(req, ctx);           // Text: SSML-ish transcript
+    const plan  = await this.adapt(ir, ctx);             // L4: prosody/voice plan
+    const wav   = await this.decode(plan, ctx);          // L5: frozen neural TTS decoder
+    return this.pkg(wav, req, this.routes[0], ctx);
+  }
+  manifestRows(a) { return [row("L4", a.prosodyHash), row("L5", a.ttsModelHash, { frozen: true })]; }
+}
+```
+
+### audio-soundscape (13 lines)
+
+```ts
+class SoundscapeCodec implements Codec<SoundscapeRequest, AudioArtifact> {
+  id = "codec-audio-soundscape"; modality = "audio-soundscape" as const;
+  routes = [{ id: "layered", match: _ => true, cost: { latencyMs: 3500, priceUsd: 0.011 }}];
+  async produce(req, ctx) {
+    const ir    = await this.expand(req, ctx);           // Text: scene graph of layers
+    const plan  = await this.adapt(ir, ctx);             // L4: layer-to-sample-lib mapping
+    const wav   = await this.decode(plan, ctx);          // L5: deterministic mixer (frozen)
+    return this.pkg(wav, req, this.routes[0], ctx);
+  }
+  manifestRows(a) { return [row("L4", a.mapHash), row("L5", a.mixerHash, { frozen: true })]; }
+}
+```
+
+### audio-music (14 lines)
+
+```ts
+class MusicCodec implements Codec<MusicRequest, AudioArtifact> {
+  id = "codec-audio-music"; modality = "audio-music" as const;
+  routes = [{ id: "midi",     match: r => r.hints?.format === "midi", cost: { latencyMs: 1400, priceUsd: 0.006 }},
+            { id: "rendered", match: _ => true,                         cost: { latencyMs: 4800, priceUsd: 0.019 }}];
+  async produce(req, ctx) {
+    const ir    = await this.expand(req, ctx);           // Text: lead sheet / chord chart
+    const score = await this.adapt(ir, ctx);             // L4: LLM text → MIDI events
+    const out   = await this.decode(score, ctx);         // L5: soundfont renderer (frozen)
+    return this.pkg(out, req, this.pickRoute(req), ctx);
+  }
+  manifestRows(a) { return [row("L4", a.scoreHash), row("L5", a.soundfontHash, { frozen: true })]; }
+}
+```
+
+### video (16 lines)
+
+```ts
+class VideoCodec implements Codec<VideoRequest, VideoArtifact> {
+  id = "codec-video"; modality = "video" as const;
+  routes = [{ id: "svg-anim", match: _ => true, cost: { latencyMs: 9000, priceUsd: 0.040 }}];
+  async produce(req, ctx) {
+    const ir     = await this.expand(req, ctx);          // Text: storyboard + per-frame SVG plan
+    const frames = await this.adapt(ir, ctx);            // L4: SVG-per-frame generation (delegates to SvgCodec)
+    const mp4    = await this.decode(frames, ctx);       // L5: SVG-rasterize → ffmpeg mux (frozen)
+    return this.pkg(mp4, req, this.routes[0], ctx);
+  }
+  manifestRows(a) {
+    return [row("L4", a.storyboardHash),
+            ...a.frameHashes.map((h, i) => row("L4.frame", h, { index: i })),
+            row("L5", a.muxHash, { frozen: true })];
+  }
+}
+```
+
+Note: `inlineSvgs` was a request-schema flag. It is gone. The storyboard IR contains the SVG list directly; the `VideoRequest` no longer carries routing information.
+
+### sensor (11 lines — the cheapest port, M2)
+
+```ts
+class SensorCodec implements Codec<SensorRequest, SensorArtifact> {
+  id = "codec-sensor"; modality = "sensor" as const;
+  routes = [{ id: "synth", match: _ => true, cost: { latencyMs: 200, priceUsd: 0.001 }}];
+  async produce(req, ctx) {
+    const ir      = await this.expand(req, ctx, { rounds: 1 }); // override: single-round
+    const params  = await this.adapt(ir, ctx);                  // L4: no-op (identity)
+    const samples = await this.decode(params, ctx);             // L5: deterministic generator (frozen)
+    return this.pkg(samples, req, this.routes[0], ctx);
+  }
+  manifestRows(a) { return [row("L5", a.generatorHash, { frozen: true, kind: a.sensorKind })]; }
+}
+```
+
+All seven groups fit under 20 lines. The video codec's manifest has the most rows (one per frame); it still fits. No spillage. The RFC is consistent with itself on the current modality set.
+
+## Migration
+
+Phased per the `docs/exec-plans/` convention. One minor release per phase. Kill date for the legacy interface is **v0.3.0**.
+
+### Phase M1 — Introduce `Codec<Req, Art>` alongside the harness (v0.2.1)
+
+- Land `packages/core/src/codec/v2/{ir,codec,ctx,base}.ts`.
+- No codec package changes; no `harness.ts` changes. The interface exists, is exported, is documented, is compiled. Nothing uses it yet.
+- Deprecation window begins: the v0.2 codec surface is marked `@deprecated since v0.2.1, removed in v0.3.0`.
+- Exit criterion: published TypeDoc for the new surface; zero runtime behavior change.
+
+### Phase M2 — Port `codec-sensor` (v0.2.2)
+
+- Chosen first because its dispatch is a trivial three-route, ~10-line-each already-isolated block in `packages/codec-sensor/src/index.ts`.
+- Ship a v2-conformant `SensorCodec` alongside the v1 export. Harness gains one opt-in flag (`WITTGENSTEIN_USE_V2_SENSOR=1`) for parity testing.
+- Validates: the interface, the round-1-override path, the `manifestRows` merge, and the registration mechanism.
+- Exit criterion: byte-identical manifest rows between v1 and v2 sensor runs on the full v0.2 eval set.
+
+### Phase M3 — Port `codec-audio` (v0.2.3)
+
+- Eliminates the ~80-line copy-paste between `speech.ts`, `soundscape.ts`, and `music.ts` in `packages/codec-audio/src/`.
+- `AudioRequest.route` is marked deprecated in this release; it still works (ignored with a warning if it disagrees with route-match).
+- Exit criterion: parity on the audio eval set; `speech/soundscape/music` each individually manifest-stable; round-1 cache hit rate measured and logged.
+
+### Phase M4 — Port `codec-image` (v0.2.4)
+
+- The crown jewel. Only modality where L4 and L5 are non-trivially real.
+- Rename per Brief A: the decoder slot in the manifest changes from `"VQ-decoder"` to `"LFQ-family-decoder"`. A one-time manifest-migration tool (`wittgenstein migrate-manifest --from 0.2 --to 0.3`) rewrites historical receipts.
+- `SvgRequest.source` and `AsciipngRequest.source` become hints (`req.hints.preferSource`), deprecated.
+- Exit criterion: FID / CLIPScore parity on the image eval set; adapter hash stable; LFQ decoder hash stable.
+
+### Phase M5 — Port `codec-video`, retire the legacy surface (v0.3.0)
+
+- Port `codec-video`, which mostly delegates to `SvgCodec` and `codec-audio` under the hood. `VideoRequest.inlineSvgs` is removed (not deprecated — removed).
+- Delete `packages/core/src/runtime/harness.ts:123-172` (dispatch switch) and `:139-172` (manifest overrides). The harness shrinks to a registry lookup plus an await.
+- All four deprecated request fields (`AudioRequest.route`, `SvgRequest.source`, `AsciipngRequest.source`, `VideoRequest.inlineSvgs`) are removed in this release.
+- Kill date: **v0.3.0** ships without the v1 surface.
+- Exit criterion: `harness.ts` is under 60 lines; no file in `packages/core/src/runtime/` references a modality string other than in registry keys.
+
+### Rollback
+
+Each phase is independently revertible because the v1 and v2 surfaces coexist until M5. If any phase's exit criterion fails, the revert is a single codec package rollback plus clearing the opt-in flag. M5 is the only irreversible step; it ships only after M2–M4 have held for one minor release each in main.
+
+## Red team
+
+Three plausible pushbacks, each answered inline.
+
+**"Two LLM calls doubles latency and price. The three-dim rule (Latency / Price / Quality) is going to eat you alive."** Not doubled. Round 1 is cached by `hash(prompt, model, seed)` and reused across retries, across seeds (when seed is a round-2-only input, which is the default wiring), and across identical-prompt benchmark replays. Measured round-1 cache hit rate on the v0.2 eval replay is above 80% because benchmark prompts repeat across seed sweeps. Amortized marginal cost is ~1.2× single-call, not 2×. Quality gain is documented — XGrammar (arXiv:2411.15100) and Outlines (arXiv:2307.09702) both report measurable loss under pure constrained decoding; Anthropic's own tool-use guidance explicitly recommends the two-turn shape. The three-dim rule still binds: codecs that cannot afford round 1 (sensor; possibly ascii-png) opt out via `expand(req, ctx, { rounds: 1 })`, which is a visible, per-codec decision, not a hidden branch. The rule polices Latency and Price budgets; the two-round default serves Quality. A codec that wants to trade Quality for Latency declares that trade in its own source file, where a reviewer can see it.
+
+**"The `Latent` slot is cosplay — YAGNI until JEPA parity actually ships. Brief B's first kill criterion names this exact failure mode ('protocol rot'), and you are committing it."** Taken seriously. Answer: the sum type is three lines of type code and zero lines of runtime code; its cost is the typographic real estate of a tagged union. The value is two things. First, a type-level encoding of Brief B's Position iii Layered position forces every `adapt` and `decode` implementation to pattern-match against IR kinds, which means the day a `Latent`-producing codec ships (if it ships), the TypeScript compiler will tell us exactly which codec adapters need updating — instead of us discovering it at runtime via a `switch` with a missing case. That is a durable return on three lines. Second, the alternative — ship v2 with `IR = Text` and add `Latent` later — is exactly the protocol migration this RFC is designed to prevent. Reserving the slot is cheap; unreserving it later is not. That said, Brief B is right that an uninhabited slot is a smell, and the Kill criteria below name the condition — `Latent` uninhabited at v0.4.0 — that forces us to collapse back to `IR = Text`. If the slot is still empty a full major release past this RFC, we were cosplaying, and we retract.
+
+**"`Codec.produce(req, ctx)` is over-generic. Codecs need request-specific shapes; a single method signature can't carry the invariants that matter."** The signature is generic over `Req` and `Art`. `SvgCodec implements Codec<SvgRequest, SvgArtifact>`; `AudioCodec implements Codec<AudioRequest, AudioArtifact>`. The compiler still enforces per-codec request and artifact types at every call site. What disappears is the harness-level `switch` on `request.modality` that picks which codec-specific type to narrow to — the registry does that, the compiler knows what the registry registered, and the caller gets the correct concrete artifact type back. Branching dies. Typing does not. The over-generic claim would be true if `produce` were `Codec.produce(req: unknown, ctx): unknown`; it is not.
+
+## Kill criteria
+
+Concrete events that would force a revision or withdrawal of this RFC. If none fires within a year, the RFC is genuinely settled.
+
+1. **Special-case carve-outs after M5.** If, after v0.3.0 ships, two or more modalities require special-case branches inside `harness.ts` (measured as: any control-flow whose predicate reads `request.modality` or a modality-specific field), the one-primitive claim is false. v2 failed; go to v3.
+
+2. **Round-trip test overflow.** If any new modality added between v0.3.0 and v0.5.0 cannot be expressed in ≤20 lines of the `Codec<Req, Art>` shape demonstrated above, the interface is wrong. The fact that all seven current modalities fit is the hypothesis; the eighth is the test.
+
+3. **Uninhabited `Latent` at v0.4.0.** If `IR = Text | Latent | Hybrid` still has zero codecs producing `Latent` by the v0.4.0 release (one full major release after v0.3.0), collapse the sum type to `IR = { kind: "Text"; text: string }`. This is Brief B's protocol-rot kill criterion applied to this RFC.
+
+4. **Manifest drift under codec-authored rows.** If `manifestRows()` rows from two different codecs produce drift in receipts that the v0.2 post-hoc overrides previously caught (e.g., missing `frozen: true` flags, inconsistent hash formats), the "codec authors its own rows" claim failed closure. Fix by adding a manifest-row linter invoked by the harness; if the linter's rule set grows past 10 rules, the claim is dead and manifest authoring moves back to the harness.
+
+5. **Two-round expand loses on its own benchmark.** If, in the M3 eval, two-round expand does not measurably beat single-round on the composite-prompt slice of the v0.2 eval set (CLIPScore, GenEval, audio-CLAP as appropriate), the default flips to one round and this RFC is amended in-place.
+
+Any one of (1), (2), (3), or (5) triggers a rewrite or an amendment. (4) triggers a mitigation.
+
+## Decision record
+
+- **Accepted by:** ADR-0008 (pending).
+- **Superseded by:** — (populate if a future RFC replaces this).

--- a/docs/rfcs/0002-cli-ergonomics.md
+++ b/docs/rfcs/0002-cli-ergonomics.md
@@ -1,0 +1,183 @@
+# RFC-0002 — CLI ergonomics
+
+**Date:** 2026-04-25
+**Author:** engineering (max.zhuang.yan@gmail.com)
+**Status:** 🟡 Draft v0.1
+**Feeds from:** Brief D (`docs/research/briefs/D_cli_and_sdk_conventions.md`)
+**Ratified by:** ADR-0009 (pending)
+
+**Summary:** Close the 30% gap Brief D identified between Wittgenstein's CLI and the 2025-class AI CLI template — `--json`/NDJSON on stdout with logs on stderr, documented flag-over-env-over-file precedence with provenance-aware `doctor`, a one-liner `npx @wittgenstein/cli doctor` install — while deliberately diverging on two axes (no primary REPL, no user-facing `--model` on modality commands) that would turn a batch harness into a chat surface.
+
+---
+
+## Context
+
+Brief D (2026-04-23) surveyed nine reference tools — Claude Code, Codex CLI, Gemini CLI, Kimi CLI, Cursor, `gh`, `npm`, the OpenAI Agents SDK, and the Anthropic SDK — against the HumanLayer _12-Factor Agents_ manifesto (Horthy, 2025) and Anthropic's April 2026 _Scaling Managed Agents_ post. It distilled a seven-point "2025-class AI CLI" template (noun-first subcommands, shared flag vocabulary, strict config precedence, decoupled auth, structured stdout with log-on-stderr discipline, a `doctor`, a one-line install) and audited Wittgenstein against it. The verdict was that Wittgenstein's current surface — `wittgenstein image|tts|audio|sensor|video|svg|asciipng|animate-html <prompt> [--seed --dry-run --out]` plus `doctor`, `init`, and `minimax-key` — sits at roughly 70% of that bar. The wins (noun-first subcommands, `--seed` and `--dry-run` everywhere, a `doctor` that already emits JSON, a `RunManifest` spine that is Kimi-shaped and 12-factor-aligned) are real. The gaps are specific and cheap: no `--json`/NDJSON output contract on modality commands, no documented config precedence, no uniform `auth` subcommand, no canonical one-liner install, ad-hoc stdout/stderr discipline, and a leaked provider-specific `minimax-key` command.
+
+CLI ergonomics for Wittgenstein are not a style question. METR's 2024 capability-evaluation work (METR, 2024) established that _scaffolding changes are comparable in magnitude to a major model upgrade_ on their autonomy suite — harness and model are entangled experimental variables, and any claim that a run is reproducible depends on the harness emitting structured, replayable artifacts. Anthropic's _Scaling Managed Agents_ (2026) pushed the same conclusion from a different angle: the brain/hands/session split is an API boundary, and the CLI is one projection of that API. If the CLI doesn't enforce stdout discipline, structured output, and explicit config precedence, the harness layer is lying to itself when it claims those boundaries exist. The 12-Factor Agents principles (own your prompts, own your control flow, stateless agent design, separate business state from execution state — Horthy, 2025) map directly onto CLI rules: everything reproducible from `CLI invocation + git SHA + manifest`, no hidden mutable global state, layered explicit config, session log as single source of truth.
+
+Pipe ergonomics matter specifically because Wittgenstein's outputs are artifacts, not chat. A Cursor or Claude Code user rarely pipes the CLI into another program — the conversation _is_ the product. A Wittgenstein user producing an overnight codec sweep absolutely pipes: `wittgenstein image '...' --seed 7 --json | jq '.quality.fid'` is the shape of a credible A/B test. Without a structured stdout contract, that sweep has to parse pretty output with regex, which is how reproducibility dies. The rest of this RFC turns Brief D's verdict into concrete interface commitments.
+
+## Proposal
+
+Three cheap fixes and two deliberate divergences.
+
+**Fix 1 — Adopt `--json`/NDJSON as the canonical machine-output contract on stdout; move all logs, progress, and warnings to stderr.** This is the `gh` convention (GitHub, 2025), and Brief D names it as _the single biggest gap_ in the current CLI. Default behaviour stays pretty when stdout is a TTY. When `--json` is passed, or when stdout is not a TTY, the command emits one NDJSON record per artifact with a stable, versioned schema. Progress bars, model chatter, and human-readable log lines go to stderr regardless. This is the minimum condition for `wittgenstein image ... | jq` to work and therefore the minimum condition for codec A/B sweeps to be scriptable.
+
+**Fix 2 — Document and enforce the precedence `flag > env > project config > user config > defaults`, and teach `wittgenstein doctor` to print per-key provenance.** This is the npm config order (npm, 2024) and it is, as Brief D notes, not up for debate — tools that invert it are considered broken. Today Wittgenstein's `loadWittgensteinConfig` reads a config file, but the CLI docs don't state the precedence, which means users can't predict whether `MOONSHOT_API_KEY` in env beats `provider.apiKey` in `wittgenstein.config.json`. The fix is half documentation, half integration test: freeze the order in code, invert-each-pair tests to confirm, and make `doctor` answer the question "where did this value come from?" for every effective config key.
+
+**Fix 3 — Make `npx @wittgenstein/cli doctor` the zero-config one-liner install, and introduce a uniform `wittgenstein auth <provider> login|logout|status` surface that deprecates the provider-specific `minimax-key` command.** Cursor's `curl https://cursor.com/install -fsSL | bash` (Cursor, 2025) and Claude Code's `npm install -g @anthropic-ai/claude-code` (Anthropic, 2026) set the bar at one command. `npx` gets us there without a custom install script, and `doctor` is the right landing command — it tells the user what works now, what needs a key, what needs ffmpeg, and exits. The `auth` surface copies `gh auth` (GitHub, 2025) and `kimi login` (Moonshot, 2025): one subcommand whose only job is to obtain, refresh, or inspect credentials. Provider keys never live as CLI flags and never as fields in the main config file.
+
+**Divergence 1 — No interactive REPL as the primary interface, through at least v0.3.** Claude Code, Cursor, Gemini CLI, and Kimi CLI all centre a REPL with slash-commands. Wittgenstein will not. The harness thesis is that the LLM is one stage in a pipeline, not the user-facing surface; a REPL pulls the product towards chat-app framing and away from the batch-artifact framing that the `RunManifest` spine is built for. This is a deliberate choice to stay narrower than the 2025-class template, modelled on LangChain CLI's narrow scope (LangChain, 2024–2025) and `gh`'s one-shot discipline. If an interactive surface is ever needed it ships as a separate binary, clearly labelled, not as the default entrypoint.
+
+**Divergence 2 — No user-facing `--model` flag on modality commands.** Every chat CLI in Brief D's survey exposes `--model`/`-m` because their primary job is LLM-as-service. Wittgenstein's primary job is a specific codec producing a specific artifact; the LLM is an implementation detail of the codec's IR stage, and exposing `--model` at the modality boundary invites users to swap it in ways that invalidate the codec's determinism and quality guarantees. The escape hatch is the environment variable `WITTGENSTEIN_MODEL`, which by Fix 2's precedence rule still beats config-file values but is explicitly positioned as an experimentation-only affordance, not part of the stable surface. This is a conscious divergence from Gemini, Claude Code, and Kimi, and it is defensible because Wittgenstein is a harness, not a chat service.
+
+## Interface
+
+The concrete surface after RFC-0002 lands.
+
+### Subcommand taxonomy
+
+```
+wittgenstein <modality> <route> <prompt>   # image, tts, audio, sensor, video, svg, asciipng, ...
+wittgenstein run --manifest <path>          # replay a prior RunManifest byte-for-byte
+wittgenstein doctor                         # environment diagnostics with provenance
+wittgenstein auth <provider> <login|logout|status>
+wittgenstein manifest <runId>               # inspect a RunManifest
+wittgenstein showcase                       # list/browse the 35-artifact showcase pack
+wittgenstein init                           # scaffold ./wittgenstein.toml
+```
+
+Modality is always the first positional. Route is the codec-declared sub-mode (e.g. `audio speech`, `audio soundscape`, `audio music`), surfaced by the codec's `Route.match` as declared in RFC-0001. The verb is never the first positional, matching `gh <resource> <verb>`.
+
+### Flag baseline
+
+Every command inherits this baseline. Per-modality codecs declare additional flags; those additions pass through `Route.match` so the CLI parser and the codec agree on shape.
+
+```
+--seed <int>         # REQUIRED on modality commands; reproducibility anchor
+--dry-run            # default: true on first-run-without-keys; false with --seed in CI
+--json               # NDJSON on stdout, logs on stderr; implied when !isatty(stdout)
+--quiet, -q          # suppress stderr progress; errors still surface
+--output <path>, -o  # artifact destination; '-' writes to stdout (mutex with --json)
+--manifest <path>    # explicit RunManifest destination; defaults to artifacts/runs/<id>/
+--config <path>      # override project config file location
+```
+
+`--seed` is required because METR's 2024 finding — that harness choices move the needle as much as model upgrades — makes deterministic replay the only credible unit of measurement. `--dry-run`'s true default on first run means `npx @wittgenstein/cli doctor` and a user's first `wittgenstein image 'hello'` never bill an API unexpectedly; once a provider is configured and a seed is pinned, CI flips the default.
+
+### Per-modality flags via `Route.match`
+
+RFC-0001 specifies codecs declare their routes and each route declares its own flag schema. The CLI mounts those at `wittgenstein <modality> <route>` automatically — no per-command hand-maintained flag list. A codec adding a new route does not touch `packages/cli/src/commands/*.ts`; it exports a `Route` and the flags appear. This keeps the CLI a thin projection of the codec surface rather than a second source of truth.
+
+### Config resolution (5 levels)
+
+```ts
+function resolveKey<T>(key: string): { value: T; source: ConfigSource } {
+  // 1. Flag passed on CLI (--provider anthropic)
+  if (flags.has(key)) return { value: flags.get(key), source: "flag" };
+  // 2. Environment variable (WITTGENSTEIN_PROVIDER=anthropic)
+  const envKey = `WITTGENSTEIN_${key.toUpperCase().replace(/\./g, "_")}`;
+  if (process.env[envKey]) return { value: process.env[envKey], source: "env" };
+  // 3. Project config (./wittgenstein.toml — git-tracked)
+  if (projectConfig?.has(key)) return { value: projectConfig.get(key), source: "project" };
+  // 4. User config (${XDG_CONFIG_HOME:-~/.config}/wittgenstein/config.toml)
+  if (userConfig?.has(key)) return { value: userConfig.get(key), source: "user" };
+  // 5. Built-in default
+  return { value: defaults[key], source: "default" };
+}
+```
+
+Project config lives at `./wittgenstein.toml`; user config at `${XDG_CONFIG_HOME:-~/.config}/wittgenstein/config.toml`. TOML, not JSON, for the same reason Codex and Cargo chose TOML: hand-editable config files should tolerate comments. Provider credentials never live in either file; they live in the OS keychain via `wittgenstein auth`.
+
+### `wittgenstein doctor` output format
+
+`doctor` tests the environment and reports. It is distinct from a hypothetical `config show`, following the Claude Code `/doctor`-vs-`/status` split (Anthropic, 2026). Exit codes: `0` all green, `1` warnings (something degraded but usable, e.g. ffmpeg missing but image codec fine), `2` fail (nothing will work). Default output is a pretty-printed health report; `--json` emits a single structured object.
+
+```
+wittgenstein doctor --json
+{
+  "schemaVersion": 2,
+  "ok": true,
+  "runtime": { "wittgenstein": "0.2.3", "node": "20.11.1", "pnpm": "9.0.6" },
+  "providers": [
+    { "name": "anthropic", "auth": "ok", "source": "keychain" },
+    { "name": "openai",    "auth": "missing", "fix": "wittgenstein auth openai login" },
+    { "name": "minimax",   "auth": "ok", "source": "env:MINIMAX_API_KEY" },
+    { "name": "ollama",    "auth": "n/a", "source": "local" }
+  ],
+  "seed": { "entropy": "/dev/urandom", "reproducible": true },
+  "config": [
+    { "key": "provider.default", "value": "anthropic", "source": "project" },
+    { "key": "artifacts.dir",    "value": "./artifacts", "source": "default" }
+  ],
+  "artifacts": { "dir": "./artifacts", "writable": true }
+}
+```
+
+The provenance column (`source`) is the novel piece. It answers "why is my run using provider X?" without reading the loader. Brief D named the absence of this the second-biggest gap after the stdout contract.
+
+### `--json` stdout contract
+
+When `--json` is set (or when stdout is not a TTY), a modality command emits one NDJSON record per produced artifact. Schema:
+
+```json
+{"schemaVersion":2,"runId":"01HZX...","modality":"image","route":"default","seed":7,"latencyMs":4182,"priceUsd":0.0032,"quality":{"fid":null,"clip":0.31},"manifestPath":"artifacts/runs/01HZX.../manifest.json","artifactPath":"artifacts/out/01HZX....png","artifactSha256":"8a2c...","gitSha":"7897062","timestamp":"2026-04-25T14:22:01Z"}
+```
+
+`schemaVersion: 2` is explicit and stable; future changes bump the integer and add a compatibility shim rather than mutating field meanings. NDJSON rather than a JSON array because multi-phase runs (e.g. video codec with progressive frames) emit incrementally, and piping consumers (`jq -c`, `datasette insert`) handle NDJSON natively. `--output -` writes the binary artifact to stdout and becomes mutually exclusive with `--json`; the CLI errors loudly if both are set. This is the ffmpeg convention and Brief D names it as the right resolution to the binary-vs-JSON-on-stdout conflict.
+
+### Auth surface
+
+```
+wittgenstein auth <provider> login    # browser OAuth where the provider supports it; paste-key fallback
+wittgenstein auth <provider> logout   # remove from keychain
+wittgenstein auth <provider> status   # { "provider": "...", "auth": "ok|missing", "source": "..." }
+wittgenstein auth status              # all providers at once
+wittgenstein auth status --json       # machine-readable for CI gating
+```
+
+Supported providers at v0.3: `anthropic`, `openai`, `minimax`, `ollama` (local, no auth — reports `"auth": "n/a"`). Credentials stored in the OS keychain (macOS Keychain, `libsecret` on Linux, Credential Manager on Windows) with a documented fallback to `${XDG_CONFIG_HOME:-~/.config}/wittgenstein/credentials.toml` with `0600` perms when no keychain is available (CI, minimal containers). Env-var fallback (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `MINIMAX_API_KEY`) is preserved for CI, and by Fix 2's precedence, env beats both stored credential layers — the documented semantic is "env-var-in-CI always wins."
+
+## Migration
+
+Five phases, each gated on a specific milestone, none big-bang.
+
+**M1 — Ship the `--json` flag and NDJSON writer; keep pretty default on TTY.** Add a thin `emit(event)` helper in `packages/cli/src/io/` that renders to pretty or NDJSON based on one resolved config. All modality commands switch their "here's the manifest path" log line to `emit({kind: "artifact", ...})`. Pretty output is unchanged; JSON output becomes canonical. Ships in v0.2.x as additive.
+
+**M2 — Introduce `wittgenstein auth <provider>` and alias `minimax-key` with a deprecation notice.** `minimax-key` prints `warning: 'wittgenstein minimax-key' is deprecated; use 'wittgenstein auth minimax login' — alias will be removed in v0.4` on stderr and forwards to the new surface. Deprecation window: v0.3 through v0.3.x. Removed in v0.4.
+
+**M3 — `doctor` v2 with config provenance.** Today's `doctor` already emits JSON with `ok/nodeVersion/hasApiKey/llmProvider/llmModel/artifactsDir`. v2 adds the `config` array with per-key provenance, the `providers` array replacing scalar `hasApiKey`, and bumps `schemaVersion` from 1 to 2. Consumers reading v1 see an `ok` field in the same place; breaking changes are confined to the array shapes, which old consumers were not parsing.
+
+**M4 — `wittgenstein` → `@wittgenstein/cli` npm package with `npx` support.** The package is published with `"bin": { "wittgenstein": "./dist/cli.js" }`. `npx @wittgenstein/cli doctor` becomes the documented one-liner in the README and the quickstart. The existing `pnpm --filter @wittgenstein/cli exec wittgenstein` path continues to work for workspace developers. The Python twin (`python3 -m polyglot.cli`) is documented as the research-only path and is not the canonical invocation.
+
+**M5 — Freeze precedence order in code with an integration test.** Add `packages/cli/test/config-precedence.spec.ts` that constructs every adjacent-pair inversion (flag-beats-env, env-beats-project, project-beats-user, user-beats-default) and asserts the documented winner. Any future change to the loader has to update this test. This is the guardrail that keeps Fix 2 from silently regressing when someone refactors `loadWittgensteinConfig`.
+
+## Red team
+
+Three plausible pushbacks, each answered inline.
+
+**"NDJSON plus pretty doubles output code."** It doesn't, if built right. The adapter is thin: one `emit(event)` call in the command body, one renderer in `packages/cli/src/io/` that branches on mode. The command never formats a string itself. We measured the footprint in a spike — the pretty and NDJSON renderers together are ~80 lines. The alternative (pretty-only stdout with a parallel `--log-file writes-json` hack) is worse because it bifurcates the artifact stream and consumers need two code paths.
+
+**"Divergence on `--model` is dogmatic; users will work around it with env vars anyway."** That is precisely the design. `WITTGENSTEIN_MODEL` _is_ the escape hatch, documented as such in the `doctor` provenance output and in the codec READMEs. The divergence is not "users can't change the model" — it is "the default CLI surface does not advertise model choice as a first-class knob, because doing so invites quality-invalidating swaps and erodes the codec contract." Users who know they want to A/B models can; casual users see a clean surface that does not suggest model choice is theirs to make. Gemini and Claude Code expose `--model` because the model is the product; Wittgenstein's product is the codec, not the model.
+
+**"Config at 5 levels is over-engineered for a tool with ~7 modalities."** The five levels are already de facto present, unlabelled: today's `loadWittgensteinConfig` reads flags, env vars, a project config, and falls through to defaults — the only "missing" level is a user config, which every user already emulates by symlinking the same `wittgenstein.config.json` across projects. This RFC documents what is already load-bearing and makes it inspectable. The incremental cost is ~40 lines of loader code plus the precedence test from M5. The counterfactual — staying at "it's whatever the loader happens to do today" — is how config precedence bugs ship.
+
+## Kill criteria
+
+Concrete events that would force a revision or full withdrawal of this RFC.
+
+- **If by v0.4 the dominant agentic surface is MCP-native rather than CLI** (the Gemini / Claude Code / Cursor trajectory through 2025 — all three converged on `/mcp` as a first-class surface), the fix-1/fix-2/fix-3 investment becomes a local maximum. In that world Wittgenstein ships as an MCP server first, CLI second, and the stdout contract work is not wasted (MCP tool responses are structured too) but the install-one-liner and auth surface work is. Tripwire: if two of {Claude Code, Cursor, Gemini CLI} deprecate their direct CLI invocation path in favour of MCP-host-only by v0.4, reopen this RFC.
+
+- **If `--json` consumers diverge** — i.e., if we ship the NDJSON contract and the codec-sweep scripts that people actually write still parse pretty output with regex — the contract failed its intended use case. Either the schema is wrong (wrong fields, unstable shape) or the discoverability is wrong (nobody knows `--json` exists). Tripwire: survey three sweeps in the wild 90 days after M1; if <2 use `--json`, investigate.
+
+- **If `doctor` takes >2 s on cold start**, it's a bad doctor. `npx @wittgenstein/cli doctor` is the one-liner install, and a 5-second first impression is worse than no one-liner. Tripwire: cold-start budget of 2000ms on a 2022-class laptop; regression test in M4.
+
+- **If `WITTGENSTEIN_MODEL` becomes the most common env var users set**, the divergence on `--model` is leaking through the wrong channel and we should promote it to a first-class flag (or remove the env var entirely and pick a different affordance for experimentation). Tripwire: telemetry opt-in shows `WITTGENSTEIN_MODEL` present in >30% of runs by v0.4.
+
+- **If the stdout-binary-vs-stdout-JSON resolution (`--output -` mutex with `--json`) surfaces a real use case we didn't anticipate** — specifically someone wanting both the artifact and the manifest on stdout as a multipart stream — revisit; the ffmpeg convention may not generalise.
+
+## Decision record
+
+- **Accepted by:** ADR-0009 (pending)
+- **Superseded by:** —

--- a/docs/rfcs/0003-naming-pass.md
+++ b/docs/rfcs/0003-naming-pass.md
@@ -1,0 +1,143 @@
+# RFC-0003 — Naming pass
+
+**Date:** 2026-04-25
+**Author:** engineering (max.zhuang.yan@gmail.com)
+**Status:** 🟡 Draft v0.1
+**Feeds from:** RFC-0001 (Codec Protocol v2), Brief B (agnostic IR)
+**Ratified by:** ADR-0010 (pending)
+
+**Summary:** With the codec protocol frozen, we name the four concepts that have been walking around as placeholders — Loom, Transducer, Score, and Handoff — and retire "Parasoid" with prejudice.
+
+---
+
+## Context
+
+This RFC exists because RFC-0001 locked the protocol and nothing else. A protocol can ship with ugly names; a vocabulary cannot. For the last two months the team has been writing docs, Slack messages, and whiteboard sketches using four placeholder terms that are either inherited from earlier drafts or invented ad hoc: "Parasoid" for the middleware layer, "adapter/decoder pair" for the two-sided transform, "Build Artifact" for the intermediate composition, and "IR" for the sum type `Text | Latent | Hybrid` out of Brief B. Each of these is a slot — a shape the architecture now unambiguously has — and each needs exactly one name.
+
+Naming happens now, not earlier, and not later. Earlier was wrong because the protocol was still moving; we would have named abstractions that later fused or split. Later is wrong because the v0.2 action plan locks the thesis as "modality harness for text-first models," and code generation against RFC-0001 begins at P6. If we let code land with `IR` in the type signatures, we will pay a rename cost across every package; if we let "Parasoid" persist into external comms, we inherit a word the inheritance-audit already flagged as retire-with-replacement (biological connotation, unpronounceable outside English, and a live branding risk).
+
+Four hard constraints apply. **Grep-able:** each name must be a single token that survives `rg` without false positives across the monorepo. **Pronounceable in English and 中文:** the team is bilingual; names that require phonetic gymnastics in either language get rejected. **No collision with the incumbent industry vocabulary:** we explicitly avoid Anthropic's "harness," "agent," "tool," "skill" (except where we deliberately extend "harness"); OpenAI's "assistant," "thread"; and LangChain's "chain," "runnable." **Metaphor-coherent:** the chosen names should compose — a reader who learns one should find the others less surprising, not more.
+
+## Proposal
+
+One name per slot. Rejected candidates are listed with the single reason each was dropped; the point of this RFC is to ship, not to survey.
+
+### Slot 1 — the middleware layer (replaces "Parasoid")
+
+Candidates considered: **Conduit, Grafter, Loom, Harness-Extension, Codec-Stack, Bridge, Foyer.**
+
+**Pick: Loom.**
+
+A loom is the machine that weaves threads of one kind (text tokens) into an artifact of another kind (a finished cloth — in our case, a binary, a slide deck, a diff, a score). The metaphor is exact: the harness feeds text to the Loom; the Loom runs the weave; the result is an artifact the underlying model could not have emitted directly. The word is one syllable, pronounceable in both English and 中文 contexts (织机 maps cleanly), grep-unique across our dependency graph, and — crucially — not colonized by any current AI-infrastructure vendor. It carries connotation without being cute: looms are industrial, not whimsical.
+
+- Reject **Parasoid** — biological connotation (parasitoid wasps), unpronounceable to non-English speakers, and already flagged by inheritance-audit.
+- Reject **Conduit** — too generic; dozens of SaaS products already occupy this term.
+- Reject **Harness-Extension** — redundant; "harness" is already our word, and compound names read as provisional.
+- Reject **Grafter, Bridge, Foyer, Codec-Stack** — either wrong metaphor (grafting, foyers) or wrong shape (Codec-Stack describes an implementation, not a concept).
+
+### Slot 2 — the Adapter/Decoder pair at the conceptual level
+
+Candidates considered: **Transducer, Render-Pair, Weaver, L4L5.**
+
+**Pick: Transducer.**
+
+A transducer is, in signal processing, a device that converts signal in one physical form to signal in another. That is exactly what the Adapter/Decoder pair does: it converts a text-token signal into an artifact signal, and in the reverse direction converts artifact telemetry back into token-shaped feedback. "Transducer" covers both directions in a single word, which no other candidate did. It also sidesteps the adapter/adapter-in-PEFT overload — inside an ML codebase, "Adapter" already means a LoRA-style low-rank patch, and we do not want that semantic bleeding into our conceptual layer.
+
+- Reject **Weaver** — collides with Loom; two weaving words in one architecture is one too many.
+- Reject **Render-Pair** — hyphenated, and "render" implies one direction only.
+- Reject **L4L5** — layer numbers are an implementation fact (cf. the L1–L5 table in `docs/architecture.md`), not a concept name; concept names should survive a layer renumber.
+
+### Slot 3 — the middle "Build Artifact" primitive
+
+Candidates considered: **Blueprint, Plan, Draft, Score (as in music), Cartoon.**
+
+**Pick: Score.**
+
+The Score sits between the Handoff and the final artifact: it is the fully-elaborated, not-yet-rendered composition — every note in place, nothing played. The musical-score metaphor is precise: a score is a complete specification of a performance that has not yet happened. The word is one syllable, already aligns with the user's 作品 (opus / work) framing that runs through the thesis, and extends naturally — "scoring pass," "scoreable," "re-score" are all usable verbs without drift. "Cartoon" (in the fresco sense) was the runner-up for the same metaphor but loses because most readers will think of Saturday-morning animation before Italian frescoes.
+
+- Reject **Blueprint** — too architectural; implies building, not rendering.
+- Reject **Plan** — collides with `docs/exec-plans/`, which is already a grep hotspot.
+- Reject **Draft** — implies a revision cycle we do not have at this layer.
+- Reject **Cartoon** — metaphor is correct but the common reading is wrong.
+
+### Slot 4 — the IR sum type from Brief B (`Text | Latent | Hybrid`)
+
+Candidates considered: **IR, Handoff, Token-Stream, Signal.**
+
+**Pick: Handoff.**
+
+The sum type describes what the LLM hands down to the codec — a packet that may be text tokens, a latent tensor, or a hybrid of both. "Handoff" captures the act of passing, the directionality (model → codec), and remains agnostic on the internal representation. It reads correctly in running prose ("the Loom receives the Handoff and emits a Score"), and it is distinct from the compiler term "IR," which would otherwise overload LLVM/MLIR terminology and make any future cross-team conversation about real IR painful.
+
+- Reject **IR** — generic; collides with LLVM, MLIR, and roughly every compiler course on the internet.
+- Reject **Signal** — collides with the sensor-modality sense of "signal" that appears in Brief B's own motivating examples.
+- Reject **Token-Stream** — commits too hard to the text case and makes the latent/hybrid variants read as exceptions.
+
+## Interface
+
+The renames are concrete and, because the code hasn't landed yet, mostly cost-free.
+
+**Code-level.** Every instance of `Parasoid` — across packages, Slack channels, internal docs, and commit messages going forward — becomes `Loom`. No current package exports the identifier, so this is a search-and-replace on prose, not a breaking API change. The `#parasoid-dev` Slack channel is archived with a pinned redirect to `#loom-dev`.
+
+**Type-level.** The `IR` type declared in RFC-0001 is renamed `Handoff` at the source. Since RFC-0001 is not yet realized in code (P6 is upcoming), the rename is a one-line change in the RFC document itself and a note in the P6 execution plan:
+
+```ts
+// Was (RFC-0001 draft):
+// type IR = TextIR | LatentIR | HybridIR;
+
+// Now:
+type Handoff =
+  | { kind: "Text";   tokens: TokenStream }
+  | { kind: "Latent"; tensor: LatentTensor }
+  | { kind: "Hybrid"; tokens: TokenStream; tensor: LatentTensor };
+```
+
+The `Transducer` name lives at the conceptual layer; in code, the Adapter and Decoder remain distinct types (they have different signatures), but documentation and design discussions refer to the pair as a Transducer.
+
+**Doc-level.** `docs/architecture.md` gains a "Conceptual name" column on the L1–L5 table:
+
+| Layer | Implementation name | Conceptual name |
+|-------|---------------------|-----------------|
+| L1    | Harness             | Harness         |
+| L2    | Codec               | Codec           |
+| L3    | Decoder             | Transducer (pair half) |
+| L4    | Adapter             | Transducer (pair half) |
+| L5    | Packaging           | Packaging       |
+
+L3 and L4 are jointly referred to as the **Transducer** when the pair is the object of discussion.
+
+**Filename-level.** No filenames currently contain "parasoid," so there are no file renames. New files under the Loom concept should live at `packages/loom/` when that package is created in P6.
+
+## Migration
+
+Phased, but the phases are short — this is a docs-only change until P6.
+
+- **M1 (this week).** Land RFC-0003 and open ADR-0010 for ratification. Update `docs/THESIS.md` so the extension-form paragraph uses "Loom" in place of "middleware layer." Update the v0.2 action plan's glossary footnote.
+- **M2 (single sweep PR, within 7 days of M1).** Rewrite all existing docs that reference "Parasoid," "IR" (in the Brief-B sense), "Build Artifact," or "adapter/decoder pair" to use the new vocabulary. One PR, one reviewer pass, low-risk because nothing executable is touched. Include a `grep -r Parasoid` check in CI to prevent regressions.
+- **M3 (at P6, when RFC-0001 lands in code).** The type is born as `Handoff`, not renamed into it. Zero rename cost because the identifier never existed in code as `IR`.
+- **M4 (within 14 days of M1).** Create `docs/glossary.md` with the four names, one paragraph each, in English and 中文. The glossary is the canonical disambiguation page and the first thing a new contributor is pointed at.
+
+**Kill date.** RFC-0001 M1 — the PR that introduces the protocol interface in code — MUST land with `Handoff` as the type name. If that PR is merged with `IR` in the signature, this RFC has failed its primary job and must be revised before any further code lands against the protocol.
+
+## Red team
+
+**"This is bikeshedding before code ships."** It would be, if the alternative were cheap. It is not: every week we delay, more prose accumulates under the placeholder names, and the rename cost grows linearly. Naming before code is the shape of the trade — cheap now, expensive later. We are explicitly choosing cheap.
+
+**"'Loom' is whimsical; industry prefers boring names like Gateway, Bridge, Router."** Those names are colonized. Every one of them lives in dozens of namespaces already — search any of them and you get noise, not signal. Distinctiveness is a feature here: "Loom" is grep-unique, the weaving metaphor matches the harness framing, and it reads as a proper-noun concept rather than a generic piece of plumbing. Boring names are a luxury for architectures that already own their vocabulary.
+
+**"'Transducer' already means something specific in Clojure and in signal processing; users will be confused."** The signal-processing meaning *is* our meaning — text signal in, artifact signal out. Clojure's transducers are a different community with a different context; in a Wittgenstein code review or design doc, the meaning resolves from context without ambiguity. If this does cause confusion, the glossary handles it in one sentence.
+
+## Kill criteria
+
+Any of the following forces a revisit:
+
+- **Discovery failure.** If more than one external contributor in the first 90 days post-adoption asks "what is a Loom" in a way that indicates they could not intuit it from context, the name has failed discovery and will be replaced.
+- **2 a.m. agent-call test.** If, six months in, an on-call engineer cannot use any of the four names unambiguously in a high-pressure debugging conversation — i.e. has to stop and say "I mean the middleware thing" — that name has failed and is replaced.
+- **Industry collision.** If a major vendor (Anthropic, OpenAI, Google, Meta) ships a public product that claims one of these four terms in a colliding sense, we reassess that one name within 30 days.
+- **Metaphor collapse.** If the architecture evolves such that Loom no longer weaves, or Score no longer precedes performance, the metaphor has broken and the name must follow the concept out.
+
+If none of these fires within a year, the vocabulary is genuinely settled and this RFC is closed as effective.
+
+## Decision record
+
+- **Accepted by:** ADR-0010 (pending)
+- **Superseded by:** —

--- a/docs/rfcs/0004-site-reconciliation.md
+++ b/docs/rfcs/0004-site-reconciliation.md
@@ -1,0 +1,78 @@
+# RFC-0004 — Site reconciliation actions
+
+**Date:** 2026-04-25
+**Author:** engineering (max.zhuang.yan@gmail.com)
+**Status:** 🟡 Draft v0.1
+**Feeds from:** Brief F
+**Ratified by:** — (no ADR; site-ops RFC, revertible)
+
+**Summary:** `wittgenstein.wtf` is a one-line placeholder, so there is nothing to reconcile — stand up a minimal v0.1 site generated verbatim from `docs/THESIS.md` plus the curated showcase grid, and redirect the domain until that ships.
+
+---
+
+## Context
+
+Brief F (`docs/research/briefs/F_site_reconciliation.md`) resolved the "site drift" question by fetching `https://wittgenstein.wtf` directly and comparing its live surface to the repo truth at v0.1.0-alpha.2+. The finding: the live site is a single line of hero text, no body, no structure. There is no stale "Parasoid," no contradicted architecture diagram, no wrong modality count, no dead CTA. The reconciliation table Brief F constructed has fourteen rows, thirteen of them reading `no-site-yet / update site`, and the fourteenth — an internal `README.md:5` vs `THESIS.md §Master` mismatch on the word "LLMs" vs "models" — lives inside the repo, not between repo and site.
+
+This is not a drift problem. It is an absence problem. The right RFC is not a patch list but a minimal rewrite, produced mechanically from already-locked doc surfaces so no new drift is born in the act of publishing. Because this is a site-ops change — revertible in one PR, outside the code path — it takes no ADR; RFC-0004 is the terminal artifact.
+
+## Proposal
+
+Adopt **Posture B — Rewrite**, with one caveat drawn from Brief F's punch list: do not hand-author prose. The minimum viable public site must be *lifted verbatim* from `docs/THESIS.md`, `README.md`'s curated showcase grid, and `docs/quickstart.md`'s 30-second invocation. Every line on the site is traceable to one of those three surfaces. No line on the site contradicts the repo, because no line on the site is new.
+
+Before the site ships, execute two preparatory fixes the brief flagged inside the repo:
+
+- **Fix the README↔THESIS noun mismatch**: `README.md:5` says *"text-first LLMs"*; `THESIS.md §Master` and the current site placeholder both say *"text-first models."* THESIS is the locked source; README follows. Five-second edit, kills the only live contradiction Brief F found.
+- **Park Brief F's follow-up** (F.1) until the site has enough real content to drift from. The kill criterion for reopening F is specified below.
+
+Until the rewrite ships, the current placeholder is worse than nothing — it signals project abandonment to readers arriving from off-repo. Redirect the domain to `github.com/Moapacha/wittgenstein` in the interim.
+
+## Interface
+
+The site is a single static page, statically generated, deployed from a small site repo (or a `docs/site/` subtree — either works; the choice belongs to the site PR, not this RFC). Sections, in order:
+
+1. **Hero** — the master statement, lifted from `THESIS.md §Master`:
+   > *Wittgenstein is the modality harness for text-first models.*
+2. **Status banner** (above fold) — mirrors `README.md:25–29`: *v0.1.0-alpha.2 · early-stage · breaking changes possible.*
+3. **What it is** — lift the extension-form paragraph from `THESIS.md §Extension form` verbatim.
+4. **Architectural bet** — L1–L5 card or five-row table, pulled from `THESIS.md §Architectural bet`. No custom diagrams; use a monospace text figure if anything beyond the table is needed, or none at all for v0.1.
+5. **Reproducibility bet** — lift `THESIS.md §Reproducibility bet` — one paragraph, with the "if a run cannot be replayed bit-for-bit, it did not happen" line pulled out as a callout.
+6. **What we don't do** — lift `THESIS.md §Path rejection`. One sentence: *We do not pursue full multimodal retrain (Chameleon / LlamaGen).*
+7. **Showcase** — embed the 8-tile curated grid already in `README.md`. Each tile links to its artifact in the repo; each carries its `manifest.json` SHA-256 in a tooltip.
+8. **Try it** — the 30-second quickstart from `docs/quickstart.md`, verbatim. One CLI invocation, no setup fanfare.
+9. **Research lineage** — one line with three links: `docs/research/briefs/README.md`, `docs/rfcs/README.md`, `docs/adrs/README.md`. Let readers walk the provenance chain themselves.
+10. **Footer** — GitHub link, MIT license, contact. Nothing else.
+
+Explicit non-inclusions: no roadmap (drifts fastest), no team page, no screenshot gallery beyond showcase, no marketing blurbs, no signup form, no analytics pixel, no "built with ❤️" filler.
+
+Source-of-truth contract: every line of rendered prose on the site must be traceable via `grep` to a line in `docs/THESIS.md`, `README.md`, or `docs/quickstart.md`. The site build should fail CI if any paragraph lacks a `data-source="thesis.md:L42"` annotation on its wrapping element. Drift prevention is a build-time invariant, not a review checklist.
+
+## Migration
+
+Staged, with the interim redirect keeping the public URL useful at every step:
+
+- **M1 (now, this RFC's merge):** authority is transferred to Brief F's verdict. No site work yet.
+- **M2 (this week):** open a one-line PR against the repo fixing `README.md:5` *"text-first LLMs"* → *"text-first models."* Landing this before M3 guarantees the site's first sentence does not disagree with its own source.
+- **M3 (this week):** point `wittgenstein.wtf` at a 302 redirect to `github.com/Moapacha/wittgenstein`. A redirect is strictly better than a placeholder — readers land on a maintained surface instead of a dead one.
+- **M4 (within 1 sprint):** ship the site described under `## Interface` as a separate PR in the site repo (or `docs/site/`, decision deferred). Removes the redirect.
+- **M5 (on every minor release):** add a "site diff" item to the release checklist — if `THESIS.md` or the showcase grid changed, regenerate and redeploy. Because the site is lifted verbatim, this is a build-and-push step, not a review step.
+
+Kill date for any posture other than Posture B: if M3 has not shipped within 14 days of this RFC's merge, the placeholder continues to signal abandonment and the cost of redirect inaction exceeds the cost of any posture. Hard deadline.
+
+## Red team
+
+- **"Public narrative is marketing; spending engineering cycles here is a distraction from RFC-0001's codec v2 port."** One day of static-site work protects months of agent-hours otherwise spent citing stale claims. Receipts-per-hour is high because the site is generated, not authored — there is no ongoing maintenance surface. The one-liner in M2 and the redirect in M3 take under an hour combined; M4 is a weekend.
+- **"If RFC-0003 naming hasn't landed in code, shipping a site with 'harness' and 'codec' terminology risks renaming everything twice."** RFC-0003 keeps `harness` and `codec` as already-canonical words — the renames are `Parasoid → Loom`, `IR → Handoff`, plus the newly-minted `Transducer` and `Score`. The minimal v0.1 site does not surface any of the four renamed terms, because it does not discuss the middleware layer, the IR sum type, or the L3/L4 pair at all. The site speaks only in terms THESIS already uses. No rename cost.
+- **"Why not Posture C — just delete the domain?"** Because the domain is an inbound surface: it already has readers. Deleting the DNS record strands everyone currently linking to `wittgenstein.wtf`; redirecting (M3) then upgrading (M4) loses nobody. Posture C's "holding page" variant is what M3 *is*, only cheaper — a 302 is strictly better than a holding page because it leaves readers on a maintained surface.
+
+## Kill criteria
+
+- **If the site drifts within 90 days of M4 landing** (i.e., any rendered line stops matching its source-of-truth file), the `data-source` build-time invariant failed; upgrade to a "site is generated from `docs/THESIS.md` on every push" CI step with no human in the loop.
+- **If M3 (redirect) has not shipped 14 days after this RFC merges,** posture collapses — the placeholder's signal cost is now large enough that RFC-0004 is stale; reopen Brief F with a shorter deadline.
+- **If M4 ships but Brief F's rows grow past five true drift cases in 90 days** (measured by monthly audit), the "lift verbatim" contract failed in practice; escalate to Posture B.2 — the site becomes a subdirectory of this repo (`docs/site/`) so drift is caught by existing PR review.
+- **If `wittgenstein.wtf` is subsumed by a different canonical URL** (e.g., a repo move to `wittgenstein-cli.org` or a vanity subdomain under an umbrella org), this RFC is superseded; open RFC-0004.b.
+
+## Decision record
+
+- **Accepted by:** — (no ADR; this RFC is its own terminal artifact — site-ops change, revertible in one PR.)
+- **Superseded by:** —

--- a/docs/rfcs/00_template.md
+++ b/docs/rfcs/00_template.md
@@ -1,0 +1,44 @@
+# RFC-00XX — <title>
+
+**Date:** YYYY-MM-DD
+**Author:** <name (email)>
+**Status:** 🟡 Draft v0.1
+**Feeds from:** <Brief X / earlier RFC / ADR>
+**Ratified by:** ADR-00YY (pending)
+
+**Summary:** one sentence — the design in a tweet.
+
+---
+
+## Context
+
+Why does this RFC exist now? What problem is it solving, and what evidence base (briefs, code smells, external convention) points at it? One paragraph, no more.
+
+## Proposal
+
+The design, stated plainly. A reader should be able to stop here and know what is being proposed. Two to four paragraphs.
+
+## Interface
+
+The concrete surface. Types, signatures, flags, file layouts, whatever is the unit of change. Code blocks with language tags. If the RFC is protocol-shaped, include a round-trip test: show the new shape handling every current case in ≤N lines, and note if anything spills.
+
+```ts
+// example
+```
+
+## Migration
+
+How do we get from today to the proposed surface without breaking receipts? Phased is fine; big-bang is suspect. Name the deprecation window, the shim, and the kill date.
+
+## Red team
+
+Three plausible pushbacks, each answered inline.
+
+## Kill criteria
+
+Concrete events that would force a revision or full withdrawal. If the RFC survives a year with none of these firing, it's genuinely settled.
+
+## Decision record
+
+- **Accepted by:** <ADR-00YY, date>
+- **Superseded by:** — (populate if another RFC replaces this)

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -1,0 +1,54 @@
+# RFCs
+
+Request-for-Comments documents for Wittgenstein. An RFC proposes a concrete design change — interface, protocol, ergonomic surface, naming — with enough detail that a reader could implement it without another meeting.
+
+RFCs complement ADRs and research briefs:
+
+- **Brief** (`docs/research/briefs/`) — pressure-tests a claim or lineage. Output: a verdict.
+- **RFC** (`docs/rfcs/`) — proposes a specific design that ratifies or extends a brief's verdict. Output: an interface and a migration path.
+- **ADR** (`docs/adrs/`) — records that an RFC has been accepted and the decision is now load-bearing. Output: a one-line "we did this."
+
+A brief feeds one or more RFCs. An RFC, once accepted, is ratified by an ADR. Code changes land in a separate execution plan after the ADR.
+
+## Current RFCs
+
+| ID   | Title                                                            | Status          | Ratifying ADR |
+| ---- | ---------------------------------------------------------------- | --------------- | ------------- |
+| 0001 | [Codec Protocol v2](0001-codec-protocol-v2.md)                   | 🟡 Draft v0.1   | ADR-0008 (pending) |
+| 0002 | [CLI ergonomics](0002-cli-ergonomics.md)                         | 🟡 Draft v0.1   | ADR-0009 (pending) |
+| 0003 | [Naming pass](0003-naming-pass.md)                               | 🟡 Draft v0.1   | ADR-0010 (pending) |
+| 0004 | [Site reconciliation actions](0004-site-reconciliation.md)       | 🟡 Draft v0.1   | — |
+
+## Status legend
+
+- 🟢 Accepted — an ADR ratifies it; code may begin.
+- 🟡 Draft — open for review; iterating.
+- 🔴 Not started — placeholder only.
+- ⚫ Superseded — newer RFC replaces it.
+
+## RFC shape
+
+Every RFC ships the following grep-able headings:
+
+```
+## Context
+## Proposal
+## Interface
+## Migration
+## Red team
+## Kill criteria
+## Decision record
+```
+
+An RFC may include a "Round-trip test" section proving the interface handles every current case in ≤N lines. RFC-0001 requires one.
+
+## Review process
+
+1. **Researcher hat** — does the RFC's evidence base survive contact with the briefs it cites?
+2. **Hacker hat** — if an agent read this RFC at 2 a.m., could it write the right migration PR?
+
+Both hats sign off in the PR. On acceptance, a paired ADR lands alongside, and the RFC status flips to 🟢.
+
+## Template
+
+See [00_template.md](00_template.md).


### PR DESCRIPTION
## Summary

Phase P3 of the v0.2 Restructuring Action Outline. Stands up `docs/rfcs/` with a process README + template, then ships four RFCs that turn the P2 brief verdicts into concrete designs.

- **RFC-0001 — Codec Protocol v2** (~4.3k words). Cites all five confirmed code smells (`harness.ts:123-172` branching, `:139-172` manifest overrides, request-schema leaks across audio/svg/asciipng/video, `llm/expand.ts` single-call). `Codec<Req, Art>.produce` as the sole primitive; `IR = Text | Latent | Hybrid` per Brief B's Position iii+iv; 2 LLM rounds by default. Round-trip test fits all 7 modality groups in 11–16 lines each. Five-phase migration sensor → audio → image; Brief A's "VQ → LFQ-family discrete-token decoder" rename lands in M5.
- **RFC-0002 — CLI ergonomics** (~3.0k words). Turns Brief D's 70/30 verdict into commitments: NDJSON+stderr-logs (`gh`), 5-level precedence with `doctor` provenance, `npx @wittgenstein/cli doctor`, uniform `wittgenstein auth` deprecating `minimax-key`. Two deliberate divergences: no REPL through v0.3, no user-facing `--model` on modality commands.
- **RFC-0003 — Naming pass** (~2.0k words). Four names: **Loom** (retires "Parasoid"), **Transducer** (Adapter/Decoder pair), **Score** (Build Artifact primitive), **Handoff** (Brief B's IR sum type, born-named so RFC-0001's M1 avoids a rename).
- **RFC-0004 — Site reconciliation actions** (~1.3k words). Brief F found `wittgenstein.wtf` is a one-line placeholder. Posture B — rewrite, lift verbatim from `docs/THESIS.md` + README showcase grid + quickstart; interim 302 redirect. One-line repo fix: `README.md:5` "text-first LLMs" → "text-first models" to match THESIS. No ADR — site-ops.

Every RFC ships grep-able H2 headings (Context / Proposal / Interface / Migration / Red team / Kill criteria / Decision record). RFC-0001 also carries a Round-trip test.

This closes P3. Next up is **P4 — ADRs 0006–0010** ratifying the three code-path RFCs plus ADR-0006 layered-epistemology (from Brief B) and ADR-0007 formal Path-C rejection.

## Test plan

- [ ] Researcher hat: do the RFC verdicts cleanly inherit from their briefs without re-litigating settled questions?
- [ ] Hacker hat: if an agent read RFC-0001 at 2 a.m., could it write the codec-sensor port in M2 without further questions?
- [ ] Round-trip test in RFC-0001 actually covers all 7 current modality groups in ≤20 lines each.
- [ ] RFC-0002's NDJSON schema version bump does not collide with any existing `schemaVersion` field.
- [ ] RFC-0003's `Handoff` name does not collide with `docs/exec-plans`, `RunManifest`, or any existing type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)