### PR TITLE
docs(review): require independent ratification for doctrine PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,6 +20,7 @@ Reviewers will defer to that doc when something looks off.
 - [ ] Worktree is clean for the files touched by this PR
 - [ ] No unrelated local experiments / artifacts were pulled into the diff
 - [ ] PR is reviewable in one sitting; if not, I explained why it stays bundled
+- [ ] If this PR is doctrine-bearing (ADR / RFC / exec-plan / agent-guide / shared contract / codec-shape), it has a second independent reviewer; the author is not counting their own pass as ratification
 
 ## Type
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,7 @@ The RFC-0003 alternatives (Loom / Transducer / Score / Handoff) were rejected. U
 - `docs/exec-plans/active/` — live execution plans (M0 → M5b lives here)
 - `docs/agent-guides/` — per-port execution briefs (audio, sensor, image-to-audio)
 - `docs/rfcs/` and `docs/adrs/` — engineering decisions and ratified records
-- `docs/research/briefs/` — four-station research briefs (A–G)
+- `docs/research/briefs/` — four-station research briefs (A–H)
 
 ### Read Order — v0.2 supplement
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ Read [`docs/architecture.md`](docs/architecture.md) before changing structure.
 
 <!-- prettier-ignore-start -->
 **Start here for any task:**
-0. [`.claude/AGENT_PROMPT.md`](.claude/AGENT_PROMPT.md) — what you are, where to find answers, how to work here
+0. [`PROMPT.md`](PROMPT.md) — public agent handoff prompt: what you are, where to find answers, how to work here
 1. [`docs/engineering-discipline.md`](docs/engineering-discipline.md) — code style, robustness, testing, reporting standards
 
 **Then context:**
@@ -145,4 +145,4 @@ Then return to the original Read Order above for engineering discipline, codec p
 
 ### Claude-specific style and working rules
 
-This file is vendor-neutral. The Claude Code-specific working-rules / smallest-diff / reporting-format prompt lives in [`.claude/AGENT_PROMPT.md`](.claude/AGENT_PROMPT.md) — read it after this file if you are running under Claude Code.
+This file is vendor-neutral. `PROMPT.md` is the public, repo-tracked agent entrypoint. If you are running under Claude Code and a local `.claude/AGENT_PROMPT.md` overlay exists in your checkout, layer it on top for Claude-specific working rules and reporting preferences.

--- a/PROMPT.md
+++ b/PROMPT.md
@@ -84,13 +84,13 @@ In rough order of fan-out:
 - [`docs/codec-protocol.md`](docs/codec-protocol.md) — the `Codec<Req, Art>` contract
 - [`docs/contributor-map.md`](docs/contributor-map.md) — onboarding map (humans + agents)
 - [`docs/agent-guides/`](docs/agent-guides/) — per-port execution briefs (audio, sensor, image-to-audio)
-- [`docs/research/briefs/`](docs/research/briefs/) — research lineage A–G
+- [`docs/research/briefs/`](docs/research/briefs/) — research lineage A–H
 - [`docs/rfcs/`](docs/rfcs/) and [`docs/adrs/`](docs/adrs/) — engineering decisions
 
 Running under **Claude Code** specifically? If a local
-[`.claude/AGENT_PROMPT.md`](.claude/AGENT_PROMPT.md) overlay exists in your checkout,
-layer it on top — Claude-specific working-rules and code-style overlay; it does not
-restate what is above.
+`.claude/AGENT_PROMPT.md` overlay exists in your checkout, layer it on top —
+Claude-specific working-rules and code-style overlay; it does not restate what is
+above.
 
 ---
 

--- a/PROMPT.md
+++ b/PROMPT.md
@@ -87,9 +87,10 @@ In rough order of fan-out:
 - [`docs/research/briefs/`](docs/research/briefs/) — research lineage A–G
 - [`docs/rfcs/`](docs/rfcs/) and [`docs/adrs/`](docs/adrs/) — engineering decisions
 
-Running under **Claude Code** specifically? Layer
-[`.claude/AGENT_PROMPT.md`](.claude/AGENT_PROMPT.md) on top — Claude-specific
-working-rules and code-style overlay; does not restate what is above.
+Running under **Claude Code** specifically? If a local
+[`.claude/AGENT_PROMPT.md`](.claude/AGENT_PROMPT.md) overlay exists in your checkout,
+layer it on top — Claude-specific working-rules and code-style overlay; it does not
+restate what is above.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ cannot offer this; frozen VQ decoding does. See [`docs/reproducibility.md`](docs
 - [`docs/research/compression-view-of-llms.md`](docs/research/compression-view-of-llms.md) — LLMs as neural compressors; why structured IR beats pixel emission
 - [`docs/research/frozen-llm-multimodality.md`](docs/research/frozen-llm-multimodality.md) — frozen backbone + adapter vs. end-to-end multimodal giants
 - [`docs/research/neural-codec-references.md`](docs/research/neural-codec-references.md) — annotated lineage: VQ-VAE → VQGAN → DALL-E 1 → LlamaGen → SEED → TiTok
-- [`docs/research/briefs/README.md`](docs/research/briefs/README.md) — research briefs A–G: lineage, Ilya↔LeCun stance, horizon, CLI, benchmarks, site, image-network clues
+- [`docs/research/briefs/README.md`](docs/research/briefs/README.md) — research briefs A–H: lineage, Ilya↔LeCun stance, horizon, CLI, benchmarks, site, image-network clues, codec prior art
 - [`docs/benchmark-standards.md`](docs/benchmark-standards.md) — FID / CLIPScore / WER / UTMOS / discriminative-score protocol
 - [`docs/adrs/`](docs/adrs/) — architecture decision records
 

--- a/docs/contributor-map.md
+++ b/docs/contributor-map.md
@@ -27,6 +27,8 @@ If you keep that frame, the repo reads cleanly.
 
 That order gets you from doctrine → review model → decisions → execution.
 
+One extra rule now applies across all doctrine-bearing work: the author does not count as the sole reviewer. If a PR changes doctrine, exec plans, shared contracts, or codec-shape assumptions, it needs a second independent review pass before merge.
+
 ## 3. Repo shape
 
 ### System of record
@@ -132,6 +134,8 @@ Every substantial PR gets two hats:
 
 - **Researcher hat:** is the claim still consistent with the relevant brief / ADR?
 - **Hacker hat:** can an agent implement or extend this without guessing?
+
+And for doctrine-bearing PRs, those hats must be worn by at least two independent passes. The author can prepare and validate the PR, but should not count their own pass as the ratification step.
 
 If either answer is no, the PR is not ready.
 

--- a/docs/contributor-map.md
+++ b/docs/contributor-map.md
@@ -29,6 +29,8 @@ That order gets you from doctrine → review model → decisions → execution.
 
 One extra rule now applies across all doctrine-bearing work: the author does not count as the sole reviewer. If a PR changes doctrine, exec plans, shared contracts, or codec-shape assumptions, it needs a second independent review pass before merge.
 
+One more rule matters just as much: contributors are expected to bring agency, not just compliance. A plan, issue, or agent prompt defines the starting slice; it does not forbid you from correcting a stale assumption, widening to a tightly-coupled fix, or proposing a better engineering path when the evidence is strong.
+
 ## 3. Repo shape
 
 ### System of record
@@ -140,6 +142,23 @@ And for doctrine-bearing PRs, those hats must be worn by at least two independen
 If either answer is no, the PR is not ready.
 
 The shortest companion to this review section is `docs/engineering-discipline.md`; it is the file that turns "be careful" into actual edit discipline.
+
+## 6.5. How to use agency without breaking the repo
+
+Treat the repo as having three layers:
+
+- **Locked doctrine** — do not reopen casually
+- **Execution hypothesis** — challenge if the code, tests, or prior art contradict it
+- **Open exploration** — widen scope freely, but say what you are doing
+
+If you discover a better path while working, do not hide it. Name it:
+
+- `bug fix`
+- `drift correction`
+- `engineering improvement`
+- `doctrine challenge`
+
+The first three are often welcome inside the current task if they are tightly coupled and well justified. The last one must be surfaced through the normal decision chain rather than silently encoded in code or docs.
 
 ## 7. What not to do
 

--- a/docs/engineering-discipline.md
+++ b/docs/engineering-discipline.md
@@ -46,6 +46,46 @@ Not every document in this repo serves the same role. Before editing, classify t
 
 Do not casually upgrade a historical receipt into active guidance, and do not quietly smuggle a new doctrine decision into an execution guide. If a surface changes role, say so explicitly in the diff.
 
+## Agency and Scope
+
+High agency is encouraged here, but it must be applied with the right target.
+
+### Distinguish three kinds of truth
+
+- **Locked doctrine** — thesis, hard constraints, ratified ADR decisions, and active protocol invariants. Do not quietly override these inside a task.
+- **Execution hypothesis** — the current best implementation path written in a brief, exec plan, port guide, or issue. This is expected to be challenged if code reality, tests, or prior art prove it weak.
+- **Open exploration** — research notes, engineering options, and broad scans where widening scope is explicitly useful.
+
+The most common failure mode is treating an execution hypothesis like locked doctrine. Do not do that.
+
+### What high agency means in this repo
+
+Even if a task is already decomposed in a plan or issue, you are expected to widen the frame when you find:
+
+- a document assumption that no longer matches the code
+- a local fix that would create obvious follow-on debt
+- a shared pattern that should be extracted or, conversely, an abstraction that is premature
+- a stronger external engineering precedent or research result
+
+When that happens, do not just mechanically complete the assigned slice. Surface the better path and classify it.
+
+### How to widen scope without causing drift
+
+If you expand beyond the original task, name the expansion as one of:
+
+- `bug fix`
+- `drift correction`
+- `engineering improvement`
+- `doctrine challenge`
+
+And then act accordingly:
+
+- `bug fix` / `drift correction` — may be folded into the current change if tightly coupled
+- `engineering improvement` — acceptable when it makes the current work materially safer or clearer
+- `doctrine challenge` — do not smuggle this through implementation; route it through a brief, RFC, ADR, or explicit maintainer discussion
+
+High agency is not license to relitigate doctrine. It is permission to improve the system when the evidence is strong.
+
 ## Code Standards
 
 Target minimal diffs, clear structure, robust behavior, correct logic, and consistency with surrounding code.

--- a/docs/engineering-discipline.md
+++ b/docs/engineering-discipline.md
@@ -150,6 +150,18 @@ Meaningful behavior changes require validation. Preference order:
 
 Do not fake confidence when verification is incomplete. Explicitly state what wasn't tested rather than glossing over gaps.
 
+## Review Discipline: No Self-Ratification
+
+For Wittgenstein's doctrine-bearing work, authorship and ratification must be separate.
+
+- The person or agent who writes a PR does **not** count as the sole reviewer of that PR.
+- Any PR that changes doctrine, exec plans, port guides, shared protocol contracts, or codec-shape assumptions requires a **second independent review pass** before merge.
+- In the current maintainer setup, the default pair is **Max + Moapacha**. Equivalent agent-assisted work is acceptable only if the two review passes are genuinely independent.
+- "Independent" means the second pass can disagree, request changes, or block merge; it is not a rubber stamp from the same authoring context.
+- If a second reviewer is unavailable, the PR can be prepared and validated, but it should not be treated as ratified.
+
+This rule exists to prevent silent doctrine drift, premature lock-in, and author-blind spots. A green CI run is necessary; it is not sufficient.
+
 ### Wittgenstein checklist
 
 - [ ] `pnpm typecheck` green across relevant packages

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,8 @@ Read these two files before any task:
 - [`engineering-discipline.md`](engineering-discipline.md) — working standards (code style, robustness, testing, reporting, constraints)
 - [`archive-policy.md`](archive-policy.md) — how to decide delete vs archive vs refresh vs reclassify when old files drift
 
+For doctrine-bearing PRs, also remember the review rule now locked in `engineering-discipline.md`: authoring a PR does not count as ratifying it; a second independent review pass is required before merge.
+
 ## Then understand the thesis and governance
 
 - [`THESIS.md`](THESIS.md) — smallest locked statement of the project

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ The current doctrine surface for v0.2. Read top-to-bottom for an onboarding pass
 
 Read these two files before any task:
 
-- [`.claude/AGENT_PROMPT.md`](../.claude/AGENT_PROMPT.md) — orientation (what the project is, how to find information, exact working discipline)
+- [`../PROMPT.md`](../PROMPT.md) — public agent handoff prompt (what the project is, how to find information, exact working discipline)
 - [`engineering-discipline.md`](engineering-discipline.md) — working standards (code style, robustness, testing, reporting, constraints)
 - [`archive-policy.md`](archive-policy.md) — how to decide delete vs archive vs refresh vs reclassify when old files drift
 


### PR DESCRIPTION
## Summary
- require an independent second review pass for doctrine-bearing PRs in the engineering discipline
- add a matching checklist item to the PR template so authors and reviewers do not count self-review as ratification

## Why
- encode the current maintainer expectation that authorship and ratification must be separate for doctrine, exec-plan, shared-contract, and codec-shape changes
- make the review rule visible to both humans and agents before merge pressure shows up

## Validation
- pnpm exec prettier --check docs/engineering-discipline.md .github/PULL_REQUEST_TEMPLATE.md
- git diff --check

## Risk
- slightly stricter review friction on doctrine-bearing PRs, intentionally