### PR TITLE
docs(briefs): add Brief J and audio CLI addendum

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ cannot offer this; frozen VQ decoding does. See [`docs/reproducibility.md`](docs
 ### For maintainers and contributing agents
 
 - [`docs/engineering-discipline.md`](docs/engineering-discipline.md) — the sharp working standard for how to inspect, change, validate, and report in this repo
+- [`docs/archive-policy.md`](docs/archive-policy.md) — how this repo decides delete vs archive vs refresh when old surfaces drift
 - [`docs/exec-plans/active/codec-v2-port.md`](docs/exec-plans/active/codec-v2-port.md) — the live P6 plan (M0 → M5b) for porting all codecs to Codec Protocol v2
 - [`docs/agent-guides/README.md`](docs/agent-guides/README.md) — index of prompt-ready execution briefs
 - [`docs/agent-guides/image-to-audio-port.md`](docs/agent-guides/image-to-audio-port.md) — cross-line context (M0–M2)

--- a/docs/archive-policy.md
+++ b/docs/archive-policy.md
@@ -1,0 +1,131 @@
+# Archive Policy
+
+This document defines how Wittgenstein treats stale, superseded, historical, and mixed-surface files.
+
+The goal is **not** to keep everything forever, and **not** to delete everything aggressively. The goal is to preserve provenance without polluting active guidance.
+
+---
+
+## The four outcomes
+
+When you find an old file, choose exactly one of these outcomes:
+
+### 1. Delete
+
+Delete the file if all of the following are true:
+
+- it is low-value or purely temporary;
+- it has no meaningful role in current reasoning or provenance;
+- it is not linked from current docs, issues, RFCs, ADRs, or execution guides;
+- git history is enough if someone ever needs it again.
+
+Typical examples:
+
+- one-off scratch notes;
+- abandoned duplicates;
+- generated intermediates;
+- half-finished drafts with no surviving references.
+
+### 2. Archive
+
+Archive the file if it is no longer active guidance **but still matters historically**.
+
+Archive is the right move when the file:
+
+- carried a real decision path, milestone, or handoff;
+- is explicitly superseded by a newer surface;
+- is still useful for provenance, release history, or research traceability;
+- would be misleading if left in an active path.
+
+Typical examples:
+
+- superseded day-1 plans;
+- old showcase or benchmark snapshots;
+- replaced RFCs / ADRs / handoff materials that still explain why a later decision exists.
+
+### 3. Refresh
+
+Refresh the file if it is still meant to be active guidance but has drifted.
+
+Use this when the file still occupies a live slot in:
+
+- `README.md`
+- `docs/index.md`
+- `AGENTS.md`
+- contributor onboarding
+- current issue / PR / exec-plan flows
+
+If a file is still on the main path, do not silently let it rot.
+
+### 4. Reclassify
+
+Some files are neither purely active nor purely historical. They are **mixed-surface** documents: still useful, but no longer the canonical execution brief.
+
+In that case:
+
+- keep the path stable if many references already point to it;
+- add a clear status banner at the top;
+- explicitly point readers to the current active surface;
+- say what historical or legacy role the page still serves.
+
+This is usually better than a rushed archive move.
+
+---
+
+## Archive placement rules
+
+Prefer **surface-local archive paths**, not one giant catch-all graveyard.
+
+Good examples:
+
+- `docs/exec-plans/archive/`
+- `docs/research/archive/` if research notes later need it
+- a codec-local or site-local archive folder if that surface accumulates its own history
+
+Every archive folder should contain a `README.md` that answers:
+
+1. What lives here?
+2. Why was it archived?
+3. What active surface supersedes it?
+4. What should readers use instead?
+
+Do not link archived files as active guidance.
+
+---
+
+## Required metadata for archived material
+
+When archiving a file, say at least:
+
+- **status** — archived / superseded / historical
+- **reason** — why it moved out of the active path
+- **superseded by** — exact current file or issue if one exists
+- **usage rule** — e.g. "kept for provenance, not for execution"
+
+If a file cannot be described this way, it is often a sign it should be deleted instead.
+
+---
+
+## Review checklist
+
+Before archiving or deleting a file, check:
+
+- Is it linked from `README.md`, `docs/index.md`, `AGENTS.md`, or contributor guides?
+- Is it cited by an RFC, ADR, exec-plan, issue, or PR that still matters?
+- Is it a historical receipt that supports a release, benchmark, or milestone claim?
+- Would an agent mistake it for active guidance if it stayed where it is?
+
+If the answer to the last question is yes, action is required: archive, refresh, or reclassify.
+
+---
+
+## Current repo stance
+
+For Wittgenstein specifically:
+
+- **active guidance** should stay concentrated in `AGENTS.md`, `docs/index.md`, active exec-plans, current agent guides, and the current doctrine documents;
+- **locked doctrine** lives in thesis / ADR / hard-constraints / naming surfaces;
+- **historical receipts** should be preserved when they explain a milestone, benchmark, release, or handoff;
+- **mixed-surface pages** should be clearly marked rather than quietly left ambiguous.
+
+This policy is an extension of `docs/engineering-discipline.md`, not a replacement for it.

--- a/docs/engineering-discipline.md
+++ b/docs/engineering-discipline.md
@@ -9,6 +9,7 @@ This document establishes the working principles for Wittgenstein development, a
 The foundational directive is to **inspect the relevant code, tests, config, and nearby patterns before editing.**
 
 This means:
+
 - Understanding existing implementation patterns before adding to them
 - Knowing what tests already exist and what they cover
 - Seeing how the build, lint, and type-check systems are configured
@@ -35,6 +36,16 @@ Because Wittgenstein's doctrine is load-bearing:
 - Do not add a second image path, a new operator, or a new modality without an RFC
 - Do not make the harness modality-branch again (M4 cleanup is scheduled; don't jump it early)
 
+### Documentation surface discipline
+
+Not every document in this repo serves the same role. Before editing, classify the surface you are touching:
+
+- **Active guidance** — current execution guidance (`AGENTS.md`, active exec-plans, current agent guides)
+- **Locked doctrine** — thesis / ADR / hard constraints / naming decisions
+- **Historical receipts** — archived plans, prior showcase packs, benchmark snapshots, past handoff context
+
+Do not casually upgrade a historical receipt into active guidance, and do not quietly smuggle a new doctrine decision into an execution guide. If a surface changes role, say so explicitly in the diff.
+
 ## Code Standards
 
 Target minimal diffs, clear structure, robust behavior, correct logic, and consistency with surrounding code.
@@ -56,7 +67,7 @@ Avoid broad rewrites or speculative architecture. If you find the problem is big
 
 **Reuse existing patterns** before inventing new ones. Don't create utility modules without clear justification.
 
-**Avoid premature abstraction.** Every abstraction must solve a real *present* problem. Direct implementations are preferable when they're easier to understand and maintain.
+**Avoid premature abstraction.** Every abstraction must solve a real _present_ problem. Direct implementations are preferable when they're easier to understand and maintain.
 
 **Extend existing code paths** over building parallel systems. Make data flow and side effects explicit and visible. Enable local reasoning rather than creating distributed indirection.
 
@@ -66,6 +77,7 @@ Avoid broad rewrites or speculative architecture. If you find the problem is big
 - Codec manifest authorship is now codec-owned (not harness-overridden) — respect this split
 - The `quality.partial` invariant protects against silent fallbacks — use it
 - Goldens are the regression baseline — byte-for-byte for deterministic, structural for LLM-driven
+- Parallel modality lines may explore locally, but shared shape converges explicitly later — do not silently promote modality-local practice into shared contract
 
 ## Robustness: Never Hide Errors
 
@@ -74,15 +86,19 @@ Avoid broad rewrites or speculative architecture. If you find the problem is big
 All failures must preserve diagnostic information and remain inspectable.
 
 ### Input validation
+
 External data (LLM outputs, user prompts, config) must be scrutinized:
+
 - Treat incoming information as potentially compromised
 - Validate all assumptions at system boundaries
 - Make invalid states architecturally difficult to create
 
 ### Behavioral consistency
+
 Maintain established functionality unless change is explicitly needed. Select straightforward approaches over sophisticated but fragile solutions. Avoid unintended degradation unless it represents a deliberate product choice.
 
 ### Debuggability
+
 **Printability is a feature.** Code should be straightforward to log, test, examine, and troubleshoot. Operational clarity matters for production systems.
 
 Manifests and run records are not overhead — they are the evidence that reproducibility holds.
@@ -116,6 +132,7 @@ Prioritize code that future developers can act correctly from without asking que
 **State exactly what you verified, and do not imply checks you did not run.**
 
 Meaningful behavior changes require validation. Preference order:
+
 1. Specific tests (unit, integration, round-trip)
 2. Type checking and linting
 3. Building
@@ -145,6 +162,7 @@ Do not fake confidence when verification is incomplete. Explicitly state what wa
 ## No Drive-By Refactor
 
 **Stay on task.** Avoid:
+
 - Renaming unrelated symbols
 - Moving files unnecessarily
 - Reformatting unrelated code sections
@@ -199,6 +217,7 @@ run. That is correct behavior.
 ## Success Looks Like This
 
 You finish the task, and:
+
 - The code is minimal, readable, and testable
 - Behavior is preserved unless change was required
 - Errors surface as structured data with context

--- a/docs/exec-plans/active/codec-v2-port.md
+++ b/docs/exec-plans/active/codec-v2-port.md
@@ -1,9 +1,9 @@
 # Codec v2 Port — P6 execution plan
 
 **Date opened:** 2026-04-25
-**Last amended:** 2026-04-25 (stub → full plan; per-package diff, golden contract, migration tests, rollback criteria)
+**Last amended:** 2026-04-26 (M0/M1 landed; status + file-path drift corrected for the live plan)
 **Feeds from:** ADR-0008 (Codec Protocol v2 adoption), ADR-0011 (naming v2), RFC-0001, Brief A (LFQ rename), Brief E (benchmarks v2 targets), `docs/v02-final-audit.md`
-**Status:** 🟡 Plan ready — awaiting M0 kickoff
+**Status:** 🟡 Active — M0 and M1 landed; M2 is the next execution line
 
 ## Purpose
 
@@ -109,20 +109,23 @@ A single dissent blocks the gate.
 
 **Files added:**
 
-- `packages/schemas/src/codec-v2.ts` — `Codec<Req, Art>`, `IR = Text | Latent | Hybrid`,
-  `Route`, `HarnessCtx`, `Artifact`, `BaseCodec` abstract class. Tagged `@experimental`.
-- `packages/schemas/src/index.ts` — re-export from `codec-v2.ts` under a single
-  `import { Codec } from "@wittgenstein/schemas/v2"` entry point.
+- `packages/schemas/src/codec/v2/*` — split protocol surface:
+  `codec.ts`, `base.ts`, `ctx.ts`, `ir.ts`, `sidecar.ts`, `warning.ts`,
+  `standard-schema.ts`, plus the barrel `index.ts`. Together they define
+  `Codec<Req, Art>`, `IR = Text | Latent | Hybrid`, `Route`, `HarnessCtx`,
+  `ManifestRow`, and the `BaseCodec` abstract class. Tagged `@experimental`.
+- `packages/schemas/src/index.ts` — re-exports the v2 surface as
+  `codecV2` from `./codec/v2/index.js`.
 
 **Files unchanged:** every codec, every harness file, every CLI surface.
 
 **Migration tests:**
 
 - `pnpm typecheck` green across the workspace.
-- New file `packages/schemas/test/codec-v2.contract.test.ts`: instantiates a no-op
-  `BaseCodec` subclass for each of the 7 modalities with a fake request and asserts the
-  type compiles. ≤20 lines per modality (this is RFC-0001's round-trip test, run as
-  type-only).
+- `packages/schemas/test/codec-v2.test.ts` — smoke-tests the v2 protocol surface
+  (`BaseCodec.produce`, warning folding, IR guards, `HarnessCtx.fork`).
+- `packages/schemas/test/contract.test.ts` — keeps the locked schema exports honest
+  (`Modality`, `RenderResultSchema`, `RunManifestSchema`).
 
 **Rollback criteria:** revert is one PR. No runtime code depends on the new types yet,
 so revert is safe at any time before M1.
@@ -221,7 +224,7 @@ soundscape, music) each have their own route file in `codec-audio/src/routes/`.
 
 - `packages/codec-audio/src/codec.ts` — rewrite as `class AudioCodec extends BaseCodec<AudioRequest, AudioArtifact>`. The codec's `route()` method dispatches to the
   appropriate sub-route.
-- `packages/codec-audio/src/routes/{speech,soundscape,music}.ts` — refactor each into a
+- `packages/codec-audio/src/routes/{speech,soundscape,music}/index.ts` — refactor each into a
   `Route` object that the codec composes; shared logic moves into a `BaseAudioRoute`.
   The 80-line copy-paste collapses to ~20 lines per route.
 - `packages/codec-audio/src/runtime.ts` — manifest authorship moves into the codec's

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1,5 +1,19 @@
 # Extending Wittgenstein
 
+> **Status:** mixed-surface reference. This page still contains useful extension recipes,
+> especially for `polyglot-mini` and older v0.1-era codec patterns, but it is **not**
+> the canonical execution brief for the current Codec v2 migration.
+>
+> For active v0.2 work, start with:
+>
+> - `AGENTS.md`
+> - `docs/exec-plans/active/codec-v2-port.md`
+> - `docs/agent-guides/`
+> - `docs/archive-policy.md` when deciding whether to refresh, archive, or retire an older surface
+>
+> Keep this page for reusable extension patterns and legacy recipes; do not treat every
+> example below as the current shipping shape.
+
 Wittgenstein has two surfaces that share one architecture:
 
 - **TypeScript monorepo** (`packages/*`) — production harness with typed contracts,

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -1,5 +1,15 @@
 # Implementation Status
 
+> **Status:** mixed ledger. This page is a practical status matrix across the TypeScript
+> harness and the legacy / demo-oriented `polyglot-mini` surface, but it is **not** the
+> sole source of truth for the active Codec v2 migration order.
+>
+> For current execution priority and gates, use:
+>
+> - `docs/exec-plans/active/codec-v2-port.md`
+> - `docs/agent-guides/`
+> - `docs/archive-policy.md` if a row here starts to drift into historical-only status
+>
 > Last updated: 2026-04-20. "Ships" = produces real output today. "Stub" = typed interface,
 > throws `NotImplementedError`, waiting for a renderer. "Partial" = some routes work.
 
@@ -9,108 +19,116 @@
 
 Everything below runs with `python3 -m polyglot.cli <cmd>`.
 
-| Component | Status | Notes |
-|---|---|---|
-| **Image — LLM code-as-painter** | ✅ Ships | LLM → Python PIL/NumPy/SciPy → sandboxed subprocess → PNG |
-| **Image — MLP fallback painter** | ✅ Ships | text → hashed-BoW embed → MLP → palette+layout → procedural PNG |
-| **Image — COCO training pipeline** | ✅ Ships | `train/build_dataset_coco.py` + `train/train.py`; 781 examples, 9 s |
-| **TTS — speech** | ✅ Ships | macOS `say` → AIFF → `afconvert` → M4A (zero deps) |
-| **TTS — procedural ambient** | ✅ Ships | AudioMLP classifier → rain/wind/city/forest/electronic/white\_noise → NumPy+SciPy synth → mixed M4A |
-| **Audio adapter training** | ✅ Ships | `train/train_audio.py`; 369 examples, < 5 s |
-| **Sensor — dry-run expand** | ✅ Ships | Built-in ECG/accelerometer/temperature specs → numpy arrays → CSV + PNG |
-| **Sensor — LLM expand** | ✅ Ships | LLM → operator-spec JSON → same expand path |
-| **Sensor — Loupe HTML dashboard** | ✅ Ships | CSV → `loupe.py` → self-contained interactive HTML |
-| **LLM provider routing** | ✅ Ships | Kimi K2 / MiniMax / OpenAI-compat / Anthropic via env vars |
-| **Dry-run / no-LLM modes** | ✅ Ships | All three commands work without an API key |
+| Component                          | Status   | Notes                                                                                              |
+| ---------------------------------- | -------- | -------------------------------------------------------------------------------------------------- |
+| **Image — LLM code-as-painter**    | ✅ Ships | LLM → Python PIL/NumPy/SciPy → sandboxed subprocess → PNG                                          |
+| **Image — MLP fallback painter**   | ✅ Ships | text → hashed-BoW embed → MLP → palette+layout → procedural PNG                                    |
+| **Image — COCO training pipeline** | ✅ Ships | `train/build_dataset_coco.py` + `train/train.py`; 781 examples, 9 s                                |
+| **TTS — speech**                   | ✅ Ships | macOS `say` → AIFF → `afconvert` → M4A (zero deps)                                                 |
+| **TTS — procedural ambient**       | ✅ Ships | AudioMLP classifier → rain/wind/city/forest/electronic/white_noise → NumPy+SciPy synth → mixed M4A |
+| **Audio adapter training**         | ✅ Ships | `train/train_audio.py`; 369 examples, < 5 s                                                        |
+| **Sensor — dry-run expand**        | ✅ Ships | Built-in ECG/accelerometer/temperature specs → numpy arrays → CSV + PNG                            |
+| **Sensor — LLM expand**            | ✅ Ships | LLM → operator-spec JSON → same expand path                                                        |
+| **Sensor — Loupe HTML dashboard**  | ✅ Ships | CSV → `loupe.py` → self-contained interactive HTML                                                 |
+| **LLM provider routing**           | ✅ Ships | Kimi K2 / MiniMax / OpenAI-compat / Anthropic via env vars                                         |
+| **Dry-run / no-LLM modes**         | ✅ Ships | All three commands work without an API key                                                         |
 
 ---
 
-## @wittgenstein/* TypeScript packages
+## @wittgenstein/\* TypeScript packages
 
 The TS monorepo is the **production harness layer** (L1–L5). Core, schemas, CLI, and sensor/audio
 codecs are wired. Image and video codecs are typed stubs — intentional until training is complete.
 
 ### @wittgenstein/schemas
-| Export | Status | Notes |
-|---|---|---|
-| `WittgensteinCodec<Req,Parsed>` interface | ✅ Ships | Full type contract |
-| `RenderResult`, `RenderCtx`, `RunManifest` | ✅ Ships | |
-| `Modality` enum | ✅ Ships | image / audio / video / sensor |
-| `SensorRequest`, `AudioRequest`, `ImageRequest` | ✅ Ships | Zod schemas |
+
+| Export                                          | Status   | Notes                          |
+| ----------------------------------------------- | -------- | ------------------------------ |
+| `WittgensteinCodec<Req,Parsed>` interface       | ✅ Ships | Full type contract             |
+| `RenderResult`, `RenderCtx`, `RunManifest`      | ✅ Ships |                                |
+| `Modality` enum                                 | ✅ Ships | image / audio / video / sensor |
+| `SensorRequest`, `AudioRequest`, `ImageRequest` | ✅ Ships | Zod schemas                    |
 
 ### @wittgenstein/core
-| Component | Status | Notes |
-|---|---|---|
-| `harness.ts` — `Wittgenstein` class | ✅ Ships | render(), route dispatching, manifest write |
-| `registry.ts` — codec registry | ✅ Ships | |
-| `router.ts` — modality routing | ✅ Ships | |
-| `manifest.ts` — run manifest emitter | ✅ Ships | writes `artifacts/runs/<id>/manifest.json` |
-| `telemetry.ts` — artifact logger | ✅ Ships | |
-| `budget.ts` — token/cost tracker | ✅ Ships | |
-| `retry.ts` — retry policy | ✅ Ships | |
-| `seed.ts` — deterministic RNG | ✅ Ships | |
-| `errors.ts` — error taxonomy | ✅ Ships | `NotImplementedError`, `BudgetExceededError`, etc. |
-| `config.ts` — config loader | ✅ Ships | `polyglot.config.ts` + env vars |
-| `llm/openai-compatible.ts` | ✅ Ships | Moonshot/MiniMax/DeepSeek/Qwen/OpenAI |
-| `llm/anthropic.ts` | ✅ Ships | Claude via `x-api-key` |
+
+| Component                            | Status   | Notes                                              |
+| ------------------------------------ | -------- | -------------------------------------------------- |
+| `harness.ts` — `Wittgenstein` class  | ✅ Ships | render(), route dispatching, manifest write        |
+| `registry.ts` — codec registry       | ✅ Ships |                                                    |
+| `router.ts` — modality routing       | ✅ Ships |                                                    |
+| `manifest.ts` — run manifest emitter | ✅ Ships | writes `artifacts/runs/<id>/manifest.json`         |
+| `telemetry.ts` — artifact logger     | ✅ Ships |                                                    |
+| `budget.ts` — token/cost tracker     | ✅ Ships |                                                    |
+| `retry.ts` — retry policy            | ✅ Ships |                                                    |
+| `seed.ts` — deterministic RNG        | ✅ Ships |                                                    |
+| `errors.ts` — error taxonomy         | ✅ Ships | `NotImplementedError`, `BudgetExceededError`, etc. |
+| `config.ts` — config loader          | ✅ Ships | `polyglot.config.ts` + env vars                    |
+| `llm/openai-compatible.ts`           | ✅ Ships | Moonshot/MiniMax/DeepSeek/Qwen/OpenAI              |
+| `llm/anthropic.ts`                   | ✅ Ships | Claude via `x-api-key`                             |
 
 ### @wittgenstein/codec-sensor
-| Component | Status | Notes |
-|---|---|---|
-| Schema + Zod validation | ✅ Ships | |
-| Signal expander (oscillator, noise, drift, pulse, step, ECG template) | ✅ Ships | Pure TypeScript, deterministic |
-| Loupe HTML dashboard integration | ✅ Ships | searches 4 candidate paths for `loupe.py` |
-| JSON + CSV sidecar output | ✅ Ships | |
-| LLM operator-spec route | ✅ Ships | |
+
+| Component                                                             | Status   | Notes                                     |
+| --------------------------------------------------------------------- | -------- | ----------------------------------------- |
+| Schema + Zod validation                                               | ✅ Ships |                                           |
+| Signal expander (oscillator, noise, drift, pulse, step, ECG template) | ✅ Ships | Pure TypeScript, deterministic            |
+| Loupe HTML dashboard integration                                      | ✅ Ships | searches 4 candidate paths for `loupe.py` |
+| JSON + CSV sidecar output                                             | ✅ Ships |                                           |
+| LLM operator-spec route                                               | ✅ Ships |                                           |
 
 ### @wittgenstein/codec-audio
-| Component | Status | Notes |
-|---|---|---|
-| Schema + Zod validation | ✅ Ships | |
-| Speech route (`renderSpeechRoute`) | ✅ Ships | WAV via stdlib encoder |
+
+| Component                                  | Status   | Notes                        |
+| ------------------------------------------ | -------- | ---------------------------- |
+| Schema + Zod validation                    | ✅ Ships |                              |
+| Speech route (`renderSpeechRoute`)         | ✅ Ships | WAV via stdlib encoder       |
 | Soundscape route (`renderSoundscapeRoute`) | ✅ Ships | Procedural ambient synthesis |
-| Music route (`renderMusicRoute`) | ✅ Ships | Symbolic → synth |
-| Ambient adapter (`ambient-adapter.ts`) | ✅ Ships | BoW → category heuristic |
-| WAV encoding runtime | ✅ Ships | `runtime.ts`, zero deps |
+| Music route (`renderMusicRoute`)           | ✅ Ships | Symbolic → synth             |
+| Ambient adapter (`ambient-adapter.ts`)     | ✅ Ships | BoW → category heuristic     |
+| WAV encoding runtime                       | ✅ Ships | `runtime.ts`, zero deps      |
 
 ### @wittgenstein/codec-image
-| Component | Status | Notes |
-|---|---|---|
-| Schema + Zod scene spec | ✅ Ships | |
-| `expand.ts` — prompt → scene JSON | ✅ Ships | LLM-driven |
-| `adapter.ts` — scene → latent codes | ⚠️ Partial | `placeholderLatents()` fires (deterministic FNV-1a seed), `resolveMlpForScene()` loads user-written MLP if weights present |
-| `decoder.ts` — latent codes → raster | ⚠️ Partial | `renderSky()` / `renderTerrain()` functional; `tryDecodeReferenceLandscape()` fires when reference weights present |
-| `package.ts` — raster → PNG | ✅ Ships | |
-| `decoders/llamagen.ts` | 🔴 Stub | Throws `NotImplementedError` — bridge to LlamaGen VQ-VAE decoder, not yet wired |
-| `decoders/seed.ts` | 🔴 Stub | Throws `NotImplementedError` — bridge to SEED decoder |
-| `training/` | 📋 Recipe only | Dataset choice, loss, LoRA config documented; no weights committed |
+
+| Component                            | Status         | Notes                                                                                                                      |
+| ------------------------------------ | -------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| Schema + Zod scene spec              | ✅ Ships       |                                                                                                                            |
+| `expand.ts` — prompt → scene JSON    | ✅ Ships       | LLM-driven                                                                                                                 |
+| `adapter.ts` — scene → latent codes  | ⚠️ Partial     | `placeholderLatents()` fires (deterministic FNV-1a seed), `resolveMlpForScene()` loads user-written MLP if weights present |
+| `decoder.ts` — latent codes → raster | ⚠️ Partial     | `renderSky()` / `renderTerrain()` functional; `tryDecodeReferenceLandscape()` fires when reference weights present         |
+| `package.ts` — raster → PNG          | ✅ Ships       |                                                                                                                            |
+| `decoders/llamagen.ts`               | 🔴 Stub        | Throws `NotImplementedError` — bridge to LlamaGen VQ-VAE decoder, not yet wired                                            |
+| `decoders/seed.ts`                   | 🔴 Stub        | Throws `NotImplementedError` — bridge to SEED decoder                                                                      |
+| `training/`                          | 📋 Recipe only | Dataset choice, loss, LoRA config documented; no weights committed                                                         |
 
 ### @wittgenstein/codec-video
-| Component | Status | Notes |
-|---|---|---|
-| Schema + Zod | ✅ Ships | |
-| `hyperframes-wrapper.ts` | 🔴 Stub | Throws `NotImplementedError` — HyperFrames not yet forked |
+
+| Component                | Status   | Notes                                                     |
+| ------------------------ | -------- | --------------------------------------------------------- |
+| Schema + Zod             | ✅ Ships |                                                           |
+| `hyperframes-wrapper.ts` | 🔴 Stub  | Throws `NotImplementedError` — HyperFrames not yet forked |
 
 ### @wittgenstein/cli
-| Command | Status | Notes |
-|---|---|---|
-| `wittgenstein image` | ✅ Ships | Calls codec-image; renders with available adapter/decoder |
-| `wittgenstein audio` | ✅ Ships | Full speech + soundscape + music routes |
-| `wittgenstein sensor` | ✅ Ships | Full signal expand + Loupe dashboard |
-| `wittgenstein video` | 🔴 Stub | Codec throws `NotImplementedError` |
-| `wittgenstein doctor` | ✅ Ships | Checks node, pnpm, env vars, package links |
+
+| Command               | Status   | Notes                                                     |
+| --------------------- | -------- | --------------------------------------------------------- |
+| `wittgenstein image`  | ✅ Ships | Calls codec-image; renders with available adapter/decoder |
+| `wittgenstein audio`  | ✅ Ships | Full speech + soundscape + music routes                   |
+| `wittgenstein sensor` | ✅ Ships | Full signal expand + Loupe dashboard                      |
+| `wittgenstein video`  | 🔴 Stub  | Codec throws `NotImplementedError`                        |
+| `wittgenstein doctor` | ✅ Ships | Checks node, pnpm, env vars, package links                |
 
 ### @wittgenstein/sandbox
-| Component | Status |
-|---|---|
+
+| Component                             | Status                    |
+| ------------------------------------- | ------------------------- |
 | `exec.ts` — `execProgram()` interface | ✅ Ships (typed boundary) |
 
 ---
 
 ## loupe.py (repo root)
 
-| Component | Status | Notes |
-|---|---|---|
+| Component                                  | Status   | Notes                                            |
+| ------------------------------------------ | -------- | ------------------------------------------------ |
 | CSV / JSON → self-contained HTML dashboard | ✅ Ships | 117 KB HTML, zero external deps, dark/light mode |
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@ Read these two files before any task:
 
 - [`.claude/AGENT_PROMPT.md`](../.claude/AGENT_PROMPT.md) — orientation (what the project is, how to find information, exact working discipline)
 - [`engineering-discipline.md`](engineering-discipline.md) — working standards (code style, robustness, testing, reporting, constraints)
+- [`archive-policy.md`](archive-policy.md) — how to decide delete vs archive vs refresh vs reclassify when old files drift
 
 ## Then understand the thesis and governance
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,6 +50,7 @@ Read these two files before any task:
 - [`research/briefs/F_site_reconciliation.md`](research/briefs/F_site_reconciliation.md) — site ↔ repo reconciliation
 - [`research/briefs/G_image_network_clues.md`](research/briefs/G_image_network_clues.md) — image decoder / data / packaging (M1 prerequisite)
 - [`research/briefs/H_codec_engineering_prior_art.md`](research/briefs/H_codec_engineering_prior_art.md) — codec protocol prior art; F1/F2 RFC-0001 amendments (M1A prerequisite)
+- [`research/briefs/J_audio_engineering_and_routes.md`](research/briefs/J_audio_engineering_and_routes.md) — M2 route shape, manifest rows, fixture strategy, and deprecation contract
 
 ## Long-form research notes (predate the briefs)
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,5 +1,13 @@
 # Quickstart
 
+> **Status:** demo-surface quickstart. This page is still valid for hands-on runs,
+> especially the deterministic and `polyglot-mini` paths, but it is **not** the main
+> execution brief for the active `M0 → M5b` migration.
+>
+> Use this page when you want to produce a file quickly. Use
+> `docs/exec-plans/active/codec-v2-port.md` and `docs/agent-guides/` when you are
+> changing code or porting a codec.
+
 Three paths to a real file in under a minute. None of them need an API key — they all run
 against the deterministic codec paths.
 
@@ -17,8 +25,9 @@ open /tmp/ecg.html     # macOS; or xdg-open on Linux
 ```
 
 What you get: `/tmp/ecg.json` (operator spec) + `/tmp/ecg.csv` (2,500 samples)
-+ `/tmp/ecg.png` (matplotlib chart) + `/tmp/ecg.html` (~117 KB interactive loupe dashboard,
-zero external dependencies).
+
+- `/tmp/ecg.png` (matplotlib chart) + `/tmp/ecg.html` (~117 KB interactive loupe dashboard,
+  zero external dependencies).
 
 The dashboard has sortable tables, summary stats, and dark/light mode. The whole thing is
 one HTML file with no CDN calls, no analytics, no JavaScript imports.

--- a/docs/research/briefs/D_cli_and_sdk_conventions.md
+++ b/docs/research/briefs/D_cli_and_sdk_conventions.md
@@ -156,7 +156,41 @@ Two deliberate divergences from the 2025-class AI CLI template.
 
 - **No `--model` override on modality commands by default.** The chat CLIs all expose `--model` because their primary job is LLM-as-service. Wittgenstein's primary job is a specific codec producing a specific artifact; the model is an internal implementation detail of the harness, and exposing it at the CLI invites users to swap it in ways that invalidate the codec's guarantees. Instead, expose `--provider <name>` (choose which configured provider) and let the provider's config pin the model. Power users who need fine-grained model control can set `WITTGENSTEIN_LLM_MODEL=...` in env; the precedence rule from (2) means that still works. This is a divergence from Gemini / Claude Code / Kimi and it is defensible because we are a harness, not a chat service.
 
-Net: six decisions to write into RFC-0002, two of which are industry-standard, two of which are industry-standard-with-Wittgenstein-shape (config order with provenance-aware `doctor`, noun-first with `--manifest` replay), and two of which are deliberate divergences from chat-CLI framing. The current CLI is about 70% of the way to the bar the 2025-class AI CLIs have set; the remaining 30% is mostly the output contract and the config precedence, and both are cheap to fix. — research, 2026-04-23.
+Net: six decisions to write into RFC-0002, two of which are industry-standard, two of which are industry-standard-with-Wittgenstein-shape (config order with provenance-aware `doctor`, noun-first with `--manifest` replay), and two of which are deliberate divergences from chat-CLI framing. The current CLI is about 70% of the way to the bar the 2025-class AI CLIs have set; the remaining 30% is mostly the output contract and the config precedence, and both are cheap to fix. For M2, the audio-specific CLI / SDK audit below should be read as an addendum rather than a counter-proposal — it refines the route-level UX, not the top-level CLI doctrine. — research, 2026-04-23.
+
+## Audio addendum (M2)
+
+This addendum exists because M2 audio needs a narrower survey than the main CLI doctrine brief. The top-level question of Brief D is “what should `wittgenstein` look like?” The M2 question is “what should an audio route inherit from existing speech / transcription / hosted-audio tools, and what should it deliberately refuse?”
+
+### Piper
+
+`piper` is the cleanest local-TTS CLI in the set because it is brutally explicit: model path, config path, text input, output path. It does not pretend to be a chat tool or a hosted SDK. The important transferable conventions are that synthesis is file-first, flags are narrow, and the output artifact is the primary unit. What does **not** transfer is Piper's willingness to let the voice/model choice dominate the user-facing surface. In Wittgenstein, the user asks for a speech artifact; the specific decoder family sits underneath the codec boundary.
+
+### Coqui TTS / `tts`
+
+Coqui's `tts` CLI shows the opposite extreme: many flags, many synthesis modes, several voice / speaker / language switches, and a surface that is great for research but noisy for a harness. What transfers is the separation between “synthesis request” and “speaker / model configuration,” plus the ability to write directly to a file path. What does not transfer is exposing the full model zoo or a long tail of decoder-specific flags on the primary modality command.
+
+### Whisper / speech tooling CLIs
+
+Whisper-style CLIs are useful here not because Wittgenstein is a transcription tool, but because they establish good audio-I/O habits: explicit input file, explicit output format, explicit language or auto-detect, and a machine-readable mode when results need piping. The part worth borrowing is the contract that audio tooling should say exactly what file it consumed and what file it emitted. The part to avoid is turning every audio modality command into a generic speech-lab interface with dozens of transcription-oriented toggles.
+
+### OpenAI Audio API
+
+The OpenAI Audio API represents the hosted-SDK shape: programmatic, model-first, and explicit about whether output is a stream or a file. Its useful lesson for Wittgenstein is not “copy the model flag,” but “make structured output and binary output mutually explicit.” When a route produces a file, the caller should never have to infer whether stdout contains bytes, JSON, or logs. The hosted API also normalizes the idea that voice/model selection is configuration, not usually the first user concern.
+
+### ElevenLabs SDK / CLI patterns
+
+ElevenLabs is the strongest reminder that premium speech UX often grows around hosted features that are structurally incompatible with our doctrine: mutable voices, account-scoped assets, cloud-side caching, and nontrivial vendor state. That makes it bad architectural prior art for the core path, but still useful negative prior art. The main thing to borrow is the user expectation that “speech” is a route with explicit output control and predictable latency reporting. The things to reject are vendor-bound voice management and any CLI that makes account state the hidden center of the workflow.
+
+### Keep / change / borrow table
+
+| Tool / family                  | Keep                                                                | Change                                                                  | Borrow                                                                        |
+| ------------------------------ | ------------------------------------------------------------------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| Piper                          | File-first local synthesis and explicit output path                 | Do not expose decoder identity as the primary user surface              | Minimal local-TTS CLI posture for the `speech` route                          |
+| Coqui TTS                      | Separation between synthesis request and decoder config             | Avoid surfacing research-zoo flags on `wittgenstein tts`                | Keep decoder choice in config / provider layer, not modality command          |
+| Whisper-style CLIs             | Explicit audio input/output contracts and machine-readable mode     | Do not import transcription-specific option sprawl                      | Strong binary-vs-JSON output discipline for audio tooling                     |
+| OpenAI Audio API               | Explicit stream/file distinction and structured result shape        | Do not expose model-first semantics as the default UX                   | Clear stdout contract and route-level latency / metadata reporting            |
+| ElevenLabs-style hosted speech | User expectation of polished speech output and explicit file result | Reject account-centric / mutable cloud asset workflows in the core path | Negative prior art for what the on-device deterministic route must not become |
 
 ## References
 

--- a/docs/research/briefs/J_audio_engineering_and_routes.md
+++ b/docs/research/briefs/J_audio_engineering_and_routes.md
@@ -1,0 +1,177 @@
+# Brief J — Audio engineering and routes
+
+**Date:** 2026-04-27
+**Status:** 🟡 Draft v0.1
+**Author:** engineering (Codex)
+**Question:** Given Wittgenstein's current `codec-audio` surface, what engineering shape should M2 actually adopt for route dispatch, shared helpers, manifest rows, fixture classes, and `AudioRequest.route` deprecation?
+**Feeds into:** `docs/agent-guides/audio-port.md`, `docs/exec-plans/active/codec-v2-port.md` §M2, future `ADR-0012`.
+
+> This brief is the audio analog of Brief H, but it is intentionally narrower and more skeptical. The plan assumption that audio still hides an “80-line route copy-paste” was directionally useful, but the current repository has already partially collapsed the obvious duplication into `runtime.ts`. So the real question is not “how do we invent a grand audio abstraction?” — it is “what is the smallest honest M2 port that preserves route clarity, moves authorship into the codec, and does not overfit a premature `BaseAudioRoute`?”
+
+---
+
+## Context
+
+M0 landed the Codec Protocol v2 surface in `packages/schemas/src/codec/v2/`. M1A landed image as the first real port and proved the four-stage seam is viable: `expand -> adapt -> decode -> package`. M2 is now the next active line, and audio is the first modality that tests whether the same seam can handle a **layered** codec rather than a single-route decoder.
+
+The current `codec-audio` shape is already more disciplined than the plan's first-pass audit suggested:
+
+- `packages/codec-audio/src/codec.ts` is still v0.1-style (`WittgensteinCodec.render(parsed, ctx)`), but it delegates to three small route implementations rather than a single giant renderer.
+- `packages/codec-audio/src/routes/{speech,soundscape,music}/index.ts` are each short, but they still repeat five responsibilities: timing, ambient recommendation, route-specific render, artifact finalization, and metadata patching.
+- `packages/codec-audio/src/runtime.ts` already centralizes the true shared render primitives: `finalizeAudioArtifact`, `generateAmbient`, `mixTracks`, `renderMacSpeech`, `synthSpeech`, `synthMusic`.
+- `docs/agent-guides/audio-port.md` still talks about collapsing “~80-line copy-paste,” which is no longer literally true. The engineering problem has become more subtle: shared logic exists, but not all of it deserves a class boundary.
+
+That subtlety matters. M2 is not “make audio elegant.” M2 is “port audio to Codec v2 without baking route-specific choices into shared doctrine.” This brief answers five engineering questions needed before code execution:
+
+1. what multi-route pattern to borrow;
+2. whether `BaseAudioRoute` is justified;
+3. which audio-specific manifest rows are load-bearing;
+4. which fixture classes should be byte-parity vs structural-parity;
+5. how `AudioRequest.route` should deprecate.
+
+---
+
+## Steelman
+
+### 1. Multi-route codec patterns: what to adopt and reject
+
+The relevant prior art is not “audio framework” specific. It is any production system that multiplexes a small set of route-specific handlers inside one typed resource boundary.
+
+**Express `Router` / Hono sub-apps** contribute the useful pattern: a flat dispatch surface with tiny handlers and shared middleware that is narrow enough to reason about locally. The transferable idea for M2 is not nested routers themselves, but a **codec-owned route table** where each route declares only `id + match + decode/package-local behavior`, and shared pre/post work lives outside the route file. This matches `Route<Req>` in `packages/schemas/src/codec/v2/codec.ts` almost exactly.
+
+**Fastify nested plugins** are only partially relevant. Their strength is explicit encapsulation and decoration scoping, but their plugin lifecycle is too heavyweight for three route variants that all live inside one codec package. The insight worth copying is “route-local registration can be isolated,” not the plugin graph itself.
+
+**tRPC sub-routers** are the cleanest fit for the _shape_ of the problem: one top-level surface, several typed sub-surfaces, shared context, and explicit composition. What transfers is the discipline that each route should own its input narrowing and output shape declaratively. What does **not** transfer is a proliferation of sub-router files or route-local middleware stacks. Audio does not need an RPC tree.
+
+**Apollo subgraphs** are the wrong abstraction entirely. Their value comes from distributed ownership and federation. `codec-audio` has three sibling routes in one package; importing federation concepts would only blur the seam.
+
+**Verdict for Q1:** adopt the **flat route-table + thin route objects** pattern; borrow selective compositional discipline from tRPC and Hono; reject Fastify-style nested plugin lifecycle and reject Apollo-style composition.
+
+### 2. `BaseAudioRoute`: premature or load-bearing?
+
+The repository's current code is the decisive signal here.
+
+The three route files are not identical copies:
+
+- `speech` is the only route with host-specific TTS probing (`renderMacSpeech`) and WAV decoding.
+- `soundscape` is the only route whose render body is almost entirely “ambient category + deterministic operator render.”
+- `music` is the only route that mixes symbolic synth output with ambient.
+
+What _is_ shared today is smaller and more mechanical:
+
+- derive or normalize the ambient category;
+- compute a duration constant or duration heuristic;
+- call a route-specific render primitive;
+- call `finalizeAudioArtifact`;
+- stamp route-local metadata such as `durationMs`.
+
+That is real duplication, but not class-worthy duplication. A `BaseAudioRoute` class at this moment would mostly be a place to hide five helper methods and three protected hooks. It would increase ceremony before the decoder-family verdict exists, and it would create a new inheritance surface exactly when M2 should be converging toward the already-accepted `BaseCodec` seam, not inventing a second one.
+
+The better shape is:
+
+- keep the real abstract lifecycle in `BaseCodec`;
+- add a small `audio-route-helpers.ts` or equivalent module for shared helper functions;
+- if, after the decoder-family verdict lands, all three routes converge on the same route-local lifecycle, re-evaluate a `BaseAudioRoute` in a follow-up.
+
+**Verdict for Q2:** **no base class yet; helper functions now.** `BaseAudioRoute` is premature at current code size and decoder uncertainty.
+
+### 3. Audio-specific manifest fields
+
+Audio needs more explicit structural metadata than image because “a WAV exists” is not enough to describe its reproducible shape. The current runtime already knows the minimum facts needed to describe the artifact honestly, and M2 should elevate those to codec-authored manifest rows.
+
+At minimum, M2 should introduce one codec-authored row keyed as `audio.render` with:
+
+- `sampleRateHz`
+- `channels`
+- `durationSec`
+- `container` (`wav` today)
+- `bitDepth` (`16` today)
+- `determinismClass` (`byte-parity` or `structural-parity`)
+- `decoderId` when a neural or host TTS engine participates
+- `decoderHash` when a pinned neural decoder or weights artifact exists
+
+This should sit alongside the generic artifact row rather than trying to overload `artifact.*`. The artifact row answers “what file was written?” The audio row answers “what acoustic structure did we intend to produce?”
+
+For route-specific quality receipts:
+
+- `speech` should emit `quality.partial.reason` when the host TTS engine is missing or when only structural parity can be asserted.
+- `soundscape` and `music` should explicitly mark themselves `byte-parity` while they remain deterministic operator/symbolic synthesis paths.
+
+**Verdict for Q3:** add a dedicated `audio.render` manifest row; do not rely on generic artifact metadata alone.
+
+### 4. Test fixture strategy by route
+
+The correct fixture split follows determinism, not modality:
+
+**Speech** is structurally reproducible but not byte-stable across hosts once `renderMacSpeech()` is allowed to participate. Even with fixed seed, the host engine and platform can change waveform bytes while preserving intelligibility and duration. So speech should gate on:
+
+- exact sample rate
+- exact channel count
+- duration within a narrow tolerance band
+- a stable `quality.partial` or `determinismClass` declaration
+
+If a future neural TTS decoder is chosen and only CPU inference is deterministic, the same structural class still applies unless the decoder family can prove byte-stable replay on the supported path.
+
+**Soundscape** is currently a pure operator-library render keyed off seed and category. That is exactly the kind of path that should stay byte-for-byte. If SHA-256 drifts, it is a real regression.
+
+**Music** is currently a tiny symbolic synth plus ambient mix. It is just as deterministic as soundscape under the present runtime and should also remain byte-for-byte. If M2 later introduces a decoder-backed music route, this verdict must be revisited.
+
+**Verdict for Q4:** speech = structural parity; soundscape = byte parity; music = byte parity.
+
+### 5. Soft-deprecation contract for `AudioRequest.route`
+
+The repo doctrine is already explicit: strategy lives on the codec, not on the request. M2 should therefore not normalize `req.route` as a permanent user-controlled truth; it should keep it only as a compatibility hint for one minor version.
+
+The deprecation needs to be machine-copyable and stable. Proposed warning text:
+
+> `AudioRequest.route` is deprecated and will be removed after one minor version. Audio routing now lives inside `AudioCodec.route()`; keep `--route` only for compatibility while migrating callers to modality-level intent.
+
+Preconditions for actual removal:
+
+1. CLI help and examples no longer advertise `--route` as the primary interface.
+2. `docs/codecs/audio.md` and `docs/agent-guides/audio-port.md` both describe route selection as codec-internal.
+3. No tests, examples, or apps under `apps/` depend on request-side route selection as the only way to express intent.
+4. The codec has a stable default intent mapping for speech / soundscape / music so removing the field does not silently collapse user intent.
+
+The warning should live at the codec boundary, not in the harness and not in every route file.
+
+**Verdict for Q5:** one-minor-version soft deprecation with the exact warning string above; remove only after docs/examples/app callers are clean.
+
+---
+
+## Red team
+
+The strongest objection is that this brief is overfitting a transient implementation. If Brief I picks a neural decoder family with its own tokenizer, some of today's helper-level decisions may become obsolete. That is true, but it cuts in favor of _smaller_ abstractions, not larger ones. A premature `BaseAudioRoute` would fossilize the current operator-library shape just when the decoder family is still open.
+
+The second objection is that a dedicated `audio.render` manifest row may duplicate generic artifact metadata. Also true, but duplication is cheaper than ambiguity here. Image can get away with one structural story because the shipping path is a single raster file. Audio has route-level determinism differences that need to be visible at a glance if M5b is to compare parity honestly.
+
+The third objection is that the plan explicitly asked for `BaseAudioRoute`, so deviating from it could look like ignoring process. I think the right reading is the opposite: the plan asked for the engineering verdict, not blind obedience. The current codebase no longer supports the stronger “80-line copy-paste” premise, so the honest answer is to dial the abstraction down.
+
+---
+
+## Kill criteria
+
+The engineering recommendations in this brief should be considered wrong, and therefore not promoted into the code port, if any of the following happens during M2:
+
+1. A helper-functions-only port leaves any route file with >30 lines of true shared-mechanical logic duplicated across siblings. At that point, the “no `BaseAudioRoute`” verdict is too conservative and should flip.
+2. The proposed `audio.render` row fails to cleanly encode one route's reproducibility story without leaking route-specific hacks into generic manifest fields. If that happens, the manifest schema needs a second iteration before the port lands.
+3. Speech proves byte-stable on all supported hosts for the chosen decoder path. In that case, the structural-parity verdict is too loose and should be tightened.
+4. Removing `AudioRequest.route` from real downstream callers requires more than one minor version of migration. If that signal appears, extend the deprecation window rather than force a breaking cleanup into M2.
+
+---
+
+## Verdict
+
+1. **Multi-route pattern:** use a flat codec-owned route table with thin route objects; reject nested plugin and federation patterns.
+2. **`BaseAudioRoute`:** do not introduce it in M2; use helper functions first and revisit only if duplication remains >30 lines after the port.
+3. **Manifest fields:** add a dedicated `audio.render` row with `sampleRateHz`, `channels`, `durationSec`, `container`, `bitDepth`, `determinismClass`, and optional decoder identity/hash.
+4. **Fixture classes:** speech gets structural parity; soundscape and music get byte-for-byte parity.
+5. **`AudioRequest.route` deprecation:** soft-warn for one minor version with a fixed message, and remove only after docs/examples/apps no longer depend on it as the canonical intent surface.
+
+Net: M2 should be a **small-shape port**, not a local framework invention. The engineering win is moving authorship into the codec and clarifying route determinism, not proving how many abstractions TypeScript can hold.
+
+## References
+
+- Wittgenstein repo (2026). `packages/codec-audio/src/codec.ts`, `packages/codec-audio/src/routes/{speech,soundscape,music}/index.ts`, `packages/codec-audio/src/runtime.ts`, `docs/agent-guides/audio-port.md`, `docs/exec-plans/active/codec-v2-port.md`.
+- Brief H — `docs/research/briefs/H_codec_engineering_prior_art.md`
+- RFC-0001 — `docs/rfcs/0001-codec-protocol-v2.md`

--- a/docs/research/briefs/README.md
+++ b/docs/research/briefs/README.md
@@ -4,16 +4,17 @@ First-pass research briefs produced under **Phase P2** of the v0.2 Restructuring
 
 ## Brief index
 
-| ID  | Title                                                                          | Question                                                                                           | Status        |
-| --- | ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- | ------------- |
-| A   | [VQ / VLM lineage 2026 refresh](A_vq_vlm_lineage_audit.md)                     | Does the VQ-token / frozen-decoder path still look like the right bet in April 2026?               | 🟡 Draft v0.1 |
-| B   | [Compression vs world models — Ilya ↔ LeCun](B_compression_vs_world_models.md) | Where does Wittgenstein stand on the Ilya/LeCun tension? _(critical-path brief)_                   | 🟡 Draft v0.1 |
-| C   | [Unproven-but-interesting horizon scan](C_unproven_horizon.md)                 | Which 6–8 unvalidated hypotheses should shape the 18-month roadmap?                                | 🟡 Draft v0.1 |
-| D   | [CLI / SDK / harness conventions](D_cli_and_sdk_conventions.md)                | How do modern AI CLIs and SDKs look; where is Wittgenstein off the grid?                           | 🟡 Draft v0.1 |
-| E   | [Per-modality quality benchmarks](E_benchmarks_v2.md)                          | What's the smallest set of real (non-structural) quality metrics per modality?                     | 🟡 Draft v0.1 |
-| F   | [Site ↔ repo reconciliation](F_site_reconciliation.md)                         | Which `wittgenstein.wtf` claims contradict v0.1.0-alpha.2?                                         | 🟡 Draft v0.1 |
-| G   | [Image-network clues](G_image_network_clues.md)                                | Which decoder / data / packaging form ships for `codec-image` at exec-plan M1?                     | 🟡 Draft v0.1 |
-| H   | [Codec engineering prior art](H_codec_engineering_prior_art.md)                | Which production-validated TS projects share our `Codec<Req, Art>` shape, and what to copy at M1A? | 🟡 Draft v0.1 |
+| ID  | Title                                                                          | Question                                                                                                     | Status        |
+| --- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ | ------------- |
+| A   | [VQ / VLM lineage 2026 refresh](A_vq_vlm_lineage_audit.md)                     | Does the VQ-token / frozen-decoder path still look like the right bet in April 2026?                         | 🟡 Draft v0.1 |
+| B   | [Compression vs world models — Ilya ↔ LeCun](B_compression_vs_world_models.md) | Where does Wittgenstein stand on the Ilya/LeCun tension? _(critical-path brief)_                             | 🟡 Draft v0.1 |
+| C   | [Unproven-but-interesting horizon scan](C_unproven_horizon.md)                 | Which 6–8 unvalidated hypotheses should shape the 18-month roadmap?                                          | 🟡 Draft v0.1 |
+| D   | [CLI / SDK / harness conventions](D_cli_and_sdk_conventions.md)                | How do modern AI CLIs and SDKs look; where is Wittgenstein off the grid?                                     | 🟡 Draft v0.1 |
+| E   | [Per-modality quality benchmarks](E_benchmarks_v2.md)                          | What's the smallest set of real (non-structural) quality metrics per modality?                               | 🟡 Draft v0.1 |
+| F   | [Site ↔ repo reconciliation](F_site_reconciliation.md)                         | Which `wittgenstein.wtf` claims contradict v0.1.0-alpha.2?                                                   | 🟡 Draft v0.1 |
+| G   | [Image-network clues](G_image_network_clues.md)                                | Which decoder / data / packaging form ships for `codec-image` at exec-plan M1?                               | 🟡 Draft v0.1 |
+| H   | [Codec engineering prior art](H_codec_engineering_prior_art.md)                | Which production-validated TS projects share our `Codec<Req, Art>` shape, and what to copy at M1A?           | 🟡 Draft v0.1 |
+| J   | [Audio engineering and routes](J_audio_engineering_and_routes.md)              | What is the smallest honest M2 engineering shape for audio routes, manifest rows, fixtures, and deprecation? | 🟡 Draft v0.1 |
 
 ## Where briefs land (map)
 
@@ -26,6 +27,7 @@ flowchart LR
   E["Brief E: benchmarks v2"] -->|defines metrics| RFC
   F["Brief F: site↔repo diff"] -->|reconciles public narrative| RFC
   H["Brief H: codec engineering prior art"] -->|amends protocol typing + warnings| RFC
+  J["Brief J: audio engineering + routes"] -->|pins M2 route/manifest/deprecation shape| Code
 
   RFC --> Code["Code changes\npackages/*, docs/*"]
   ADR --> Code


### PR DESCRIPTION
## Summary
- add `docs/research/briefs/J_audio_engineering_and_routes.md` as the M2 engineering brief for audio route shape, manifest rows, fixture classes, and `AudioRequest.route` deprecation
- amend `docs/research/briefs/D_cli_and_sdk_conventions.md` with an audio-specific CLI / SDK addendum covering Piper, Coqui TTS, Whisper-style CLIs, the OpenAI Audio API, and ElevenLabs-style hosted speech
- update the briefs index so the M2 research surface is discoverable alongside A–H

## Why this shape
- follows the plan split: Claude takes the higher-stakes decoder-family / lineage call (`Brief I`), while this PR handles the engineering prior-art / route-shape side (`Brief J + D addendum`)
- intentionally challenges one stale plan assumption: the repo no longer contains a literal "80-line route copy-paste", so `Brief J` argues for helper functions over a premature `BaseAudioRoute`
- keeps the deliverable inside the repo's four-station brief contract (`Steelman`, `Red team`, `Kill criteria`, `Verdict`)

## Outputs
- `Brief J` answers five engineering questions:
  1. multi-route pattern to adopt/reject
  2. whether `BaseAudioRoute` is load-bearing or premature
  3. which audio-specific manifest rows should exist
  4. which routes get structural vs byte parity
  5. exact soft-deprecation contract for `AudioRequest.route`
- `Brief D` now has an explicit M2 audio addendum plus a keep/change/borrow table for audio tooling conventions

## Verification
- `pnpm exec prettier --check docs/research/briefs/J_audio_engineering_and_routes.md docs/research/briefs/D_cli_and_sdk_conventions.md docs/research/briefs/README.md docs/index.md`
- `git diff --check`
