### PR TITLE
fix(ci): release notes extraction matched every section

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,9 +37,14 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           # Pull the section between [VERSION] and the next top-level "## [" heading.
-          awk -v ver="[$VERSION]" '
-            $0 ~ "^## " ver { flag=1; next }
-            flag && /^## \[/ { exit }
+          # Uses index() literal-string match instead of regex so brackets in
+          # the version (e.g. "[0.2.0-alpha.1]") are not interpreted as a
+          # character class. This is the bug that bit v0.2.0-alpha.1's first
+          # publish — the regex "^## [0.2.0-alpha.1]" matched every `## [...]`
+          # heading because `[0.2-alpha1]` parsed as a char class.
+          awk -v marker="## [$VERSION]" '
+            index($0, marker) == 1 { flag=1; next }
+            flag && index($0, "## [") == 1 { exit }
             flag { print }
           ' CHANGELOG.md > .release-notes.md
           if [ ! -s .release-notes.md ]; then


### PR DESCRIPTION
## Summary

The release.yml awk pattern \`^## [VERSION]\` was being interpreted as a regex where \`[0.2-alpha1]\` is a character class — so it matched **every** \`## [...]\` heading in CHANGELOG, not just the target version. \`next\` kept consuming them, the exit rule never fired, and v0.2.0-alpha.1's release body included the entire alpha.2 and alpha.1 sections too.

The published v0.2.0-alpha.1 notes have been **retroactively fixed** via \`gh release edit\`. This PR fixes the workflow so the next release won't hit the bug.

## Fix

Switched both the start-of-section and end-of-section detectors from regex to \`index()\` literal-string matching. No more regex over user-controlled version strings.

\`\`\`diff
- awk -v ver="[\$VERSION]" '
-   \$0 ~ "^## " ver { flag=1; next }
-   flag && /^## \[/ { exit }
-   flag { print }
- ' CHANGELOG.md > .release-notes.md
+ awk -v marker="## [\$VERSION]" '
+   index(\$0, marker) == 1 { flag=1; next }
+   flag && index(\$0, "## [") == 1 { exit }
+   flag { print }
+ ' CHANGELOG.md > .release-notes.md
\`\`\`

## Validation

- Reproduced the bug locally — old pattern returned 204 lines (full file from v0.2.0-alpha.1 onward); new pattern returns 98 lines, ending exactly at the correct boundary.
- Already corrected the published v0.2.0-alpha.1 release body.

## Risk

Low. The release workflow only runs on tag push; this change makes it more correct, not less.