### PR TITLE
chore(github): doctrine guardrail + monthly markdown link check

### DIFF
--- a/.github/workflows/doctrine-guardrail.yml
+++ b/.github/workflows/doctrine-guardrail.yml
@@ -1,0 +1,96 @@
+name: Doctrine guardrail
+
+# Gentle guardrail (per ADR-0014): when a PR touches a doctrine-bearing
+# surface, check that the PR body references an ADR or RFC. If not, post
+# a comment reminder. Does NOT block merge — this is a nudge, not a gate.
+#
+# The list of doctrine-bearing files mirrors ADR-0013 §1.
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  guardrail:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Detect doctrine touches
+        id: detect
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const doctrinePatterns = [
+              /^docs\/engineering-discipline\.md$/,
+              /^docs\/THESIS\.md$/,
+              /^docs\/architecture\.md$/,
+              /^docs\/hard-constraints\.md$/,
+              /^docs\/codec-protocol\.md$/,
+              /^docs\/reproducibility\.md$/,
+              /^docs\/labels\.md$/,
+              /^docs\/archive-policy\.md$/,
+              /^docs\/contributor-map\.md$/,
+              /^docs\/glossary\.md$/,
+              /^docs\/tracks\.md$/,
+              /^AGENTS\.md$/,
+              /^PROMPT\.md$/,
+              /^CONTRIBUTING\.md$/,
+              /^README\.md$/,
+              /^\.github\/CODEOWNERS$/,
+              /^\.github\/PULL_REQUEST_TEMPLATE\.md$/,
+              /^docs\/adrs\//,
+              /^docs\/rfcs\//,
+              /^docs\/exec-plans\/active\//,
+              /^docs\/agent-guides\//,
+              /^docs\/research\/briefs\//,
+              /^packages\/schemas\/src\/codec\/v2\//,
+            ];
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              per_page: 100,
+            });
+            const touched = files
+              .map((f) => f.filename)
+              .filter((p) => doctrinePatterns.some((re) => re.test(p)));
+            const refRegex = /\b(ADR|RFC)[-\s]?\d{3,4}\b/i;
+            const body = (context.payload.pull_request.body || "") + "\n" +
+                         (context.payload.pull_request.title || "");
+            const hasRef = refRegex.test(body);
+            core.setOutput("touched", touched.length > 0 ? "yes" : "no");
+            core.setOutput("hasref", hasRef ? "yes" : "no");
+            core.setOutput("files", touched.slice(0, 5).join(", "));
+
+      - name: Post nudge comment if missing reference
+        if: steps.detect.outputs.touched == 'yes' && steps.detect.outputs.hasref == 'no'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = "<!-- doctrine-guardrail -->";
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            if (comments.some((c) => c.body && c.body.includes(marker))) {
+              return; // already nudged
+            }
+            const body = `${marker}\n` +
+              `### Doctrine guardrail (gentle nudge — does not block)\n\n` +
+              `This PR touches a doctrine-bearing surface (per ADR-0013 §1) but the PR body / title does not reference an ADR-XXXX or RFC-XXXX.\n\n` +
+              `Touched files (first 5): \`${{ steps.detect.outputs.files }}\`\n\n` +
+              `Per ADR-0014, doctrine changes should land via the **governance lane** \`(Governance Note →) ADR → inline summary\`. If this PR carries doctrine, please:\n\n` +
+              `- cite the ratifying ADR / RFC ID in the PR body, or\n` +
+              `- pair this PR with an ADR PR (and reference it here), or\n` +
+              `- if this is execution / drift correction (not doctrine), say so explicitly in the body.\n\n` +
+              `_This is an informational nudge. Merge is not blocked._`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,49 @@
+name: Markdown link check
+
+# Monthly link check across docs surfaces. Files an issue if broken
+# links are detected. Manual dispatch supported for one-off runs.
+#
+# Runs on the 1st of each month at 02:00 UTC. Off-hours, low-noise.
+
+on:
+  schedule:
+    - cron: "0 2 1 * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run lychee link check
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --no-progress
+            --max-concurrency 4
+            --exclude-mail
+            --exclude-loopback
+            --accept 200..=299,403,429
+            'docs/**/*.md'
+            'README.md'
+            'AGENTS.md'
+            'PROMPT.md'
+            'CONTRIBUTING.md'
+            'CHANGELOG.md'
+          fail: false
+          format: markdown
+          output: ./lychee/out.md
+
+      - name: Open issue if broken
+        if: steps.lychee.outputs.exit_code != '0'
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: "[docs] monthly link check found broken links"
+          content-filepath: ./lychee/out.md
+          labels: documentation

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -40,10 +40,38 @@ jobs:
           format: markdown
           output: ./lychee/out.md
 
-      - name: Open issue if broken
+      - name: Reuse existing issue or open a new one if broken
         if: steps.lychee.outputs.exit_code != '0'
-        uses: peter-evans/create-issue-from-file@v5
+        uses: actions/github-script@v7
         with:
-          title: "[docs] monthly link check found broken links"
-          content-filepath: ./lychee/out.md
-          labels: documentation
+          script: |
+            const fs = require("fs");
+            const title = "[docs] monthly link check found broken links";
+            const body = fs.readFileSync("./lychee/out.md", "utf8");
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              labels: "documentation",
+              per_page: 100,
+            });
+            const existing = issues.find((issue) => issue.title === title);
+
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body: `## Monthly link-check update\n\n${body}`,
+              });
+              core.info(`Updated existing issue #${existing.number}`);
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ["documentation"],
+              });
+              core.info("Opened new monthly link-check issue");
+            }


### PR DESCRIPTION
## Summary

Tier 2 automation, deliberately quiet (separate PR from #84 per the original plan).

### What lands

- **\`.github/workflows/doctrine-guardrail.yml\`** — when a PR touches a doctrine-bearing surface (ADR-0013 §1) but the PR body or title does not reference an ADR-XXXX or RFC-XXXX, the workflow posts a one-time nudge comment. **Does NOT block merge** — this is an informational guardrail per ADR-0014's "doctrine should cite its ratifying ADR" rule. The comment carries an HTML marker so it never duplicates on subsequent runs.

- **\`.github/workflows/link-check.yml\`** — monthly \`lychee\` run across \`docs/\`, README, AGENTS, PROMPT, CONTRIBUTING, CHANGELOG. Files an issue tagged \`documentation\` if broken links are detected. Cron 02:00 UTC on the 1st of each month; manual dispatch supported.

### Design choices

- Doctrine guardrail uses \`pull_request_target\` so it can comment on forked PRs without write tokens leaking. \`actions/github-script\` keeps the logic in-line; no external action needed.
- Link check uses \`fail: false\` so the workflow itself never red-flags CI; the only output is an issue when something is actually broken. Issues file under the existing \`documentation\` label.

### Validation

- \`pnpm exec prettier --check .github/workflows/doctrine-guardrail.yml .github/workflows/link-check.yml\` — green.

### Per ADR-0013

This PR adds new workflows under \`.github/workflows/\` which are doctrine-bearing per ADR-0013 §1. Independent ratification requested.