### PR TITLE
ci: make typos check resilient to GitHub release flakiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,8 +153,30 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Install typos (retry)
+        env:
+          TYPOS_VERSION: v1.45.1
+        run: |
+          set -euo pipefail
+          archive="typos-${TYPOS_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          url="https://github.com/crate-ci/typos/releases/download/${TYPOS_VERSION}/${archive}"
+          tmpdir="$(mktemp -d)"
+          for attempt in 1 2 3 4 5; do
+            echo "Downloading typos ${TYPOS_VERSION} (attempt ${attempt}/5)"
+            if curl --fail --location --retry 3 --retry-all-errors --connect-timeout 15 \
+              --output "${tmpdir}/${archive}" "${url}"; then
+              tar -xzf "${tmpdir}/${archive}" -C "${tmpdir}"
+              install "${tmpdir}/typos" /usr/local/bin/typos
+              typos --version
+              exit 0
+            fi
+            sleep $((attempt * 2))
+          done
+          echo "Failed to install typos after repeated retries" >&2
+          exit 1
+
       - name: Typos
-        uses: crate-ci/typos@v1
+        run: typos --config typos.toml
 
       - name: Actionlint
         uses: reviewdog/action-actionlint@v1


### PR DESCRIPTION
## Summary

The README CI badge is red because the latest `main` run failed in `Static checks`, but the failure is not a repo typo or code regression.

The `crate-ci/typos@v1` action tried to download the `typos` release archive from GitHub and hit a transient `502 Bad Gateway`, which marked the whole CI run red on `main`.

This PR keeps the same check semantics while making the install path more resilient:
- replace the opaque action download with an explicit install step
- use `curl --retry` plus an outer retry loop
- run `typos --config typos.toml` locally after install

## Why this fix

We still want `Typos` as a blocking static check. The problem was flakiness in the install transport, not the check itself.

This approach is more robust because:
- the workflow retries transient GitHub/CDN failures
- the failure mode is clearer in logs
- the actual spelling check remains unchanged

## Validation

- `pnpm exec prettier --check .github/workflows/ci.yml`
- `git diff --check`
- local YAML structure parse via Ruby (`YAML.load_file`) to confirm the new `static-checks` steps are valid

## Scope

CI-only. No product/runtime/doc behavior changes.
