### PR TITLE
docs(m2): close preflight drift and route inventory

### DIFF
--- a/docs/agent-guides/audio-port.md
+++ b/docs/agent-guides/audio-port.md
@@ -13,6 +13,10 @@ Read `docs/agent-guides/image-to-audio-port.md` first for the cross-line context
 
 ## 1. Mission
 
+The protocol target and deprecation window below are locked. The exact helper / route
+collapse shape is still an **execution hypothesis** for M2, not a ratified local
+framework decision.
+
 Port `codec-audio` from the v0.1 surface to the Codec v2 protocol shape ratified by ADR-0008, while:
 
 - collapsing the remaining shared-mechanical route duplication across `speech / soundscape / music`;
@@ -49,7 +53,13 @@ If M1 image has already landed, also read its merged PR diff — your changes mi
 - artifact finalization,
 - route-local metadata patching.
 
-The port's win is **not** inventing a new local framework. The win is moving the shared-mechanical bits into helper functions or a tiny shared module, while leaving each route file as a thin, readable declaration of route-specific behavior. If the port still leaves obvious duplicated scaffolding across siblings, the helper-first collapse failed. If helper extraction still leaves >30 lines of genuinely shared-mechanical duplication, only then should a `BaseAudioRoute` be reconsidered in a follow-up.
+The port's win is **not** inventing a new local framework. The win is moving the
+shared-mechanical bits into helper functions or a tiny shared module, while leaving
+each route file as a thin, readable declaration of route-specific behavior. If the
+port still leaves obvious duplicated scaffolding across siblings, the helper-first
+collapse failed. If helper extraction still leaves >30 lines of genuinely
+shared-mechanical duplication, only then should a `BaseAudioRoute` be reconsidered in
+a follow-up. It is not the assumed answer going into M2.
 
 ## 4. M2 deliverables
 
@@ -95,7 +105,9 @@ If you find yourself writing manifest rows from anywhere outside the codec's `pa
 
 ### Researcher hat
 
-- Are the route picks (Piper-class TTS, deterministic operator-library soundscape, symbolic-synth music) still consistent with `docs/codecs/audio.md`?
+- Are the route picks still consistent with `docs/codecs/audio.md` and the
+  decoder-family ratification work, without quietly widening M2 into a decoder-choice
+  PR?
 - Does the port preserve the ADR-0005 boundary (decoder ≠ generator)? Specifically, no MusicLM-class generator slipping in via "convenience"?
 - Does Brief E's metric pick (UTMOS + WER for speech, librosa for soundscape, LAION-CLAP for music) survive without changes? If you modify them, M5b breaks.
 

--- a/docs/exec-plans/active/codec-v2-port.md
+++ b/docs/exec-plans/active/codec-v2-port.md
@@ -222,6 +222,10 @@ sub-modalities (speech, soundscape, music) each have their own route file in
 `codec-audio/src/routes/`, but the current code is already smaller than the first-pass
 audit assumed.
 
+The protocol target and the one-minor-version `AudioRequest.route` deprecation window
+are locked. The exact helper / route-collapse shape below remains the **current best
+engineering hypothesis** for M2, not a permanently ratified local framework choice.
+
 **Files touched:**
 
 - `packages/codec-audio/src/codec.ts` — rewrite as `class AudioCodec extends BaseCodec<AudioRequest, AudioArtifact>`. The codec's `route()` method dispatches to the

--- a/docs/research/briefs/M2-route-deprecation-inventory.md
+++ b/docs/research/briefs/M2-route-deprecation-inventory.md
@@ -1,0 +1,93 @@
+# M2 Route Deprecation Inventory
+
+**Status:** prep artifact for M2 preflight  
+**Date:** 2026-04-28  
+**Scope:** request-side `AudioRequest.route`, CLI `--route`, and route-first docs/examples  
+**Related issues:** #76, #79
+
+This note completes the bounded preflight inventory for the M2 audio port. It does
+not start the port itself. Its job is to answer one narrow question before
+`packages/codec-audio` changes:
+
+> Where does request-side audio routing still exist today, and which of those surfaces
+> should be kept, migrated, or removed once routing becomes codec-owned?
+
+## Caller table
+
+| Path                                                     | Kind                    | Keep / migrate / remove | Notes                                                                                                                                                              |
+| -------------------------------------------------------- | ----------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `packages/cli/src/commands/audio.ts`                     | primary CLI surface     | migrate                 | Public `wittgenstein audio` still advertises `--route`. Keep the command; treat `--route` as the one-minor-version compatibility shim that enters soft-warn at M2. |
+| `packages/cli/src/commands/tts.ts`                       | convenience CLI surface | migrate                 | Keep `wittgenstein tts` as the speech-specialized entrypoint, but stop relying on request-side `route: "speech"` once codec-owned routing lands.                   |
+| `packages/codec-audio/test/codec.test.ts`                | test caller             | migrate                 | Update to whatever the post-M2 request shape becomes; this is not a public compatibility surface.                                                                  |
+| `packages/cli/README.md`                                 | CLI doc example         | migrate                 | Current `audio --route music` example should become intent-first or be explicitly marked transitional once M2 lands.                                               |
+| `README.md`                                              | repo-level example      | migrate                 | Same as the CLI README: keep audio launch examples, but do not keep route-first examples as the canonical public surface after M2.                                 |
+| `docs/codecs/audio.md`                                   | canonical codec doc     | migrate                 | The doc can keep `--route` as a transitional compatibility note, but the examples should stop presenting it as the default interface.                              |
+| `docs/modality-launch-surface.md`                        | launch-surface table    | migrate                 | Audio row currently bakes in `--route music`; update after M2 to show intent-first invocation.                                                                     |
+| `docs/technical-details-script.md`                       | script / narration doc  | migrate                 | Historical script can retain historical wording if clearly marked; otherwise migrate the live command example.                                                     |
+| `docs/quickstart.md`                                     | demo-surface quickstart | migrate                 | Keep as a demo-surface doc, but update examples so `--route` is not presented as the recommended long-term surface.                                                |
+| `docs/research/briefs/D_cli_and_sdk_conventions.md`      | research note           | keep                    | This is analysis of the current CLI surface, not a shipping interface contract. It should stay as a receipt.                                                       |
+| `docs/research/briefs/J_audio_engineering_and_routes.md` | research note           | keep                    | This brief intentionally discusses `--route` deprecation as a research/design decision. Keep as-is.                                                                |
+| `docs/exec-plans/active/codec-v2-port.md`                | exec plan               | keep                    | Keep the deprecation target here; it is the right place to record that the caller-visible field exists today and deprecates at M2.                                 |
+| `docs/agent-guides/audio-port.md`                        | implementation guide    | keep                    | Keep the deprecation work item and migration note; the guide should describe the transition, not erase it.                                                         |
+
+## Blockers
+
+No blockers were found that should prevent opening the M2 implementation PR after the
+decoder-family ratification closes.
+
+The remaining route-first surfaces are expected migration surfaces, not surprises:
+
+- one public compatibility flag (`wittgenstein audio --route ...`);
+- one convenience command whose internal request shape still pins `route: "speech"`;
+- a small set of docs/examples that should migrate alongside the implementation PR.
+
+That means `#76` can close with this inventory. The actual caller migration remains part
+of the M2 implementation train, not a separate doctrine question.
+
+## Migration snippets
+
+### 1. Public CLI note for `wittgenstein audio`
+
+When M2 lands, the command help and docs should describe `--route` as compatibility-only
+rather than as the primary interface:
+
+```text
+--route <route>  Deprecated compatibility hint; audio routing now lives inside AudioCodec.route()
+```
+
+### 2. `wittgenstein tts` posture
+
+Keep the dedicated speech entrypoint, but describe it as a convenience surface rather
+than as proof that request-side routing remains canonical:
+
+```text
+wittgenstein tts "launch line" --ambient rain --out out.wav
+```
+
+Its internal request construction can change in the M2 PR without changing the command
+itself.
+
+### 3. Intent-first audio example
+
+After M2 lands, the canonical audio example should stop advertising `--route` unless the
+example is explicitly about transitional compatibility:
+
+```text
+wittgenstein audio "soft launch music with a slow synthetic pulse" --out out.wav
+```
+
+If a route-first example remains in docs, it should be marked as transitional:
+
+```text
+wittgenstein audio "soft launch music" --route music --out out.wav
+# compatibility-only during the one-minor-version deprecation window
+```
+
+## Done when
+
+This prep artifact has done its job when the M2 implementation PR can point to one place
+for:
+
+- the full caller inventory,
+- the compatibility-vs-migration split,
+- the fact that no hidden blockers remain before codec work starts.

--- a/docs/research/briefs/README.md
+++ b/docs/research/briefs/README.md
@@ -71,6 +71,7 @@ If either hat dissents, the brief iterates; otherwise the verdict lands in an AD
 - `docs/rfcs/` — engineering decisions that ratify brief verdicts
 - `docs/adrs/` — permanent record of accepted verdicts
 - `docs/agent-guides/` — prompt-ready recipes for phase-specific implementation work
+- `M2-route-deprecation-inventory.md` — bounded preflight inventory for `AudioRequest.route` / `--route` migration work before the M2 port opens
 
 If `docs/THESIS.md` and `docs/inheritance-audit.md` are not present in your checkout yet,
 merge PR #6 first, then treat this folder as Phase P2.


### PR DESCRIPTION
## What changed
- added `docs/research/briefs/M2-route-deprecation-inventory.md` as the bounded prep artifact for `#76`
- softened `docs/agent-guides/audio-port.md` so helper-first route collapse stays framed as an execution hypothesis, not a ratified local framework
- aligned `docs/exec-plans/active/codec-v2-port.md` with the same hypothesis-vs-decision framing
- linked the new inventory note from `docs/research/briefs/README.md`

## Why
M2 is now at a clean preflight point, but two loose ends remained before implementation:
1. `#79`: some audio docs still read a little too much like the route-collapse shape was already settled doctrine
2. `#76`: the repo still needed one inventory receipt for request-side `AudioRequest.route` / CLI `--route` callers before touching `codec-audio`

This PR closes both without starting M2 implementation work.

## Validation
- `pnpm exec prettier --check docs/agent-guides/audio-port.md docs/exec-plans/active/codec-v2-port.md docs/research/briefs/M2-route-deprecation-inventory.md docs/research/briefs/README.md`
- `git diff --check`
- `rg -n "BaseAudioRoute|AudioRequest\\.route|--route|copy-paste" docs/agent-guides/audio-port.md docs/exec-plans/active/codec-v2-port.md docs/research/briefs/M2-route-deprecation-inventory.md`

## Boundaries
- no `packages/codec-audio` changes
- no CLI behavior changes
- no decoder-family ratification here; that lands in ADR-0015 separately

Closes #79
Closes #76
