### PR TITLE
chore(deps): tighten dependabot for alpha-stage realities

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,32 +1,109 @@
+# Dependabot policy for Wittgenstein.
+#
+# Philosophy (alpha-stage, pre-1.0):
+#   - Auto-merge what's safe (minor + patch + grouped) via auto-merge-dependabot.yml.
+#   - Open individual PRs for things humans should look at (e.g. @types/* major,
+#     github-actions major).
+#   - DO NOT open weekly PRs for framework majors that we've deliberately deferred
+#     until codec-v2 + M0/M1 land. When we're ready to migrate, we delete the
+#     `ignore` entry — explicit opt-in beats weekly opt-out.
+#   - polyglot-mini is research-grade Python; security patches only, monthly cadence.
+#
+# When to revisit:
+#   - After M1 (image) lands → consider unfreezing typescript major.
+#   - After M5b (benchmarks) → consider unfreezing zod, react/next majors.
+#   - Any time a CVE lands → security updates bypass `ignore` automatically.
+
 version: 2
 updates:
+  # ---------------------------------------------------------------------------
+  # npm — root monorepo (packages/*, apps/*)
+  # ---------------------------------------------------------------------------
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 4
+    open-pull-requests-limit: 5
     labels:
       - "dependencies"
       - "npm"
     commit-message:
       prefix: "chore(deps)"
       include: "scope"
+
     groups:
+      # Dev-only minor+patch — auto-merge eligible.
       npm-dev:
         dependency-type: "development"
         update-types:
           - "minor"
           - "patch"
+        # eslint stack and @types/* have their own groups below.
+        exclude-patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@typescript-eslint/*"
+          - "@types/*"
+
+      # Prod minor+patch — auto-merge eligible.
       npm-prod:
         dependency-type: "production"
         update-types:
           - "minor"
           - "patch"
 
+      # @types/* travel together, low blast radius. Minor+patch only;
+      # majors stay as individual PRs because @types majors track upstream
+      # major releases (Node 24, etc.) and warrant a human glance.
+      types:
+        patterns:
+          - "@types/*"
+        update-types:
+          - "minor"
+          - "patch"
+
+      # eslint, eslint-config-*, @typescript-eslint/* upgrade in concert.
+      # Ungrouped, they create three PRs that all need to land together
+      # or CI fails.
+      eslint-stack:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@typescript-eslint/*"
+        update-types:
+          - "minor"
+          - "patch"
+
+    ignore:
+      # Framework majors deliberately deferred during alpha (codec-v2 port
+      # + M1 are the priority). Remove a line here when you're ready to
+      # do the migration deliberately.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "zod"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "next"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "tailwindcss"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
+
+  # ---------------------------------------------------------------------------
+  # pip — polyglot-mini (research-grade Python)
+  # ---------------------------------------------------------------------------
+  # Conservative on purpose. polyglot-mini is the Python rapid-prototype
+  # surface — moving floors here churns notebooks and the CI smoke path
+  # without producing user-facing value. Security advisories will still
+  # bypass the ignore rules.
   - package-ecosystem: "pip"
     directory: "/polyglot-mini"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 1
     labels:
       - "dependencies"
@@ -37,13 +114,19 @@ updates:
     groups:
       pip-runtime:
         update-types:
-          - "minor"
           - "patch"
     ignore:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
+          - "version-update:semver-minor"
 
+  # ---------------------------------------------------------------------------
+  # github-actions
+  # ---------------------------------------------------------------------------
+  # Actions ecosystem is small and well-behaved. Group minor+patch;
+  # majors come as individual PRs (e.g. softprops/action-gh-release v2→v3,
+  # dependabot/fetch-metadata v2→v3 — both safely merged manually).
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary

Last week's bot triage was 4-merged / 4-closed across 8 PRs. Of the four closes, **three were the same shape** — framework major bumps deliberately deferred during alpha (typescript 5→6 #44, react 18→19 #45, zod 3→4 #47) — and one was a Python lower-bound bump in research-grade code (#40 matplotlib). All four were predictable noise that consumed human triage cycles without producing useful signal.

This PR codifies the human triage rules into the config so dependabot stops opening PRs we reliably close.

## What changed

| Change | Why |
|---|---|
| Add \`ignore\` entries for **typescript, zod, react, react-dom, next, tailwindcss, eslint** majors | Framework majors deliberately deferred during alpha. When ready, remove the line — explicit opt-in beats weekly opt-out |
| Group **@types/\*** (minor+patch only) | Major @types bumps still come individually for human inspection (the @types/node 20→25 #46 pattern) |
| Group **eslint-stack** (eslint + eslint-config-\* + @typescript-eslint/\*) | These ship in concert; ungrouped they produce three PRs that must all land together |
| \`npm-dev\` group now \`exclude-patterns\` for eslint and @types | Prevent group overlap (each dep belongs to exactly one group) |
| **polyglot-mini** → monthly cadence, ignore minor + major (patch only) | Research-grade Python; no user-facing churn value. Security advisories still bypass ignore |
| \`open-pull-requests-limit\` 4 → 5 | Absorb the new group split |
| Header comment | Documents alpha-stage philosophy + when-to-revisit milestones |

## What still flows

- Minor + patch updates for prod and dev (unchanged)
- Grouped @types/\* and eslint-stack
- github-actions minor+patch (unchanged) and majors as individual PRs
- @types/\* majors as individual PRs
- **Security advisories** — bypass \`ignore\` rules automatically
- polyglot-mini security patches (still monthly, but flowing)

## When to revisit

Header comment names the checkpoints:

- **After M1 (image) lands** → consider unfreezing typescript major
- **After M5b (benchmarks) lands** → consider unfreezing zod, react/next majors
- **CVE for an ignored package** → security update bypasses automatically; no config change needed

## Validation

- \`pnpm format:check\` green
- \`actionlint\` will validate on this PR
- The auto-merge workflow (\`auto-merge-dependabot.yml\`) is unchanged and continues to handle the "yes" cases

## Risk

Low. Worst case is an actively-broken transitive minor we miss — but those flow through the prod minor channel (unchanged) or via security advisories (bypass ignore entirely).