### PR TITLE
docs(audio): ratify decoder family in ADR-0015

### DIFF
--- a/docs/adrs/0015-audio-decoder-family.md
+++ b/docs/adrs/0015-audio-decoder-family.md
@@ -1,0 +1,80 @@
+# 0015 Audio Decoder Family
+
+## Status
+
+Accepted (ratifies Brief I).
+
+## Context
+
+Audio is the next execution line after M1A. `Brief J` already pinned the smallest honest
+M2 engineering shape for route collapse, manifest authorship, fixtures, and
+`AudioRequest.route` deprecation. What remained unratified was the decoder-family
+decision itself.
+
+`docs/codecs/audio.md` still carried a Piper-centered v0.2 demo description even after
+`Brief I` concluded that the calibrated v0.3 speech path should be:
+
+- **Kokoro-82M-family decoder** as the default speech decoder family;
+- **Piper-family** as the named fallback if the M2 parity test rejects Kokoro on the
+  pinned deterministic backend;
+- **no audio tokenizer** at the v0.3 harness boundary;
+- **procedural soundscape and procedural/symbolic music** through v0.3;
+- **CPU byte-parity / GPU structural-parity** as the reproducibility contract for neural
+  TTS.
+
+M2 should not open while those facts exist only as a research-brief verdict. The
+canonical audio docs, port guide, and exec-plan must all point at the same ratified
+decoder-family decision before implementation starts.
+
+## Decision
+
+1. **Speech decoder family**
+   - Wittgenstein names **Kokoro-82M-family decoder** as the default speech decoder family
+     for v0.3 audio.
+   - **Piper-family** is the explicit fallback if Kokoro fails the pinned M2
+     reproducibility gate on the deterministic backend.
+
+2. **Tokenizer boundary**
+   - Wittgenstein does **not** add an audio tokenizer at the v0.3 harness boundary.
+   - The audio codec consumes waveform output directly from the speech decoder family.
+   - `IR` remains `Text`-inhabited only at v0.3; `Latent` and `Hybrid` stay reserved for
+     future bidirectional audio work.
+
+3. **Soundscape and music**
+   - `soundscape` remains procedural through v0.3.
+   - `music` remains procedural / symbolic through v0.3.
+   - No neural soundscape or neural music decoder is part of the M2 execution line.
+
+4. **Reproducibility contract**
+   - Neural TTS is ratified as a **two-tier** contract:
+     - **CPU deterministic backend:** byte-parity
+     - **GPU backend:** structural-parity only
+   - The codec's `package` stage must write the determinism class into the manifest so
+     downstream users can tell whether a speech artifact's SHA is expected to replay
+     bit-exactly.
+   - This ADR ratifies the evidence requirement, not the exact manifest serialization
+     key. The M2 implementation PR and its implementation memo pin that schema-level
+     key.
+
+5. **Boundary with M2 implementation**
+   - This ADR ratifies the decoder family and the reproducibility contract.
+   - It does **not** ratify a local route-collapse framework. The helper-first route
+     collapse remains an execution hypothesis governed by the M2 port guide and exec
+     plan.
+
+## Consequence
+
+- `docs/codecs/audio.md` becomes canonical for:
+  - Kokoro default / Piper fallback,
+  - no tokenizer at the harness boundary,
+  - procedural soundscape/music through v0.3,
+  - CPU byte-parity / GPU structural-parity for speech.
+- `docs/agent-guides/audio-port.md` may name the speech decoder family and parity
+  contract explicitly, while continuing to treat helper extraction / `BaseAudioRoute`
+  questions as execution hypotheses rather than doctrine.
+- `docs/exec-plans/active/codec-v2-port.md` may reference the ratified speech decoder
+  family and parity contract in M2, but should not silently promote route-collapse
+  tactics into doctrine.
+- If both Kokoro and Piper fail the deterministic CPU gate during M2, reopen this ADR
+  and fall back to procedural OS speech (`say` / `espeak-ng`) per Brief I's kill
+  criterion.

--- a/docs/adrs/0015-audio-decoder-family.md
+++ b/docs/adrs/0015-audio-decoder-family.md
@@ -31,8 +31,17 @@ decoder-family decision before implementation starts.
 1. **Speech decoder family**
    - Wittgenstein names **Kokoro-82M-family decoder** as the default speech decoder family
      for v0.3 audio.
-   - **Piper-family** is the explicit fallback if Kokoro fails the pinned M2
-     reproducibility gate on the deterministic backend.
+   - **Piper-family** is the explicit fallback only when the Kokoro path is unavailable,
+     cannot initialize, or fails the pinned M2 reproducibility gate on the deterministic
+     CPU backend.
+   - A speech render that falls back from Kokoro to Piper must leave manifest evidence
+     of the concrete decoder used (`decoderId`) and determinism class; if the fallback
+     was triggered by a gate failure rather than a missing backend, the codec should
+     also preserve a structured partial/failure reason rather than silently presenting
+     the run as a normal Kokoro render.
+   - If neither Kokoro nor Piper is available, the codec returns a structured
+     partial/failure path. It does **not** silently fall back to host TTS (`say`,
+     platform speech services, or similar demo-only shortcuts).
 
 2. **Tokenizer boundary**
    - Wittgenstein does **not** add an audio tokenizer at the v0.3 harness boundary.
@@ -66,6 +75,7 @@ decoder-family decision before implementation starts.
 
 - `docs/codecs/audio.md` becomes canonical for:
   - Kokoro default / Piper fallback,
+  - explicit fallback trigger conditions and no-silent-host-fallback behavior,
   - no tokenizer at the harness boundary,
   - procedural soundscape/music through v0.3,
   - CPU byte-parity / GPU structural-parity for speech.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -18,6 +18,7 @@ Architecture Decision Records capture decisions that should survive chat history
 - 0012 issue / PR label taxonomy (ratifies `docs/labels.md` introduced via PR #71)
 - 0013 independent ratification for doctrine-bearing PRs (ratifies the rule introduced via PR #75)
 - 0014 governance lane for meta-process doctrine — defines `(Governance Note →) ADR → inline summary` as the legal path for review / archive / labels / agency / surface-classification decisions
+- 0015 audio decoder family — ratifies Brief I (Kokoro-82M-family default, Piper fallback, no tokenizer at v0.3, procedural soundscape/music, CPU byte-parity / GPU structural-parity)
 
 ## Lanes
 

--- a/docs/agent-guides/audio-port.md
+++ b/docs/agent-guides/audio-port.md
@@ -13,10 +13,9 @@ Read `docs/agent-guides/image-to-audio-port.md` first for the cross-line context
 
 ## 1. Mission
 
-The protocol target and deprecation window below are locked. The exact helper / route
-collapse shape is still an **execution hypothesis** for M2, not a ratified local
-framework decision.
-
+The protocol target, decoder-family choice, determinism contract, and deprecation window
+below are locked. The exact helper / route collapse shape is still an **execution
+hypothesis** for M2, not a ratified local framework decision.
 Port `codec-audio` from the v0.1 surface to the Codec v2 protocol shape ratified by ADR-0008, while:
 
 - collapsing the remaining shared-mechanical route duplication across `speech / soundscape / music`;
@@ -73,14 +72,15 @@ In order:
 6. **`packages/core/src/codecs/audio.ts`** is now a thin shim that delegates to `AudioCodec.produce`. The audio branch in `packages/core/src/runtime/harness.ts` is deleted.
 7. **Migration tests** under `packages/codec-audio/test/`:
    - `route-collapse.test.ts` — fails if helper extraction leaves obvious sibling duplication beyond the accepted threshold.
-   - `parity-tts.test.ts` — TTS structural parity (sample rate, channels, duration ±5%) against the recorded golden manifest.
+   - `parity-tts.test.ts` — CPU byte-parity on the pinned deterministic backend; GPU structural parity (sample rate, channels, duration ±5%) when a GPU path is exercised.
    - `parity-soundscape.test.ts` and `parity-music.test.ts` — byte-for-byte SHA-256 against goldens (deterministic synthesis).
 
 ## 5. Goldens and parity
 
 Pin the v0.1 baseline at PR-open in `packages/codec-audio/test/goldens.json`:
 
-- `artifacts/showcase/workflow-examples/tts/` — speech route. **Structural parity only** (LLM stage drift is in the loop).
+- `artifacts/showcase/workflow-examples/tts/` — speech route. **CPU byte-parity on the
+  pinned deterministic backend; GPU structural parity only**.
 - `artifacts/showcase/workflow-examples/soundscape/` — deterministic synthesis. **Byte-for-byte SHA-256**.
 - `artifacts/showcase/workflow-examples/music/` — deterministic synthesis. **Byte-for-byte SHA-256**.
 
@@ -105,9 +105,10 @@ If you find yourself writing manifest rows from anywhere outside the codec's `pa
 
 ### Researcher hat
 
-- Are the route picks still consistent with `docs/codecs/audio.md` and the
-  decoder-family ratification work, without quietly widening M2 into a decoder-choice
-  PR?
+- Are the route picks (Kokoro-82M-family speech decoder, deterministic operator-library
+  soundscape, symbolic-synth music, with Piper-family fallback for speech) still
+  consistent with `docs/codecs/audio.md` and ADR-0015, without quietly widening M2 into
+  a decoder-choice PR?
 - Does the port preserve the ADR-0005 boundary (decoder ≠ generator)? Specifically, no MusicLM-class generator slipping in via "convenience"?
 - Does Brief E's metric pick (UTMOS + WER for speech, librosa for soundscape, LAION-CLAP for music) survive without changes? If you modify them, M5b breaks.
 

--- a/docs/agent-guides/audio-port.md
+++ b/docs/agent-guides/audio-port.md
@@ -123,6 +123,10 @@ If any answer is no, the gate is not met.
 ## 8. Failure modes you will hit
 
 - **TTS engine not installed on CI** — the `quality.partial: { reason: "tts_engine_missing" }` invariant must trigger; the build must not fail silently. Add a CI check that asserts the partial reason is recorded for that case.
+- **Kokoro is installed but fails the pinned deterministic CPU gate** — Piper may take
+  over as the ratified fallback, but the manifest must show the concrete `decoderId`
+  and determinism class actually used, and the run must not masquerade as a clean
+  Kokoro byte-parity render.
 - **AudioPlan zod parse fails on a real LLM output** — surface the structured error to the user; the codec must not "fix up" the plan silently. If a recurring parse failure appears, the right move is to tighten the prompt preamble, not to loosen the schema.
 - **Soundscape SHA-256 drifts after a refactor** — the synthesis runtime is deterministic by contract. Drift means a real bug; bisect.
 - **`AudioRequest.route` removal breaks a downstream user** — pause M2's hard-warn on that field; document the migration in `docs/agent-guides/`. Do not revert the codec collapse.

--- a/docs/codecs/audio.md
+++ b/docs/codecs/audio.md
@@ -8,11 +8,21 @@ Audio is the second-priority modality after image. It ships three internal route
 
 Audio is a _layered_ modality, not a single decoder. Each route picks its own L3:
 
-- `speech` — local TTS render (fast path) plus optional ambient layer.
+- `speech` — `Kokoro-82M-family` local TTS render by default, with `Piper-family`
+  fallback, plus optional ambient layer.
 - `soundscape` — deterministic ambient texture render from a small operator library.
 - `music` — tiny symbolic synthesizer (chords, melody, rhythm) plus optional ambient layer.
 
-This means audio's "decoder" is per-route, not a single frozen artifact like image's decoder. The ADR-0005 "decoder ≠ generator" line still holds: every render path is deterministic given the AudioPlan + seed, and no path samples from a learned distribution at inference time. There is no audio diffusion in the core path.
+This means audio's "decoder" is per-route, not a single frozen artifact like image's
+decoder. The ADR-0005 "decoder ≠ generator" line still holds: no path samples from a
+learned distribution at inference time, and every route has an explicit reproducibility
+contract. Procedural routes are byte-stable by construction; speech is byte-stable on
+the pinned deterministic CPU backend and structural-only on GPU. There is no audio
+diffusion in the core path.
+
+At the v0.3 harness boundary there is also **no audio tokenizer**. The speech decoder
+emits a waveform directly; the codec packages waveform bytes plus manifest rows without
+an intermediate EnCodec / DAC / Mimi layer.
 
 ## CLI Surface
 
@@ -37,7 +47,8 @@ The LLM does not emit raw audio, MIDI bytes, or sample arrays. It emits a _plan_
 
 ### Speech route
 
-- Local TTS engine (the v0.2 demo path uses a small open-source TTS model, e.g. Piper or a comparable on-device synth).
+- `Kokoro-82M-family` decoder by default, with `Piper-family` as the fallback speech
+  path if the deterministic CPU gate fails on Kokoro.
 - Optional ambient layer mixed at a fixed gain.
 - Output: 16-bit mono WAV at 22050 Hz (configurable via the AudioPlan).
 
@@ -55,26 +66,32 @@ The LLM does not emit raw audio, MIDI bytes, or sample arrays. It emits a _plan_
 
 ## Decoder Choices and Why
 
-The v0.2 demo path picks render libraries on three constraints, in order: **license-clean, on-device, deterministic.**
+The v0.3 path picks render libraries on three constraints, in order: **license-clean,
+on-device, deterministic.**
 
-| Route      | v0.2 default                           | Why this and not X                                                                                                                                           |
-| ---------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| speech     | local Piper-class TTS                  | ElevenLabs / cloud TTS would violate "on-device deterministic." Whisper-trained TTS clones are heavier than the v0.2 surface needs.                          |
-| soundscape | deterministic operator-library render  | No external sample packs (license risk); no neural soundscape model (not deterministic in the ADR-0005 sense).                                               |
-| music      | symbolic synth (chord → note → sample) | MusicLM / Riffusion are generators in the ADR-0005 sense — out of scope. MIDI rendering against a frozen soundfont is in-scope and on the v0.3 upgrade path. |
+| Route      | v0.3 default                              | Why this and not X                                                                                                                                                                   |
+| ---------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| speech     | Kokoro-82M-family default; Piper fallback | ElevenLabs / cloud TTS would violate "on-device deterministic." F5 / XTTS-class paths either fail the commercial-license bar or create a less reproducible inference story for v0.3. |
+| soundscape | deterministic operator-library render     | No external sample packs (license risk); no neural soundscape model (not deterministic in the ADR-0005 sense).                                                                       |
+| music      | symbolic synth (chord → note → sample)    | MusicLM / Riffusion are generators in the ADR-0005 sense — out of scope. MIDI rendering against a frozen soundfont is in-scope and on the v0.3 upgrade path.                         |
 
 The v0.3+ upgrade path is named in `docs/exec-plans/active/codec-v2-port.md` M5b (audio benchmark bridge): UTMOS + Whisper-WER for speech, librosa spectral metrics for soundscape, LAION-CLAP for music.
 
 ## Adapter Role
 
-Audio does not have a trained L4 adapter at v0.2. The route renders take the AudioPlan directly. This is the same pattern as `codec-sensor`: when the LLM's structured output is _already_ the renderer's input language, no L4 bridge is needed.
+Audio does not have a trained L4 adapter at v0.3. The route renders take the AudioPlan
+directly. This is the same pattern as `codec-sensor`: when the LLM's structured output
+is _already_ the renderer's input language, no L4 bridge is needed.
 
-If a future audio decoder (e.g. a frozen mel-spectrogram-to-waveform vocoder) requires a token-grid input, an L4 adapter slot is reserved in the codec's `adapt` stage. Until then `adapt` is a pass-through (`BaseCodec.passthrough`).
+If a future audio decoder (e.g. a frozen mel-spectrogram-to-waveform vocoder) requires a
+token-grid input, an L4 adapter slot is reserved in the codec's `adapt` stage. Until
+then `adapt` is a pass-through (`BaseCodec.passthrough`) and the harness boundary stays
+waveform-direct.
 
 ## Pipeline Stages (post-M2 shape)
 
 - `expand` — LLM call(s) producing the AudioPlan; one round by default, two with `--expand`.
-- `adapt` — pass-through at v0.2.
+- `adapt` — pass-through at v0.3.
 - `decode` — route-internal render: `speech.ts` / `soundscape.ts` / `music.ts`.
 - `package` — codec authors its own manifest rows: `route`, `seed`, `model_id`, `quality.structural`, optional `quality.partial`.
 
@@ -93,9 +110,12 @@ The current fast path emits 16-bit WAV. Sample rate and channel count are record
 
 `artifacts/showcase/workflow-examples/{tts,soundscape,music}/` are the preserved
 `v0.1.0-alpha.1` hackathon receipt pack, still used as the current regression corpus until
-the post-lock Codec v2 showcase refresh lands. TTS bytes drift with the LLM, so structural
-parity (sample rate, channels, duration ±5%) is the gate; soundscape and music synthesis
-are deterministic and get byte-for-byte SHA-256 checks.
+the post-lock Codec v2 showcase refresh lands. For speech, the ratified contract is:
+
+- **CPU deterministic backend:** byte-parity
+- **GPU backend:** structural parity only (sample rate, channels, duration ±5%)
+
+Soundscape and music synthesis stay deterministic and get byte-for-byte SHA-256 checks.
 
 ## Benchmark Case
 
@@ -103,10 +123,13 @@ See `tts-launch` and `audio-music` in `benchmarks/cases.json`. Quality bridges l
 
 ## Honest Risk Statement
 
-Audio quality at v0.2 is _structurally honest_, not _aesthetically frontier_:
+Audio quality at v0.3 is _structurally honest_, not _aesthetically frontier_:
 
-- Speech intelligibility from a Piper-class TTS is good but not ElevenLabs-good.
+- Speech intelligibility from the Kokoro-82M-family default is strong for local TTS, but
+  still not ElevenLabs-grade; the Piper fallback is slightly lower.
 - Soundscape texture is recognizable but not field-recording-grade.
 - Music is identifiable as music in the requested key but is not Suno / Udio quality.
 
-The thesis surface is preserved: the LLM plans, the codec renders, the manifest records, the artifact reproduces from seed. Quality lift is a v0.3 concern via M5b benchmarks and a future frozen-vocoder integration.
+The thesis surface is preserved: the LLM plans, the codec renders, the manifest records,
+and the artifact reproduces from seed within its declared determinism class. Quality lift
+remains a v0.3 concern via M5b benchmarks and a future frozen-vocoder integration.

--- a/docs/codecs/audio.md
+++ b/docs/codecs/audio.md
@@ -48,9 +48,15 @@ The LLM does not emit raw audio, MIDI bytes, or sample arrays. It emits a _plan_
 ### Speech route
 
 - `Kokoro-82M-family` decoder by default, with `Piper-family` as the fallback speech
-  path if the deterministic CPU gate fails on Kokoro.
+  path only when the Kokoro path is unavailable, cannot initialize, or fails the
+  pinned deterministic CPU gate.
 - Optional ambient layer mixed at a fixed gain.
 - Output: 16-bit mono WAV at 22050 Hz (configurable via the AudioPlan).
+
+Fallback to Piper must leave manifest evidence of the concrete decoder actually used
+(`decoderId`, `determinismClass`). If the Kokoro path was present but rejected by the
+CPU reproducibility gate, the codec should also preserve a structured partial/failure
+reason rather than silently presenting the run as a normal Kokoro render.
 
 ### Soundscape route
 
@@ -99,6 +105,10 @@ waveform-direct.
 
 - The LLM emits an AudioPlan with an out-of-range route — caught by zod parse, surfaced as a structured error.
 - The TTS engine is unavailable on the host — codec writes `quality.partial: { reason: "tts_engine_missing" }` and a manifest row noting the failure; no silent fallback.
+- The Kokoro path is present but fails the pinned deterministic CPU gate — codec may
+  fall back to Piper, but must record the fallback in manifest evidence and preserve a
+  structured partial/failure reason if the render no longer satisfies the Kokoro path's
+  byte-parity contract.
 - The music plan specifies a key/tempo combination the synth cannot render — error surfaced to the user with the offending plan field; no down-tuning happens silently.
 - An ambient layer file is missing — fall back to silence with a structured warning, never to a different ambient.
 

--- a/docs/exec-plans/active/codec-v2-port.md
+++ b/docs/exec-plans/active/codec-v2-port.md
@@ -225,7 +225,9 @@ audit assumed.
 The protocol target and the one-minor-version `AudioRequest.route` deprecation window
 are locked. The exact helper / route-collapse shape below remains the **current best
 engineering hypothesis** for M2, not a permanently ratified local framework choice.
-
+The speech decoder family and parity contract, however, are now ratified separately by
+ADR-0015: Kokoro-82M-family default, Piper-family fallback, CPU byte-parity, GPU
+structural-parity.
 **Files touched:**
 
 - `packages/codec-audio/src/codec.ts` — rewrite as `class AudioCodec extends BaseCodec<AudioRequest, AudioArtifact>`. The codec's `route()` method dispatches to the
@@ -247,9 +249,10 @@ engineering hypothesis** for M2, not a permanently ratified local framework choi
 **Goldens:**
 
 - `artifacts/showcase/workflow-examples/{tts,soundscape,music}/` — pinned at PR open.
-- TTS bytes are LLM-stage-driven; structural parity is enforced (sample rate, channels,
-  duration ±5%). Soundscape and music have deterministic synthesis paths where
-  applicable; those get byte-for-byte parity.
+- Speech uses the ratified Kokoro-82M-family default with Piper-family fallback. CPU runs
+  on the pinned deterministic backend get byte-parity; GPU runs get structural parity
+  (sample rate, channels, duration ±5%). Soundscape and music have deterministic
+  synthesis paths where applicable; those get byte-for-byte parity.
 
 **Migration tests:**
 

--- a/docs/research/briefs/I_audio_codec_landscape.md
+++ b/docs/research/briefs/I_audio_codec_landscape.md
@@ -1,7 +1,7 @@
 # Brief I — Audio codec landscape
 
 **Date:** 2026-04-27
-**Status:** 🟡 Draft v0.1
+**Status:** 🟢 Merged v0.1 (verdict ratified by ADR-0015)
 **Question:** Which open-weight TTS decoder family, audio tokenizer, soundscape stance, and music stance should Wittgenstein adopt at v0.3, given license, reproducibility, and quality constraints?
 **Feeds into:** ADR-0015 (audio decoder family), `docs/agent-guides/audio-port.md` amendment, `docs/exec-plans/active/codec-v2-port.md` §M2.
 **Companion:** Brief J (`J_audio_engineering_and_routes.md`) — engineering shape; Brief E (`E_benchmarks_v2.md`) — quality bar (UTMOS / WER / DNSMOS / CLAP).

--- a/docs/research/briefs/README.md
+++ b/docs/research/briefs/README.md
@@ -4,18 +4,18 @@ First-pass research briefs produced under **Phase P2** of the v0.2 Restructuring
 
 ## Brief index
 
-| ID  | Title                                                                          | Question                                                                                                     | Status        |
-| --- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ | ------------- |
-| A   | [VQ / VLM lineage 2026 refresh](A_vq_vlm_lineage_audit.md)                     | Does the VQ-token / frozen-decoder path still look like the right bet in April 2026?                         | 🟡 Draft v0.1 |
-| B   | [Compression vs world models — Ilya ↔ LeCun](B_compression_vs_world_models.md) | Where does Wittgenstein stand on the Ilya/LeCun tension? _(critical-path brief)_                             | 🟡 Draft v0.1 |
-| C   | [Unproven-but-interesting horizon scan](C_unproven_horizon.md)                 | Which 6–8 unvalidated hypotheses should shape the 18-month roadmap?                                          | 🟡 Draft v0.1 |
-| D   | [CLI / SDK / harness conventions](D_cli_and_sdk_conventions.md)                | How do modern AI CLIs and SDKs look; where is Wittgenstein off the grid?                                     | 🟡 Draft v0.1 |
-| E   | [Per-modality quality benchmarks](E_benchmarks_v2.md)                          | What's the smallest set of real (non-structural) quality metrics per modality?                               | 🟡 Draft v0.1 |
-| F   | [Site ↔ repo reconciliation](F_site_reconciliation.md)                         | Which `wittgenstein.wtf` claims contradict v0.1.0-alpha.2?                                                   | 🟡 Draft v0.1 |
-| G   | [Image-network clues](G_image_network_clues.md)                                | Which decoder / data / packaging form ships for `codec-image` at exec-plan M1?                               | 🟡 Draft v0.1 |
-| H   | [Codec engineering prior art](H_codec_engineering_prior_art.md)                | Which production-validated TS projects share our `Codec<Req, Art>` shape, and what to copy at M1A?           | 🟡 Draft v0.1 |
-| I   | [Audio codec landscape](I_audio_codec_landscape.md)                            | Which open-weight TTS decoder, audio tokenizer, and soundscape/music stance should v0.3 audio adopt?         | 🟡 Draft v0.1 |
-| J   | [Audio engineering and routes](J_audio_engineering_and_routes.md)              | What is the smallest honest M2 engineering shape for audio routes, manifest rows, fixtures, and deprecation? | 🟡 Draft v0.1 |
+| ID  | Title                                                                          | Question                                                                                                     | Status                  |
+| --- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ | ----------------------- |
+| A   | [VQ / VLM lineage 2026 refresh](A_vq_vlm_lineage_audit.md)                     | Does the VQ-token / frozen-decoder path still look like the right bet in April 2026?                         | 🟡 Draft v0.1           |
+| B   | [Compression vs world models — Ilya ↔ LeCun](B_compression_vs_world_models.md) | Where does Wittgenstein stand on the Ilya/LeCun tension? _(critical-path brief)_                             | 🟡 Draft v0.1           |
+| C   | [Unproven-but-interesting horizon scan](C_unproven_horizon.md)                 | Which 6–8 unvalidated hypotheses should shape the 18-month roadmap?                                          | 🟡 Draft v0.1           |
+| D   | [CLI / SDK / harness conventions](D_cli_and_sdk_conventions.md)                | How do modern AI CLIs and SDKs look; where is Wittgenstein off the grid?                                     | 🟡 Draft v0.1           |
+| E   | [Per-modality quality benchmarks](E_benchmarks_v2.md)                          | What's the smallest set of real (non-structural) quality metrics per modality?                               | 🟡 Draft v0.1           |
+| F   | [Site ↔ repo reconciliation](F_site_reconciliation.md)                         | Which `wittgenstein.wtf` claims contradict v0.1.0-alpha.2?                                                   | 🟡 Draft v0.1           |
+| G   | [Image-network clues](G_image_network_clues.md)                                | Which decoder / data / packaging form ships for `codec-image` at exec-plan M1?                               | 🟡 Draft v0.1           |
+| H   | [Codec engineering prior art](H_codec_engineering_prior_art.md)                | Which production-validated TS projects share our `Codec<Req, Art>` shape, and what to copy at M1A?           | 🟡 Draft v0.1           |
+| I   | [Audio codec landscape](I_audio_codec_landscape.md)                            | Which open-weight TTS decoder, audio tokenizer, and soundscape/music stance should v0.3 audio adopt?         | 🟢 Ratified by ADR-0015 |
+| J   | [Audio engineering and routes](J_audio_engineering_and_routes.md)              | What is the smallest honest M2 engineering shape for audio routes, manifest rows, fixtures, and deprecation? | 🟡 Draft v0.1           |
 
 ## Where briefs land (map)
 
@@ -51,7 +51,7 @@ Plus a dated header and a version tag (`v0.1`, `v0.2`, …) so iteration is visi
 
 ## Status legend
 
-- 🟢 Merged (verdict final, cited by an ADR)
+- 🟢 Ratified by ADR-NNNN (verdict final, cited by an ADR)
 - 🟡 Draft (first pass complete; invites review)
 - 🔴 Not started
 


### PR DESCRIPTION
## What changed
- added `docs/adrs/0015-audio-decoder-family.md`
- aligned `docs/codecs/audio.md` with Brief I: Kokoro-82M-family default, Piper-family fallback, no tokenizer at the v0.3 harness boundary, procedural soundscape/music through v0.3
- updated `docs/agent-guides/audio-port.md` where the decoder family name and reproducibility contract are now ratified
- updated `docs/exec-plans/active/codec-v2-port.md` where M2 depends on the ratified speech decoder family and parity contract
- marked Brief I as ratified in `docs/research/briefs/README.md` and its own header
- added ADR-0015 to `docs/adrs/README.md`

## Why
Brief I is now strong enough to promote. Before M2 starts, the repo needs the audio decoder family to exist as a ratified decision rather than only as a research-brief verdict.

This PR closes the doctrine gap without starting M2 implementation work.

## Validation
- `pnpm exec prettier --check docs/adrs/0015-audio-decoder-family.md docs/codecs/audio.md docs/agent-guides/audio-port.md docs/exec-plans/active/codec-v2-port.md docs/research/briefs/README.md docs/research/briefs/I_audio_codec_landscape.md docs/adrs/README.md`
- `git diff --check`
- manual consistency check across Brief I, ADR-0015, `docs/codecs/audio.md`, `docs/agent-guides/audio-port.md`, and `docs/exec-plans/active/codec-v2-port.md`

## Boundaries
- no `packages/codec-audio` changes
- no CLI behavior changes
- no route-collapse framework ratification; helper-first collapse remains an execution hypothesis
