### PR TITLE
docs(agents): append v0.2 doctrine lock Supplementary section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ Read [`docs/architecture.md`](docs/architecture.md) before changing structure.
 
 ## Read Order
 
+<!-- prettier-ignore-start -->
 **Start here for any task:**
 0. [`.claude/AGENT_PROMPT.md`](.claude/AGENT_PROMPT.md) — what you are, where to find answers, how to work here
 1. [`docs/engineering-discipline.md`](docs/engineering-discipline.md) — code style, robustness, testing, reporting standards
@@ -70,8 +71,10 @@ Read [`docs/architecture.md`](docs/architecture.md) before changing structure.
 11. [`docs/exec-plans/active/codec-v2-port.md`](docs/exec-plans/active/codec-v2-port.md) — the live P6 plan
 12. [`docs/codecs/`](docs/codecs/) — per-modality docs (image.md, audio.md, sensor.md)
 13. [`docs/agent-guides/`](docs/agent-guides/) — port recipes and implementation briefs
+<!-- prettier-ignore-end -->
 
 **Optional depth:**
+
 - [`packages/agent-contact-text/README.md`](packages/agent-contact-text/README.md) + context corpus for long-form context
 - [`docs/team-split.md`](docs/team-split.md)
 
@@ -81,3 +84,65 @@ Read [`docs/architecture.md`](docs/architecture.md) before changing structure.
 - Do not hide modality contracts in prompt prose only.
 - Do not write artifacts outside `artifacts/` unless the CLI command explicitly asks for an output path.
 - Do not bypass the manifest spine for “quick experiments”.
+
+---
+
+## Post-lock addendum — v0.2 doctrine deltas
+
+> Everything above this line is the original hackathon-era agent primer and is preserved for continuity. The notes below are the deltas from the v0.2 doctrine lock (`v0.2.0-alpha.1`, 2026-04-25). When the two disagree, **this section wins** — but check both, because most of the original guidance is still correct.
+
+### Locked vocabulary (ADR-0011 — supersedes the L1–L5 names above)
+
+| Term          | Layer | Meaning                                                                                            |
+| ------------- | ----- | -------------------------------------------------------------------------------------------------- |
+| **Harness**   | L1    | Routing, retry, seed, validate, budget, record                                                     |
+| **Codec**     | L2    | Modality implementation (owns schema + render)                                                     |
+| **Spec**      | L2    | Structured artifact (`ImageSceneSpec`, `AudioPlan`, …)                                             |
+| **IR**        | L3    | Internal representation; sum type `Text \| Latent \| Hybrid`; **only `Text` is inhabited at v0.2** |
+| **Decoder**   | L3    | IR → bytes; frozen, deterministic, never generative (ADR-0005)                                     |
+| **Adapter**   | L4    | Learned bridge (Spec → latent); optional, image only today                                         |
+| **Packaging** | L5    | CLI · npm · manifests · install (was “Distribution” above)                                         |
+
+The RFC-0003 alternatives (Loom / Transducer / Score / Handoff) were rejected. Use the table above. Full reference: [`docs/glossary.md`](docs/glossary.md).
+
+### Constraint deltas (additions to the "Locked Constraints" section above)
+
+- **Codec Protocol v2 is the only codec contract.** Every codec implements `Codec<Req, Art>.produce`. The harness does **not** branch on modality. Source: [`docs/rfcs/0001-codec-protocol-v2.md`](docs/rfcs/0001-codec-protocol-v2.md), ratified by [ADR-0008](docs/adrs/0008-codec-protocol-v2-adoption.md).
+- **Path C rejected through v0.4.** No Chameleon / LlamaGen-style fused multimodal retrain. Base model stays text-only. ([ADR-0007](docs/adrs/0007-path-c-rejected.md))
+- **The "no raster fallback" rule above applies to the TS `codec-image` core path only.** The `polyglot-mini` Python image code-as-painter sandbox is a documented ⚠️ Research-grade surface (see `README.md` "Experimental surfaces" + [`SECURITY.md`](SECURITY.md)). It is not a TS escape hatch and does not contradict the rule.
+- **Manifest spine is non-negotiable.** Every run writes git SHA, lockfile hash, seed, full LLM I/O, and artifact SHA-256. No silent fallbacks; failures return structured errors with a manifest. Canonical: [`docs/hard-constraints.md`](docs/hard-constraints.md).
+
+### Repo Map deltas
+
+- `packages/codec-asciipng/` — ASCII-PNG codec (added after the original map was written)
+- `apps/presentation/` — slide deck app (Hackathon launch + v0.2 narrative)
+- `apps/wittgenstein-kimi/` — Kimi-flavored agent demo
+- `docs/exec-plans/active/` — live execution plans (M0 → M5b lives here)
+- `docs/agent-guides/` — per-port execution briefs (audio, sensor, image-to-audio)
+- `docs/rfcs/` and `docs/adrs/` — engineering decisions and ratified records
+- `docs/research/briefs/` — four-station research briefs (A–G)
+
+### Read Order — v0.2 supplement
+
+The original Read Order is still valid as a depth path. Before that, an agent landing on this repo cold should read these **first**, in order:
+
+1. [`docs/THESIS.md`](docs/THESIS.md) — the smallest locked statement page
+2. [`docs/glossary.md`](docs/glossary.md) — locked vocabulary (the table above)
+3. [`docs/contributor-map.md`](docs/contributor-map.md) — onboarding map (humans + agents)
+4. [`docs/hard-constraints.md`](docs/hard-constraints.md) — what will not change (canonical, supersedes the bullets above)
+5. [`docs/exec-plans/active/codec-v2-port.md`](docs/exec-plans/active/codec-v2-port.md) — the live P6 plan; M0 is the active migration target
+6. [`docs/inheritance-audit.md`](docs/inheritance-audit.md) — what survived / was promoted / was retired in the v0.2 lock
+7. [`docs/SYNTHESIS_v0.2.md`](docs/SYNTHESIS_v0.2.md) — branch-level merge brief
+8. [`docs/v02-final-audit.md`](docs/v02-final-audit.md) — pre-lock decision ledger
+
+Then return to the original Read Order above for engineering discipline, codec protocol, and per-modality depth.
+
+### What's currently active
+
+- **Doctrine:** locked at v0.2.0-alpha.1.
+- **Code:** Codec Protocol v2 port — sequenced **M0 image → M1 image refinement → M2 audio → M3 sensor → M4 video stub → M5a/b benchmarks**. M0 is the first migration target.
+- **Out of scope until M5b:** new modalities, diffusion samplers, trained model weights, website rewrite, RFC-0003 renaming.
+
+### Claude-specific style and working rules
+
+This file is vendor-neutral. The Claude Code-specific working-rules / smallest-diff / reporting-format prompt lives in [`.claude/AGENT_PROMPT.md`](.claude/AGENT_PROMPT.md) — read it after this file if you are running under Claude Code.


### PR DESCRIPTION
## Summary

Per maintainer direction: the original \`AGENTS.md\` is preserved verbatim — no content was rewritten. This PR appends a single \"补充环节\" (supplementary section) at the bottom that catches the file up to \`v0.2.0-alpha.1\` without disturbing the hackathon-era primer above it.

## Why this shape

\`AGENTS.md\` predates the v0.2 doctrine lock and uses pre-lock vocabulary (\"L3 Renderer / Decoder\", \"L5 Distribution\"), references retired claims (\"no painter tier\" — now contradicts the documented \`polyglot-mini\` ⚠️ Research-grade sandbox), and is missing the v0.2 lock artifacts (THESIS, glossary, contributor-map, exec-plans/active, etc.). Rather than rewrite, the maintainer chose to append. When the original and the addendum disagree, the addendum wins.

## What's in the addendum

- **Locked vocabulary table** (ADR-0011) — supersedes the L1–L5 names above
- **Constraint deltas** — codec protocol v2 (RFC-0001 / ADR-0008), Path C rejection (ADR-0007), \`polyglot-mini\` painter sandbox clarification, manifest spine canonical pointer
- **Repo Map deltas** — \`codec-asciipng\`, \`apps/presentation\`, \`apps/wittgenstein-kimi\`, \`docs/exec-plans/active\`, \`docs/agent-guides\`, \`docs/rfcs\` + \`docs/adrs\`, \`docs/research/briefs\`
- **v0.2-supplement read order** — THESIS → glossary → contributor-map → hard-constraints → codec-v2-port → inheritance-audit → SYNTHESIS → final-audit
- **Active workstream** — M0 → M5b sequence, M0 is the first migration target
- **Vendor split note** — \`AGENTS.md\` is vendor-neutral; Claude-specific style/working-rules live in \`.claude/AGENT_PROMPT.md\`

## Naming verdict (recorded for the record)

\`AGENTS.md\` is the cross-vendor convention (agentsmd.net; Codex / Cursor / OpenAI Agents SDK / Claude Code default). Renaming or splitting would cost portability for no benefit. The vendor-neutral / Claude-specific split already exists at the file level (\`AGENTS.md\` ↔ \`.claude/AGENT_PROMPT.md\`).

## Formatting note

Wrapped the original Read Order in \`<!-- prettier-ignore -->\` fences because its zero-indexed list (\`0.\`) was being collapsed by prettier into a single line. Purely a formatting protection of existing content, not a content change.

## Test plan

- [x] \`pnpm exec prettier --check AGENTS.md\` — clean
- [x] \`git diff\` shows only additions plus the prettier-ignore wrap; original prose is byte-identical
- [x] All link targets exist in repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)