### PR TITLE
docs(governance): surface two-lane decision model + extend CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,23 +14,23 @@
 
 # ----- Code surfaces (per-modality, modality-team or fallback) -----
 
-/packages/core/src/runtime/ @wittgenstein-core
-/packages/core/src/llm/ @wittgenstein-core
-/packages/core/src/codecs/image.ts @wittgenstein-image
-/packages/core/src/codecs/audio.ts @wittgenstein-audio
-/packages/core/src/codecs/video.ts @wittgenstein-video
-/packages/core/src/codecs/sensor.ts @wittgenstein-sensor
-/packages/schemas/ @wittgenstein-core
-/packages/sandbox/ @wittgenstein-core
-/packages/codec-image/ @wittgenstein-image
-/packages/codec-audio/ @wittgenstein-audio
-/packages/codec-video/ @wittgenstein-video
-/packages/codec-sensor/ @wittgenstein-sensor
+/packages/core/src/runtime/ @Jah-yee @Moapacha @wittgenstein-core
+/packages/core/src/llm/ @Jah-yee @Moapacha @wittgenstein-core
+/packages/core/src/codecs/image.ts @Jah-yee @Moapacha @wittgenstein-image
+/packages/core/src/codecs/audio.ts @Jah-yee @Moapacha @wittgenstein-audio
+/packages/core/src/codecs/video.ts @Jah-yee @Moapacha @wittgenstein-video
+/packages/core/src/codecs/sensor.ts @Jah-yee @Moapacha @wittgenstein-sensor
+/packages/schemas/ @Jah-yee @Moapacha @wittgenstein-core
+/packages/sandbox/ @Jah-yee @Moapacha @wittgenstein-core
+/packages/codec-image/ @Jah-yee @Moapacha @wittgenstein-image
+/packages/codec-audio/ @Jah-yee @Moapacha @wittgenstein-audio
+/packages/codec-video/ @Jah-yee @Moapacha @wittgenstein-video
+/packages/codec-sensor/ @Jah-yee @Moapacha @wittgenstein-sensor
 /apps/site/ @Jah-yee @Moapacha
-/docs/codecs/image.md @wittgenstein-image
-/docs/codecs/audio.md @wittgenstein-audio
-/docs/codecs/video.md @wittgenstein-video
-/docs/codecs/sensor.md @wittgenstein-sensor
+/docs/codecs/image.md @Jah-yee @Moapacha @wittgenstein-image
+/docs/codecs/audio.md @Jah-yee @Moapacha @wittgenstein-audio
+/docs/codecs/video.md @Jah-yee @Moapacha @wittgenstein-video
+/docs/codecs/sensor.md @Jah-yee @Moapacha @wittgenstein-sensor
 
 # ----- Doctrine surfaces (ADR-0013 §1) -----
 # These require independent ratification per ADR-0013. Always route to the

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,18 @@
-* @max
+# CODEOWNERS — automatic review-request routing.
+#
+# This file is read by GitHub when a PR is opened. Every owner listed for a
+# touched path is auto-requested for review. ADR-0013 makes this load-bearing
+# for doctrine-bearing surfaces: changes to those surfaces MUST receive an
+# independent ratification pass, not just self-review.
+#
+# Maintainer pair (per ADR-0013): @Jah-yee + @Moapacha.
+# Per-modality team handles are aspirational; if the team is not yet provisioned
+# in the org, the catchall pair still receives the review request.
+
+# Default fallback — every PR auto-requests the maintainer pair.
+* @Jah-yee @Moapacha
+
+# ----- Code surfaces (per-modality, modality-team or fallback) -----
 
 /packages/core/src/runtime/ @wittgenstein-core
 /packages/core/src/llm/ @wittgenstein-core
@@ -12,8 +26,45 @@
 /packages/codec-audio/ @wittgenstein-audio
 /packages/codec-video/ @wittgenstein-video
 /packages/codec-sensor/ @wittgenstein-sensor
-/apps/site/ @max
+/apps/site/ @Jah-yee @Moapacha
 /docs/codecs/image.md @wittgenstein-image
 /docs/codecs/audio.md @wittgenstein-audio
 /docs/codecs/video.md @wittgenstein-video
 /docs/codecs/sensor.md @wittgenstein-sensor
+
+# ----- Doctrine surfaces (ADR-0013 §1) -----
+# These require independent ratification per ADR-0013. Always route to the
+# maintainer pair regardless of who else is in the file.
+
+/AGENTS.md @Jah-yee @Moapacha
+/PROMPT.md @Jah-yee @Moapacha
+/CONTRIBUTING.md @Jah-yee @Moapacha
+/README.md @Jah-yee @Moapacha
+/.github/CODEOWNERS @Jah-yee @Moapacha
+/.github/PULL_REQUEST_TEMPLATE.md @Jah-yee @Moapacha
+/.github/ISSUE_TEMPLATE/ @Jah-yee @Moapacha
+/.github/dependabot.yml @Jah-yee @Moapacha
+/.github/labeler.yml @Jah-yee @Moapacha
+/.github/workflows/ @Jah-yee @Moapacha
+
+/docs/THESIS.md @Jah-yee @Moapacha
+/docs/architecture.md @Jah-yee @Moapacha
+/docs/hard-constraints.md @Jah-yee @Moapacha
+/docs/engineering-discipline.md @Jah-yee @Moapacha
+/docs/codec-protocol.md @Jah-yee @Moapacha
+/docs/reproducibility.md @Jah-yee @Moapacha
+/docs/labels.md @Jah-yee @Moapacha
+/docs/archive-policy.md @Jah-yee @Moapacha
+/docs/contributor-map.md @Jah-yee @Moapacha
+/docs/glossary.md @Jah-yee @Moapacha
+/docs/tracks.md @Jah-yee @Moapacha
+/docs/index.md @Jah-yee @Moapacha
+
+/docs/adrs/ @Jah-yee @Moapacha
+/docs/rfcs/ @Jah-yee @Moapacha
+/docs/exec-plans/active/ @Jah-yee @Moapacha
+/docs/agent-guides/ @Jah-yee @Moapacha
+/docs/research/briefs/ @Jah-yee @Moapacha
+
+# Shared protocol contracts at the schema level
+/packages/schemas/src/codec/v2/ @Jah-yee @Moapacha

--- a/.github/ISSUE_TEMPLATE/discussion.md
+++ b/.github/ISSUE_TEMPLATE/discussion.md
@@ -1,0 +1,32 @@
+---
+name: Discussion
+about: Open architectural deliberation — the issue itself is the deliberation
+title: "[discussion] "
+labels: discussion
+assignees: ""
+---
+
+## The question
+
+<!-- One sentence. What is the open architectural question? -->
+
+## Why now
+
+<!-- Why does this need to be deliberated now (not in three months)? -->
+
+## What outcomes would close this issue
+
+<!-- Pick at least one:
+     - [ ] a research brief gets amended
+     - [ ] an RFC is opened
+     - [ ] a horizon-spike is filed
+     - [ ] this issue closes as wontfix or duplicate
+-->
+
+## Boundaries
+
+<!-- What is explicitly out of scope for this discussion? -->
+
+## Inputs
+
+<!-- Briefs / ADRs / RFCs / prior discussions / external links -->

--- a/.github/ISSUE_TEMPLATE/experimental-feedback.md
+++ b/.github/ISSUE_TEMPLATE/experimental-feedback.md
@@ -2,7 +2,7 @@
 name: Experimental feedback
 about: Report findings on an ⚠️ Partial or 🔴 Stub component (see docs/implementation-status.md)
 title: "[experimental] "
-labels: experimental, feedback
+labels: bug
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/governance-note.md
+++ b/.github/ISSUE_TEMPLATE/governance-note.md
@@ -1,0 +1,37 @@
+---
+name: Governance note
+about: A scoped working note for a meta-process decision that may become an ADR (per ADR-0014)
+title: "[governance] "
+labels: discussion, documentation
+assignees: ""
+---
+
+## The governance question
+
+<!-- One sentence. Examples:
+     - "Should the label set introduce prefixes once we cross 20 entries?"
+     - "Should research notes split into scope / object / theory / reference subdirs?"
+     - "What is the soft-deprecation default lifetime across the repo?" -->
+
+## Why this is governance, not engineering
+
+<!-- Brief: this affects how the project decides / reviews / classifies / archives /
+     describes its surfaces — not how a codec or modality is built.
+     If unclear, see ADR-0014 §1 (governance scope). -->
+
+## Surfaces affected
+
+<!-- Which operating docs would carry the inline summary once an ADR ratifies?
+     e.g. docs/labels.md, AGENTS.md, docs/engineering-discipline.md, ... -->
+
+## Outcome
+
+<!-- Pick one:
+     - [ ] this issue produces an ADR (likely outcome — most governance questions land as ADRs)
+     - [ ] this issue produces a research brief first (if alternatives need exploring)
+     - [ ] this issue closes as wontfix (the question was not actually scoped) -->
+
+## Inputs
+
+- Source: <!-- prior issue / discussion / audit memo / external prior art -->
+- Related ADRs: <!-- e.g. ADR-0014 -->

--- a/.github/ISSUE_TEMPLATE/horizon-spike.md
+++ b/.github/ISSUE_TEMPLATE/horizon-spike.md
@@ -1,0 +1,32 @@
+---
+name: Horizon spike
+about: Brief-C horizon hypothesis turned into a time-boxed experiment with explicit kill criteria
+title: "horizon-spike: H?? — "
+labels: horizon-spike, research-derived
+assignees: ""
+---
+
+## Hypothesis (verbatim from brief)
+
+<!-- Cite the brief (e.g. "Brief C v0.2 H10") and restate the claim verbatim. -->
+
+## What to run
+
+<!-- The smallest experiment that would move confidence. -->
+
+## Kill criteria (↑ / ↓ confidence-flip thresholds, from the brief)
+
+<!-- Both directions. ↑ flip-up signal (e.g. "0.3 → 0.6 if X"); ↓ flip-down signal. -->
+
+## Validation gate
+
+<!-- Concrete output that would let us flip confidence. Define it before starting. -->
+
+## Time box
+
+<!-- e.g. "≤ 1 day", "≤ 1 sprint". Spike, not project. -->
+
+## Inputs
+
+- Source brief: `docs/research/briefs/C_unproven_horizon.md` §H??
+- ...

--- a/.github/ISSUE_TEMPLATE/tracker.md
+++ b/.github/ISSUE_TEMPLATE/tracker.md
@@ -1,0 +1,36 @@
+---
+name: Tracker (watch on external event)
+about: Standing watch on an external event — not actionable until the named gating event trips
+title: "tracker: "
+labels: tracker
+assignees: ""
+---
+
+## What we are watching
+
+<!-- One sentence. The external event we are waiting on. -->
+
+## Why this is a tracker, not actionable work
+
+<!-- Why are we waiting on the world rather than executing internally? -->
+
+## Gating event(s)
+
+<!-- Concrete signals that would flip this issue from "watch" to "act":
+     e.g. "open-weights LFQ-family decoder lands with commercial license"
+          "OpenAI publishes ___ benchmark"
+          "library X releases v?.0 with ___"
+-->
+
+## Re-evaluation date
+
+<!-- If the event has not tripped by this date, re-evaluate.
+     ISO date, e.g. "2026-Q4". -->
+
+## What flipping looks like
+
+<!-- When the gate trips: what concrete next step does this become? -->
+
+## Inputs
+
+<!-- Briefs / ADRs / vendors / papers we are tracking -->

--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -1,0 +1,19 @@
+# Title-keyword issue auto-labeler config (consumed by .github/workflows/issue-labeler.yml).
+#
+# Pattern format: regex matched against issue title (case-insensitive).
+# Aligns with docs/labels.md (ratified by ADR-0012).
+#
+# Issue templates already auto-apply primary type labels via frontmatter
+# (bug / enhancement / question / discussion / etc.). This labeler covers
+# the case where a contributor opens a blank issue or imports from elsewhere.
+
+bug: '\[bug\]|^bug[:\s]'
+enhancement: '\[feat\]|\[enhancement\]'
+question: '\[q\]|\[question\]'
+documentation: '\[docs?\]|^docs?[:\s]'
+discussion: '\[discussion\]|^discussion[:\s]|协作规范|并行推进'
+horizon-spike: 'horizon[\s-]spike|H\d{1,2}\b'
+tracker: '^tracker[:\s]|\[tracker\]|watch[:\s]'
+research-derived: 'Brief\s+[A-Z]\b|brief-derived'
+adr-derived: 'ADR-?\d{3,4}'
+rfc-derived: 'RFC-?\d{3,4}'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,40 @@
+# Path-based PR auto-labeler config (consumed by .github/workflows/labeler.yml).
+#
+# Aligns with docs/labels.md (ratified by ADR-0012). Each label below maps to
+# the body convention in that doc:
+#   - documentation       → any change under docs/, README, AGENTS, PROMPT, CONTRIBUTING
+#   - research-derived    → docs/research/briefs/* (must cite Brief letter in body)
+#   - adr-derived         → docs/adrs/* (must cite ADR ID in body)
+#   - rfc-derived         → docs/rfcs/* (must cite RFC ID in body)
+#   - refactor            → packages/* code-only changes that touch ≥3 files (heuristic)
+#
+# Auto-labeler does not assign type labels (bug / enhancement) — those reflect
+# author intent, not file paths. The PR template's checkbox row remains the
+# source of truth for type.
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**"
+          - "README.md"
+          - "AGENTS.md"
+          - "PROMPT.md"
+          - "CONTRIBUTING.md"
+          - "SHOWCASE.md"
+          - "SUPPORT.md"
+          - "CHANGELOG.md"
+
+research-derived:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/research/briefs/**"
+
+adr-derived:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/adrs/**"
+
+rfc-derived:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/rfcs/**"

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,25 @@
+name: Issue auto-labeler
+
+# Title-keyword issue labeler. Reads .github/issue-labeler.yml.
+# Adds labels per docs/labels.md (ADR-0012); does not remove other labels.
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: github/issue-labeler@v3.4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/issue-labeler.yml
+          enable-versioned-regex: 0
+          include-title: 1
+          include-body: 0
+          sync-labels: 0

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,22 @@
+name: PR auto-labeler
+
+# Path-based PR labeler. Reads .github/labeler.yml.
+# Adds labels per docs/labels.md (ADR-0012); does not remove other labels.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+          sync-labels: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,15 @@ Read [`docs/architecture.md`](docs/architecture.md) before changing structure.
 - Put future architectural choices in ADRs instead of burying them in PR text.
 - When in doubt, prefer traceability over convenience.
 
+## Two Decision Lanes
+
+The repo runs on **two separate decision lanes**. Pick the right one before you write doctrine.
+
+- **Engineering lane** — `Brief → RFC → ADR → exec-plan → code`. For codec / modality / protocol / runtime decisions. Canonical example: M1A landed via Brief A+G+H → RFC-0001 → ADR-0008 → exec-plan §M1 → PR #68.
+- **Governance lane** — `(optional Governance Note) → ADR → inline summary`. For review process, archive policy, label taxonomy, agency boundaries, surface classification, research-surface taxonomy, contributor-map structure, agent-handoff conventions. See ADR-0014.
+
+**Critical:** if you find yourself wanting to append a new section to `docs/engineering-discipline.md`, `CONTRIBUTING.md`, `AGENTS.md`, or any other operating doc — **stop and open an ADR first**. Inline summaries are pointers to ratifying ADRs, not the doctrine itself. This rule is locked in ADR-0013 and ADR-0014.
+
 ## Read Order
 
 <!-- prettier-ignore-start -->

--- a/PROMPT.md
+++ b/PROMPT.md
@@ -84,8 +84,15 @@ In rough order of fan-out:
 - [`docs/codec-protocol.md`](docs/codec-protocol.md) — the `Codec<Req, Art>` contract
 - [`docs/contributor-map.md`](docs/contributor-map.md) — onboarding map (humans + agents)
 - [`docs/agent-guides/`](docs/agent-guides/) — per-port execution briefs (audio, sensor, image-to-audio)
-- [`docs/research/briefs/`](docs/research/briefs/) — research lineage A–H
+- [`docs/research/briefs/`](docs/research/briefs/) — research lineage A–J
 - [`docs/rfcs/`](docs/rfcs/) and [`docs/adrs/`](docs/adrs/) — engineering decisions
+
+## Two decision lanes (read before changing any operating doc)
+
+- **Engineering lane** — `Brief → RFC → ADR → exec-plan → code`. For codecs / modalities / protocols / runtime.
+- **Governance lane** — `(optional Governance Note) → ADR → inline summary`. For review process, archive policy, label taxonomy, agency boundaries, surface classification.
+
+If you want to append a new section to `docs/engineering-discipline.md`, `AGENTS.md`, `CONTRIBUTING.md`, or any operating doc — **open an ADR first**. The inline text is a pointer; the ADR is the doctrine. See ADR-0013 / ADR-0014.
 
 Running under **Claude Code** specifically? If a local
 `.claude/AGENT_PROMPT.md` overlay exists in your checkout, layer it on top —

--- a/README.md
+++ b/README.md
@@ -239,7 +239,8 @@ cannot offer this; frozen VQ decoding does. See [`docs/reproducibility.md`](docs
 - [`docs/agent-guides/audio-port.md`](docs/agent-guides/audio-port.md) — audio line, M2 (route collapse, soft-deprecation)
 - [`docs/agent-guides/sensor-port.md`](docs/agent-guides/sensor-port.md) — sensor line, M3 (no-L4 confirmation case)
 - [`docs/rfcs/README.md`](docs/rfcs/README.md) — engineering decisions (RFCs 0001 codec v2, 0002 CLI, 0004 site, 0005 naming)
-- [`docs/adrs/README.md`](docs/adrs/README.md) — ratified decisions (ADRs 0006 layered IR, 0007 Path C rejected, 0008 codec v2, 0009 CLI v2, 0011 naming v2)
+- [`docs/adrs/README.md`](docs/adrs/README.md) — ratified decisions (engineering lane: ADRs 0006 layered IR, 0007 Path C rejected, 0008 codec v2, 0009 CLI v2, 0011 naming v2; governance lane: ADRs 0012 labels, 0013 independent ratification, 0014 governance lane itself)
+- [`docs/labels.md`](docs/labels.md) — canonical issue / PR label taxonomy (ratified by ADR-0012)
 
 ### For hackers
 

--- a/docs/contributor-map.md
+++ b/docs/contributor-map.md
@@ -27,9 +27,18 @@ If you keep that frame, the repo reads cleanly.
 
 That order gets you from doctrine → review model → decisions → execution.
 
-One extra rule now applies across all doctrine-bearing work: the author does not count as the sole reviewer. If a PR changes doctrine, exec plans, shared contracts, or codec-shape assumptions, it needs a second independent review pass before merge.
+One extra rule now applies across all doctrine-bearing work: the author does not count as the sole reviewer. If a PR changes doctrine, exec plans, shared contracts, or codec-shape assumptions, it needs a second independent review pass before merge. (Locked in ADR-0013.)
 
 One more rule matters just as much: contributors are expected to bring agency, not just compliance. A plan, issue, or agent prompt defines the starting slice; it does not forbid you from correcting a stale assumption, widening to a tightly-coupled fix, or proposing a better engineering path when the evidence is strong.
+
+### Two decision lanes
+
+The repo runs on two separate decision lanes — pick the right one before writing doctrine:
+
+- **Engineering lane** — `Brief → RFC → ADR → exec-plan → code`. For codec / modality / protocol / runtime decisions. Canonical example: M1A landed via Briefs A+G+H → RFC-0001 → ADR-0008 → exec-plan §M1 → PR #68.
+- **Governance lane** — `(optional Governance Note) → ADR → inline summary`. For review process, archive policy, label taxonomy, agency boundaries, surface classification, research-surface taxonomy, agent-handoff conventions. See ADR-0014.
+
+If you want to append a new section to `docs/engineering-discipline.md`, `AGENTS.md`, `CONTRIBUTING.md`, `docs/labels.md`, or any operating doc — **open an ADR first**. Inline summaries are pointers to ratifying ADRs; they are not the doctrine themselves.
 
 ## 3. Repo shape
 


### PR DESCRIPTION
## Summary

Closes the last visible gap from the 2026-04-27 audit: the governance lane (ADR-0014) was locked, but the contributor entry surfaces did not name it. New contributors would still default to inline doctrine drops because the first-read docs did not point at the chain.

### Changes

- **AGENTS.md / PROMPT.md / contributor-map.md / README.md** — each now names both lanes (engineering vs governance) with one short paragraph + ADR pointer. Wording is identical in spirit but tuned to each surface's voice. The instruction is uniform: "if you want to append a section to an operating doc, open an ADR first."
- **CODEOWNERS** — extended to cover doctrine surfaces explicitly (\`AGENTS.md\`, \`PROMPT.md\`, \`CONTRIBUTING.md\`, \`README.md\`, \`docs/engineering-discipline.md\`, \`docs/labels.md\`, all of \`docs/adrs/\`, \`docs/rfcs/\`, \`docs/exec-plans/active/\`, \`docs/agent-guides/\`, \`docs/research/briefs/\`, and shared protocol contracts under \`packages/schemas/src/codec/v2/\`). The catchall handle changed from the placeholder \`@max\` to the maintainer pair locked in ADR-0013.

### Why this shape

The audit found that \`engineering-discipline.md\` was being treated as a doctrine dump because the chain had no governance lane. ADR-0014 fixed the chain. This PR makes the chain visible to the people / agents arriving at the repo, and CODEOWNERS auto-routes them to the right reviewers.

Per-modality team handles in CODEOWNERS (\`@wittgenstein-image\`, etc.) are left as aspirational placeholders; if those teams are not provisioned, GitHub falls through to the catchall pair.

### Validation

- \`pnpm exec prettier --check AGENTS.md PROMPT.md docs/contributor-map.md README.md\` — green.

### Per ADR-0013

This PR touches doctrine-bearing surfaces and requires the second independent review pass.