### PR TITLE
docs(briefs): add Brief J and audio CLI addendum

### DIFF
--- a/docs/agent-guides/audio-port.md
+++ b/docs/agent-guides/audio-port.md
@@ -4,7 +4,7 @@ This guide is for a contributor or coding agent picking up the **audio codec por
 
 It is deliberately narrow:
 
-- **in scope:** porting `codec-audio` to the v2 protocol shape; collapsing the route copy-paste; writing the audio benchmark bridge stub for M5b.
+- **in scope:** porting `codec-audio` to the v2 protocol shape; tightening the remaining shared-mechanical route logic; writing the audio benchmark bridge stub for M5b.
 - **out of scope:** image, sensor, video, site, CLI ergonomics, doctrine relitigation, picking a new TTS engine.
 
 Read `docs/agent-guides/image-to-audio-port.md` first for the cross-line context. This guide is the audio specialization.
@@ -15,7 +15,7 @@ Read `docs/agent-guides/image-to-audio-port.md` first for the cross-line context
 
 Port `codec-audio` from the v0.1 surface to the Codec v2 protocol shape ratified by ADR-0008, while:
 
-- collapsing the ~80-line route copy-paste across `speech / soundscape / music`;
+- collapsing the remaining shared-mechanical route duplication across `speech / soundscape / music`;
 - preserving every shipping artifact's structural manifest (sample rate, channels, duration);
 - moving manifest authorship into the codec's `package` stage;
 - soft-deprecating `AudioRequest.route` (one minor version of warning before hard-deprecation at M4).
@@ -39,30 +39,30 @@ You are not allowed to:
 
 If M1 image has already landed, also read its merged PR diff — your changes mirror its shape.
 
-## 3. The 80-line copy-paste
+## 3. The remaining shared route logic
 
-`packages/codec-audio/src/routes/{speech,soundscape,music}.ts` each carry their own copies of:
+`packages/codec-audio/src/routes/{speech,soundscape,music}.ts` are already smaller than the first-pass plan assumed, because `runtime.ts` now owns the real render primitives. What remains duplicated is the lighter-weight route-local scaffolding around those primitives:
 
-- LLM-prompt assembly,
-- AudioPlan parsing and zod validation,
-- ambient-layer mixing,
-- WAV writer,
-- manifest-row authorship.
+- duration / timing normalization,
+- ambient recommendation plumbing,
+- route-specific render invocation,
+- artifact finalization,
+- route-local metadata patching.
 
-The port's win is collapsing the shared bits into a `BaseAudioRoute` and leaving each route file at ≤20 lines of *route-specific* logic. If your final diff has any route file longer than ~20 lines of non-shared code, the collapse failed.
+The port's win is **not** inventing a new local framework. The win is moving the shared-mechanical bits into helper functions or a tiny shared module, while leaving each route file as a thin, readable declaration of route-specific behavior. If the port still leaves obvious duplicated scaffolding across siblings, the helper-first collapse failed. If helper extraction still leaves >30 lines of genuinely shared-mechanical duplication, only then should a `BaseAudioRoute` be reconsidered in a follow-up.
 
 ## 4. M2 deliverables
 
 In order:
 
 1. **`AudioCodec extends BaseCodec<AudioRequest, AudioArtifact>`** in `packages/codec-audio/src/codec.ts`. The codec's `route(req)` method dispatches to the appropriate sub-route.
-2. **`BaseAudioRoute`** carrying the shared LLM, parse, mix, and writer logic.
-3. **Three thin route files** (`speech.ts`, `soundscape.ts`, `music.ts`) each ≤20 lines.
+2. **Shared audio route helpers** carrying the mechanical pieces that do not belong in each route file independently.
+3. **Three thin route files** (`speech.ts`, `soundscape.ts`, `music.ts`) that read as route-specific logic first, with shared scaffolding pulled down into helpers where honest.
 4. **`package` stage authors manifest rows** — `route`, `seed`, `model_id`, `quality.structural` (sample rate, channels, duration), `quality.partial` if a metric is unavailable.
 5. **`AudioRequest.route` soft-warn deprecation** — emits a one-line `console.warn` pointing to the codec's new `route()` declaration.
 6. **`packages/core/src/codecs/audio.ts`** is now a thin shim that delegates to `AudioCodec.produce`. The audio branch in `packages/core/src/runtime/harness.ts` is deleted.
 7. **Migration tests** under `packages/codec-audio/test/`:
-   - `route-collapse.test.ts` — fails if any route file exceeds the line budget.
+   - `route-collapse.test.ts` — fails if helper extraction leaves obvious sibling duplication beyond the accepted threshold.
    - `parity-tts.test.ts` — TTS structural parity (sample rate, channels, duration ±5%) against the recorded golden manifest.
    - `parity-soundscape.test.ts` and `parity-music.test.ts` — byte-for-byte SHA-256 against goldens (deterministic synthesis).
 
@@ -101,7 +101,7 @@ If you find yourself writing manifest rows from anywhere outside the codec's `pa
 
 ### Hacker hat
 
-- Are the three route files ≤20 lines of route-specific logic?
+- Do the route files read as thin route-specific declarations, without obvious shared-mechanical scaffolding copied across siblings?
 - Is the harness still modality-blind for audio after the port?
 - Can the next codec (sensor, M3) be ported in the same shape using this PR's diff as a template?
 
@@ -119,7 +119,7 @@ If any answer is no, the gate is not met.
 > You are implementing the Wittgenstein v0.2 audio codec port (M2).
 > Stay inside the locked doctrine: three routes (speech / soundscape / music), no TTS-engine swap, no fourth route, decoder ≠ generator, manifest spine preserved, modality branching moves out of the harness.
 > Read `AGENTS.md`, `docs/THESIS.md`, `docs/codecs/audio.md`, `docs/exec-plans/active/codec-v2-port.md` §M2, and `docs/rfcs/0001-codec-protocol-v2.md` first.
-> Your task is to land M2: collapse the route copy-paste, move manifest authorship into the codec, soft-deprecate `AudioRequest.route`, and pass the three parity tests.
+> Your task is to land M2: collapse the remaining shared route scaffolding, move manifest authorship into the codec, soft-deprecate `AudioRequest.route`, and pass the three parity tests.
 > Do not relitigate doctrine. Do not introduce a music generator. Do not widen scope to image, sensor, or benchmarks-heavy work.
 > Prefer small diffs, structural parity over byte parity for LLM-driven outputs, and receipt-preserving behavior.
 

--- a/docs/exec-plans/active/codec-v2-port.md
+++ b/docs/exec-plans/active/codec-v2-port.md
@@ -33,7 +33,7 @@ land as confirmations, not discoveries.
 | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | M0    | Introduce `Codec<Req, Art>`, `IR`, `Route`, `HarnessCtx` types in `packages/schemas` behind an `@experimental` tag. No call-site change.                                                                                                                                                                                                                                   | Types land; `pnpm typecheck` green.                                                                                                                         |
 | M1    | Port `codec-image` (raster) first — only modality with both L4 adapter slot and non-trivial L5, so it stresses the protocol hardest. `codec-svg` and `codec-asciipng` are tracked as sibling follow-up ports, not internal image routes. Default pipeline stays one LLM round (schema-in-preamble). `--expand` flag opts into a round-1 expansion pass for A/B comparison. | Goldens preserve; manifest rows codec-authored; round-trip test ≤20 lines; Brief A's "LFQ-family discrete-token decoder" rename lands in ADR-0005 addendum. |
-| M2    | Port `codec-audio` (speech, soundscape, music) — eliminates the 80-line route copy-paste.                                                                                                                                                                                                                                                                                  | Goldens preserve; `AudioRequest.route` deprecated with warning.                                                                                             |
+| M2    | Port `codec-audio` (speech, soundscape, music) — collapses the remaining shared-mechanical route scaffolding without inventing a premature local framework.                                                                                                                                                                                                                | Goldens preserve; `AudioRequest.route` deprecated with warning.                                                                                             |
 | M3    | Port `codec-sensor` (ecg, gyro, temperature) — confirmation case (no L4), closes the modality sweep.                                                                                                                                                                                                                                                                       | Goldens preserve; `SensorRequest` surface unchanged from user side.                                                                                         |
 | M4    | Retire `harness.ts:123-172` modality branching + `:139-172` manifest overrides. Remove `AudioRequest.route`, `SvgRequest.source`, `AsciipngRequest.source`, `VideoRequest.inlineSvgs`.                                                                                                                                                                                     | Harness is modality-blind; `codec-video` (🔴 stub) awaits its own M-slot.                                                                                   |
 | M5a   | Land image benchmark bridge first (Brief E): VQAScore + CLIPScore fallback, wired into the default tier only.                                                                                                                                                                                                                                                              | Image metric runs locally; `quality_partial` invariant enforced.                                                                                            |
@@ -217,16 +217,19 @@ request and route logic until their follow-up ports land.
 
 ### M2 — Port `codec-audio`
 
-Audio's win is collapsing the 80-line route copy-paste. Three sub-modalities (speech,
-soundscape, music) each have their own route file in `codec-audio/src/routes/`.
+Audio's win is collapsing the remaining shared-mechanical route scaffolding. Three
+sub-modalities (speech, soundscape, music) each have their own route file in
+`codec-audio/src/routes/`, but the current code is already smaller than the first-pass
+audit assumed.
 
 **Files touched:**
 
 - `packages/codec-audio/src/codec.ts` — rewrite as `class AudioCodec extends BaseCodec<AudioRequest, AudioArtifact>`. The codec's `route()` method dispatches to the
   appropriate sub-route.
 - `packages/codec-audio/src/routes/{speech,soundscape,music}/index.ts` — refactor each into a
-  `Route` object that the codec composes; shared logic moves into a `BaseAudioRoute`.
-  The 80-line copy-paste collapses to ~20 lines per route.
+  `Route` object that the codec composes; shared-mechanical logic moves into helper
+  functions or a tiny shared module. A `BaseAudioRoute` is only justified if
+  post-port duplication still exceeds the accepted threshold.
 - `packages/codec-audio/src/runtime.ts` — manifest authorship moves into the codec's
   `package` stage.
 - `packages/core/src/codecs/audio.ts` — thin shim, same pattern as image.
@@ -246,8 +249,8 @@ soundscape, music) each have their own route file in `codec-audio/src/routes/`.
 
 **Migration tests:**
 
-- `packages/codec-audio/test/route-collapse.test.ts` — count lines in each route file;
-  fail if any spills past the 20-line round-trip budget.
+- `packages/codec-audio/test/route-collapse.test.ts` — assert that the port did not
+  leave obvious shared-mechanical scaffolding duplicated across sibling routes.
 - Standard parity tests against goldens.
 
 **Rollback criteria:**
@@ -258,7 +261,7 @@ soundscape, music) each have their own route file in `codec-audio/src/routes/`.
   pause deprecation and document the migration in `docs/agent-guides/`.
 
 **Gate:** goldens preserve; `AudioRequest.route` deprecated with warning; route files
-each ≤20 lines of codec-specific logic.
+read as thin route-specific declarations with shared-mechanical scaffolding collapsed.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,6 +50,7 @@ Read these two files before any task:
 - [`research/briefs/F_site_reconciliation.md`](research/briefs/F_site_reconciliation.md) — site ↔ repo reconciliation
 - [`research/briefs/G_image_network_clues.md`](research/briefs/G_image_network_clues.md) — image decoder / data / packaging (M1 prerequisite)
 - [`research/briefs/H_codec_engineering_prior_art.md`](research/briefs/H_codec_engineering_prior_art.md) — codec protocol prior art; F1/F2 RFC-0001 amendments (M1A prerequisite)
+- [`research/briefs/J_audio_engineering_and_routes.md`](research/briefs/J_audio_engineering_and_routes.md) — M2 route shape, manifest rows, fixture strategy, and deprecation contract
 
 ## Long-form research notes (predate the briefs)
 

--- a/docs/research/briefs/D_cli_and_sdk_conventions.md
+++ b/docs/research/briefs/D_cli_and_sdk_conventions.md
@@ -156,7 +156,41 @@ Two deliberate divergences from the 2025-class AI CLI template.
 
 - **No `--model` override on modality commands by default.** The chat CLIs all expose `--model` because their primary job is LLM-as-service. Wittgenstein's primary job is a specific codec producing a specific artifact; the model is an internal implementation detail of the harness, and exposing it at the CLI invites users to swap it in ways that invalidate the codec's guarantees. Instead, expose `--provider <name>` (choose which configured provider) and let the provider's config pin the model. Power users who need fine-grained model control can set `WITTGENSTEIN_LLM_MODEL=...` in env; the precedence rule from (2) means that still works. This is a divergence from Gemini / Claude Code / Kimi and it is defensible because we are a harness, not a chat service.
 
-Net: six decisions to write into RFC-0002, two of which are industry-standard, two of which are industry-standard-with-Wittgenstein-shape (config order with provenance-aware `doctor`, noun-first with `--manifest` replay), and two of which are deliberate divergences from chat-CLI framing. The current CLI is about 70% of the way to the bar the 2025-class AI CLIs have set; the remaining 30% is mostly the output contract and the config precedence, and both are cheap to fix. — research, 2026-04-23.
+Net: six decisions to write into RFC-0002, two of which are industry-standard, two of which are industry-standard-with-Wittgenstein-shape (config order with provenance-aware `doctor`, noun-first with `--manifest` replay), and two of which are deliberate divergences from chat-CLI framing. The current CLI is about 70% of the way to the bar the 2025-class AI CLIs have set; the remaining 30% is mostly the output contract and the config precedence, and both are cheap to fix. For M2, the audio-specific CLI / SDK audit below should be read as an addendum rather than a counter-proposal — it refines the route-level UX, not the top-level CLI doctrine. — research, 2026-04-23.
+
+## Audio addendum (M2)
+
+This addendum exists because M2 audio needs a narrower survey than the main CLI doctrine brief. The top-level question of Brief D is “what should `wittgenstein` look like?” The M2 question is “what should an audio route inherit from existing speech / transcription / hosted-audio tools, and what should it deliberately refuse?”
+
+### Piper
+
+`piper` is the cleanest local-TTS CLI in the set because it is brutally explicit: model path, config path, text input, output path. It does not pretend to be a chat tool or a hosted SDK. The important transferable conventions are that synthesis is file-first, flags are narrow, and the output artifact is the primary unit. What does **not** transfer is Piper's willingness to let the voice/model choice dominate the user-facing surface. In Wittgenstein, the user asks for a speech artifact; the specific decoder family sits underneath the codec boundary.
+
+### Coqui TTS / `tts`
+
+Coqui's `tts` CLI shows the opposite extreme: many flags, many synthesis modes, several voice / speaker / language switches, and a surface that is great for research but noisy for a harness. What transfers is the separation between “synthesis request” and “speaker / model configuration,” plus the ability to write directly to a file path. What does not transfer is exposing the full model zoo or a long tail of decoder-specific flags on the primary modality command.
+
+### Whisper / speech tooling CLIs
+
+Whisper-style CLIs are useful here not because Wittgenstein is a transcription tool, but because they establish good audio-I/O habits: explicit input file, explicit output format, explicit language or auto-detect, and a machine-readable mode when results need piping. The part worth borrowing is the contract that audio tooling should say exactly what file it consumed and what file it emitted. The part to avoid is turning every audio modality command into a generic speech-lab interface with dozens of transcription-oriented toggles.
+
+### OpenAI Audio API
+
+The OpenAI Audio API represents the hosted-SDK shape: programmatic, model-first, and explicit about whether output is a stream or a file. Its useful lesson for Wittgenstein is not “copy the model flag,” but “make structured output and binary output mutually explicit.” When a route produces a file, the caller should never have to infer whether stdout contains bytes, JSON, or logs. The hosted API also normalizes the idea that voice/model selection is configuration, not usually the first user concern.
+
+### ElevenLabs SDK / CLI patterns
+
+ElevenLabs is the strongest reminder that premium speech UX often grows around hosted features that are structurally incompatible with our doctrine: mutable voices, account-scoped assets, cloud-side caching, and nontrivial vendor state. That makes it bad architectural prior art for the core path, but still useful negative prior art. The main thing to borrow is the user expectation that “speech” is a route with explicit output control and predictable latency reporting. The things to reject are vendor-bound voice management and any CLI that makes account state the hidden center of the workflow.
+
+### Keep / change / borrow table
+
+| Tool / family                  | Keep                                                                | Change                                                                  | Borrow                                                                        |
+| ------------------------------ | ------------------------------------------------------------------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| Piper                          | File-first local synthesis and explicit output path                 | Do not expose decoder identity as the primary user surface              | Minimal local-TTS CLI posture for the `speech` route                          |
+| Coqui TTS                      | Separation between synthesis request and decoder config             | Avoid surfacing research-zoo flags on `wittgenstein tts`                | Keep decoder choice in config / provider layer, not modality command          |
+| Whisper-style CLIs             | Explicit audio input/output contracts and machine-readable mode     | Do not import transcription-specific option sprawl                      | Strong binary-vs-JSON output discipline for audio tooling                     |
+| OpenAI Audio API               | Explicit stream/file distinction and structured result shape        | Do not expose model-first semantics as the default UX                   | Clear stdout contract and route-level latency / metadata reporting            |
+| ElevenLabs-style hosted speech | User expectation of polished speech output and explicit file result | Reject account-centric / mutable cloud asset workflows in the core path | Negative prior art for what the on-device deterministic route must not become |
 
 ## References
 

--- a/docs/research/briefs/D_cli_and_sdk_conventions.md
+++ b/docs/research/briefs/D_cli_and_sdk_conventions.md
@@ -164,23 +164,23 @@ This addendum exists because M2 audio needs a narrower survey than the main CLI 
 
 ### Piper
 
-`piper` is the cleanest local-TTS CLI in the set because it is brutally explicit: model path, config path, text input, output path. It does not pretend to be a chat tool or a hosted SDK. The important transferable conventions are that synthesis is file-first, flags are narrow, and the output artifact is the primary unit. What does **not** transfer is Piper's willingness to let the voice/model choice dominate the user-facing surface. In Wittgenstein, the user asks for a speech artifact; the specific decoder family sits underneath the codec boundary.
+`piper` is the cleanest local-TTS CLI in the set because it is brutally explicit: the docs show text on **stdin**, `--model /path/to/voice.onnx`, and `--output_file output.wav` as the primary shape, with `--speaker` layered on for multi-speaker models. It does not pretend to be a chat tool or a hosted SDK. The important transferable conventions are that synthesis is file-first, flags are narrow, and the output artifact is the primary unit. What does **not** transfer is Piper's willingness to let the voice/model choice dominate the user-facing surface. In Wittgenstein, the user asks for a speech artifact; the specific decoder family sits underneath the codec boundary.
 
 ### Coqui TTS / `tts`
 
-Coqui's `tts` CLI shows the opposite extreme: many flags, many synthesis modes, several voice / speaker / language switches, and a surface that is great for research but noisy for a harness. What transfers is the separation between “synthesis request” and “speaker / model configuration,” plus the ability to write directly to a file path. What does not transfer is exposing the full model zoo or a long tail of decoder-specific flags on the primary modality command.
+Coqui's `tts` surface shows the opposite extreme: many flags, many synthesis modes, several voice / speaker / language switches, and a surface that is great for research but noisy for a harness. Even the core inference docs emphasize API calls like `tts.tts_to_file(...)`, `voice_conversion_to_file(...)`, and `tts_with_vc_to_file(...)` rather than one tiny stable CLI contract. What transfers is the separation between “synthesis request” and “speaker / model configuration,” plus the ability to write directly to a file path. What does not transfer is exposing the full model zoo or a long tail of decoder-specific flags on the primary modality command.
 
 ### Whisper / speech tooling CLIs
 
-Whisper-style CLIs are useful here not because Wittgenstein is a transcription tool, but because they establish good audio-I/O habits: explicit input file, explicit output format, explicit language or auto-detect, and a machine-readable mode when results need piping. The part worth borrowing is the contract that audio tooling should say exactly what file it consumed and what file it emitted. The part to avoid is turning every audio modality command into a generic speech-lab interface with dozens of transcription-oriented toggles.
+Whisper-style CLIs are useful here not because Wittgenstein is a transcription tool, but because they establish good audio-I/O habits. OpenAI Whisper's CLI takes positional audio files plus explicit flags like `--model`, `--language`, and `--task translate`, and it requires `ffmpeg` on the host. `whisper.cpp` goes even further toward file-tool explicitness: build `whisper-cli`, point `-m` at a model file, point `-f` at an audio file, optionally add VAD flags, and get a deterministic file-driven transcription path. The part worth borrowing is the contract that audio tooling should say exactly what file it consumed and what file it emitted. The part to avoid is turning every audio modality command into a generic speech-lab interface with dozens of transcription-oriented toggles.
 
 ### OpenAI Audio API
 
-The OpenAI Audio API represents the hosted-SDK shape: programmatic, model-first, and explicit about whether output is a stream or a file. Its useful lesson for Wittgenstein is not “copy the model flag,” but “make structured output and binary output mutually explicit.” When a route produces a file, the caller should never have to infer whether stdout contains bytes, JSON, or logs. The hosted API also normalizes the idea that voice/model selection is configuration, not usually the first user concern.
+The OpenAI Audio API represents the hosted-SDK shape: programmatic, model-first, and explicit about whether output is a stream or a file. The text-to-speech guide shows both `audio.speech.create(...)` and `with_streaming_response.create(...)`; the default response format is `mp3`, but `wav`, `opus`, `aac`, `flac`, and `pcm` are all explicit options. The speech-to-text guide sits on the same principle: file inputs are explicit, and realtime/streaming are not ambiguous “maybe stdout, maybe callback” side-effects. Its useful lesson for Wittgenstein is not “copy the model flag,” but “make structured output and binary output mutually explicit.” When a route produces a file, the caller should never have to infer whether stdout contains bytes, JSON, or logs. The hosted API also normalizes the idea that voice/model selection is configuration, not usually the first user concern.
 
 ### ElevenLabs SDK / CLI patterns
 
-ElevenLabs is the strongest reminder that premium speech UX often grows around hosted features that are structurally incompatible with our doctrine: mutable voices, account-scoped assets, cloud-side caching, and nontrivial vendor state. That makes it bad architectural prior art for the core path, but still useful negative prior art. The main thing to borrow is the user expectation that “speech” is a route with explicit output control and predictable latency reporting. The things to reject are vendor-bound voice management and any CLI that makes account state the hidden center of the workflow.
+ElevenLabs is the strongest reminder that premium speech UX often grows around hosted features that are structurally incompatible with our doctrine: mutable voices, account-scoped assets, cloud-side caching, and nontrivial vendor state. The official quickstart expects `ELEVENLABS_API_KEY` in environment or app config, and the SDK exposes both `convert` (file-oriented) and `stream` (low-latency) paths. That makes it bad architectural prior art for the core path, but still useful negative prior art. The main thing to borrow is the user expectation that “speech” is a route with explicit output control and predictable latency reporting. The things to reject are vendor-bound voice management and any CLI that makes account state the hidden center of the workflow.
 
 ### Keep / change / borrow table
 
@@ -205,4 +205,12 @@ ElevenLabs is the strongest reminder that premium speech UX often grows around h
 - Moonshot AI (2025). "Kimi Code CLI." https://github.com/MoonshotAI/kimi-cli and https://moonshotai.github.io/kimi-cli/en/reference/kimi-command.html
 - npm / npm Inc. (2024). "npm-config." https://docs.npmjs.com/cli/v11/using-npm/config/
 - OpenAI (2025). "Codex CLI Reference." https://developers.openai.com/codex/cli/reference ; "Agents SDK." https://openai.github.io/openai-agents-python/
+- OpenAI (2026). "Text to speech." https://developers.openai.com/api/docs/guides/text-to-speech
+- OpenAI (2026). "Speech to text." https://developers.openai.com/api/docs/guides/speech-to-text
+- Piper docs. "Usage." https://tderflinger.github.io/piper-docs/guides/usage/
+- Coqui TTS docs. "Synthesizing speech." https://coqui-tts.readthedocs.io/en/latest/inference.html
+- OpenAI Whisper repo. "Command-line usage." https://github.com/openai/whisper
+- whisper.cpp repo. "Quick start / whisper-cli." https://github.com/ggml-org/whisper.cpp
+- ElevenLabs docs. "Text to speech quickstart." https://elevenlabs.io/docs/eleven-api/guides/cookbooks/text-to-speech
+- ElevenLabs docs. "Streaming text to speech." https://elevenlabs.io/docs/eleven-api/guides/how-to/text-to-speech/streaming
 - Wittgenstein repo (2026). `packages/cli/src/commands/*.ts`, `packages/cli/README.md`, `docs/quickstart.md`.

--- a/docs/research/briefs/D_cli_and_sdk_conventions.md
+++ b/docs/research/briefs/D_cli_and_sdk_conventions.md
@@ -162,6 +162,8 @@ Net: six decisions to write into RFC-0002, two of which are industry-standard, t
 
 This addendum exists because M2 audio needs a narrower survey than the main CLI doctrine brief. The top-level question of Brief D is “what should `wittgenstein` look like?” The M2 question is “what should an audio route inherit from existing speech / transcription / hosted-audio tools, and what should it deliberately refuse?”
 
+The current internal surface matters here. Today `packages/cli/src/commands/audio.ts` still exposes `wittgenstein audio <prompt> [--route speech|soundscape|music] [--ambient ...] [--duration-sec ...]`, and `docs/codecs/audio.md` already frames that `--route` flag as a legacy compatibility path headed for soft-warn deprecation at M2. So the useful prior art is not "what would a greenfield audio CLI look like?" but "which external conventions help us migrate from a route-first flag surface to an intent-first codec-owned surface without breaking reproducibility?"
+
 ### Piper
 
 `piper` is the cleanest local-TTS CLI in the set because it is brutally explicit: the docs show text on **stdin**, `--model /path/to/voice.onnx`, and `--output_file output.wav` as the primary shape, with `--speaker` layered on for multi-speaker models. It does not pretend to be a chat tool or a hosted SDK. The important transferable conventions are that synthesis is file-first, flags are narrow, and the output artifact is the primary unit. What does **not** transfer is Piper's willingness to let the voice/model choice dominate the user-facing surface. In Wittgenstein, the user asks for a speech artifact; the specific decoder family sits underneath the codec boundary.
@@ -191,6 +193,8 @@ ElevenLabs is the strongest reminder that premium speech UX often grows around h
 | Whisper-style CLIs             | Explicit audio input/output contracts and machine-readable mode     | Do not import transcription-specific option sprawl                      | Strong binary-vs-JSON output discipline for audio tooling                     |
 | OpenAI Audio API               | Explicit stream/file distinction and structured result shape        | Do not expose model-first semantics as the default UX                   | Clear stdout contract and route-level latency / metadata reporting            |
 | ElevenLabs-style hosted speech | User expectation of polished speech output and explicit file result | Reject account-centric / mutable cloud asset workflows in the core path | Negative prior art for what the on-device deterministic route must not become |
+
+Net for M2: keep `wittgenstein audio <prompt>` as the public noun-first entrypoint, keep explicit file-oriented flags like `--out` and `--duration-sec`, retain `--ambient` as a codec-level intent hint, and treat `--route` as a compatibility shim whose removal is governed by Brief J's deprecation contract rather than by aesthetics.
 
 ## References
 

--- a/docs/research/briefs/J_audio_engineering_and_routes.md
+++ b/docs/research/briefs/J_audio_engineering_and_routes.md
@@ -1,0 +1,177 @@
+# Brief J — Audio engineering and routes
+
+**Date:** 2026-04-27
+**Status:** 🟡 Draft v0.1
+**Author:** engineering (Codex)
+**Question:** Given Wittgenstein's current `codec-audio` surface, what engineering shape should M2 actually adopt for route dispatch, shared helpers, manifest rows, fixture classes, and `AudioRequest.route` deprecation?
+**Feeds into:** `docs/agent-guides/audio-port.md`, `docs/exec-plans/active/codec-v2-port.md` §M2, future `ADR-0012`.
+
+> This brief is the audio analog of Brief H, but it is intentionally narrower and more skeptical. The plan assumption that audio still hides an “80-line route copy-paste” was directionally useful, but the current repository has already partially collapsed the obvious duplication into `runtime.ts`. So the real question is not “how do we invent a grand audio abstraction?” — it is “what is the smallest honest M2 port that preserves route clarity, moves authorship into the codec, and does not overfit a premature `BaseAudioRoute`?”
+
+---
+
+## Context
+
+M0 landed the Codec Protocol v2 surface in `packages/schemas/src/codec/v2/`. M1A landed image as the first real port and proved the four-stage seam is viable: `expand -> adapt -> decode -> package`. M2 is now the next active line, and audio is the first modality that tests whether the same seam can handle a **layered** codec rather than a single-route decoder.
+
+The current `codec-audio` shape is already more disciplined than the plan's first-pass audit suggested:
+
+- `packages/codec-audio/src/codec.ts` is still v0.1-style (`WittgensteinCodec.render(parsed, ctx)`), but it delegates to three small route implementations rather than a single giant renderer.
+- `packages/codec-audio/src/routes/{speech,soundscape,music}/index.ts` are each short, but they still repeat five responsibilities: timing, ambient recommendation, route-specific render, artifact finalization, and metadata patching.
+- `packages/codec-audio/src/runtime.ts` already centralizes the true shared render primitives: `finalizeAudioArtifact`, `generateAmbient`, `mixTracks`, `renderMacSpeech`, `synthSpeech`, `synthMusic`.
+- `docs/agent-guides/audio-port.md` still talks about collapsing “~80-line copy-paste,” which is no longer literally true. The engineering problem has become more subtle: shared logic exists, but not all of it deserves a class boundary.
+
+That subtlety matters. M2 is not “make audio elegant.” M2 is “port audio to Codec v2 without baking route-specific choices into shared doctrine.” This brief answers five engineering questions needed before code execution:
+
+1. what multi-route pattern to borrow;
+2. whether `BaseAudioRoute` is justified;
+3. which audio-specific manifest rows are load-bearing;
+4. which fixture classes should be byte-parity vs structural-parity;
+5. how `AudioRequest.route` should deprecate.
+
+---
+
+## Steelman
+
+### 1. Multi-route codec patterns: what to adopt and reject
+
+The relevant prior art is not “audio framework” specific. It is any production system that multiplexes a small set of route-specific handlers inside one typed resource boundary.
+
+**Express `Router` / Hono sub-apps** contribute the useful pattern: a flat dispatch surface with tiny handlers and shared middleware that is narrow enough to reason about locally. The transferable idea for M2 is not nested routers themselves, but a **codec-owned route table** where each route declares only `id + match + decode/package-local behavior`, and shared pre/post work lives outside the route file. This matches `Route<Req>` in `packages/schemas/src/codec/v2/codec.ts` almost exactly.
+
+**Fastify nested plugins** are only partially relevant. Their strength is explicit encapsulation and decoration scoping, but their plugin lifecycle is too heavyweight for three route variants that all live inside one codec package. The insight worth copying is “route-local registration can be isolated,” not the plugin graph itself.
+
+**tRPC sub-routers** are the cleanest fit for the _shape_ of the problem: one top-level surface, several typed sub-surfaces, shared context, and explicit composition. What transfers is the discipline that each route should own its input narrowing and output shape declaratively. What does **not** transfer is a proliferation of sub-router files or route-local middleware stacks. Audio does not need an RPC tree.
+
+**Apollo subgraphs** are the wrong abstraction entirely. Their value comes from distributed ownership and federation. `codec-audio` has three sibling routes in one package; importing federation concepts would only blur the seam.
+
+**Verdict for Q1:** adopt the **flat route-table + thin route objects** pattern; borrow selective compositional discipline from tRPC and Hono; reject Fastify-style nested plugin lifecycle and reject Apollo-style composition.
+
+### 2. `BaseAudioRoute`: premature or load-bearing?
+
+The repository's current code is the decisive signal here.
+
+The three route files are not identical copies:
+
+- `speech` is the only route with host-specific TTS probing (`renderMacSpeech`) and WAV decoding.
+- `soundscape` is the only route whose render body is almost entirely “ambient category + deterministic operator render.”
+- `music` is the only route that mixes symbolic synth output with ambient.
+
+What _is_ shared today is smaller and more mechanical:
+
+- derive or normalize the ambient category;
+- compute a duration constant or duration heuristic;
+- call a route-specific render primitive;
+- call `finalizeAudioArtifact`;
+- stamp route-local metadata such as `durationMs`.
+
+That is real duplication, but not class-worthy duplication. A `BaseAudioRoute` class at this moment would mostly be a place to hide five helper methods and three protected hooks. It would increase ceremony before the decoder-family verdict exists, and it would create a new inheritance surface exactly when M2 should be converging toward the already-accepted `BaseCodec` seam, not inventing a second one.
+
+The better shape is:
+
+- keep the real abstract lifecycle in `BaseCodec`;
+- add a small `audio-route-helpers.ts` or equivalent module for shared helper functions;
+- if, after the decoder-family verdict lands, all three routes converge on the same route-local lifecycle, re-evaluate a `BaseAudioRoute` in a follow-up.
+
+**Verdict for Q2:** **no base class yet; helper functions now.** `BaseAudioRoute` is premature at current code size and decoder uncertainty.
+
+### 3. Audio-specific manifest fields
+
+Audio needs more explicit structural metadata than image because “a WAV exists” is not enough to describe its reproducible shape. The current runtime already knows the minimum facts needed to describe the artifact honestly, and M2 should elevate those to codec-authored manifest rows.
+
+At minimum, M2 should introduce one codec-authored row keyed as `audio.render` with:
+
+- `sampleRateHz`
+- `channels`
+- `durationSec`
+- `container` (`wav` today)
+- `bitDepth` (`16` today)
+- `determinismClass` (`byte-parity` or `structural-parity`)
+- `decoderId` when a neural or host TTS engine participates
+- `decoderHash` when a pinned neural decoder or weights artifact exists
+
+This should sit alongside the generic artifact row rather than trying to overload `artifact.*`. The artifact row answers “what file was written?” The audio row answers “what acoustic structure did we intend to produce?”
+
+For route-specific quality receipts:
+
+- `speech` should emit `quality.partial.reason` when the host TTS engine is missing or when only structural parity can be asserted.
+- `soundscape` and `music` should explicitly mark themselves `byte-parity` while they remain deterministic operator/symbolic synthesis paths.
+
+**Verdict for Q3:** add a dedicated `audio.render` manifest row; do not rely on generic artifact metadata alone.
+
+### 4. Test fixture strategy by route
+
+The correct fixture split follows determinism, not modality:
+
+**Speech** is structurally reproducible but not byte-stable across hosts once `renderMacSpeech()` is allowed to participate. Even with fixed seed, the host engine and platform can change waveform bytes while preserving intelligibility and duration. So speech should gate on:
+
+- exact sample rate
+- exact channel count
+- duration within a narrow tolerance band
+- a stable `quality.partial` or `determinismClass` declaration
+
+If a future neural TTS decoder is chosen and only CPU inference is deterministic, the same structural class still applies unless the decoder family can prove byte-stable replay on the supported path.
+
+**Soundscape** is currently a pure operator-library render keyed off seed and category. That is exactly the kind of path that should stay byte-for-byte. If SHA-256 drifts, it is a real regression.
+
+**Music** is currently a tiny symbolic synth plus ambient mix. It is just as deterministic as soundscape under the present runtime and should also remain byte-for-byte. If M2 later introduces a decoder-backed music route, this verdict must be revisited.
+
+**Verdict for Q4:** speech = structural parity; soundscape = byte parity; music = byte parity.
+
+### 5. Soft-deprecation contract for `AudioRequest.route`
+
+The repo doctrine is already explicit: strategy lives on the codec, not on the request. M2 should therefore not normalize `req.route` as a permanent user-controlled truth; it should keep it only as a compatibility hint for one minor version.
+
+The deprecation needs to be machine-copyable and stable. Proposed warning text:
+
+> `AudioRequest.route` is deprecated and will be removed after one minor version. Audio routing now lives inside `AudioCodec.route()`; keep `--route` only for compatibility while migrating callers to modality-level intent.
+
+Preconditions for actual removal:
+
+1. CLI help and examples no longer advertise `--route` as the primary interface.
+2. `docs/codecs/audio.md` and `docs/agent-guides/audio-port.md` both describe route selection as codec-internal.
+3. No tests, examples, or apps under `apps/` depend on request-side route selection as the only way to express intent.
+4. The codec has a stable default intent mapping for speech / soundscape / music so removing the field does not silently collapse user intent.
+
+The warning should live at the codec boundary, not in the harness and not in every route file.
+
+**Verdict for Q5:** one-minor-version soft deprecation with the exact warning string above; remove only after docs/examples/app callers are clean.
+
+---
+
+## Red team
+
+The strongest objection is that this brief is overfitting a transient implementation. If Brief I picks a neural decoder family with its own tokenizer, some of today's helper-level decisions may become obsolete. That is true, but it cuts in favor of _smaller_ abstractions, not larger ones. A premature `BaseAudioRoute` would fossilize the current operator-library shape just when the decoder family is still open.
+
+The second objection is that a dedicated `audio.render` manifest row may duplicate generic artifact metadata. Also true, but duplication is cheaper than ambiguity here. Image can get away with one structural story because the shipping path is a single raster file. Audio has route-level determinism differences that need to be visible at a glance if M5b is to compare parity honestly.
+
+The third objection is that the plan explicitly asked for `BaseAudioRoute`, so deviating from it could look like ignoring process. I think the right reading is the opposite: the plan asked for the engineering verdict, not blind obedience. The current codebase no longer supports the stronger “80-line copy-paste” premise, so the honest answer is to dial the abstraction down.
+
+---
+
+## Kill criteria
+
+The engineering recommendations in this brief should be considered wrong, and therefore not promoted into the code port, if any of the following happens during M2:
+
+1. A helper-functions-only port leaves any route file with >30 lines of true shared-mechanical logic duplicated across siblings. At that point, the “no `BaseAudioRoute`” verdict is too conservative and should flip.
+2. The proposed `audio.render` row fails to cleanly encode one route's reproducibility story without leaking route-specific hacks into generic manifest fields. If that happens, the manifest schema needs a second iteration before the port lands.
+3. Speech proves byte-stable on all supported hosts for the chosen decoder path. In that case, the structural-parity verdict is too loose and should be tightened.
+4. Removing `AudioRequest.route` from real downstream callers requires more than one minor version of migration. If that signal appears, extend the deprecation window rather than force a breaking cleanup into M2.
+
+---
+
+## Verdict
+
+1. **Multi-route pattern:** use a flat codec-owned route table with thin route objects; reject nested plugin and federation patterns.
+2. **`BaseAudioRoute`:** do not introduce it in M2; use helper functions first and revisit only if duplication remains >30 lines after the port.
+3. **Manifest fields:** add a dedicated `audio.render` row with `sampleRateHz`, `channels`, `durationSec`, `container`, `bitDepth`, `determinismClass`, and optional decoder identity/hash.
+4. **Fixture classes:** speech gets structural parity; soundscape and music get byte-for-byte parity.
+5. **`AudioRequest.route` deprecation:** soft-warn for one minor version with a fixed message, and remove only after docs/examples/apps no longer depend on it as the canonical intent surface.
+
+Net: M2 should be a **small-shape port**, not a local framework invention. The engineering win is moving authorship into the codec and clarifying route determinism, not proving how many abstractions TypeScript can hold.
+
+## References
+
+- Wittgenstein repo (2026). `packages/codec-audio/src/codec.ts`, `packages/codec-audio/src/routes/{speech,soundscape,music}/index.ts`, `packages/codec-audio/src/runtime.ts`, `docs/agent-guides/audio-port.md`, `docs/exec-plans/active/codec-v2-port.md`.
+- Brief H — `docs/research/briefs/H_codec_engineering_prior_art.md`
+- RFC-0001 — `docs/rfcs/0001-codec-protocol-v2.md`

--- a/docs/research/briefs/J_audio_engineering_and_routes.md
+++ b/docs/research/briefs/J_audio_engineering_and_routes.md
@@ -19,6 +19,8 @@ The current `codec-audio` shape is already more disciplined than the plan's firs
 - `packages/codec-audio/src/codec.ts` is still v0.1-style (`WittgensteinCodec.render(parsed, ctx)`), but it delegates to three small route implementations rather than a single giant renderer.
 - `packages/codec-audio/src/routes/{speech,soundscape,music}/index.ts` are each short, but they still repeat five responsibilities: timing, ambient recommendation, route-specific render, artifact finalization, and metadata patching.
 - `packages/codec-audio/src/runtime.ts` already centralizes the true shared render primitives: `finalizeAudioArtifact`, `generateAmbient`, `mixTracks`, `renderMacSpeech`, `synthSpeech`, `synthMusic`.
+- `packages/core/src/codecs/audio.ts` is already just a registry hook, which means "make the core shim thin" is no longer a meaningful M2 engineering win. The real work sits inside `codec-audio`, not in `core`.
+- `packages/cli/src/commands/audio.ts` still exposes `--route`, so any deprecation story has to account for a live downstream caller rather than pretending request-side routing is only a schema concern.
 - `docs/agent-guides/audio-port.md` still talks about collapsing “~80-line copy-paste,” which is no longer literally true. The engineering problem has become more subtle: shared logic exists, but not all of it deserves a class boundary.
 
 That subtlety matters. M2 is not “make audio elegant.” M2 is “port audio to Codec v2 without baking route-specific choices into shared doctrine.” This brief answers five engineering questions needed before code execution:
@@ -128,7 +130,7 @@ The deprecation needs to be machine-copyable and stable. Proposed warning text:
 
 Preconditions for actual removal:
 
-1. CLI help and examples no longer advertise `--route` as the primary interface.
+1. `packages/cli/src/commands/audio.ts` no longer advertises `--route` as the primary interface, and the remaining compatibility path is documented as transitional only.
 2. `docs/codecs/audio.md` and `docs/agent-guides/audio-port.md` both describe route selection as codec-internal.
 3. No tests, examples, or apps under `apps/` depend on request-side route selection as the only way to express intent.
 4. The codec has a stable default intent mapping for speech / soundscape / music so removing the field does not silently collapse user intent.

--- a/docs/research/briefs/J_audio_engineering_and_routes.md
+++ b/docs/research/briefs/J_audio_engineering_and_routes.md
@@ -37,13 +37,13 @@ That subtlety matters. M2 is not “make audio elegant.” M2 is “port audio t
 
 The relevant prior art is not “audio framework” specific. It is any production system that multiplexes a small set of route-specific handlers inside one typed resource boundary.
 
-**Express `Router` / Hono sub-apps** contribute the useful pattern: a flat dispatch surface with tiny handlers and shared middleware that is narrow enough to reason about locally. The transferable idea for M2 is not nested routers themselves, but a **codec-owned route table** where each route declares only `id + match + decode/package-local behavior`, and shared pre/post work lives outside the route file. This matches `Route<Req>` in `packages/schemas/src/codec/v2/codec.ts` almost exactly.
+**Express `Router` / Hono sub-apps** contribute the useful pattern: a flat dispatch surface with tiny handlers and shared middleware that is narrow enough to reason about locally. Express explicitly frames `express.Router()` as a mini-app, while Hono documents route grouping through a child `Hono` instance mounted with `app.route(path, app)`. The transferable idea for M2 is not nested routers themselves, but a **codec-owned route table** where each route declares only `id + match + decode/package-local behavior`, and shared pre/post work lives outside the route file. This matches `Route<Req>` in `packages/schemas/src/codec/v2/codec.ts` almost exactly.
 
-**Fastify nested plugins** are only partially relevant. Their strength is explicit encapsulation and decoration scoping, but their plugin lifecycle is too heavyweight for three route variants that all live inside one codec package. The insight worth copying is “route-local registration can be isolated,” not the plugin graph itself.
+**Fastify nested plugins** are only partially relevant. Their strength is explicit encapsulation and decoration scoping: `register()` creates a new scope, descendants inherit from ancestors, and the docs describe the resulting DAG plus route prefixing. But that plugin lifecycle is too heavyweight for three route variants that all live inside one codec package. The insight worth copying is “route-local registration can be isolated,” not the plugin graph itself.
 
-**tRPC sub-routers** are the cleanest fit for the _shape_ of the problem: one top-level surface, several typed sub-surfaces, shared context, and explicit composition. What transfers is the discipline that each route should own its input narrowing and output shape declaratively. What does **not** transfer is a proliferation of sub-router files or route-local middleware stacks. Audio does not need an RPC tree.
+**tRPC sub-routers** are the cleanest fit for the _shape_ of the problem: one top-level surface, several typed sub-surfaces, shared context, and explicit composition. The docs show both `router({...})` and inline sub-routers, and insist that the `t` root be initialized exactly once per application. What transfers is the discipline that each route should own its input narrowing and output shape declaratively. What does **not** transfer is a proliferation of sub-router files or route-local middleware stacks. Audio does not need an RPC tree.
 
-**Apollo subgraphs** are the wrong abstraction entirely. Their value comes from distributed ownership and federation. `codec-audio` has three sibling routes in one package; importing federation concepts would only blur the seam.
+**Apollo subgraphs** are the wrong abstraction entirely. Their value comes from distributed ownership and federation under a subgraph specification, not from keeping three sibling handlers tidy inside one package. `codec-audio` has no cross-team ownership boundary, so importing federation concepts would only blur the seam.
 
 **Verdict for Q1:** adopt the **flat route-table + thin route objects** pattern; borrow selective compositional discipline from tRPC and Hono; reject Fastify-style nested plugin lifecycle and reject Apollo-style composition.
 
@@ -175,3 +175,8 @@ Net: M2 should be a **small-shape port**, not a local framework invention. The e
 - Wittgenstein repo (2026). `packages/codec-audio/src/codec.ts`, `packages/codec-audio/src/routes/{speech,soundscape,music}/index.ts`, `packages/codec-audio/src/runtime.ts`, `docs/agent-guides/audio-port.md`, `docs/exec-plans/active/codec-v2-port.md`.
 - Brief H — `docs/research/briefs/H_codec_engineering_prior_art.md`
 - RFC-0001 — `docs/rfcs/0001-codec-protocol-v2.md`
+- Express routing — https://expressjs.com/en/guide/routing.html
+- Hono routing / grouping — https://hono.dev/docs/api/routing and https://www.honojs.com/docs/api/hono
+- Fastify plugins / encapsulation — https://fastify.dev/docs/latest/Reference/Plugins/ and https://fastify.dev/docs/latest/Reference/Encapsulation/
+- tRPC routers — https://trpc.io/docs/server/routers
+- Apollo Federation subgraph specification — https://www.apollographql.com/docs/graphos/schema-design/federated-schemas/reference/subgraph-spec

--- a/docs/research/briefs/README.md
+++ b/docs/research/briefs/README.md
@@ -4,16 +4,17 @@ First-pass research briefs produced under **Phase P2** of the v0.2 Restructuring
 
 ## Brief index
 
-| ID  | Title                                                                          | Question                                                                                           | Status        |
-| --- | ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- | ------------- |
-| A   | [VQ / VLM lineage 2026 refresh](A_vq_vlm_lineage_audit.md)                     | Does the VQ-token / frozen-decoder path still look like the right bet in April 2026?               | 🟡 Draft v0.1 |
-| B   | [Compression vs world models — Ilya ↔ LeCun](B_compression_vs_world_models.md) | Where does Wittgenstein stand on the Ilya/LeCun tension? _(critical-path brief)_                   | 🟡 Draft v0.1 |
-| C   | [Unproven-but-interesting horizon scan](C_unproven_horizon.md)                 | Which 6–8 unvalidated hypotheses should shape the 18-month roadmap?                                | 🟡 Draft v0.1 |
-| D   | [CLI / SDK / harness conventions](D_cli_and_sdk_conventions.md)                | How do modern AI CLIs and SDKs look; where is Wittgenstein off the grid?                           | 🟡 Draft v0.1 |
-| E   | [Per-modality quality benchmarks](E_benchmarks_v2.md)                          | What's the smallest set of real (non-structural) quality metrics per modality?                     | 🟡 Draft v0.1 |
-| F   | [Site ↔ repo reconciliation](F_site_reconciliation.md)                         | Which `wittgenstein.wtf` claims contradict v0.1.0-alpha.2?                                         | 🟡 Draft v0.1 |
-| G   | [Image-network clues](G_image_network_clues.md)                                | Which decoder / data / packaging form ships for `codec-image` at exec-plan M1?                     | 🟡 Draft v0.1 |
-| H   | [Codec engineering prior art](H_codec_engineering_prior_art.md)                | Which production-validated TS projects share our `Codec<Req, Art>` shape, and what to copy at M1A? | 🟡 Draft v0.1 |
+| ID  | Title                                                                          | Question                                                                                                     | Status        |
+| --- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ | ------------- |
+| A   | [VQ / VLM lineage 2026 refresh](A_vq_vlm_lineage_audit.md)                     | Does the VQ-token / frozen-decoder path still look like the right bet in April 2026?                         | 🟡 Draft v0.1 |
+| B   | [Compression vs world models — Ilya ↔ LeCun](B_compression_vs_world_models.md) | Where does Wittgenstein stand on the Ilya/LeCun tension? _(critical-path brief)_                             | 🟡 Draft v0.1 |
+| C   | [Unproven-but-interesting horizon scan](C_unproven_horizon.md)                 | Which 6–8 unvalidated hypotheses should shape the 18-month roadmap?                                          | 🟡 Draft v0.1 |
+| D   | [CLI / SDK / harness conventions](D_cli_and_sdk_conventions.md)                | How do modern AI CLIs and SDKs look; where is Wittgenstein off the grid?                                     | 🟡 Draft v0.1 |
+| E   | [Per-modality quality benchmarks](E_benchmarks_v2.md)                          | What's the smallest set of real (non-structural) quality metrics per modality?                               | 🟡 Draft v0.1 |
+| F   | [Site ↔ repo reconciliation](F_site_reconciliation.md)                         | Which `wittgenstein.wtf` claims contradict v0.1.0-alpha.2?                                                   | 🟡 Draft v0.1 |
+| G   | [Image-network clues](G_image_network_clues.md)                                | Which decoder / data / packaging form ships for `codec-image` at exec-plan M1?                               | 🟡 Draft v0.1 |
+| H   | [Codec engineering prior art](H_codec_engineering_prior_art.md)                | Which production-validated TS projects share our `Codec<Req, Art>` shape, and what to copy at M1A?           | 🟡 Draft v0.1 |
+| J   | [Audio engineering and routes](J_audio_engineering_and_routes.md)              | What is the smallest honest M2 engineering shape for audio routes, manifest rows, fixtures, and deprecation? | 🟡 Draft v0.1 |
 
 ## Where briefs land (map)
 
@@ -26,6 +27,7 @@ flowchart LR
   E["Brief E: benchmarks v2"] -->|defines metrics| RFC
   F["Brief F: site↔repo diff"] -->|reconciles public narrative| RFC
   H["Brief H: codec engineering prior art"] -->|amends protocol typing + warnings| RFC
+  J["Brief J: audio engineering + routes"] -->|pins M2 route/manifest/deprecation shape| Code
 
   RFC --> Code["Code changes\npackages/*, docs/*"]
   ADR --> Code


### PR DESCRIPTION
## Summary
- add `docs/research/briefs/J_audio_engineering_and_routes.md` as the M2 engineering brief for audio route shape, manifest rows, fixture classes, and `AudioRequest.route` deprecation
- amend `docs/research/briefs/D_cli_and_sdk_conventions.md` with an audio-specific CLI / SDK addendum covering Piper, Coqui TTS, Whisper-style CLIs, the OpenAI Audio API, and ElevenLabs-style hosted speech
- update the briefs index so the M2 research surface is discoverable alongside A–H

## Why this shape
- follows the current split of labor: Claude handles the higher-stakes decoder-family / lineage verdict (`Brief I`), while this PR handles the engineering prior-art / route-shape side (`Brief J + D addendum`)
- intentionally corrects one stale plan assumption: the repo no longer has a literal "80-line route copy-paste", so `Brief J` argues for helper functions over a premature `BaseAudioRoute`
- keeps the work inside the repo's four-station brief contract (`Steelman`, `Red team`, `Kill criteria`, `Verdict`)

## Outputs
- `Brief J` answers five engineering questions:
  1. multi-route pattern to adopt/reject
  2. whether `BaseAudioRoute` is load-bearing or premature
  3. which audio-specific manifest rows should exist
  4. which routes get structural vs byte parity
  5. exact soft-deprecation contract for `AudioRequest.route`
- `Brief D` now has an explicit M2 audio addendum plus a keep/change/borrow table for audio tooling conventions

## Verification
- `pnpm exec prettier --check docs/research/briefs/J_audio_engineering_and_routes.md docs/research/briefs/D_cli_and_sdk_conventions.md docs/research/briefs/README.md docs/index.md`
- `git diff --check`
