### PR TITLE
docs(roadmap): align audio path with ADR-0015

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -59,10 +59,10 @@ First:
 
 Then:
 
-- [ ] Integrate Coqui XTTS or Piper as local TTS engine (cross-platform)
-- [ ] Keep `say` fallback for zero-setup demos
-- [ ] Add UTMOS scoring to benchmark harness
-- [ ] Extend ambient categories and add a music route (symbolic → synth)
+- [ ] Integrate Kokoro-82M-family as the default speech decoder, with Piper-family fallback
+- [ ] Keep host TTS (`say` / platform speech) out of the canonical v0.3 fallback path
+- [ ] Add UTMOS + Whisper-WER scoring to the benchmark harness
+- [ ] Extend procedural soundscape categories and symbolic music quality without adding a neural music decoder
 
 ## Phase 3 — Video codec real
 


### PR DESCRIPTION
## What changed
- replaced the stale "Coqui XTTS or Piper" roadmap line with the ratified Kokoro-82M-family default / Piper-family fallback path
- removed host TTS as a canonical fallback from the roadmap wording
- updated the benchmark and soundscape/music roadmap language to match ADR-0015 and Brief I

## Why
#88 ratified ADR-0015, so ROADMAP.md needed the tiny post-merge cleanup already tracked on #63.

## Validation
- `pnpm exec prettier --check ROADMAP.md`
- `git diff --check`
- `rg -n "Coqui XTTS or Piper|Keep say fallback|add a music route|Piper-class|local Piper-class TTS" ROADMAP.md README.md docs/codecs/audio.md docs/agent-guides/audio-port.md docs/exec-plans/active/codec-v2-port.md` returns no matches

## Boundaries
- docs-only
- no M2 implementation
- route-first examples remain for M2 Slice C, as planned