### PR TITLE
docs: raise engineering discipline in maintainer entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ cannot offer this; frozen VQ decoding does. See [`docs/reproducibility.md`](docs
 
 ### For maintainers and contributing agents
 
+- [`docs/engineering-discipline.md`](docs/engineering-discipline.md) — the sharp working standard for how to inspect, change, validate, and report in this repo
 - [`docs/exec-plans/active/codec-v2-port.md`](docs/exec-plans/active/codec-v2-port.md) — the live P6 plan (M0 → M5b) for porting all codecs to Codec Protocol v2
 - [`docs/agent-guides/README.md`](docs/agent-guides/README.md) — index of prompt-ready execution briefs
 - [`docs/agent-guides/image-to-audio-port.md`](docs/agent-guides/image-to-audio-port.md) — cross-line context (M0–M2)
@@ -219,6 +220,7 @@ cannot offer this; frozen VQ decoding does. See [`docs/reproducibility.md`](docs
 
 - [`SHOWCASE.md`](SHOWCASE.md) — 35 real artifacts across 7 modality groups, click to open
 - [`docs/quickstart.md`](docs/quickstart.md) — 30 seconds to a real file
+- [`docs/engineering-discipline.md`](docs/engineering-discipline.md) — how to make sharp, minimal, evidence-backed changes without fighting the repo
 - [`polyglot-mini/README.md`](polyglot-mini/README.md) — Python surface deep-dive
 - [`docs/extending.md`](docs/extending.md) — add a codec, train an adapter, plug in a provider
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — branch workflow, first-PR paths

--- a/docs/contributor-map.md
+++ b/docs/contributor-map.md
@@ -16,13 +16,14 @@ If you keep that frame, the repo reads cleanly.
 ## 2. Read this first
 
 1. `AGENTS.md`
-2. `docs/THESIS.md`
-3. `docs/tracks.md`
-4. `docs/inheritance-audit.md`
-5. `docs/rfcs/README.md`
-6. `docs/adrs/README.md`
-7. `docs/research/briefs/README.md`
-8. `docs/exec-plans/active/codec-v2-port.md`
+2. `docs/engineering-discipline.md`
+3. `docs/THESIS.md`
+4. `docs/tracks.md`
+5. `docs/inheritance-audit.md`
+6. `docs/rfcs/README.md`
+7. `docs/adrs/README.md`
+8. `docs/research/briefs/README.md`
+9. `docs/exec-plans/active/codec-v2-port.md`
 
 That order gets you from doctrine → review model → decisions → execution.
 
@@ -49,6 +50,7 @@ That order gets you from doctrine → review model → decisions → execution.
 - `packages/agent-contact-text/` — long-form context for humans and agents
 - `docs/research/briefs/` — research pressure tests
 - `docs/agent-guides/` — prompt-ready implementation guides for agents
+- `docs/engineering-discipline.md` — the sharp house style for reading before writing, minimal diffs, and evidence-backed validation
 
 ## 4. Two contributing lines
 
@@ -69,6 +71,7 @@ Typical work:
 Success criterion:
 
 - a new contributor can orient themselves without chat history.
+- they also know the repo's engineering tone before they touch code.
 
 ### Line B — image → audio execution
 
@@ -131,6 +134,8 @@ Every substantial PR gets two hats:
 - **Hacker hat:** can an agent implement or extend this without guessing?
 
 If either answer is no, the PR is not ready.
+
+The shortest companion to this review section is `docs/engineering-discipline.md`; it is the file that turns "be careful" into actual edit discipline.
 
 ## 7. What not to do
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -143,7 +143,7 @@ parameter spaces. They are tiny by design.
   If your adapter needs torch, it is probably doing too much work — consider moving the
   intelligence into the codec's renderer instead.
 - **Hashed bag-of-words embedding.** See `polyglot-mini/train/train.py::embed()`. Double-hash
-  + bigrams + L2 norm gets you dim 256–512 feature vectors with zero vocab to maintain.
+  - bigrams + L2 norm gets you dim 256–512 feature vectors with zero vocab to maintain.
 - **One-hop MLP.** Two to three hidden layers is enough. Adam with gradient clipping.
 - **Save as `.npz`.** Load via `np.load()`. No pickle, no custom serialisation.
 
@@ -250,11 +250,12 @@ A new codec is not done until these are updated:
 
 ## Where to look for precedent
 
-| You want to... | Read this first |
-|---|---|
-| Add a new codec in TS | `packages/codec-sensor/src/` (end-to-end real renderer, no external deps) |
-| Add a new codec in Python | `polyglot-mini/polyglot/sensor.py` (same codec, Python surface) |
-| Train a small adapter | `polyglot-mini/train/train_audio.py` (cleanest, smallest, fastest) |
-| Add an LLM provider | `polyglot-mini/polyglot/llm.py::_call_kimi_k2()` (stdlib urllib, no SDK) |
-| Add a sandbox boundary | `polyglot-mini/polyglot/sandbox.py` (subprocess with pre-injected globals) |
-| Shape a new IR schema | `packages/codec-sensor/src/schema.ts` (zod + preamble generator) |
+| You want to...                                            | Read this first                                                            |
+| --------------------------------------------------------- | -------------------------------------------------------------------------- |
+| Understand the repo's engineering standard before editing | `docs/engineering-discipline.md`                                           |
+| Add a new codec in TS                                     | `packages/codec-sensor/src/` (end-to-end real renderer, no external deps)  |
+| Add a new codec in Python                                 | `polyglot-mini/polyglot/sensor.py` (same codec, Python surface)            |
+| Train a small adapter                                     | `polyglot-mini/train/train_audio.py` (cleanest, smallest, fastest)         |
+| Add an LLM provider                                       | `polyglot-mini/polyglot/llm.py::_call_kimi_k2()` (stdlib urllib, no SDK)   |
+| Add a sandbox boundary                                    | `polyglot-mini/polyglot/sandbox.py` (subprocess with pre-injected globals) |
+| Shape a new IR schema                                     | `packages/codec-sensor/src/schema.ts` (zod + preamble generator)           |

--- a/packages/agent-contact-text/README.md
+++ b/packages/agent-contact-text/README.md
@@ -4,13 +4,13 @@ This package holds **extended narrative context** for coding agents and human op
 
 ## Canonical vs. extended
 
-| Tier | Where | Role |
-| --- | --- | --- |
-| **Primary** | [`AGENTS.md`](../../AGENTS.md), [`docs/architecture.md`](../../docs/architecture.md), [`docs/hard-constraints.md`](../../docs/hard-constraints.md) | Locked rules, repo map, where code must live |
-| **System of record** | [`docs/`](../../docs/) | ADRs, codec contracts, reproducibility, exec plans |
-| **Extended (this package)** | `00_INDEX.md` … `03_*.md` | Build book, execution mindset, research dossier—depth for agents that need project history and rationale |
+| Tier                        | Where                                                                                                                                                                                                                        | Role                                                                                                     |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| **Primary**                 | [`AGENTS.md`](../../AGENTS.md), [`docs/engineering-discipline.md`](../../docs/engineering-discipline.md), [`docs/architecture.md`](../../docs/architecture.md), [`docs/hard-constraints.md`](../../docs/hard-constraints.md) | Locked rules, edit discipline, repo map, where code must live                                            |
+| **System of record**        | [`docs/`](../../docs/)                                                                                                                                                                                                       | ADRs, codec contracts, reproducibility, exec plans                                                       |
+| **Extended (this package)** | `00_INDEX.md` … `03_*.md`                                                                                                                                                                                                    | Build book, execution mindset, research dossier—depth for agents that need project history and rationale |
 
-When instructions conflict, **trust `AGENTS.md` and `docs/` first**.
+When instructions conflict, **trust `AGENTS.md`, `docs/engineering-discipline.md`, and `docs/` first**.
 
 ## Architecture (coding-agent view)
 
@@ -26,18 +26,19 @@ Wittgenstein is a **five-layer modality harness**: the LLM plans in text; the re
 
 ## Contents of this package
 
-| File | Purpose |
-| --- | --- |
-| [`00_INDEX.md`](./00_INDEX.md) | Delivery index / map of the reference set |
-| [`01_Build_Book.md`](./01_Build_Book.md) | Full build book (product and technical narrative) |
-| [`01_Build_Book.docx`](./01_Build_Book.docx) | Same as Word source (optional) |
-| [`02_AI_Execution_Context.md`](./02_AI_Execution_Context.md) | How agents should behave in this codebase day to day |
-| [`03_Research_Reference_Dossier.md`](./03_Research_Reference_Dossier.md) | Research-backed reference notes |
+| File                                                                     | Purpose                                              |
+| ------------------------------------------------------------------------ | ---------------------------------------------------- |
+| [`00_INDEX.md`](./00_INDEX.md)                                           | Delivery index / map of the reference set            |
+| [`01_Build_Book.md`](./01_Build_Book.md)                                 | Full build book (product and technical narrative)    |
+| [`01_Build_Book.docx`](./01_Build_Book.docx)                             | Same as Word source (optional)                       |
+| [`02_AI_Execution_Context.md`](./02_AI_Execution_Context.md)             | How agents should behave in this codebase day to day |
+| [`03_Research_Reference_Dossier.md`](./03_Research_Reference_Dossier.md) | Research-backed reference notes                      |
 
 Shorter mirrors of some reference material also exist under [`docs/references/`](../../docs/references/) for inline reading next to implementation docs; the **00–03 set here is the bundled “agent contact” corpus**.
 
 ## Suggested read order (agent)
 
 1. [`AGENTS.md`](../../AGENTS.md) — rules and repo map (short).
-2. [`docs/architecture.md`](../../docs/architecture.md) — layer table and dataflow.
-3. This package: `02_AI_Execution_Context.md` → `00_INDEX.md` → skim `01_*` / `03_*` as needed for depth.
+2. [`docs/engineering-discipline.md`](../../docs/engineering-discipline.md) — how to inspect, change, validate, and report here.
+3. [`docs/architecture.md`](../../docs/architecture.md) — layer table and dataflow.
+4. This package: `02_AI_Execution_Context.md` → `00_INDEX.md` → skim `01_*` / `03_*` as needed for depth.


### PR DESCRIPTION
## Summary

`docs/engineering-discipline.md` is one of the sharpest and most opinionated docs in the repo, but it was still acting more like a side document than a first-hop maintainer surface.

This PR raises its priority without changing doctrine:
- surface it earlier in the root README for maintainers and hackers
- make it part of the first read-order in `docs/contributor-map.md`
- treat it as a primary norm in `packages/agent-contact-text/README.md`
- add it to the precedent table in `docs/extending.md`

## Why

The file is valuable because it translates repo philosophy into engineering behavior:
- read before write
- smallest effective change
- no hidden errors
- evidence-backed validation
- no drive-by refactor

Those rules are more useful when they are encountered before implementation, not after.

## Validation

- `pnpm exec prettier --check README.md docs/contributor-map.md packages/agent-contact-text/README.md docs/extending.md`
- `git diff --check`

## Scope

Docs only. No doctrine changes, no runtime changes.
