### PR TITLE
Extract M2 Slice B audio route helpers

### DIFF
--- a/packages/codec-audio/src/codec.ts
+++ b/packages/codec-audio/src/codec.ts
@@ -1,5 +1,7 @@
-import type { AudioRequest, WittgensteinCodec, RenderCtx, RenderResult } from "@wittgenstein/schemas";
-import { Modality } from "@wittgenstein/schemas";
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import type { AudioRequest, RenderCtx } from "@wittgenstein/schemas";
+import { Modality, codecV2 } from "@wittgenstein/schemas";
 import {
   AudioPlanSchema,
   AudioRequestSchema,
@@ -10,34 +12,304 @@ import {
 import { renderSpeechRoute } from "./routes/speech/index.js";
 import { renderSoundscapeRoute } from "./routes/soundscape/index.js";
 import { renderMusicRoute } from "./routes/music/index.js";
+import type { AudioArtifact, AudioRoute } from "./types.js";
 
-export const audioCodec: WittgensteinCodec<AudioRequest, AudioPlan> = {
-  name: "audio",
-  modality: Modality.Audio,
-  schemaPreamble: audioSchemaPreamble,
-  requestSchema: AudioRequestSchema,
-  outputSchema: AudioPlanSchema,
-  parse: parseAudioPlan,
-  async render(parsed: AudioPlan, ctx: RenderCtx): Promise<RenderResult> {
-    try {
-      if (parsed.route === "speech") {
-        return await renderSpeechRoute(parsed, ctx);
-      }
+interface AudioCodecLlmService {
+  readonly provider: string;
+  readonly model: string;
+  readonly maxOutputTokens: number;
+  readonly temperature: number;
+  generate(request: {
+    messages: Array<{ role: "system" | "user" | "assistant"; content: string }>;
+    model: string;
+    maxOutputTokens: number;
+    temperature: number;
+    seed: number | null;
+    responseFormat?: "json" | "text";
+  }): Promise<{
+    text: string;
+    tokens: { input: number; output: number };
+    costUsd: number;
+    raw?: unknown;
+  }>;
+}
 
-      if (parsed.route === "soundscape") {
-        return await renderSoundscapeRoute(parsed, ctx);
-      }
+interface AudioCodecTelemetryService {
+  writeText(name: string, value: string): Promise<void>;
+}
 
-      return await renderMusicRoute(parsed, ctx);
-    } catch (error) {
-      throw createNotImplementedError("codec: audio", error);
+interface AudioCodecServices {
+  readonly llm?: AudioCodecLlmService;
+  readonly telemetry?: AudioCodecTelemetryService;
+  readonly dryRun?: boolean;
+}
+
+interface AudioPlanPayload {
+  readonly plan: AudioPlan;
+  readonly promptExpanded: string;
+  readonly llmOutputRaw: string;
+  readonly llmTokens: { input: number; output: number };
+  readonly costUsd: number;
+}
+
+const standardSchema = toStandardSchema(AudioRequestSchema);
+
+function injectSchemaPreamble(prompt: string, schemaPreamble: string): string {
+  return [
+    "You are Wittgenstein.",
+    "Return valid JSON only.",
+    schemaPreamble.trim(),
+    `User prompt:\n${prompt.trim()}`,
+  ].join("\n\n");
+}
+
+function toStandardSchema(
+  schema: typeof AudioRequestSchema,
+): codecV2.StandardSchemaV1<unknown, AudioRequest> {
+  const maybeStandard = (
+    schema as typeof schema & {
+      ["~standard"]?: codecV2.StandardSchemaV1<unknown, AudioRequest>["~standard"];
     }
-  },
-};
+  )["~standard"];
+  if (maybeStandard) {
+    return { "~standard": maybeStandard };
+  }
+  return {
+    "~standard": {
+      version: 1,
+      vendor: "zod",
+      validate: (value) => {
+        const parsed = schema.safeParse(value);
+        if (parsed.success) {
+          return { value: parsed.data };
+        }
+        return {
+          issues: parsed.error.issues.map((issue) => ({
+            message: issue.message,
+            path: issue.path,
+          })),
+        };
+      },
+    },
+  };
+}
 
-function createNotImplementedError(scope: string, cause?: unknown): Error & { code: string } {
-  return Object.assign(new Error(`NotImplementedError(${scope})`, { cause }), {
-    name: "NotImplementedError",
-    code: "NOT_IMPLEMENTED",
+function hashString(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function hashBytes(value: Uint8Array): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function asServices(services: codecV2.HarnessCtx["services"]): AudioCodecServices {
+  return (services ?? {}) as AudioCodecServices;
+}
+
+function asAudioPlanPayload(ir: codecV2.IR): AudioPlanPayload {
+  if (!codecV2.isTextIR(ir) || !ir.plan) {
+    throw new Error("AudioCodec expected TextIR with AudioPlan payload.");
+  }
+  return ir.plan as AudioPlanPayload;
+}
+
+function routeFromRequest(req: AudioRequest): AudioRoute {
+  return req.route ?? "speech";
+}
+
+function createDryRunPlan(req: AudioRequest): AudioPlan {
+  const ambientCategory = isAmbientCategory(req.ambient) ? req.ambient : "auto";
+  return AudioPlanSchema.parse({
+    route: routeFromRequest(req),
+    script: req.prompt || "Wittgenstein launches a multimodal audio artifact.",
+    ambient: {
+      category: ambientCategory,
+      level: ambientCategory === "silence" ? 0 : 0.22,
+    },
+    music: {
+      motif: req.prompt.slice(0, 80) || "minimal",
+    },
   });
 }
+
+function forceRequestedRoute(plan: AudioPlan, req: AudioRequest): AudioPlan {
+  if (!req.route) {
+    return plan;
+  }
+  return { ...plan, route: req.route };
+}
+
+function isAmbientCategory(value: unknown): value is AudioPlan["ambient"]["category"] {
+  return (
+    value === "auto" ||
+    value === "silence" ||
+    value === "rain" ||
+    value === "wind" ||
+    value === "city" ||
+    value === "forest" ||
+    value === "electronic"
+  );
+}
+
+export class AudioCodec extends codecV2.BaseCodec<AudioRequest, AudioArtifact> {
+  readonly name = "audio";
+  readonly id = "audio";
+  readonly modality = Modality.Audio;
+  readonly schema = standardSchema;
+  readonly routes: ReadonlyArray<codecV2.Route<AudioRequest>> = [
+    { id: "speech", match: (req) => routeFromRequest(req) === "speech" },
+    { id: "soundscape", match: (req) => req.route === "soundscape" },
+    { id: "music", match: (req) => req.route === "music" },
+  ];
+
+  protected override async expand(req: AudioRequest, ctx: codecV2.HarnessCtx): Promise<codecV2.IR> {
+    const services = asServices(ctx.services);
+    const promptExpanded = injectSchemaPreamble(req.prompt, audioSchemaPreamble(req));
+    await services.telemetry?.writeText("llm-input.txt", promptExpanded);
+
+    if (services.dryRun) {
+      const plan = createDryRunPlan(req);
+      const llmOutputRaw = JSON.stringify(plan);
+      await services.telemetry?.writeText("llm-output.txt", llmOutputRaw);
+      return {
+        kind: "text",
+        text: llmOutputRaw,
+        plan: {
+          plan,
+          promptExpanded,
+          llmOutputRaw,
+          llmTokens: { input: 0, output: 0 },
+          costUsd: 0,
+        } satisfies AudioPlanPayload,
+      };
+    }
+
+    if (!services.llm) {
+      throw new Error("AudioCodec requires an LLM service for non-dry-run execution.");
+    }
+
+    const generation = await services.llm.generate({
+      model: services.llm.model,
+      maxOutputTokens: services.llm.maxOutputTokens,
+      temperature: services.llm.temperature,
+      seed: ctx.seed,
+      responseFormat: "json",
+      messages: [
+        {
+          role: "system",
+          content: "Return JSON only. Do not wrap it in markdown.",
+        },
+        {
+          role: "user",
+          content: promptExpanded,
+        },
+      ],
+    });
+
+    await services.telemetry?.writeText("llm-output.txt", generation.text);
+    const parsed = parseAudioPlan(generation.text);
+    if (!parsed.ok) {
+      throw new Error(parsed.error.message);
+    }
+
+    const plan = forceRequestedRoute(parsed.value, req);
+    return {
+      kind: "text",
+      text: generation.text,
+      plan: {
+        plan,
+        promptExpanded,
+        llmOutputRaw: generation.text,
+        llmTokens: generation.tokens,
+        costUsd: generation.costUsd,
+      } satisfies AudioPlanPayload,
+    };
+  }
+
+  protected override async adapt(ir: codecV2.IR): Promise<codecV2.IR> {
+    return ir;
+  }
+
+  protected override async decode(ir: codecV2.IR, ctx: codecV2.HarnessCtx): Promise<AudioArtifact> {
+    const payload = asAudioPlanPayload(ir);
+    const startedAt = ctx.clock.now();
+    const renderCtx = this.createRenderCtx(ctx);
+    const result =
+      payload.plan.route === "speech"
+        ? await renderSpeechRoute(payload.plan, renderCtx, { allowHostTts: false })
+        : payload.plan.route === "soundscape"
+          ? await renderSoundscapeRoute(payload.plan, renderCtx)
+          : await renderMusicRoute(payload.plan, renderCtx);
+    const bytes = await readFile(result.artifactPath);
+    const route = payload.plan.route;
+
+    return {
+      outPath: result.artifactPath,
+      bytes,
+      mime: "audio/wav",
+      metadata: {
+        codec: "audio",
+        route,
+        warnings: [],
+        llmTokens: payload.llmTokens,
+        costUsd: payload.costUsd,
+        durationMs: Math.max(0, ctx.clock.now() - startedAt),
+        seed: ctx.seed,
+        promptExpanded: payload.promptExpanded,
+        llmOutputRaw: payload.llmOutputRaw,
+        llmOutputParsed: payload.plan,
+        quality: {
+          structural: {
+            schemaValidated: true,
+            route,
+            deterministicClass: "cpu-byte-parity",
+          },
+          partial: {
+            reason: "procedural-runtime",
+          },
+        },
+        decoderHash: {
+          value: hashString("procedural-audio-runtime"),
+          frozen: true,
+          slot: "procedural-audio-runtime",
+        },
+        artifactSha256: hashBytes(bytes),
+      },
+    };
+  }
+
+  protected override async package(
+    art: AudioArtifact,
+    ctx: codecV2.HarnessCtx,
+  ): Promise<AudioArtifact> {
+    return super.package(art, ctx);
+  }
+
+  manifestRows(art: AudioArtifact): ReadonlyArray<codecV2.ManifestRow> {
+    return [
+      { key: "route", value: art.metadata.route },
+      { key: "quality.structural", value: art.metadata.quality.structural },
+      { key: "quality.partial", value: art.metadata.quality.partial },
+      { key: "metadata.warnings", value: art.metadata.warnings.length },
+      { key: "L5.decoderHash", value: art.metadata.decoderHash },
+      { key: "artifact.sha256", value: art.metadata.artifactSha256 },
+    ];
+  }
+
+  private createRenderCtx(ctx: codecV2.HarnessCtx): RenderCtx {
+    return {
+      runId: ctx.runId,
+      runDir: ctx.runDir,
+      seed: ctx.seed,
+      outPath: ctx.outPath,
+      logger: {
+        debug: (message, data) => ctx.logger.debug(message, data),
+        info: (message, data) => ctx.logger.info(message, data),
+        warn: (message, data) => ctx.logger.warn(message, data),
+        error: (message, data) => ctx.logger.error(message, data),
+      },
+    };
+  }
+}
+
+export const audioCodec = new AudioCodec();

--- a/packages/codec-audio/src/routes/music/index.ts
+++ b/packages/codec-audio/src/routes/music/index.ts
@@ -1,39 +1,22 @@
 import type { RenderCtx, RenderResult } from "@wittgenstein/schemas";
 import type { AudioPlan } from "../../schema.js";
-import { recommendAmbient } from "../../ambient-adapter.js";
-import {
-  finalizeAudioArtifact,
-  generateAmbient,
-  mixTracks,
-  synthMusic,
-} from "../../runtime.js";
+import { synthMusic } from "../../runtime.js";
+import { finalizeRouteRender, mixAmbientLayer, resolveAmbientCategory } from "../shared.js";
 
-export async function renderMusicRoute(
-  plan: AudioPlan,
-  ctx: RenderCtx,
-): Promise<RenderResult> {
+export async function renderMusicRoute(plan: AudioPlan, ctx: RenderCtx): Promise<RenderResult> {
   const startedAt = Date.now();
   const durationSec = 8;
-  const ambientCategory =
-    plan.ambient.category === "auto"
-      ? recommendAmbient(`${plan.script} ${plan.music.motif}`).category
-      : plan.ambient.category;
+  const ambientCategory = resolveAmbientCategory(plan, `${plan.script} ${plan.music.motif}`);
   const music = synthMusic(durationSec, plan.music.motif);
-  const ambient = generateAmbient(ambientCategory, durationSec, ctx.seed);
-  const result = await finalizeAudioArtifact(
+  return finalizeRouteRender(
     ctx,
-    mixTracks([
-      { samples: music, gain: 1 },
-      { samples: ambient, gain: plan.ambient.level * 0.8 },
-    ]),
     "music",
+    mixAmbientLayer(music, {
+      category: ambientCategory,
+      durationSec,
+      level: plan.ambient.level * 0.8,
+      seed: ctx.seed,
+    }),
+    startedAt,
   );
-
-  return {
-    ...result,
-    metadata: {
-      ...result.metadata,
-      durationMs: Date.now() - startedAt,
-    },
-  };
 }

--- a/packages/codec-audio/src/routes/shared.ts
+++ b/packages/codec-audio/src/routes/shared.ts
@@ -1,0 +1,44 @@
+import type { RenderCtx, RenderResult } from "@wittgenstein/schemas";
+import { recommendAmbient, type AmbientCategory } from "../ambient-adapter.js";
+import { finalizeAudioArtifact, generateAmbient, mixTracks } from "../runtime.js";
+import type { AudioPlan } from "../schema.js";
+
+export type AudioRouteId = "speech" | "soundscape" | "music";
+
+export function resolveAmbientCategory(plan: AudioPlan, hintText: string): AmbientCategory {
+  return plan.ambient.category === "auto"
+    ? recommendAmbient(hintText).category
+    : plan.ambient.category;
+}
+
+export function mixAmbientLayer(
+  foreground: Float32Array,
+  options: {
+    category: AmbientCategory;
+    durationSec: number;
+    level: number;
+    seed: number | null;
+  },
+): Float32Array {
+  const ambient = generateAmbient(options.category, options.durationSec, options.seed);
+  return mixTracks([
+    { samples: foreground, gain: 1 },
+    { samples: ambient, gain: options.level },
+  ]);
+}
+
+export async function finalizeRouteRender(
+  ctx: RenderCtx,
+  route: AudioRouteId,
+  samples: Float32Array,
+  startedAt: number,
+): Promise<RenderResult> {
+  const result = await finalizeAudioArtifact(ctx, samples, route);
+  return {
+    ...result,
+    metadata: {
+      ...result.metadata,
+      durationMs: Date.now() - startedAt,
+    },
+  };
+}

--- a/packages/codec-audio/src/routes/soundscape/index.ts
+++ b/packages/codec-audio/src/routes/soundscape/index.ts
@@ -1,32 +1,18 @@
 import type { RenderCtx, RenderResult } from "@wittgenstein/schemas";
 import type { AudioPlan } from "../../schema.js";
-import { recommendAmbient } from "../../ambient-adapter.js";
-import { finalizeAudioArtifact, generateAmbient } from "../../runtime.js";
+import { generateAmbient } from "../../runtime.js";
+import { finalizeRouteRender, resolveAmbientCategory } from "../shared.js";
 
 export async function renderSoundscapeRoute(
   plan: AudioPlan,
   ctx: RenderCtx,
 ): Promise<RenderResult> {
   const startedAt = Date.now();
-  const ambientCategory =
-    plan.ambient.category === "auto"
-      ? recommendAmbient(`${plan.script} ${plan.music.motif}`).category
-      : plan.ambient.category;
-  const result = await finalizeAudioArtifact(
+  const ambientCategory = resolveAmbientCategory(plan, `${plan.script} ${plan.music.motif}`);
+  return finalizeRouteRender(
     ctx,
-    generateAmbient(
-      ambientCategory === "silence" ? "forest" : ambientCategory,
-      8,
-      ctx.seed,
-    ),
     "soundscape",
+    generateAmbient(ambientCategory === "silence" ? "forest" : ambientCategory, 8, ctx.seed),
+    startedAt,
   );
-
-  return {
-    ...result,
-    metadata: {
-      ...result.metadata,
-      durationMs: Date.now() - startedAt,
-    },
-  };
 }

--- a/packages/codec-audio/src/routes/speech/index.ts
+++ b/packages/codec-audio/src/routes/speech/index.ts
@@ -1,14 +1,8 @@
 import { readFile } from "node:fs/promises";
 import type { RenderCtx, RenderResult } from "@wittgenstein/schemas";
 import type { AudioPlan } from "../../schema.js";
-import { recommendAmbient } from "../../ambient-adapter.js";
-import {
-  finalizeAudioArtifact,
-  generateAmbient,
-  mixTracks,
-  renderMacSpeech,
-  synthSpeech,
-} from "../../runtime.js";
+import { renderMacSpeech, synthSpeech } from "../../runtime.js";
+import { finalizeRouteRender, mixAmbientLayer, resolveAmbientCategory } from "../shared.js";
 
 export async function renderSpeechRoute(
   plan: AudioPlan,
@@ -17,32 +11,24 @@ export async function renderSpeechRoute(
 ): Promise<RenderResult> {
   const startedAt = Date.now();
   const durationSec = Math.max(2, inferSpeechDurationSec(plan.script));
-  const ambientRecommendation = recommendAmbient(plan.script);
-  const ambientCategory =
-    plan.ambient.category === "auto" ? ambientRecommendation.category : plan.ambient.category;
+  const ambientCategory = resolveAmbientCategory(plan, plan.script);
 
   let speechSamples = synthSpeech(plan.script, durationSec);
   if (options.allowHostTts === true && (await renderMacSpeech(plan.script, ctx.outPath))) {
     speechSamples = decodeWavToFloat32(await readFile(ctx.outPath));
   }
 
-  const ambientSamples = generateAmbient(ambientCategory, durationSec, ctx.seed);
-  const result = await finalizeAudioArtifact(
+  return finalizeRouteRender(
     ctx,
-    mixTracks([
-      { samples: speechSamples, gain: 1 },
-      { samples: ambientSamples, gain: plan.ambient.level },
-    ]),
     "speech",
+    mixAmbientLayer(speechSamples, {
+      category: ambientCategory,
+      durationSec,
+      level: plan.ambient.level,
+      seed: ctx.seed,
+    }),
+    startedAt,
   );
-
-  return {
-    ...result,
-    metadata: {
-      ...result.metadata,
-      durationMs: Date.now() - startedAt,
-    },
-  };
 }
 
 function inferSpeechDurationSec(script: string): number {

--- a/packages/codec-audio/src/routes/speech/index.ts
+++ b/packages/codec-audio/src/routes/speech/index.ts
@@ -13,6 +13,7 @@ import {
 export async function renderSpeechRoute(
   plan: AudioPlan,
   ctx: RenderCtx,
+  options: { allowHostTts?: boolean } = {},
 ): Promise<RenderResult> {
   const startedAt = Date.now();
   const durationSec = Math.max(2, inferSpeechDurationSec(plan.script));
@@ -21,7 +22,7 @@ export async function renderSpeechRoute(
     plan.ambient.category === "auto" ? ambientRecommendation.category : plan.ambient.category;
 
   let speechSamples = synthSpeech(plan.script, durationSec);
-  if (await renderMacSpeech(plan.script, ctx.outPath)) {
+  if (options.allowHostTts === true && (await renderMacSpeech(plan.script, ctx.outPath))) {
     speechSamples = decodeWavToFloat32(await readFile(ctx.outPath));
   }
 

--- a/packages/codec-audio/src/types.ts
+++ b/packages/codec-audio/src/types.ts
@@ -1,0 +1,40 @@
+import type { codecV2 } from "@wittgenstein/schemas";
+import type { AudioPlan } from "./schema.js";
+
+export type AudioRoute = "speech" | "soundscape" | "music";
+
+export interface AudioArtifactMetadata extends codecV2.BaseArtifactMetadata {
+  readonly codec: "audio";
+  readonly route: AudioRoute;
+  warnings: codecV2.CodecWarning[];
+  readonly llmTokens: { input: number; output: number };
+  readonly costUsd: number;
+  readonly durationMs: number;
+  readonly seed: number | null;
+  readonly promptExpanded: string | null;
+  readonly llmOutputRaw: string | null;
+  readonly llmOutputParsed: AudioPlan | null;
+  readonly quality: {
+    readonly structural: {
+      readonly schemaValidated: boolean;
+      readonly route: AudioRoute;
+      readonly deterministicClass: "cpu-byte-parity" | "gpu-structural-parity";
+    };
+    readonly partial: {
+      readonly reason: "procedural-runtime";
+    };
+  };
+  readonly decoderHash: {
+    readonly value: string;
+    readonly frozen: true;
+    readonly slot: "Kokoro-82M-family-decoder" | "procedural-audio-runtime";
+  };
+  artifactSha256: string | null;
+}
+
+export interface AudioArtifact extends codecV2.BaseArtifact {
+  readonly outPath: string;
+  bytes?: Uint8Array;
+  readonly mime: "audio/wav";
+  readonly metadata: AudioArtifactMetadata;
+}

--- a/packages/codec-audio/test/codec.test.ts
+++ b/packages/codec-audio/test/codec.test.ts
@@ -1,40 +1,89 @@
 import { mkdtemp, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { codecV2 } from "@wittgenstein/schemas";
 import { describe, expect, it } from "vitest";
-import { audioCodec } from "../src/index.js";
+import { audioCodec, parseAudioPlan } from "../src/index.js";
 
 describe("@wittgenstein/codec-audio", () => {
-  it("exports a typed audio codec with default parse behavior", () => {
+  it("exports a typed v2 audio codec with default route validation", async () => {
     expect(audioCodec.name).toBe("audio");
-    expect(audioCodec.parse("{}").ok).toBe(true);
+    expect(audioCodec.id).toBe("audio");
+    const validated = await audioCodec.schema["~standard"].validate({
+      modality: "audio",
+      prompt: "Render a short audio artifact.",
+    });
+    expect("value" in validated).toBe(true);
+    expect(parseAudioPlan("{}").ok).toBe(true);
   });
 
-  it("renders a wav artifact for speech with ambient overlay", async () => {
+  it("produces a wav artifact for speech with ambient overlay", async () => {
     const dir = await mkdtemp(join(tmpdir(), "witt-audio-"));
-    const planResult = audioCodec.parse(
-      JSON.stringify({
+    const art = await audioCodec.produce(
+      {
+        modality: "audio",
+        prompt: "Wittgenstein ships a hackathon-ready audio demo.",
         route: "speech",
-        script: "Wittgenstein ships a hackathon-ready audio demo.",
-        ambient: { category: "rain", level: 0.2 },
-      }),
+        ambient: "rain",
+      },
+      {
+        runId: "test-run",
+        parentRunId: null,
+        runDir: dir,
+        seed: 7,
+        outPath: join(dir, "speech.wav"),
+        logger: console,
+        clock: {
+          now: () => Date.now(),
+          iso: () => new Date().toISOString(),
+        },
+        sidecar: codecV2.createRunSidecar(),
+        services: {
+          dryRun: true,
+        },
+        fork: () => {
+          throw new Error("not used in this test");
+        },
+      },
     );
 
-    expect(planResult.ok).toBe(true);
-    if (!planResult.ok) {
-      return;
-    }
+    expect(art.mime).toBe("audio/wav");
+    expect(art.outPath.endsWith(".wav")).toBe(true);
+    expect(art.metadata.route).toBe("speech");
+    expect(art.metadata.artifactSha256).toHaveLength(64);
+    expect((await stat(art.outPath)).size).toBeGreaterThan(44);
+  });
 
-    const result = await audioCodec.render(planResult.value, {
-      runId: "test-run",
-      runDir: dir,
-      seed: 7,
-      outPath: join(dir, "speech.wav"),
-      logger: console,
-    });
+  it("keeps request-side route hints in codec-owned routing", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "witt-audio-"));
+    const art = await audioCodec.produce(
+      {
+        modality: "audio",
+        prompt: "A small procedural melody.",
+        route: "music",
+      },
+      {
+        runId: "test-run",
+        runDir: dir,
+        seed: 7,
+        parentRunId: null,
+        outPath: join(dir, "music.wav"),
+        logger: console,
+        clock: {
+          now: () => Date.now(),
+          iso: () => new Date().toISOString(),
+        },
+        sidecar: codecV2.createRunSidecar(),
+        services: {
+          dryRun: true,
+        },
+        fork: () => {
+          throw new Error("not used in this test");
+        },
+      },
+    );
 
-    expect(result.mimeType).toBe("audio/wav");
-    expect(result.artifactPath.endsWith(".wav")).toBe(true);
-    expect((await stat(result.artifactPath)).size).toBeGreaterThan(44);
+    expect(art.metadata.route).toBe("music");
+    expect((await stat(art.outPath)).size).toBeGreaterThan(44);
   });
 });

--- a/packages/core/src/runtime/harness.ts
+++ b/packages/core/src/runtime/harness.ts
@@ -491,7 +491,6 @@ function createDryRunGeneration(request: WittgensteinRequest): LlmGenerationResu
   }
 
   if (
-    request.modality !== "audio" &&
     request.modality !== "video" &&
     request.modality !== "sensor" &&
     request.modality !== "asciipng"

--- a/packages/core/test/harness-modality-blind.test.ts
+++ b/packages/core/test/harness-modality-blind.test.ts
@@ -10,4 +10,9 @@ describe("harness modality blindness", () => {
     const source = await readFile(resolve(testDir, "../src/runtime/harness.ts"), "utf8");
     expect(source.includes('request.modality === "image"')).toBe(false);
   });
+
+  it("does not branch on request.modality === audio", async () => {
+    const source = await readFile(resolve(testDir, "../src/runtime/harness.ts"), "utf8");
+    expect(source.includes('request.modality === "audio"')).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

Stacks on #93 and performs the narrow M2 Slice B helper extraction. This keeps route files thin by moving only shared-mechanical glue into `routes/shared.ts`; route-specific semantics remain local to speech, soundscape, and music.

## Scope

- Add `resolveAmbientCategory(plan, hintText)` for shared `auto` ambient resolution.
- Add `mixAmbientLayer(...)` for speech/music foreground + ambient mixing.
- Add `finalizeRouteRender(...)` for shared artifact finalization + `durationMs` stamping.
- Keep speech duration inference, host-TTS opt-in gate, soundscape silence handling, and music motif interpretation route-local.

## Out of Scope

- No `BaseAudioRoute` or route inheritance.
- No manifest schema expansion.
- No CLI `--route` warning.
- No Kokoro/Piper backend wiring.
- No parity test contract changes.

## Validation

- `pnpm exec prettier --write` on touched route files
- `pnpm --filter @wittgenstein/codec-audio typecheck`
- `pnpm --filter @wittgenstein/codec-audio test`
- `pnpm --filter @wittgenstein/codec-audio lint`
- `pnpm --filter @wittgenstein/core test`
- `pnpm typecheck`
- `pnpm test`
- `git diff --check`

## Review note

This PR is intentionally stacked on #93. Review #93 first for codec ownership, then this PR for route helper extraction.