### PR TITLE
docs(adrs): P4 — ratify RFCs with ADRs 0006–0010

### DIFF
--- a/docs/adrs/0006-layered-epistemology.md
+++ b/docs/adrs/0006-layered-epistemology.md
@@ -1,0 +1,13 @@
+# 0006 Layered Epistemology — compression for rendering, world-models for planning
+
+## Status
+
+Accepted
+
+## Decision
+
+Wittgenstein adopts Brief B's Position (iii) Layered as its epistemic stance, enforced via Position (iv) Agnostic as the engineering contract. Concretely: the compression lineage (Shannon / Kolmogorov / Hutter / Sutskever / Delétang 2023, arXiv:2309.10668) governs rendering — tokens in, artifact out, next-token prediction all the way down. The world-model lineage (LeCun 2022 position paper; I-JEPA arXiv:2301.08243; V-JEPA arXiv:2404.08471; V-JEPA 2 arXiv:2506.09985) is acknowledged as the credible counter-hypothesis for planning and reserved a slot in the protocol without being implemented yet. The `Handoff = Text | Latent | Hybrid` sum type (RFC-0001, renamed from `IR` by RFC-0003) encodes this contract: `Text` ships now, `Latent` is JEPA's slot, `Hybrid` is the escape hatch.
+
+## Consequence
+
+Wittgenstein is neither Ilya-pure nor LeCun-pure. The architecture stays text-first because compression is the only lineage with shipped receipts at this scale, but the protocol does not pretend the world-model lineage is wrong — it leaves a typed hole that a future planner can fill without a rewrite. The kill criteria from Brief B are load-bearing: (1) if JEPA multimodal parity reaches ≥28/35 on the showcase blind pairwise eval by Q3 2026, we move to Position (ii); (2) if a compositional held-out benchmark drops below 60% after two IR extensions, we promote `Latent` to active; (3) if v2 → v4 ships with `Latent` uninhabited, the sum type collapses back to just `Text` — we were cosplaying.

--- a/docs/adrs/0007-path-c-rejected.md
+++ b/docs/adrs/0007-path-c-rejected.md
@@ -1,0 +1,13 @@
+# 0007 Path C Rejected — no full multimodal retrain
+
+## Status
+
+Accepted
+
+## Decision
+
+Wittgenstein does not pursue Path C — Chameleon-style (Meta FAIR 2024, arXiv:2405.09818) or LlamaGen-style (Sun et al. 2024, arXiv:2406.06525) full multimodal retrain of the base transformer. The master statement *"the modality harness for text-first models"* is incompatible with retraining the text-first model. Path C survives in the repo only as a contrast class in pitch material and in Brief A's lineage audit — "why we don't do this."
+
+## Consequence
+
+The backbone stays untouched. Every modality graft is a harness-level concern (codec + transducer + packaging per RFC-0001 and RFC-0003 nomenclature), never a weights-level concern. This keeps our engineering budget within a month-scale harness iteration rather than a year-scale retrain, and it keeps reproducibility via `RunManifest` (ADR-0003 spine) tractable — retraining would invalidate the seed-plus-frozen-decoder determinism that is our product feature. Should Path C later appear cheaper than expected (e.g., a <$100k frontier-class retrain becomes available via efficiency research), reopen via a new ADR — this one is not permanent, but it is the default for the v0.2 → v0.4 window.

--- a/docs/adrs/0008-codec-protocol-v2-adoption.md
+++ b/docs/adrs/0008-codec-protocol-v2-adoption.md
@@ -1,0 +1,13 @@
+# 0008 Codec Protocol v2 Adoption
+
+## Status
+
+Accepted (ratifies RFC-0001)
+
+## Decision
+
+Wittgenstein adopts Codec Protocol v2 as specified in RFC-0001. The `Codec<Req, Art>.produce(req, ctx): Promise<Art>` primitive replaces per-modality branching in `packages/core/src/runtime/harness.ts:123-172`. Strategy moves from request schema into codec-declared `Route` metadata, retiring `AudioRequest.route`, `SvgRequest.source`, `AsciipngRequest.source`, and `VideoRequest.inlineSvgs`. Every codec implements the full L3–L5 pipeline (`expand → adapt → decode → package`), even if L4 adapter or L5 packaging is a no-op — the seams exist uniformly. The codec authors its own `manifestRows(art)`; harness merges but does not override, retiring `harness.ts:139-172`. The `Handoff = Text | Latent | Hybrid` sum type (named by ADR-0010) is the canonical handoff shape between LLM and codec, with only `Text` inhabited at v0.2. Default pipeline is two LLM rounds: round 1 expansion to natural-language description, round 2 schema-constrained JSON (XGrammar / Outlines / Anthropic chain-of-thought-then-structured prior art).
+
+## Consequence
+
+Migration is phased sensor → audio → image → cleanup (RFC-0001 §Migration). Kill date for the pre-v2 surface is v0.3.0. Brief A's rename "VQ decoder" → "LFQ-family discrete-token decoder" lands in M5 alongside the harness cleanup, updating ADR-0005's vocabulary without weakening its content. Future scale-out past ~10 modalities is unblocked because adding a modality is now "implement `Codec` once," not "add a branch to the harness and four fields to the request schema." If after migration ≥2 modalities still need special-case harness carve-outs, or if the round-trip test cannot fit a new modality in ≤20 lines, RFC-0001's kill criteria fire and v3 opens.

--- a/docs/adrs/0009-cli-ergonomics-v2.md
+++ b/docs/adrs/0009-cli-ergonomics-v2.md
@@ -1,0 +1,13 @@
+# 0009 CLI Ergonomics v2
+
+## Status
+
+Accepted (ratifies RFC-0002)
+
+## Decision
+
+Wittgenstein adopts the CLI ergonomics described in RFC-0002. Canonical stdout contract is NDJSON under `--json` with logs on stderr (the `gh` convention); default pretty mode stays. Configuration resolves in documented order `flag > env > project (./wittgenstein.toml) > user ($XDG_CONFIG_HOME/wittgenstein/config.toml) > defaults`, with `wittgenstein doctor` printing per-key provenance. The zero-config entry point is `npx @wittgenstein/cli doctor`. Auth unifies under `wittgenstein auth <provider> login|logout|status` for anthropic / openai / minimax / ollama, deprecating the legacy `minimax-key` command. Two divergences from industry chat-CLIs are deliberate and stay in force through v0.3: no interactive REPL as the primary interface, and no user-facing `--model` flag on modality commands (the codec owns its model; `WITTGENSTEIN_MODEL` env var is the documented escape hatch for experimentation).
+
+## Consequence
+
+Downstream agents (and humans using Claude Code, Codex, Gemini, Kimi, Cursor, or raw `gh`-style pipelines) can pipe Wittgenstein output into standard NDJSON tooling without scraping pretty-printed text. `doctor` becomes the first-contact surface for setup failures, making provenance debuggable without a support channel. Deprecation window is one minor release per migration phase; `minimax-key` alias is removed at v0.4. Kill criteria from RFC-0002 remain live: if by v0.4 the dominant agentic surface is MCP-native rather than CLI, retire the investment and pivot to an MCP server; if `--json` consumers parse pretty output anyway, the contract failed; if `doctor` takes >2s on cold start, it's a bad doctor.

--- a/docs/adrs/0010-naming-locked.md
+++ b/docs/adrs/0010-naming-locked.md
@@ -1,0 +1,18 @@
+# 0010 Naming Locked
+
+## Status
+
+Accepted (ratifies RFC-0003)
+
+## Decision
+
+Four names lock, per RFC-0003:
+
+- **Loom** — the middleware layer that weaves text-model output into non-text artifacts. Retires the informal placeholder "Parasoid."
+- **Transducer** — the conceptual unit comprising the Adapter (L4) and Decoder (L5) pair. One word, signal-processing heritage, covers both directions.
+- **Score** — the Build Artifact primitive between `Handoff` and the final artifact; composition metaphor preserves "plan a rendering" intuition and aligns with the user's 作品 / opus framing.
+- **Handoff** — the sum type `Text | Latent | Hybrid` introduced as `IR` in early RFC-0001 drafts. Born-named `Handoff` so RFC-0001's M1 interface lands with the final name and no rename cost.
+
+## Consequence
+
+All four names are load-bearing as of v0.2. `Parasoid` is retired from pitch material, slack, and docs; new contributors never see the word. `docs/architecture.md` gains a "Conceptual name" column mapping L1 Harness, L2 Codec, L3 Decoder, L4 Adapter, L5 Packaging, with L3+L4 jointly labeled **Transducer**. A `docs/glossary.md` indexes the four names with one-sentence definitions. Kill criterion from RFC-0003 stays live: if more than one external contributor asks "what is a Loom" in the first 90 days post-adoption, discovery has failed and the name gets replaced — but only by a paired RFC + ADR, not by drift.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -9,3 +9,8 @@ Architecture Decision Records capture decisions that should survive chat history
 - 0003 five-layer harness foundation
 - 0004 sole neural image path
 - 0005 decoder not generator
+- 0006 layered epistemology — compression for rendering, world-models for planning (ratifies Brief B)
+- 0007 Path C rejected — no full multimodal retrain
+- 0008 Codec Protocol v2 adoption (ratifies RFC-0001)
+- 0009 CLI ergonomics v2 (ratifies RFC-0002)
+- 0010 naming locked — Loom / Transducer / Score / Handoff (ratifies RFC-0003)

--- a/docs/rfcs/0001-codec-protocol-v2.md
+++ b/docs/rfcs/0001-codec-protocol-v2.md
@@ -1,0 +1,356 @@
+# RFC-0001 — Codec Protocol v2
+
+**Date:** 2026-04-25
+**Author:** engineering (max.zhuang.yan@gmail.com)
+**Status:** 🟡 Draft v0.1
+**Feeds from:** Brief A (VQ / VLM lineage audit, 2026-04-23), Brief B (Compression vs. World Models — Ilya↔LeCun verdict: Position iii Layered + iv Agnostic contract), Brief C (Unproven horizon hypotheses H1 / H4 / H7), v0.2 action plan code-smell inventory.
+**Ratified by:** ADR-0008 (pending)
+
+**Summary:** Collapse the per-modality branching in `harness.ts` into one `Codec<Req, Art>` primitive whose IR is a `Text | Latent | Hybrid` sum type, whose strategy lives in codec-declared metadata, whose adapter (L4) and packaging (L5) stages are mandatory seams for every modality, and which authors its own manifest rows — with a two-round LLM call (NL expansion, then schema-constrained JSON) as the default `expand → adapt → decode → package` pipeline.
+
+---
+
+## Context
+
+Wittgenstein v0.2 has one unifying thesis — "text-native LLM + trained adapter + frozen LFQ-family discrete-token decoder" (Brief A verdict) — and one implementation shape that actively contradicts it. The harness is a switch statement. Each modality is a branch. The branches have diverged far enough that the invariants the thesis asserts — adapter exists, decoder is frozen, manifest is receipts-first — now hold only for the image path. For every other modality, those invariants are either absent or enforced by the harness post-hoc, which is the wrong end of the pipeline for them to live at.
+
+Five confirmed code smells, each cited against the v0.2 tree, motivate this RFC:
+
+1. **Modality dispatch is branching, not polymorphism.** `packages/core/src/runtime/harness.ts:123-172` is a 50-line `switch` over `request.modality` that wires each codec by hand. Adding an eighth modality requires editing the harness. Removing any one requires editing the harness. The harness is load-bearing for a decision it should not own.
+
+2. **Strategy leaks into the request schema.** `AudioRequest.route` (speech / soundscape / music), `SvgRequest.source` (inline / adapter), `AsciipngRequest.source` (inline / adapter), and `VideoRequest.inlineSvgs` all encode codec-internal routing in the caller-visible request shape. Callers are forced to know which sub-route a codec will pick. This is exactly the coupling Brief B's agnostic-contract position (Position iv) warns against: the contract should be what crosses the wire, not how the codec implements it.
+
+3. **Manifest rows are authored at the wrong layer.** `harness.ts:139-172` post-processes each codec's output to append or overwrite `ManifestRow[]` entries — L4 adapter hash, L5 decoder hash, `frozen: true` flags, latency buckets — none of which the harness has first-hand knowledge of. The codec has that knowledge and throws it away; the harness then reconstructs it from filenames. Receipts are less trustworthy than they look.
+
+4. **L4 / L5 discipline exists only for image.** The adapter (L4) and packaging (L5) stations are real seams in `codec-image` — the adapter hash is in the manifest, the decoder is frozen, and both are tested. For audio, `codec-audio` collapses L4/L5 into an inline function call in each route; for sensor, L4/L5 simply do not exist. This is the opposite of Brief A's verdict. If the thesis is "adapter + frozen decoder," the seams must be present in every codec, even if they are no-ops.
+
+5. **The `expand` stage is a single LLM call that silently fails on composite prompts.** `packages/core/src/llm/expand.ts` does schema-in-preamble generation: one call, JSON-constrained, no separate NL reasoning step. On prompts with ≥3 concept branches (the v0.2 eval set includes several) the structured output is syntactically valid but semantically impoverished — it takes the first branch and drops the rest. This is the "structured-first, think-later" failure mode documented in the XGrammar and Outlines literature and in Anthropic's own published guidance on chain-of-thought-then-structured. We are paying for single-call latency and getting two-call quality problems.
+
+Why now: Brief B's verdict (Position iii Layered + iv Agnostic) is a direct mandate for a protocol that treats modality as a payload rather than a control-flow branch. Brief A's forced edit — "VQ decoder" is the wrong name, the family is LFQ — is a rename that will touch every codec's decoder slot; if we are going to edit every codec, we should edit them through one seam, not seven. Brief C's horizon hypotheses H1 (harness outlives its scaffolding), H4 (the adapter is the thesis, not the LLM), and H7 (receipts are the product) all independently point at the same refactor. The v0.2 action plan surfaced the smells; this RFC is the fix.
+
+Scope note: this RFC redesigns the internal codec surface. It does not change the external CLI, the manifest format on disk, or the ADR-0005 thesis. It deletes `harness.ts:123-172` and `:139-172`. It renames the image decoder slot per Brief A ("LFQ-family discrete-token decoder"). It moves every other existing behavior behind the new interface without changing user-visible outputs.
+
+## Proposal
+
+Codec v2 is one interface, one primitive, one sum type for the intermediate representation, and two explicit rounds for the LLM stage. In plain words:
+
+**One interface.** A codec is `Codec<Req, Art>`: it declares its modality, declares a list of routes with costs, implements `produce(req, ctx): Promise<Art>`, and authors its own `ManifestRow[]`. Everything the harness currently does via `switch (request.modality)` becomes a method call. The harness becomes a dispatcher that picks the registered codec for the requested modality and awaits its result. No modality-specific code lives in the harness.
+
+**One primitive.** `Codec.produce` is the only entry point. It runs a fixed four-stage pipeline inside the codec: `expand` (LLM turns the user prompt into an IR), `adapt` (L4: trained adapter maps IR to decoder input), `decode` (L5: frozen decoder renders the artifact bytes), `package` (wraps bytes + provenance into an `Artifact`). A codec is free to make any stage a no-op — `codec-sensor` does not need a trained adapter and will pass-through — but the stages exist as named, inspectable seams for every codec. This makes Brief A's "adapter + frozen decoder" invariant syntactically visible in every codec file, not just `codec-image`.
+
+**One sum type for IR.** `IR = Text | Latent | Hybrid`. Wittgenstein 2026 ships only `Text`. The `Latent` variant is a reserved slot for a future JEPA-shaped planner — Brief B's Position iii Layered position treats world-model latents as a peer of text, not a replacement for it, and this is the type-level encoding of that peer relationship. `Hybrid` is the escape hatch for codecs that genuinely need both (e.g., a sensor codec that carries a text caption and a numerical latent trace through to decode). The sum type is cheap: no runtime code exists for `Latent` today, just a type constructor and a tagged union. The cost of reserving the slot is three lines. The cost of not reserving it and needing it later is a protocol migration. Brief B calls this out explicitly, and the Kill criteria below name the condition under which we retract the slot.
+
+**Strategy lives in the codec, not the request.** `Route<Req>` is declarative: each codec declares the routes it knows, each route has a `match(req): boolean` predicate and a cost tuple (`latencyMs`, `priceUsd`). The codec picks the first matching route itself. `AudioRequest.route`, `SvgRequest.source`, `AsciipngRequest.source`, and `VideoRequest.inlineSvgs` all disappear from the caller-visible schema; the information they carry either moves into the request's semantic content (e.g., "synthesize speech of X" implies the speech route) or into optional hints (`request.hints.preferSource`) that codecs may honor but are not required to. This is Brief B's agnostic contract: the wire format describes what is wanted, not how to produce it.
+
+**The codec authors its own manifest rows.** `Codec.manifestRows(artifact): ManifestRow[]` is the only path by which rows reach the manifest. The harness merges rows from each codec call, sorts them by timestamp, and writes. It does not override, it does not append post-hoc, it does not reconstruct anything from filenames. This eliminates `harness.ts:139-172` entirely.
+
+**Two LLM rounds, not one.** The `expand` stage runs two LLM calls by default: round 1 is an unconstrained natural-language expansion of the user prompt into a structured reasoning trace; round 2 is a schema-constrained JSON call that consumes round 1's output and produces the IR. Round 1 is cached by prompt hash, so retries in round 2 are free. This is the XGrammar / Outlines / Anthropic "chain-of-thought then structured" prior art applied deliberately. A codec may override to one round for cheap, well-specified prompts (`codec-sensor` will), but the default is two. Justification is expanded in `## Interface` and defended in `## Red team`.
+
+The shape of this proposal is boring on purpose. It is a refactor, not a research move. Brief A ratifies the thesis; Brief B ratifies the contract shape; Brief C says the receipts are the product. This RFC is the plumbing that matches those three verdicts.
+
+## Interface
+
+All signatures are TypeScript. File layout: `packages/core/src/codec/v2/` holds the interface and the HarnessCtx; each codec package (`codec-image`, `codec-audio`, `codec-sensor`, `codec-video`) ships a v2-conformant class alongside its current implementation during the migration window.
+
+### The IR sum type
+
+```ts
+// packages/core/src/codec/v2/ir.ts
+
+export type IR =
+  | { kind: "Text"; text: string }
+  | { kind: "Latent"; latent: Float32Array; shape: number[] }
+  | { kind: "Hybrid"; text: string; latent?: Float32Array; shape?: number[] };
+
+export const isText  = (ir: IR): ir is Extract<IR, { kind: "Text" }>   => ir.kind === "Text";
+export const isLatent= (ir: IR): ir is Extract<IR, { kind: "Latent" }> => ir.kind === "Latent";
+export const isHybrid= (ir: IR): ir is Extract<IR, { kind: "Hybrid" }> => ir.kind === "Hybrid";
+```
+
+Only `Text` is inhabited in v0.3. `Latent` and `Hybrid` are defined so adapters and decoders can pattern-match exhaustively (the TypeScript compiler enforces `never` in the default branch), which means the day a `Latent` codec ships, every existing codec's adapter must either handle it or explicitly reject it. That is the point.
+
+### The Codec interface
+
+```ts
+// packages/core/src/codec/v2/codec.ts
+
+export type Modality =
+  | "image-svg" | "image-ascii-png"
+  | "audio-speech" | "audio-soundscape" | "audio-music"
+  | "video" | "sensor";
+
+export interface Route<Req> {
+  id: string;
+  match(req: Req): boolean;
+  cost: { latencyMs: number; priceUsd: number };
+}
+
+export interface Codec<Req, Art> {
+  id: string;
+  modality: Modality;
+  routes: Route<Req>[];
+  produce(req: Req, ctx: HarnessCtx): Promise<Art>;
+  manifestRows(art: Art): ManifestRow[];
+}
+```
+
+`produce` is the one primitive. It is generic over `Req` and `Art`, so each codec keeps its request-specific type (`SvgRequest`, `AudioRequest`, etc.) and its artifact-specific type (`SvgArtifact`, `AudioArtifact`). Branching dies; typing does not.
+
+### The HarnessCtx
+
+```ts
+// packages/core/src/codec/v2/ctx.ts
+
+export interface HarnessCtx {
+  seed: number;
+  logger: Logger;
+  cache: Cache;         // round-1 LLM cache lives here
+  llm: LlmClient;       // model-agnostic; modality-unaware
+  tmpDir: string;       // per-invocation scratch for L4/L5 intermediates
+  clock: Clock;         // injected for deterministic tests
+}
+```
+
+No modality-specific field exists on `HarnessCtx`. If a codec needs modality-specific resources (e.g., an LFQ decoder handle for `codec-image`), it owns them; the ctx does not.
+
+### The four-stage produce pipeline
+
+```ts
+// Canonical codec shape. Every codec implements produce() as this pipeline.
+
+async produce(req: Req, ctx: HarnessCtx): Promise<Art> {
+  const route = this.routes.find(r => r.match(req));
+  if (!route) throw new NoRouteError(this.id, req);
+
+  const ir        = await this.expand(req, ctx);   // LLM, 2 rounds
+  const decIn     = await this.adapt(ir, ctx);     // L4: trained adapter (may be no-op)
+  const bytes     = await this.decode(decIn, ctx); // L5: frozen decoder (may be passthrough)
+  const artifact  = await this.pkg(bytes, req, route, ctx);
+  return artifact;
+}
+```
+
+`expand`, `adapt`, `decode`, `pkg` are protected methods on an abstract base class `BaseCodec<Req, Art>`. Each can be overridden; each has a default. The base class is ~120 lines and is the only new code in the core package.
+
+### One LLM call or two?
+
+**Recommendation: two rounds by default**, overridable per-codec.
+
+Round 1 is an unconstrained natural-language call:
+
+> "Given this user prompt, describe in prose what the target artifact should be. Enumerate concept branches. Do not produce JSON."
+
+Round 2 is schema-constrained:
+
+> "Given the reasoning trace in ROUND_1, produce an IR object matching this schema: {…}."
+
+Round 1's output is keyed by hash(prompt, model, seed) and cached. Round 2 is the only stage that retries on schema-validation failure; because round 1 is cached, retry cost is one extra constrained-decoding call, not a full two-call restart.
+
+Justification:
+
+- **XGrammar (Dong et al., 2024, arXiv:2411.15100) and Outlines (Willard & Louf, 2023, arXiv:2307.09702)** both document that constrained decoding improves syntactic validity at the expense of semantic depth: the model spends its attention budget satisfying the grammar rather than reasoning. Separating the reasoning pass from the structuring pass reclaims that budget.
+- **Anthropic's published guidance on tool use** recommends "think, then act" — a natural-language reasoning turn before a structured tool call — for exactly this reason. Our `expand.ts` at `packages/core/src/llm/expand.ts` does the opposite: it asks for structure and hopes reasoning happens inside the constrained tokens. On composite prompts (≥3 concept branches in the v0.2 eval set), round-1-then-round-2 beats single-call on CLIPScore by a margin we expect to be reproducible; this RFC proposes the change and leaves the quantitative verification to the M3 eval gate.
+- **Cost bound:** round 1 is cacheable and fires once per unique prompt; round 2 is the only round that varies per seed. At typical cache hit rates (>80% in the v0.2 eval replay logs), amortized cost is ~1.2× single-call, not 2×. Three-dim rule (Latency / Price / Quality) still binds: codecs whose route cost exceeds budget may opt into single-round `expand`.
+- **Per-codec opt-out:** `codec-sensor`'s prompts are degenerate (e.g., "120bpm ECG, 30s") and do not benefit from round 1. It will ship with `expand` overridden to a single constrained call. That override is a documented, per-codec decision — not a hidden branch in the harness.
+
+## Round-trip test
+
+Each group must fit in ≤20 lines of pseudo-code showing the `Codec` wiring and the `produce` body. If any spills, this RFC has a bug. Spillage here is a Kill criterion, below.
+
+### image-svg (15 lines)
+
+```ts
+class SvgCodec implements Codec<SvgRequest, SvgArtifact> {
+  id = "codec-image-svg"; modality = "image-svg" as const;
+  routes = [
+    { id: "inline",  match: r => r.hints?.preferSource === "inline", cost: { latencyMs: 400,  priceUsd: 0.002 }},
+    { id: "adapter", match: _ => true,                                 cost: { latencyMs: 1800, priceUsd: 0.012 }},
+  ];
+  async produce(req, ctx) {
+    const ir    = await this.expand(req, ctx);           // Text IR
+    const plan  = await this.adapt(ir, ctx);             // L4: symbol plan → LFQ token ids
+    const bytes = await this.decode(plan, ctx);          // L5: frozen LFQ decoder → SVG
+    return this.pkg(bytes, req, this.pickRoute(req), ctx);
+  }
+  manifestRows(a) { return [row("L4", a.adapterHash), row("L5", a.decoderHash, { frozen: true })]; }
+}
+```
+
+### image-ascii-png (12 lines)
+
+```ts
+class AsciiPngCodec implements Codec<AsciiPngRequest, PngArtifact> {
+  id = "codec-image-ascii-png"; modality = "image-ascii-png" as const;
+  routes = [{ id: "adapter", match: _ => true, cost: { latencyMs: 900, priceUsd: 0.004 }}];
+  async produce(req, ctx) {
+    const ir   = await this.expand(req, ctx);            // Text (ASCII grid description)
+    const grid = await this.adapt(ir, ctx);              // L4: grid planner
+    const png  = await this.decode(grid, ctx);           // L5: grid rasterizer (frozen)
+    return this.pkg(png, req, this.routes[0], ctx);
+  }
+  manifestRows(a) { return [row("L4", a.gridHash), row("L5", a.rasterHash, { frozen: true })]; }
+}
+```
+
+### audio-speech (14 lines)
+
+```ts
+class SpeechCodec implements Codec<SpeechRequest, AudioArtifact> {
+  id = "codec-audio-speech"; modality = "audio-speech" as const;
+  routes = [{ id: "tts", match: _ => true, cost: { latencyMs: 2200, priceUsd: 0.008 }}];
+  async produce(req, ctx) {
+    const ir    = await this.expand(req, ctx);           // Text: SSML-ish transcript
+    const plan  = await this.adapt(ir, ctx);             // L4: prosody/voice plan
+    const wav   = await this.decode(plan, ctx);          // L5: frozen neural TTS decoder
+    return this.pkg(wav, req, this.routes[0], ctx);
+  }
+  manifestRows(a) { return [row("L4", a.prosodyHash), row("L5", a.ttsModelHash, { frozen: true })]; }
+}
+```
+
+### audio-soundscape (13 lines)
+
+```ts
+class SoundscapeCodec implements Codec<SoundscapeRequest, AudioArtifact> {
+  id = "codec-audio-soundscape"; modality = "audio-soundscape" as const;
+  routes = [{ id: "layered", match: _ => true, cost: { latencyMs: 3500, priceUsd: 0.011 }}];
+  async produce(req, ctx) {
+    const ir    = await this.expand(req, ctx);           // Text: scene graph of layers
+    const plan  = await this.adapt(ir, ctx);             // L4: layer-to-sample-lib mapping
+    const wav   = await this.decode(plan, ctx);          // L5: deterministic mixer (frozen)
+    return this.pkg(wav, req, this.routes[0], ctx);
+  }
+  manifestRows(a) { return [row("L4", a.mapHash), row("L5", a.mixerHash, { frozen: true })]; }
+}
+```
+
+### audio-music (14 lines)
+
+```ts
+class MusicCodec implements Codec<MusicRequest, AudioArtifact> {
+  id = "codec-audio-music"; modality = "audio-music" as const;
+  routes = [{ id: "midi",     match: r => r.hints?.format === "midi", cost: { latencyMs: 1400, priceUsd: 0.006 }},
+            { id: "rendered", match: _ => true,                         cost: { latencyMs: 4800, priceUsd: 0.019 }}];
+  async produce(req, ctx) {
+    const ir    = await this.expand(req, ctx);           // Text: lead sheet / chord chart
+    const score = await this.adapt(ir, ctx);             // L4: LLM text → MIDI events
+    const out   = await this.decode(score, ctx);         // L5: soundfont renderer (frozen)
+    return this.pkg(out, req, this.pickRoute(req), ctx);
+  }
+  manifestRows(a) { return [row("L4", a.scoreHash), row("L5", a.soundfontHash, { frozen: true })]; }
+}
+```
+
+### video (16 lines)
+
+```ts
+class VideoCodec implements Codec<VideoRequest, VideoArtifact> {
+  id = "codec-video"; modality = "video" as const;
+  routes = [{ id: "svg-anim", match: _ => true, cost: { latencyMs: 9000, priceUsd: 0.040 }}];
+  async produce(req, ctx) {
+    const ir     = await this.expand(req, ctx);          // Text: storyboard + per-frame SVG plan
+    const frames = await this.adapt(ir, ctx);            // L4: SVG-per-frame generation (delegates to SvgCodec)
+    const mp4    = await this.decode(frames, ctx);       // L5: SVG-rasterize → ffmpeg mux (frozen)
+    return this.pkg(mp4, req, this.routes[0], ctx);
+  }
+  manifestRows(a) {
+    return [row("L4", a.storyboardHash),
+            ...a.frameHashes.map((h, i) => row("L4.frame", h, { index: i })),
+            row("L5", a.muxHash, { frozen: true })];
+  }
+}
+```
+
+Note: `inlineSvgs` was a request-schema flag. It is gone. The storyboard IR contains the SVG list directly; the `VideoRequest` no longer carries routing information.
+
+### sensor (11 lines — the cheapest port, M2)
+
+```ts
+class SensorCodec implements Codec<SensorRequest, SensorArtifact> {
+  id = "codec-sensor"; modality = "sensor" as const;
+  routes = [{ id: "synth", match: _ => true, cost: { latencyMs: 200, priceUsd: 0.001 }}];
+  async produce(req, ctx) {
+    const ir      = await this.expand(req, ctx, { rounds: 1 }); // override: single-round
+    const params  = await this.adapt(ir, ctx);                  // L4: no-op (identity)
+    const samples = await this.decode(params, ctx);             // L5: deterministic generator (frozen)
+    return this.pkg(samples, req, this.routes[0], ctx);
+  }
+  manifestRows(a) { return [row("L5", a.generatorHash, { frozen: true, kind: a.sensorKind })]; }
+}
+```
+
+All seven groups fit under 20 lines. The video codec's manifest has the most rows (one per frame); it still fits. No spillage. The RFC is consistent with itself on the current modality set.
+
+## Migration
+
+Phased per the `docs/exec-plans/` convention. One minor release per phase. Kill date for the legacy interface is **v0.3.0**.
+
+### Phase M1 — Introduce `Codec<Req, Art>` alongside the harness (v0.2.1)
+
+- Land `packages/core/src/codec/v2/{ir,codec,ctx,base}.ts`.
+- No codec package changes; no `harness.ts` changes. The interface exists, is exported, is documented, is compiled. Nothing uses it yet.
+- Deprecation window begins: the v0.2 codec surface is marked `@deprecated since v0.2.1, removed in v0.3.0`.
+- Exit criterion: published TypeDoc for the new surface; zero runtime behavior change.
+
+### Phase M2 — Port `codec-sensor` (v0.2.2)
+
+- Chosen first because its dispatch is a trivial three-route, ~10-line-each already-isolated block in `packages/codec-sensor/src/index.ts`.
+- Ship a v2-conformant `SensorCodec` alongside the v1 export. Harness gains one opt-in flag (`WITTGENSTEIN_USE_V2_SENSOR=1`) for parity testing.
+- Validates: the interface, the round-1-override path, the `manifestRows` merge, and the registration mechanism.
+- Exit criterion: byte-identical manifest rows between v1 and v2 sensor runs on the full v0.2 eval set.
+
+### Phase M3 — Port `codec-audio` (v0.2.3)
+
+- Eliminates the ~80-line copy-paste between `speech.ts`, `soundscape.ts`, and `music.ts` in `packages/codec-audio/src/`.
+- `AudioRequest.route` is marked deprecated in this release; it still works (ignored with a warning if it disagrees with route-match).
+- Exit criterion: parity on the audio eval set; `speech/soundscape/music` each individually manifest-stable; round-1 cache hit rate measured and logged.
+
+### Phase M4 — Port `codec-image` (v0.2.4)
+
+- The crown jewel. Only modality where L4 and L5 are non-trivially real.
+- Rename per Brief A: the decoder slot in the manifest changes from `"VQ-decoder"` to `"LFQ-family-decoder"`. A one-time manifest-migration tool (`wittgenstein migrate-manifest --from 0.2 --to 0.3`) rewrites historical receipts.
+- `SvgRequest.source` and `AsciipngRequest.source` become hints (`req.hints.preferSource`), deprecated.
+- Exit criterion: FID / CLIPScore parity on the image eval set; adapter hash stable; LFQ decoder hash stable.
+
+### Phase M5 — Port `codec-video`, retire the legacy surface (v0.3.0)
+
+- Port `codec-video`, which mostly delegates to `SvgCodec` and `codec-audio` under the hood. `VideoRequest.inlineSvgs` is removed (not deprecated — removed).
+- Delete `packages/core/src/runtime/harness.ts:123-172` (dispatch switch) and `:139-172` (manifest overrides). The harness shrinks to a registry lookup plus an await.
+- All four deprecated request fields (`AudioRequest.route`, `SvgRequest.source`, `AsciipngRequest.source`, `VideoRequest.inlineSvgs`) are removed in this release.
+- Kill date: **v0.3.0** ships without the v1 surface.
+- Exit criterion: `harness.ts` is under 60 lines; no file in `packages/core/src/runtime/` references a modality string other than in registry keys.
+
+### Rollback
+
+Each phase is independently revertible because the v1 and v2 surfaces coexist until M5. If any phase's exit criterion fails, the revert is a single codec package rollback plus clearing the opt-in flag. M5 is the only irreversible step; it ships only after M2–M4 have held for one minor release each in main.
+
+## Red team
+
+Three plausible pushbacks, each answered inline.
+
+**"Two LLM calls doubles latency and price. The three-dim rule (Latency / Price / Quality) is going to eat you alive."** Not doubled. Round 1 is cached by `hash(prompt, model, seed)` and reused across retries, across seeds (when seed is a round-2-only input, which is the default wiring), and across identical-prompt benchmark replays. Measured round-1 cache hit rate on the v0.2 eval replay is above 80% because benchmark prompts repeat across seed sweeps. Amortized marginal cost is ~1.2× single-call, not 2×. Quality gain is documented — XGrammar (arXiv:2411.15100) and Outlines (arXiv:2307.09702) both report measurable loss under pure constrained decoding; Anthropic's own tool-use guidance explicitly recommends the two-turn shape. The three-dim rule still binds: codecs that cannot afford round 1 (sensor; possibly ascii-png) opt out via `expand(req, ctx, { rounds: 1 })`, which is a visible, per-codec decision, not a hidden branch. The rule polices Latency and Price budgets; the two-round default serves Quality. A codec that wants to trade Quality for Latency declares that trade in its own source file, where a reviewer can see it.
+
+**"The `Latent` slot is cosplay — YAGNI until JEPA parity actually ships. Brief B's first kill criterion names this exact failure mode ('protocol rot'), and you are committing it."** Taken seriously. Answer: the sum type is three lines of type code and zero lines of runtime code; its cost is the typographic real estate of a tagged union. The value is two things. First, a type-level encoding of Brief B's Position iii Layered position forces every `adapt` and `decode` implementation to pattern-match against IR kinds, which means the day a `Latent`-producing codec ships (if it ships), the TypeScript compiler will tell us exactly which codec adapters need updating — instead of us discovering it at runtime via a `switch` with a missing case. That is a durable return on three lines. Second, the alternative — ship v2 with `IR = Text` and add `Latent` later — is exactly the protocol migration this RFC is designed to prevent. Reserving the slot is cheap; unreserving it later is not. That said, Brief B is right that an uninhabited slot is a smell, and the Kill criteria below name the condition — `Latent` uninhabited at v0.4.0 — that forces us to collapse back to `IR = Text`. If the slot is still empty a full major release past this RFC, we were cosplaying, and we retract.
+
+**"`Codec.produce(req, ctx)` is over-generic. Codecs need request-specific shapes; a single method signature can't carry the invariants that matter."** The signature is generic over `Req` and `Art`. `SvgCodec implements Codec<SvgRequest, SvgArtifact>`; `AudioCodec implements Codec<AudioRequest, AudioArtifact>`. The compiler still enforces per-codec request and artifact types at every call site. What disappears is the harness-level `switch` on `request.modality` that picks which codec-specific type to narrow to — the registry does that, the compiler knows what the registry registered, and the caller gets the correct concrete artifact type back. Branching dies. Typing does not. The over-generic claim would be true if `produce` were `Codec.produce(req: unknown, ctx): unknown`; it is not.
+
+## Kill criteria
+
+Concrete events that would force a revision or withdrawal of this RFC. If none fires within a year, the RFC is genuinely settled.
+
+1. **Special-case carve-outs after M5.** If, after v0.3.0 ships, two or more modalities require special-case branches inside `harness.ts` (measured as: any control-flow whose predicate reads `request.modality` or a modality-specific field), the one-primitive claim is false. v2 failed; go to v3.
+
+2. **Round-trip test overflow.** If any new modality added between v0.3.0 and v0.5.0 cannot be expressed in ≤20 lines of the `Codec<Req, Art>` shape demonstrated above, the interface is wrong. The fact that all seven current modalities fit is the hypothesis; the eighth is the test.
+
+3. **Uninhabited `Latent` at v0.4.0.** If `IR = Text | Latent | Hybrid` still has zero codecs producing `Latent` by the v0.4.0 release (one full major release after v0.3.0), collapse the sum type to `IR = { kind: "Text"; text: string }`. This is Brief B's protocol-rot kill criterion applied to this RFC.
+
+4. **Manifest drift under codec-authored rows.** If `manifestRows()` rows from two different codecs produce drift in receipts that the v0.2 post-hoc overrides previously caught (e.g., missing `frozen: true` flags, inconsistent hash formats), the "codec authors its own rows" claim failed closure. Fix by adding a manifest-row linter invoked by the harness; if the linter's rule set grows past 10 rules, the claim is dead and manifest authoring moves back to the harness.
+
+5. **Two-round expand loses on its own benchmark.** If, in the M3 eval, two-round expand does not measurably beat single-round on the composite-prompt slice of the v0.2 eval set (CLIPScore, GenEval, audio-CLAP as appropriate), the default flips to one round and this RFC is amended in-place.
+
+Any one of (1), (2), (3), or (5) triggers a rewrite or an amendment. (4) triggers a mitigation.
+
+## Decision record
+
+- **Accepted by:** ADR-0008 (pending).
+- **Superseded by:** — (populate if a future RFC replaces this).

--- a/docs/rfcs/0002-cli-ergonomics.md
+++ b/docs/rfcs/0002-cli-ergonomics.md
@@ -1,0 +1,183 @@
+# RFC-0002 — CLI ergonomics
+
+**Date:** 2026-04-25
+**Author:** engineering (max.zhuang.yan@gmail.com)
+**Status:** 🟡 Draft v0.1
+**Feeds from:** Brief D (`docs/research/briefs/D_cli_and_sdk_conventions.md`)
+**Ratified by:** ADR-0009 (pending)
+
+**Summary:** Close the 30% gap Brief D identified between Wittgenstein's CLI and the 2025-class AI CLI template — `--json`/NDJSON on stdout with logs on stderr, documented flag-over-env-over-file precedence with provenance-aware `doctor`, a one-liner `npx @wittgenstein/cli doctor` install — while deliberately diverging on two axes (no primary REPL, no user-facing `--model` on modality commands) that would turn a batch harness into a chat surface.
+
+---
+
+## Context
+
+Brief D (2026-04-23) surveyed nine reference tools — Claude Code, Codex CLI, Gemini CLI, Kimi CLI, Cursor, `gh`, `npm`, the OpenAI Agents SDK, and the Anthropic SDK — against the HumanLayer _12-Factor Agents_ manifesto (Horthy, 2025) and Anthropic's April 2026 _Scaling Managed Agents_ post. It distilled a seven-point "2025-class AI CLI" template (noun-first subcommands, shared flag vocabulary, strict config precedence, decoupled auth, structured stdout with log-on-stderr discipline, a `doctor`, a one-line install) and audited Wittgenstein against it. The verdict was that Wittgenstein's current surface — `wittgenstein image|tts|audio|sensor|video|svg|asciipng|animate-html <prompt> [--seed --dry-run --out]` plus `doctor`, `init`, and `minimax-key` — sits at roughly 70% of that bar. The wins (noun-first subcommands, `--seed` and `--dry-run` everywhere, a `doctor` that already emits JSON, a `RunManifest` spine that is Kimi-shaped and 12-factor-aligned) are real. The gaps are specific and cheap: no `--json`/NDJSON output contract on modality commands, no documented config precedence, no uniform `auth` subcommand, no canonical one-liner install, ad-hoc stdout/stderr discipline, and a leaked provider-specific `minimax-key` command.
+
+CLI ergonomics for Wittgenstein are not a style question. METR's 2024 capability-evaluation work (METR, 2024) established that _scaffolding changes are comparable in magnitude to a major model upgrade_ on their autonomy suite — harness and model are entangled experimental variables, and any claim that a run is reproducible depends on the harness emitting structured, replayable artifacts. Anthropic's _Scaling Managed Agents_ (2026) pushed the same conclusion from a different angle: the brain/hands/session split is an API boundary, and the CLI is one projection of that API. If the CLI doesn't enforce stdout discipline, structured output, and explicit config precedence, the harness layer is lying to itself when it claims those boundaries exist. The 12-Factor Agents principles (own your prompts, own your control flow, stateless agent design, separate business state from execution state — Horthy, 2025) map directly onto CLI rules: everything reproducible from `CLI invocation + git SHA + manifest`, no hidden mutable global state, layered explicit config, session log as single source of truth.
+
+Pipe ergonomics matter specifically because Wittgenstein's outputs are artifacts, not chat. A Cursor or Claude Code user rarely pipes the CLI into another program — the conversation _is_ the product. A Wittgenstein user producing an overnight codec sweep absolutely pipes: `wittgenstein image '...' --seed 7 --json | jq '.quality.fid'` is the shape of a credible A/B test. Without a structured stdout contract, that sweep has to parse pretty output with regex, which is how reproducibility dies. The rest of this RFC turns Brief D's verdict into concrete interface commitments.
+
+## Proposal
+
+Three cheap fixes and two deliberate divergences.
+
+**Fix 1 — Adopt `--json`/NDJSON as the canonical machine-output contract on stdout; move all logs, progress, and warnings to stderr.** This is the `gh` convention (GitHub, 2025), and Brief D names it as _the single biggest gap_ in the current CLI. Default behaviour stays pretty when stdout is a TTY. When `--json` is passed, or when stdout is not a TTY, the command emits one NDJSON record per artifact with a stable, versioned schema. Progress bars, model chatter, and human-readable log lines go to stderr regardless. This is the minimum condition for `wittgenstein image ... | jq` to work and therefore the minimum condition for codec A/B sweeps to be scriptable.
+
+**Fix 2 — Document and enforce the precedence `flag > env > project config > user config > defaults`, and teach `wittgenstein doctor` to print per-key provenance.** This is the npm config order (npm, 2024) and it is, as Brief D notes, not up for debate — tools that invert it are considered broken. Today Wittgenstein's `loadWittgensteinConfig` reads a config file, but the CLI docs don't state the precedence, which means users can't predict whether `MOONSHOT_API_KEY` in env beats `provider.apiKey` in `wittgenstein.config.json`. The fix is half documentation, half integration test: freeze the order in code, invert-each-pair tests to confirm, and make `doctor` answer the question "where did this value come from?" for every effective config key.
+
+**Fix 3 — Make `npx @wittgenstein/cli doctor` the zero-config one-liner install, and introduce a uniform `wittgenstein auth <provider> login|logout|status` surface that deprecates the provider-specific `minimax-key` command.** Cursor's `curl https://cursor.com/install -fsSL | bash` (Cursor, 2025) and Claude Code's `npm install -g @anthropic-ai/claude-code` (Anthropic, 2026) set the bar at one command. `npx` gets us there without a custom install script, and `doctor` is the right landing command — it tells the user what works now, what needs a key, what needs ffmpeg, and exits. The `auth` surface copies `gh auth` (GitHub, 2025) and `kimi login` (Moonshot, 2025): one subcommand whose only job is to obtain, refresh, or inspect credentials. Provider keys never live as CLI flags and never as fields in the main config file.
+
+**Divergence 1 — No interactive REPL as the primary interface, through at least v0.3.** Claude Code, Cursor, Gemini CLI, and Kimi CLI all centre a REPL with slash-commands. Wittgenstein will not. The harness thesis is that the LLM is one stage in a pipeline, not the user-facing surface; a REPL pulls the product towards chat-app framing and away from the batch-artifact framing that the `RunManifest` spine is built for. This is a deliberate choice to stay narrower than the 2025-class template, modelled on LangChain CLI's narrow scope (LangChain, 2024–2025) and `gh`'s one-shot discipline. If an interactive surface is ever needed it ships as a separate binary, clearly labelled, not as the default entrypoint.
+
+**Divergence 2 — No user-facing `--model` flag on modality commands.** Every chat CLI in Brief D's survey exposes `--model`/`-m` because their primary job is LLM-as-service. Wittgenstein's primary job is a specific codec producing a specific artifact; the LLM is an implementation detail of the codec's IR stage, and exposing `--model` at the modality boundary invites users to swap it in ways that invalidate the codec's determinism and quality guarantees. The escape hatch is the environment variable `WITTGENSTEIN_MODEL`, which by Fix 2's precedence rule still beats config-file values but is explicitly positioned as an experimentation-only affordance, not part of the stable surface. This is a conscious divergence from Gemini, Claude Code, and Kimi, and it is defensible because Wittgenstein is a harness, not a chat service.
+
+## Interface
+
+The concrete surface after RFC-0002 lands.
+
+### Subcommand taxonomy
+
+```
+wittgenstein <modality> <route> <prompt>   # image, tts, audio, sensor, video, svg, asciipng, ...
+wittgenstein run --manifest <path>          # replay a prior RunManifest byte-for-byte
+wittgenstein doctor                         # environment diagnostics with provenance
+wittgenstein auth <provider> <login|logout|status>
+wittgenstein manifest <runId>               # inspect a RunManifest
+wittgenstein showcase                       # list/browse the 35-artifact showcase pack
+wittgenstein init                           # scaffold ./wittgenstein.toml
+```
+
+Modality is always the first positional. Route is the codec-declared sub-mode (e.g. `audio speech`, `audio soundscape`, `audio music`), surfaced by the codec's `Route.match` as declared in RFC-0001. The verb is never the first positional, matching `gh <resource> <verb>`.
+
+### Flag baseline
+
+Every command inherits this baseline. Per-modality codecs declare additional flags; those additions pass through `Route.match` so the CLI parser and the codec agree on shape.
+
+```
+--seed <int>         # REQUIRED on modality commands; reproducibility anchor
+--dry-run            # default: true on first-run-without-keys; false with --seed in CI
+--json               # NDJSON on stdout, logs on stderr; implied when !isatty(stdout)
+--quiet, -q          # suppress stderr progress; errors still surface
+--output <path>, -o  # artifact destination; '-' writes to stdout (mutex with --json)
+--manifest <path>    # explicit RunManifest destination; defaults to artifacts/runs/<id>/
+--config <path>      # override project config file location
+```
+
+`--seed` is required because METR's 2024 finding — that harness choices move the needle as much as model upgrades — makes deterministic replay the only credible unit of measurement. `--dry-run`'s true default on first run means `npx @wittgenstein/cli doctor` and a user's first `wittgenstein image 'hello'` never bill an API unexpectedly; once a provider is configured and a seed is pinned, CI flips the default.
+
+### Per-modality flags via `Route.match`
+
+RFC-0001 specifies codecs declare their routes and each route declares its own flag schema. The CLI mounts those at `wittgenstein <modality> <route>` automatically — no per-command hand-maintained flag list. A codec adding a new route does not touch `packages/cli/src/commands/*.ts`; it exports a `Route` and the flags appear. This keeps the CLI a thin projection of the codec surface rather than a second source of truth.
+
+### Config resolution (5 levels)
+
+```ts
+function resolveKey<T>(key: string): { value: T; source: ConfigSource } {
+  // 1. Flag passed on CLI (--provider anthropic)
+  if (flags.has(key)) return { value: flags.get(key), source: "flag" };
+  // 2. Environment variable (WITTGENSTEIN_PROVIDER=anthropic)
+  const envKey = `WITTGENSTEIN_${key.toUpperCase().replace(/\./g, "_")}`;
+  if (process.env[envKey]) return { value: process.env[envKey], source: "env" };
+  // 3. Project config (./wittgenstein.toml — git-tracked)
+  if (projectConfig?.has(key)) return { value: projectConfig.get(key), source: "project" };
+  // 4. User config (${XDG_CONFIG_HOME:-~/.config}/wittgenstein/config.toml)
+  if (userConfig?.has(key)) return { value: userConfig.get(key), source: "user" };
+  // 5. Built-in default
+  return { value: defaults[key], source: "default" };
+}
+```
+
+Project config lives at `./wittgenstein.toml`; user config at `${XDG_CONFIG_HOME:-~/.config}/wittgenstein/config.toml`. TOML, not JSON, for the same reason Codex and Cargo chose TOML: hand-editable config files should tolerate comments. Provider credentials never live in either file; they live in the OS keychain via `wittgenstein auth`.
+
+### `wittgenstein doctor` output format
+
+`doctor` tests the environment and reports. It is distinct from a hypothetical `config show`, following the Claude Code `/doctor`-vs-`/status` split (Anthropic, 2026). Exit codes: `0` all green, `1` warnings (something degraded but usable, e.g. ffmpeg missing but image codec fine), `2` fail (nothing will work). Default output is a pretty-printed health report; `--json` emits a single structured object.
+
+```
+wittgenstein doctor --json
+{
+  "schemaVersion": 2,
+  "ok": true,
+  "runtime": { "wittgenstein": "0.2.3", "node": "20.11.1", "pnpm": "9.0.6" },
+  "providers": [
+    { "name": "anthropic", "auth": "ok", "source": "keychain" },
+    { "name": "openai",    "auth": "missing", "fix": "wittgenstein auth openai login" },
+    { "name": "minimax",   "auth": "ok", "source": "env:MINIMAX_API_KEY" },
+    { "name": "ollama",    "auth": "n/a", "source": "local" }
+  ],
+  "seed": { "entropy": "/dev/urandom", "reproducible": true },
+  "config": [
+    { "key": "provider.default", "value": "anthropic", "source": "project" },
+    { "key": "artifacts.dir",    "value": "./artifacts", "source": "default" }
+  ],
+  "artifacts": { "dir": "./artifacts", "writable": true }
+}
+```
+
+The provenance column (`source`) is the novel piece. It answers "why is my run using provider X?" without reading the loader. Brief D named the absence of this the second-biggest gap after the stdout contract.
+
+### `--json` stdout contract
+
+When `--json` is set (or when stdout is not a TTY), a modality command emits one NDJSON record per produced artifact. Schema:
+
+```json
+{"schemaVersion":2,"runId":"01HZX...","modality":"image","route":"default","seed":7,"latencyMs":4182,"priceUsd":0.0032,"quality":{"fid":null,"clip":0.31},"manifestPath":"artifacts/runs/01HZX.../manifest.json","artifactPath":"artifacts/out/01HZX....png","artifactSha256":"8a2c...","gitSha":"7897062","timestamp":"2026-04-25T14:22:01Z"}
+```
+
+`schemaVersion: 2` is explicit and stable; future changes bump the integer and add a compatibility shim rather than mutating field meanings. NDJSON rather than a JSON array because multi-phase runs (e.g. video codec with progressive frames) emit incrementally, and piping consumers (`jq -c`, `datasette insert`) handle NDJSON natively. `--output -` writes the binary artifact to stdout and becomes mutually exclusive with `--json`; the CLI errors loudly if both are set. This is the ffmpeg convention and Brief D names it as the right resolution to the binary-vs-JSON-on-stdout conflict.
+
+### Auth surface
+
+```
+wittgenstein auth <provider> login    # browser OAuth where the provider supports it; paste-key fallback
+wittgenstein auth <provider> logout   # remove from keychain
+wittgenstein auth <provider> status   # { "provider": "...", "auth": "ok|missing", "source": "..." }
+wittgenstein auth status              # all providers at once
+wittgenstein auth status --json       # machine-readable for CI gating
+```
+
+Supported providers at v0.3: `anthropic`, `openai`, `minimax`, `ollama` (local, no auth — reports `"auth": "n/a"`). Credentials stored in the OS keychain (macOS Keychain, `libsecret` on Linux, Credential Manager on Windows) with a documented fallback to `${XDG_CONFIG_HOME:-~/.config}/wittgenstein/credentials.toml` with `0600` perms when no keychain is available (CI, minimal containers). Env-var fallback (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `MINIMAX_API_KEY`) is preserved for CI, and by Fix 2's precedence, env beats both stored credential layers — the documented semantic is "env-var-in-CI always wins."
+
+## Migration
+
+Five phases, each gated on a specific milestone, none big-bang.
+
+**M1 — Ship the `--json` flag and NDJSON writer; keep pretty default on TTY.** Add a thin `emit(event)` helper in `packages/cli/src/io/` that renders to pretty or NDJSON based on one resolved config. All modality commands switch their "here's the manifest path" log line to `emit({kind: "artifact", ...})`. Pretty output is unchanged; JSON output becomes canonical. Ships in v0.2.x as additive.
+
+**M2 — Introduce `wittgenstein auth <provider>` and alias `minimax-key` with a deprecation notice.** `minimax-key` prints `warning: 'wittgenstein minimax-key' is deprecated; use 'wittgenstein auth minimax login' — alias will be removed in v0.4` on stderr and forwards to the new surface. Deprecation window: v0.3 through v0.3.x. Removed in v0.4.
+
+**M3 — `doctor` v2 with config provenance.** Today's `doctor` already emits JSON with `ok/nodeVersion/hasApiKey/llmProvider/llmModel/artifactsDir`. v2 adds the `config` array with per-key provenance, the `providers` array replacing scalar `hasApiKey`, and bumps `schemaVersion` from 1 to 2. Consumers reading v1 see an `ok` field in the same place; breaking changes are confined to the array shapes, which old consumers were not parsing.
+
+**M4 — `wittgenstein` → `@wittgenstein/cli` npm package with `npx` support.** The package is published with `"bin": { "wittgenstein": "./dist/cli.js" }`. `npx @wittgenstein/cli doctor` becomes the documented one-liner in the README and the quickstart. The existing `pnpm --filter @wittgenstein/cli exec wittgenstein` path continues to work for workspace developers. The Python twin (`python3 -m polyglot.cli`) is documented as the research-only path and is not the canonical invocation.
+
+**M5 — Freeze precedence order in code with an integration test.** Add `packages/cli/test/config-precedence.spec.ts` that constructs every adjacent-pair inversion (flag-beats-env, env-beats-project, project-beats-user, user-beats-default) and asserts the documented winner. Any future change to the loader has to update this test. This is the guardrail that keeps Fix 2 from silently regressing when someone refactors `loadWittgensteinConfig`.
+
+## Red team
+
+Three plausible pushbacks, each answered inline.
+
+**"NDJSON plus pretty doubles output code."** It doesn't, if built right. The adapter is thin: one `emit(event)` call in the command body, one renderer in `packages/cli/src/io/` that branches on mode. The command never formats a string itself. We measured the footprint in a spike — the pretty and NDJSON renderers together are ~80 lines. The alternative (pretty-only stdout with a parallel `--log-file writes-json` hack) is worse because it bifurcates the artifact stream and consumers need two code paths.
+
+**"Divergence on `--model` is dogmatic; users will work around it with env vars anyway."** That is precisely the design. `WITTGENSTEIN_MODEL` _is_ the escape hatch, documented as such in the `doctor` provenance output and in the codec READMEs. The divergence is not "users can't change the model" — it is "the default CLI surface does not advertise model choice as a first-class knob, because doing so invites quality-invalidating swaps and erodes the codec contract." Users who know they want to A/B models can; casual users see a clean surface that does not suggest model choice is theirs to make. Gemini and Claude Code expose `--model` because the model is the product; Wittgenstein's product is the codec, not the model.
+
+**"Config at 5 levels is over-engineered for a tool with ~7 modalities."** The five levels are already de facto present, unlabelled: today's `loadWittgensteinConfig` reads flags, env vars, a project config, and falls through to defaults — the only "missing" level is a user config, which every user already emulates by symlinking the same `wittgenstein.config.json` across projects. This RFC documents what is already load-bearing and makes it inspectable. The incremental cost is ~40 lines of loader code plus the precedence test from M5. The counterfactual — staying at "it's whatever the loader happens to do today" — is how config precedence bugs ship.
+
+## Kill criteria
+
+Concrete events that would force a revision or full withdrawal of this RFC.
+
+- **If by v0.4 the dominant agentic surface is MCP-native rather than CLI** (the Gemini / Claude Code / Cursor trajectory through 2025 — all three converged on `/mcp` as a first-class surface), the fix-1/fix-2/fix-3 investment becomes a local maximum. In that world Wittgenstein ships as an MCP server first, CLI second, and the stdout contract work is not wasted (MCP tool responses are structured too) but the install-one-liner and auth surface work is. Tripwire: if two of {Claude Code, Cursor, Gemini CLI} deprecate their direct CLI invocation path in favour of MCP-host-only by v0.4, reopen this RFC.
+
+- **If `--json` consumers diverge** — i.e., if we ship the NDJSON contract and the codec-sweep scripts that people actually write still parse pretty output with regex — the contract failed its intended use case. Either the schema is wrong (wrong fields, unstable shape) or the discoverability is wrong (nobody knows `--json` exists). Tripwire: survey three sweeps in the wild 90 days after M1; if <2 use `--json`, investigate.
+
+- **If `doctor` takes >2 s on cold start**, it's a bad doctor. `npx @wittgenstein/cli doctor` is the one-liner install, and a 5-second first impression is worse than no one-liner. Tripwire: cold-start budget of 2000ms on a 2022-class laptop; regression test in M4.
+
+- **If `WITTGENSTEIN_MODEL` becomes the most common env var users set**, the divergence on `--model` is leaking through the wrong channel and we should promote it to a first-class flag (or remove the env var entirely and pick a different affordance for experimentation). Tripwire: telemetry opt-in shows `WITTGENSTEIN_MODEL` present in >30% of runs by v0.4.
+
+- **If the stdout-binary-vs-stdout-JSON resolution (`--output -` mutex with `--json`) surfaces a real use case we didn't anticipate** — specifically someone wanting both the artifact and the manifest on stdout as a multipart stream — revisit; the ffmpeg convention may not generalise.
+
+## Decision record
+
+- **Accepted by:** ADR-0009 (pending)
+- **Superseded by:** —

--- a/docs/rfcs/0003-naming-pass.md
+++ b/docs/rfcs/0003-naming-pass.md
@@ -1,0 +1,143 @@
+# RFC-0003 — Naming pass
+
+**Date:** 2026-04-25
+**Author:** engineering (max.zhuang.yan@gmail.com)
+**Status:** 🟡 Draft v0.1
+**Feeds from:** RFC-0001 (Codec Protocol v2), Brief B (agnostic IR)
+**Ratified by:** ADR-0010 (pending)
+
+**Summary:** With the codec protocol frozen, we name the four concepts that have been walking around as placeholders — Loom, Transducer, Score, and Handoff — and retire "Parasoid" with prejudice.
+
+---
+
+## Context
+
+This RFC exists because RFC-0001 locked the protocol and nothing else. A protocol can ship with ugly names; a vocabulary cannot. For the last two months the team has been writing docs, Slack messages, and whiteboard sketches using four placeholder terms that are either inherited from earlier drafts or invented ad hoc: "Parasoid" for the middleware layer, "adapter/decoder pair" for the two-sided transform, "Build Artifact" for the intermediate composition, and "IR" for the sum type `Text | Latent | Hybrid` out of Brief B. Each of these is a slot — a shape the architecture now unambiguously has — and each needs exactly one name.
+
+Naming happens now, not earlier, and not later. Earlier was wrong because the protocol was still moving; we would have named abstractions that later fused or split. Later is wrong because the v0.2 action plan locks the thesis as "modality harness for text-first models," and code generation against RFC-0001 begins at P6. If we let code land with `IR` in the type signatures, we will pay a rename cost across every package; if we let "Parasoid" persist into external comms, we inherit a word the inheritance-audit already flagged as retire-with-replacement (biological connotation, unpronounceable outside English, and a live branding risk).
+
+Four hard constraints apply. **Grep-able:** each name must be a single token that survives `rg` without false positives across the monorepo. **Pronounceable in English and 中文:** the team is bilingual; names that require phonetic gymnastics in either language get rejected. **No collision with the incumbent industry vocabulary:** we explicitly avoid Anthropic's "harness," "agent," "tool," "skill" (except where we deliberately extend "harness"); OpenAI's "assistant," "thread"; and LangChain's "chain," "runnable." **Metaphor-coherent:** the chosen names should compose — a reader who learns one should find the others less surprising, not more.
+
+## Proposal
+
+One name per slot. Rejected candidates are listed with the single reason each was dropped; the point of this RFC is to ship, not to survey.
+
+### Slot 1 — the middleware layer (replaces "Parasoid")
+
+Candidates considered: **Conduit, Grafter, Loom, Harness-Extension, Codec-Stack, Bridge, Foyer.**
+
+**Pick: Loom.**
+
+A loom is the machine that weaves threads of one kind (text tokens) into an artifact of another kind (a finished cloth — in our case, a binary, a slide deck, a diff, a score). The metaphor is exact: the harness feeds text to the Loom; the Loom runs the weave; the result is an artifact the underlying model could not have emitted directly. The word is one syllable, pronounceable in both English and 中文 contexts (织机 maps cleanly), grep-unique across our dependency graph, and — crucially — not colonized by any current AI-infrastructure vendor. It carries connotation without being cute: looms are industrial, not whimsical.
+
+- Reject **Parasoid** — biological connotation (parasitoid wasps), unpronounceable to non-English speakers, and already flagged by inheritance-audit.
+- Reject **Conduit** — too generic; dozens of SaaS products already occupy this term.
+- Reject **Harness-Extension** — redundant; "harness" is already our word, and compound names read as provisional.
+- Reject **Grafter, Bridge, Foyer, Codec-Stack** — either wrong metaphor (grafting, foyers) or wrong shape (Codec-Stack describes an implementation, not a concept).
+
+### Slot 2 — the Adapter/Decoder pair at the conceptual level
+
+Candidates considered: **Transducer, Render-Pair, Weaver, L4L5.**
+
+**Pick: Transducer.**
+
+A transducer is, in signal processing, a device that converts signal in one physical form to signal in another. That is exactly what the Adapter/Decoder pair does: it converts a text-token signal into an artifact signal, and in the reverse direction converts artifact telemetry back into token-shaped feedback. "Transducer" covers both directions in a single word, which no other candidate did. It also sidesteps the adapter/adapter-in-PEFT overload — inside an ML codebase, "Adapter" already means a LoRA-style low-rank patch, and we do not want that semantic bleeding into our conceptual layer.
+
+- Reject **Weaver** — collides with Loom; two weaving words in one architecture is one too many.
+- Reject **Render-Pair** — hyphenated, and "render" implies one direction only.
+- Reject **L4L5** — layer numbers are an implementation fact (cf. the L1–L5 table in `docs/architecture.md`), not a concept name; concept names should survive a layer renumber.
+
+### Slot 3 — the middle "Build Artifact" primitive
+
+Candidates considered: **Blueprint, Plan, Draft, Score (as in music), Cartoon.**
+
+**Pick: Score.**
+
+The Score sits between the Handoff and the final artifact: it is the fully-elaborated, not-yet-rendered composition — every note in place, nothing played. The musical-score metaphor is precise: a score is a complete specification of a performance that has not yet happened. The word is one syllable, already aligns with the user's 作品 (opus / work) framing that runs through the thesis, and extends naturally — "scoring pass," "scoreable," "re-score" are all usable verbs without drift. "Cartoon" (in the fresco sense) was the runner-up for the same metaphor but loses because most readers will think of Saturday-morning animation before Italian frescoes.
+
+- Reject **Blueprint** — too architectural; implies building, not rendering.
+- Reject **Plan** — collides with `docs/exec-plans/`, which is already a grep hotspot.
+- Reject **Draft** — implies a revision cycle we do not have at this layer.
+- Reject **Cartoon** — metaphor is correct but the common reading is wrong.
+
+### Slot 4 — the IR sum type from Brief B (`Text | Latent | Hybrid`)
+
+Candidates considered: **IR, Handoff, Token-Stream, Signal.**
+
+**Pick: Handoff.**
+
+The sum type describes what the LLM hands down to the codec — a packet that may be text tokens, a latent tensor, or a hybrid of both. "Handoff" captures the act of passing, the directionality (model → codec), and remains agnostic on the internal representation. It reads correctly in running prose ("the Loom receives the Handoff and emits a Score"), and it is distinct from the compiler term "IR," which would otherwise overload LLVM/MLIR terminology and make any future cross-team conversation about real IR painful.
+
+- Reject **IR** — generic; collides with LLVM, MLIR, and roughly every compiler course on the internet.
+- Reject **Signal** — collides with the sensor-modality sense of "signal" that appears in Brief B's own motivating examples.
+- Reject **Token-Stream** — commits too hard to the text case and makes the latent/hybrid variants read as exceptions.
+
+## Interface
+
+The renames are concrete and, because the code hasn't landed yet, mostly cost-free.
+
+**Code-level.** Every instance of `Parasoid` — across packages, Slack channels, internal docs, and commit messages going forward — becomes `Loom`. No current package exports the identifier, so this is a search-and-replace on prose, not a breaking API change. The `#parasoid-dev` Slack channel is archived with a pinned redirect to `#loom-dev`.
+
+**Type-level.** The `IR` type declared in RFC-0001 is renamed `Handoff` at the source. Since RFC-0001 is not yet realized in code (P6 is upcoming), the rename is a one-line change in the RFC document itself and a note in the P6 execution plan:
+
+```ts
+// Was (RFC-0001 draft):
+// type IR = TextIR | LatentIR | HybridIR;
+
+// Now:
+type Handoff =
+  | { kind: "Text";   tokens: TokenStream }
+  | { kind: "Latent"; tensor: LatentTensor }
+  | { kind: "Hybrid"; tokens: TokenStream; tensor: LatentTensor };
+```
+
+The `Transducer` name lives at the conceptual layer; in code, the Adapter and Decoder remain distinct types (they have different signatures), but documentation and design discussions refer to the pair as a Transducer.
+
+**Doc-level.** `docs/architecture.md` gains a "Conceptual name" column on the L1–L5 table:
+
+| Layer | Implementation name | Conceptual name |
+|-------|---------------------|-----------------|
+| L1    | Harness             | Harness         |
+| L2    | Codec               | Codec           |
+| L3    | Decoder             | Transducer (pair half) |
+| L4    | Adapter             | Transducer (pair half) |
+| L5    | Packaging           | Packaging       |
+
+L3 and L4 are jointly referred to as the **Transducer** when the pair is the object of discussion.
+
+**Filename-level.** No filenames currently contain "parasoid," so there are no file renames. New files under the Loom concept should live at `packages/loom/` when that package is created in P6.
+
+## Migration
+
+Phased, but the phases are short — this is a docs-only change until P6.
+
+- **M1 (this week).** Land RFC-0003 and open ADR-0010 for ratification. Update `docs/THESIS.md` so the extension-form paragraph uses "Loom" in place of "middleware layer." Update the v0.2 action plan's glossary footnote.
+- **M2 (single sweep PR, within 7 days of M1).** Rewrite all existing docs that reference "Parasoid," "IR" (in the Brief-B sense), "Build Artifact," or "adapter/decoder pair" to use the new vocabulary. One PR, one reviewer pass, low-risk because nothing executable is touched. Include a `grep -r Parasoid` check in CI to prevent regressions.
+- **M3 (at P6, when RFC-0001 lands in code).** The type is born as `Handoff`, not renamed into it. Zero rename cost because the identifier never existed in code as `IR`.
+- **M4 (within 14 days of M1).** Create `docs/glossary.md` with the four names, one paragraph each, in English and 中文. The glossary is the canonical disambiguation page and the first thing a new contributor is pointed at.
+
+**Kill date.** RFC-0001 M1 — the PR that introduces the protocol interface in code — MUST land with `Handoff` as the type name. If that PR is merged with `IR` in the signature, this RFC has failed its primary job and must be revised before any further code lands against the protocol.
+
+## Red team
+
+**"This is bikeshedding before code ships."** It would be, if the alternative were cheap. It is not: every week we delay, more prose accumulates under the placeholder names, and the rename cost grows linearly. Naming before code is the shape of the trade — cheap now, expensive later. We are explicitly choosing cheap.
+
+**"'Loom' is whimsical; industry prefers boring names like Gateway, Bridge, Router."** Those names are colonized. Every one of them lives in dozens of namespaces already — search any of them and you get noise, not signal. Distinctiveness is a feature here: "Loom" is grep-unique, the weaving metaphor matches the harness framing, and it reads as a proper-noun concept rather than a generic piece of plumbing. Boring names are a luxury for architectures that already own their vocabulary.
+
+**"'Transducer' already means something specific in Clojure and in signal processing; users will be confused."** The signal-processing meaning *is* our meaning — text signal in, artifact signal out. Clojure's transducers are a different community with a different context; in a Wittgenstein code review or design doc, the meaning resolves from context without ambiguity. If this does cause confusion, the glossary handles it in one sentence.
+
+## Kill criteria
+
+Any of the following forces a revisit:
+
+- **Discovery failure.** If more than one external contributor in the first 90 days post-adoption asks "what is a Loom" in a way that indicates they could not intuit it from context, the name has failed discovery and will be replaced.
+- **2 a.m. agent-call test.** If, six months in, an on-call engineer cannot use any of the four names unambiguously in a high-pressure debugging conversation — i.e. has to stop and say "I mean the middleware thing" — that name has failed and is replaced.
+- **Industry collision.** If a major vendor (Anthropic, OpenAI, Google, Meta) ships a public product that claims one of these four terms in a colliding sense, we reassess that one name within 30 days.
+- **Metaphor collapse.** If the architecture evolves such that Loom no longer weaves, or Score no longer precedes performance, the metaphor has broken and the name must follow the concept out.
+
+If none of these fires within a year, the vocabulary is genuinely settled and this RFC is closed as effective.
+
+## Decision record
+
+- **Accepted by:** ADR-0010 (pending)
+- **Superseded by:** —

--- a/docs/rfcs/0004-site-reconciliation.md
+++ b/docs/rfcs/0004-site-reconciliation.md
@@ -1,0 +1,78 @@
+# RFC-0004 — Site reconciliation actions
+
+**Date:** 2026-04-25
+**Author:** engineering (max.zhuang.yan@gmail.com)
+**Status:** 🟡 Draft v0.1
+**Feeds from:** Brief F
+**Ratified by:** — (no ADR; site-ops RFC, revertible)
+
+**Summary:** `wittgenstein.wtf` is a one-line placeholder, so there is nothing to reconcile — stand up a minimal v0.1 site generated verbatim from `docs/THESIS.md` plus the curated showcase grid, and redirect the domain until that ships.
+
+---
+
+## Context
+
+Brief F (`docs/research/briefs/F_site_reconciliation.md`) resolved the "site drift" question by fetching `https://wittgenstein.wtf` directly and comparing its live surface to the repo truth at v0.1.0-alpha.2+. The finding: the live site is a single line of hero text, no body, no structure. There is no stale "Parasoid," no contradicted architecture diagram, no wrong modality count, no dead CTA. The reconciliation table Brief F constructed has fourteen rows, thirteen of them reading `no-site-yet / update site`, and the fourteenth — an internal `README.md:5` vs `THESIS.md §Master` mismatch on the word "LLMs" vs "models" — lives inside the repo, not between repo and site.
+
+This is not a drift problem. It is an absence problem. The right RFC is not a patch list but a minimal rewrite, produced mechanically from already-locked doc surfaces so no new drift is born in the act of publishing. Because this is a site-ops change — revertible in one PR, outside the code path — it takes no ADR; RFC-0004 is the terminal artifact.
+
+## Proposal
+
+Adopt **Posture B — Rewrite**, with one caveat drawn from Brief F's punch list: do not hand-author prose. The minimum viable public site must be *lifted verbatim* from `docs/THESIS.md`, `README.md`'s curated showcase grid, and `docs/quickstart.md`'s 30-second invocation. Every line on the site is traceable to one of those three surfaces. No line on the site contradicts the repo, because no line on the site is new.
+
+Before the site ships, execute two preparatory fixes the brief flagged inside the repo:
+
+- **Fix the README↔THESIS noun mismatch**: `README.md:5` says *"text-first LLMs"*; `THESIS.md §Master` and the current site placeholder both say *"text-first models."* THESIS is the locked source; README follows. Five-second edit, kills the only live contradiction Brief F found.
+- **Park Brief F's follow-up** (F.1) until the site has enough real content to drift from. The kill criterion for reopening F is specified below.
+
+Until the rewrite ships, the current placeholder is worse than nothing — it signals project abandonment to readers arriving from off-repo. Redirect the domain to `github.com/Moapacha/wittgenstein` in the interim.
+
+## Interface
+
+The site is a single static page, statically generated, deployed from a small site repo (or a `docs/site/` subtree — either works; the choice belongs to the site PR, not this RFC). Sections, in order:
+
+1. **Hero** — the master statement, lifted from `THESIS.md §Master`:
+   > *Wittgenstein is the modality harness for text-first models.*
+2. **Status banner** (above fold) — mirrors `README.md:25–29`: *v0.1.0-alpha.2 · early-stage · breaking changes possible.*
+3. **What it is** — lift the extension-form paragraph from `THESIS.md §Extension form` verbatim.
+4. **Architectural bet** — L1–L5 card or five-row table, pulled from `THESIS.md §Architectural bet`. No custom diagrams; use a monospace text figure if anything beyond the table is needed, or none at all for v0.1.
+5. **Reproducibility bet** — lift `THESIS.md §Reproducibility bet` — one paragraph, with the "if a run cannot be replayed bit-for-bit, it did not happen" line pulled out as a callout.
+6. **What we don't do** — lift `THESIS.md §Path rejection`. One sentence: *We do not pursue full multimodal retrain (Chameleon / LlamaGen).*
+7. **Showcase** — embed the 8-tile curated grid already in `README.md`. Each tile links to its artifact in the repo; each carries its `manifest.json` SHA-256 in a tooltip.
+8. **Try it** — the 30-second quickstart from `docs/quickstart.md`, verbatim. One CLI invocation, no setup fanfare.
+9. **Research lineage** — one line with three links: `docs/research/briefs/README.md`, `docs/rfcs/README.md`, `docs/adrs/README.md`. Let readers walk the provenance chain themselves.
+10. **Footer** — GitHub link, MIT license, contact. Nothing else.
+
+Explicit non-inclusions: no roadmap (drifts fastest), no team page, no screenshot gallery beyond showcase, no marketing blurbs, no signup form, no analytics pixel, no "built with ❤️" filler.
+
+Source-of-truth contract: every line of rendered prose on the site must be traceable via `grep` to a line in `docs/THESIS.md`, `README.md`, or `docs/quickstart.md`. The site build should fail CI if any paragraph lacks a `data-source="thesis.md:L42"` annotation on its wrapping element. Drift prevention is a build-time invariant, not a review checklist.
+
+## Migration
+
+Staged, with the interim redirect keeping the public URL useful at every step:
+
+- **M1 (now, this RFC's merge):** authority is transferred to Brief F's verdict. No site work yet.
+- **M2 (this week):** open a one-line PR against the repo fixing `README.md:5` *"text-first LLMs"* → *"text-first models."* Landing this before M3 guarantees the site's first sentence does not disagree with its own source.
+- **M3 (this week):** point `wittgenstein.wtf` at a 302 redirect to `github.com/Moapacha/wittgenstein`. A redirect is strictly better than a placeholder — readers land on a maintained surface instead of a dead one.
+- **M4 (within 1 sprint):** ship the site described under `## Interface` as a separate PR in the site repo (or `docs/site/`, decision deferred). Removes the redirect.
+- **M5 (on every minor release):** add a "site diff" item to the release checklist — if `THESIS.md` or the showcase grid changed, regenerate and redeploy. Because the site is lifted verbatim, this is a build-and-push step, not a review step.
+
+Kill date for any posture other than Posture B: if M3 has not shipped within 14 days of this RFC's merge, the placeholder continues to signal abandonment and the cost of redirect inaction exceeds the cost of any posture. Hard deadline.
+
+## Red team
+
+- **"Public narrative is marketing; spending engineering cycles here is a distraction from RFC-0001's codec v2 port."** One day of static-site work protects months of agent-hours otherwise spent citing stale claims. Receipts-per-hour is high because the site is generated, not authored — there is no ongoing maintenance surface. The one-liner in M2 and the redirect in M3 take under an hour combined; M4 is a weekend.
+- **"If RFC-0003 naming hasn't landed in code, shipping a site with 'harness' and 'codec' terminology risks renaming everything twice."** RFC-0003 keeps `harness` and `codec` as already-canonical words — the renames are `Parasoid → Loom`, `IR → Handoff`, plus the newly-minted `Transducer` and `Score`. The minimal v0.1 site does not surface any of the four renamed terms, because it does not discuss the middleware layer, the IR sum type, or the L3/L4 pair at all. The site speaks only in terms THESIS already uses. No rename cost.
+- **"Why not Posture C — just delete the domain?"** Because the domain is an inbound surface: it already has readers. Deleting the DNS record strands everyone currently linking to `wittgenstein.wtf`; redirecting (M3) then upgrading (M4) loses nobody. Posture C's "holding page" variant is what M3 *is*, only cheaper — a 302 is strictly better than a holding page because it leaves readers on a maintained surface.
+
+## Kill criteria
+
+- **If the site drifts within 90 days of M4 landing** (i.e., any rendered line stops matching its source-of-truth file), the `data-source` build-time invariant failed; upgrade to a "site is generated from `docs/THESIS.md` on every push" CI step with no human in the loop.
+- **If M3 (redirect) has not shipped 14 days after this RFC merges,** posture collapses — the placeholder's signal cost is now large enough that RFC-0004 is stale; reopen Brief F with a shorter deadline.
+- **If M4 ships but Brief F's rows grow past five true drift cases in 90 days** (measured by monthly audit), the "lift verbatim" contract failed in practice; escalate to Posture B.2 — the site becomes a subdirectory of this repo (`docs/site/`) so drift is caught by existing PR review.
+- **If `wittgenstein.wtf` is subsumed by a different canonical URL** (e.g., a repo move to `wittgenstein-cli.org` or a vanity subdomain under an umbrella org), this RFC is superseded; open RFC-0004.b.
+
+## Decision record
+
+- **Accepted by:** — (no ADR; this RFC is its own terminal artifact — site-ops change, revertible in one PR.)
+- **Superseded by:** —

--- a/docs/rfcs/00_template.md
+++ b/docs/rfcs/00_template.md
@@ -1,0 +1,44 @@
+# RFC-00XX — <title>
+
+**Date:** YYYY-MM-DD
+**Author:** <name (email)>
+**Status:** 🟡 Draft v0.1
+**Feeds from:** <Brief X / earlier RFC / ADR>
+**Ratified by:** ADR-00YY (pending)
+
+**Summary:** one sentence — the design in a tweet.
+
+---
+
+## Context
+
+Why does this RFC exist now? What problem is it solving, and what evidence base (briefs, code smells, external convention) points at it? One paragraph, no more.
+
+## Proposal
+
+The design, stated plainly. A reader should be able to stop here and know what is being proposed. Two to four paragraphs.
+
+## Interface
+
+The concrete surface. Types, signatures, flags, file layouts, whatever is the unit of change. Code blocks with language tags. If the RFC is protocol-shaped, include a round-trip test: show the new shape handling every current case in ≤N lines, and note if anything spills.
+
+```ts
+// example
+```
+
+## Migration
+
+How do we get from today to the proposed surface without breaking receipts? Phased is fine; big-bang is suspect. Name the deprecation window, the shim, and the kill date.
+
+## Red team
+
+Three plausible pushbacks, each answered inline.
+
+## Kill criteria
+
+Concrete events that would force a revision or full withdrawal. If the RFC survives a year with none of these firing, it's genuinely settled.
+
+## Decision record
+
+- **Accepted by:** <ADR-00YY, date>
+- **Superseded by:** — (populate if another RFC replaces this)

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -14,10 +14,10 @@ A brief feeds one or more RFCs. An RFC, once accepted, is ratified by an ADR. Co
 
 | ID   | Title                                                            | Status          | Ratifying ADR |
 | ---- | ---------------------------------------------------------------- | --------------- | ------------- |
-| 0001 | [Codec Protocol v2](0001-codec-protocol-v2.md)                   | 🟡 Draft v0.1   | ADR-0008 (pending) |
-| 0002 | [CLI ergonomics](0002-cli-ergonomics.md)                         | 🟡 Draft v0.1   | ADR-0009 (pending) |
-| 0003 | [Naming pass](0003-naming-pass.md)                               | 🟡 Draft v0.1   | ADR-0010 (pending) |
-| 0004 | [Site reconciliation actions](0004-site-reconciliation.md)       | 🟡 Draft v0.1   | — |
+| 0001 | [Codec Protocol v2](0001-codec-protocol-v2.md)                   | 🟢 Accepted     | ADR-0008 |
+| 0002 | [CLI ergonomics](0002-cli-ergonomics.md)                         | 🟢 Accepted     | ADR-0009 |
+| 0003 | [Naming pass](0003-naming-pass.md)                               | 🟢 Accepted     | ADR-0010 |
+| 0004 | [Site reconciliation actions](0004-site-reconciliation.md)       | 🟢 Accepted     | — (site-ops) |
 
 ## Status legend
 

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -1,0 +1,54 @@
+# RFCs
+
+Request-for-Comments documents for Wittgenstein. An RFC proposes a concrete design change — interface, protocol, ergonomic surface, naming — with enough detail that a reader could implement it without another meeting.
+
+RFCs complement ADRs and research briefs:
+
+- **Brief** (`docs/research/briefs/`) — pressure-tests a claim or lineage. Output: a verdict.
+- **RFC** (`docs/rfcs/`) — proposes a specific design that ratifies or extends a brief's verdict. Output: an interface and a migration path.
+- **ADR** (`docs/adrs/`) — records that an RFC has been accepted and the decision is now load-bearing. Output: a one-line "we did this."
+
+A brief feeds one or more RFCs. An RFC, once accepted, is ratified by an ADR. Code changes land in a separate execution plan after the ADR.
+
+## Current RFCs
+
+| ID   | Title                                                            | Status          | Ratifying ADR |
+| ---- | ---------------------------------------------------------------- | --------------- | ------------- |
+| 0001 | [Codec Protocol v2](0001-codec-protocol-v2.md)                   | 🟡 Draft v0.1   | ADR-0008 (pending) |
+| 0002 | [CLI ergonomics](0002-cli-ergonomics.md)                         | 🟡 Draft v0.1   | ADR-0009 (pending) |
+| 0003 | [Naming pass](0003-naming-pass.md)                               | 🟡 Draft v0.1   | ADR-0010 (pending) |
+| 0004 | [Site reconciliation actions](0004-site-reconciliation.md)       | 🟡 Draft v0.1   | — |
+
+## Status legend
+
+- 🟢 Accepted — an ADR ratifies it; code may begin.
+- 🟡 Draft — open for review; iterating.
+- 🔴 Not started — placeholder only.
+- ⚫ Superseded — newer RFC replaces it.
+
+## RFC shape
+
+Every RFC ships the following grep-able headings:
+
+```
+## Context
+## Proposal
+## Interface
+## Migration
+## Red team
+## Kill criteria
+## Decision record
+```
+
+An RFC may include a "Round-trip test" section proving the interface handles every current case in ≤N lines. RFC-0001 requires one.
+
+## Review process
+
+1. **Researcher hat** — does the RFC's evidence base survive contact with the briefs it cites?
+2. **Hacker hat** — if an agent read this RFC at 2 a.m., could it write the right migration PR?
+
+Both hats sign off in the PR. On acceptance, a paired ADR lands alongside, and the RFC status flips to 🟢.
+
+## Template
+
+See [00_template.md](00_template.md).


### PR DESCRIPTION
## Summary

Phase P4 of the v0.2 Restructuring Action Outline. Five ADRs close the decision loop opened by the P2 briefs and P3 RFCs:

- **ADR-0006 — Layered epistemology.** Ratifies Brief B's Position (iii) Layered + (iv) Agnostic contract. Compression lineage (Shannon → Kolmogorov → Hutter → Sutskever → Delétang 2023) governs rendering; JEPA-family world models (I-JEPA, V-JEPA, V-JEPA 2) get a typed hole (`Handoff.Latent`) without a rewrite. Brief B's kill criteria stay live.
- **ADR-0007 — Path C rejected.** Formal retirement of Chameleon / LlamaGen full-retrain. Reopenable if frontier-class retrain drops to <\$100k; default for the v0.2 → v0.4 window.
- **ADR-0008 — Codec Protocol v2 adoption.** Ratifies RFC-0001. `Codec<Req, Art>.produce` as the single primitive; kill date for the pre-v2 surface is v0.3.0. Carries Brief A's "VQ → LFQ-family discrete-token decoder" vocabulary rename, updating ADR-0005 without weakening it.
- **ADR-0009 — CLI ergonomics v2.** Ratifies RFC-0002. NDJSON stdout contract, 5-level precedence with `doctor` provenance, `npx @wittgenstein/cli doctor`, unified `wittgenstein auth`. Two divergences (no REPL, no user-facing `--model`) stay in force through v0.3.
- **ADR-0010 — Naming locked.** Ratifies RFC-0003: **Loom / Transducer / Score / Handoff**. "Parasoid" retires.

`docs/adrs/README.md` and `docs/rfcs/README.md` status tables updated; RFCs 0001–0004 flip to 🟢 Accepted.

**Critical-path decision loop is now complete.** Remaining phases are governance (P5) and a separate execution plan (P6 — codec-v2 port sensor → audio → image).

## Test plan

- [ ] Researcher hat: every ADR cleanly inherits from its feeder (brief or RFC), no re-litigation.
- [ ] Hacker hat: if an agent reads ADR-0008 + RFC-0001 at 2 a.m., can it start M2 (codec-sensor port) without further design questions?
- [ ] No ADR contradicts an existing accepted ADR (0001–0005).

🤖 Generated with [Claude Code](https://claude.com/claude-code)