### PR TITLE
docs: explicit agent handoff in PROMPT.md + stable receipts emphasis in README

### DIFF
--- a/PROMPT.md
+++ b/PROMPT.md
@@ -5,6 +5,11 @@
 > agent at it — for the smallest correct briefing to act in this repo.
 > [`AGENTS.md`](AGENTS.md) is the longer reference primer; this is the
 > imperative version.
+>
+> **Important.** Do not assume an AI tool or agent will discover this file on
+> its own. If you are handing work to an AI, an agent, or an agent
+> contributor, explicitly give it this file and treat it as required input,
+> not optional background context.
 
 ## You are
 

--- a/README.md
+++ b/README.md
@@ -63,14 +63,14 @@ Wittgenstein makes three architectural bets instead:
 
 ## Receipts (not claims)
 
-| What                                     | Number                     | How                                                    |
-| ---------------------------------------- | -------------------------- | ------------------------------------------------------ |
-| Image style MLP validation loss          | **0.7698 BCE**             | 781 COCO captions, 9 s on CPU, 600 epochs              |
-| Audio ambient classifier accuracy        | **5 / 5 spot checks**      | 369 examples, < 5 s on CPU, keyword + MLP hybrid       |
-| LLM token cost: scene JSON vs raw pixels | **~ 52,000× less**         | 60 tokens vs 1024×1024×3 pixel values                  |
-| Sensor expand latency                    | **< 2 ms**                 | Pure numpy, 250 Hz × 10 s ECG with operator spec       |
-| Loupe HTML dashboard size                | **~ 117 KB**               | Zero external dependencies, single self-contained file |
-| Full typecheck + lint                    | **10 / 10 packages green** | Strict TS, ESLint, pnpm workspaces                     |
+| What                                     | Number                                  | How                                                    |
+| ---------------------------------------- | --------------------------------------- | ------------------------------------------------------ |
+| Image style MLP validation loss          | <strong>0.7698 BCE</strong>             | 781 COCO captions, 9 s on CPU, 600 epochs              |
+| Audio ambient classifier accuracy        | <strong>5 / 5 spot checks</strong>      | 369 examples, < 5 s on CPU, keyword + MLP hybrid       |
+| LLM token cost: scene JSON vs raw pixels | <strong>~ 52,000× less</strong>         | 60 tokens vs 1024×1024×3 pixel values                  |
+| Sensor expand latency                    | <strong>&lt; 2 ms</strong>              | Pure numpy, 250 Hz × 10 s ECG with operator spec       |
+| Loupe HTML dashboard size                | <strong>~ 117 KB</strong>               | Zero external dependencies, single self-contained file |
+| Full typecheck + lint                    | <strong>10 / 10 packages green</strong> | Strict TS, ESLint, pnpm workspaces                     |
 
 Adapter training stats are from real runs; see [`docs/benchmark-standards.md`](docs/benchmark-standards.md)
 for the full measurement protocol.


### PR DESCRIPTION
## Summary

Two small docs commits that landed on the fork's `main` directly and have not yet reached the organisation's `main`. Sending them now so the two trees stay in sync.

- **`docs(prompt): make agent handoff requirement explicit`** — adds 5 lines to `PROMPT.md` clarifying the agent-facing handoff requirement.
- **`docs(readme): stabilize receipts table emphasis rendering`** — 8 lines changed in the README receipts table so the bold/italic emphasis renders consistently across GitHub / npm / wittgenstein.wtf.

No code changes. No doctrine changes. No new files.

## Test plan

- [x] `pnpm exec prettier --check README.md PROMPT.md` clean
- [x] Visual check: receipts table renders correctly on GitHub preview
- [x] No links broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)