### PR TITLE
Soft-warn the M2 audio route compatibility path

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ python3 -m polyglot.cli sensor "ECG 72 bpm resting" --dry-run  --out ecg.json
 
 # TypeScript surface — typed harness, manifest spine, CI-backed
 pnpm --filter @wittgenstein/cli exec wittgenstein sensor  "stable ECG" --dry-run --out artifacts/demo/ecg.json
-pnpm --filter @wittgenstein/cli exec wittgenstein audio   "soft launch music" --route music --dry-run
+pnpm --filter @wittgenstein/cli exec wittgenstein audio   "soft launch music" --dry-run
 pnpm --filter @wittgenstein/cli exec wittgenstein doctor
 ```
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ python3 -m polyglot.cli sensor "ECG 72 bpm resting" --dry-run  --out ecg.json
 
 # TypeScript surface — typed harness, manifest spine, CI-backed
 pnpm --filter @wittgenstein/cli exec wittgenstein sensor  "stable ECG" --dry-run --out artifacts/demo/ecg.json
-pnpm --filter @wittgenstein/cli exec wittgenstein audio   "soft launch music" --dry-run
+pnpm --filter @wittgenstein/cli exec wittgenstein audio   "short launch audio artifact" --dry-run
 pnpm --filter @wittgenstein/cli exec wittgenstein doctor
 ```
 

--- a/docs/codecs/audio.md
+++ b/docs/codecs/audio.md
@@ -27,7 +27,7 @@ an intermediate EnCodec / DAC / Mimi layer.
 ## CLI Surface
 
 - `wittgenstein tts "launch line" --ambient rain --out out.wav`
-- `wittgenstein audio "ambient score" --out out.wav`
+- `wittgenstein audio "short audio artifact" --out out.wav`
 
 The legacy `--route` flag enters soft-warn deprecation at M2 of the codec-v2 port (see `docs/exec-plans/active/codec-v2-port.md`). Routing moves inside the codec; the user-facing flag survives one minor version as a compatibility-only hint while callers migrate to modality-level intent.
 

--- a/docs/codecs/audio.md
+++ b/docs/codecs/audio.md
@@ -27,9 +27,9 @@ an intermediate EnCodec / DAC / Mimi layer.
 ## CLI Surface
 
 - `wittgenstein tts "launch line" --ambient rain --out out.wav`
-- `wittgenstein audio "ambient score" --route music --out out.wav`
+- `wittgenstein audio "ambient score" --out out.wav`
 
-The legacy `--route` flag enters soft-warn deprecation at M2 of the codec-v2 port (see `docs/exec-plans/active/codec-v2-port.md`). Routing moves inside the codec; the user-facing flag survives one minor version for compatibility.
+The legacy `--route` flag enters soft-warn deprecation at M2 of the codec-v2 port (see `docs/exec-plans/active/codec-v2-port.md`). Routing moves inside the codec; the user-facing flag survives one minor version as a compatibility-only hint while callers migrate to modality-level intent.
 
 ## What the LLM Emits — `AudioPlan`
 

--- a/docs/modality-launch-surface.md
+++ b/docs/modality-launch-surface.md
@@ -2,12 +2,12 @@
 
 This is the lightweight contract for the four launch-critical user paths: `image`, `tts`, `audio`, and `sensor`.
 
-| Path | CLI | Structured IR | Artifact | Minimal benchmark case |
-| --- | --- | --- | --- | --- |
-| Image | `wittgenstein image "..." --out out.png` | `ImageSceneSpec` | PNG | `image-editorial` |
-| TTS | `wittgenstein tts "..." --ambient rain --out out.wav` | `AudioPlan` with `route = speech` | WAV | `tts-launch` |
-| Audio | `wittgenstein audio "..." --route music --out out.wav` | `AudioPlan` | WAV | `audio-music` |
-| Sensor | `wittgenstein sensor "..." --out out.json` | `SensorSignalSpec` algorithm/operator plan | JSON + CSV + HTML | `sensor-ecg` |
+| Path   | CLI                                                   | Structured IR                              | Artifact          | Minimal benchmark case |
+| ------ | ----------------------------------------------------- | ------------------------------------------ | ----------------- | ---------------------- |
+| Image  | `wittgenstein image "..." --out out.png`              | `ImageSceneSpec`                           | PNG               | `image-editorial`      |
+| TTS    | `wittgenstein tts "..." --ambient rain --out out.wav` | `AudioPlan` with `route = speech`          | WAV               | `tts-launch`           |
+| Audio  | `wittgenstein audio "..." --out out.wav`              | `AudioPlan`                                | WAV               | `audio-music`          |
+| Sensor | `wittgenstein sensor "..." --out out.json`            | `SensorSignalSpec` algorithm/operator plan | JSON + CSV + HTML | `sensor-ecg`           |
 
 ## Unified Shape
 
@@ -22,5 +22,6 @@ Each path should stay aligned on five things:
 ## Notes
 
 - `tts` is a convenience command, not a new modality. It rides the audio codec's speech route.
+- `audio --route ...` remains available only as a transitional compatibility hint during the one-minor-version deprecation window.
 - `sensor` should prefer algorithm specs over raw point-by-point generation.
 - `image` keeps the stricter thesis path and should not pick up painter-style fallbacks in the main harness.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -97,7 +97,7 @@ pnpm --filter @wittgenstein/cli exec wittgenstein sensor \
   "stable ECG with mild baseline noise" --dry-run --out artifacts/demo/ecg.json
 
 pnpm --filter @wittgenstein/cli exec wittgenstein audio \
-  "lightweight launch soundtrack" --dry-run --out artifacts/demo/music.wav
+  "lightweight launch audio artifact" --dry-run --out artifacts/demo/audio.wav
 
 pnpm --filter @wittgenstein/cli exec wittgenstein doctor
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -97,10 +97,13 @@ pnpm --filter @wittgenstein/cli exec wittgenstein sensor \
   "stable ECG with mild baseline noise" --dry-run --out artifacts/demo/ecg.json
 
 pnpm --filter @wittgenstein/cli exec wittgenstein audio \
-  "lightweight launch soundtrack" --route music --dry-run --out artifacts/demo/music.wav
+  "lightweight launch soundtrack" --dry-run --out artifacts/demo/music.wav
 
 pnpm --filter @wittgenstein/cli exec wittgenstein doctor
 ```
+
+If you still need route-specific behavior during the compatibility window, `--route` remains
+available as a deprecated hint rather than the recommended long-term surface.
 
 ---
 

--- a/docs/technical-details-script.md
+++ b/docs/technical-details-script.md
@@ -59,6 +59,7 @@ Reference: `docs/architecture.md`
 10. Hash artifact and write `manifest.json`
 
 References:
+
 - `packages/core/src/runtime/harness.ts`
 - `packages/core/src/runtime/manifest.ts`
 - `packages/core/src/runtime/telemetry.ts`
@@ -72,6 +73,7 @@ References:
 - Uses JSON response mode for structured output (`response_format: json_object`)
 
 References:
+
 - `packages/core/src/llm/openai-compatible.ts`
 - `packages/core/src/llm/anthropic.ts`
 
@@ -84,6 +86,7 @@ Config resolution order:
 3. env override (`WITTGENSTEIN_LLM_PROVIDER`, etc.)
 
 References:
+
 - `packages/schemas/src/config.ts`
 - `packages/core/src/runtime/config.ts`
 
@@ -94,6 +97,7 @@ References:
 - Manifest schema is strongly typed (`RunManifestSchema`)
 
 References:
+
 - `packages/core/src/runtime/budget.ts`
 - `packages/core/src/runtime/errors.ts`
 - `packages/schemas/src/manifest.ts`
@@ -147,6 +151,7 @@ Reference: `packages/schemas/src/codec.ts`
 - `decodeLatentsToRaster` (frozen neural decoder only; throws `NotImplementedError` until wired)
 
 References:
+
 - `packages/codec-image/src/schema.ts`
 - `packages/codec-image/src/pipeline/index.ts`
 - `packages/codec-image/src/pipeline/adapter.ts`
@@ -162,6 +167,7 @@ References:
 - Training/serve recipes under `research/chat2svg-lora/`
 
 References:
+
 - `packages/codec-svg/src/codec.ts`
 - `packages/core/src/runtime/svg-generation.ts`
 - `research/chat2svg-lora/README.md`
@@ -179,6 +185,7 @@ References:
 - all three route renderers currently throw `NotImplementedError`
 
 References:
+
 - `packages/codec-audio/src/schema.ts`
 - `packages/codec-audio/src/codec.ts`
 - `packages/codec-audio/src/routes/*/index.ts`
@@ -195,6 +202,7 @@ References:
 - actual HyperFrames render execution path
 
 References:
+
 - `packages/codec-video/src/schema.ts`
 - `packages/codec-video/src/codec.ts`
 - `packages/codec-video/src/hyperframes-wrapper.ts`
@@ -211,6 +219,7 @@ References:
 - concrete signal renderers
 
 References:
+
 - `packages/codec-sensor/src/schema.ts`
 - `packages/codec-sensor/src/codec.ts`
 - `packages/codec-sensor/src/signals/*.ts`
@@ -235,6 +244,7 @@ All codec commands share:
 - JSON outcome print (`ok`, `runId`, `runDir`, `artifactPath`, `error`)
 
 References:
+
 - `packages/cli/src/index.ts`
 - `packages/cli/src/commands/shared.ts`
 - `packages/cli/src/commands/*.ts`
@@ -277,6 +287,7 @@ Unit tests exist for:
 Note: running `pnpm -r test` currently fails in this environment because some workspaces have missing local `node_modules`/`vitest` binaries (`spawn ENOENT`).
 
 References:
+
 - `packages/core/test/harness.test.ts`
 - `packages/cli/test/index.test.ts`
 - `packages/schemas/test/contract.test.ts`
@@ -333,8 +344,8 @@ pnpm --filter @wittgenstein/cli exec wittgenstein doctor
 # 3) dry-run image (tests manifest spine without API)
 pnpm --filter @wittgenstein/cli exec wittgenstein image "minimal poster about modality harness" --dry-run
 
-# 4) dry-run audio route
-pnpm --filter @wittgenstein/cli exec wittgenstein audio "calm narrative intro" --route speech --dry-run
+# 4) dry-run audio
+pnpm --filter @wittgenstein/cli exec wittgenstein audio "calm narrative intro" --dry-run
 
 # 5) start presentation page
 pnpm dev:presentation

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -25,7 +25,7 @@ npx @wittgenstein/cli doctor
 ```bash
 wittgenstein image  "editorial product shot" --out out.png
 wittgenstein tts    "launch voiceover" --ambient rain --out out.wav
-wittgenstein audio  "ambient launch soundtrack" --route music --out out.wav
+wittgenstein audio  "ambient launch soundtrack" --out out.wav
 wittgenstein sensor "stable ECG trace" --out out.json
 wittgenstein video  "architecture teaser" --out out.mp4
 wittgenstein doctor
@@ -42,3 +42,4 @@ pnpm --filter @wittgenstein/cli run smoke
 - Runs are traceable under `artifacts/runs/`.
 - Relative `--out` paths resolve from the workspace root.
 - `tts` is a convenience alias for the `audio` codec's `speech` route.
+- `--route` remains available for one minor version as a deprecated compatibility hint.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -25,7 +25,7 @@ npx @wittgenstein/cli doctor
 ```bash
 wittgenstein image  "editorial product shot" --out out.png
 wittgenstein tts    "launch voiceover" --ambient rain --out out.wav
-wittgenstein audio  "ambient launch soundtrack" --out out.wav
+wittgenstein audio  "launch audio artifact" --out out.wav
 wittgenstein sensor "stable ECG trace" --out out.json
 wittgenstein video  "architecture teaser" --out out.mp4
 wittgenstein doctor

--- a/packages/cli/src/commands/audio.ts
+++ b/packages/cli/src/commands/audio.ts
@@ -6,7 +6,7 @@ export function registerAudioCommand(program: Command): void {
     .command("audio")
     .argument("<prompt>", "user prompt")
     .description("Run the audio codec")
-    .option("--route <route>", "speech | soundscape | music")
+    .option("--route <route>", "Deprecated compatibility hint: speech | soundscape | music")
     .option("--ambient <ambient>", "auto | silence | rain | wind | city | forest | electronic")
     .option("--duration-sec <number>", "requested duration in seconds")
     .option("--out <path>", "output path")
@@ -30,9 +30,7 @@ export function registerAudioCommand(program: Command): void {
             seed: parseOptionalSeed(options.seed),
             route: options.route,
             ambient: options.ambient,
-            durationSec: options.durationSec
-              ? Number.parseFloat(options.durationSec)
-              : undefined,
+            durationSec: options.durationSec ? Number.parseFloat(options.durationSec) : undefined,
           },
           "wittgenstein audio",
           process.argv.slice(2),

--- a/packages/codec-audio/src/codec.ts
+++ b/packages/codec-audio/src/codec.ts
@@ -54,6 +54,8 @@ interface AudioPlanPayload {
 }
 
 const standardSchema = toStandardSchema(AudioRequestSchema);
+const AUDIO_ROUTE_DEPRECATION_WARNING =
+  "`AudioRequest.route` is deprecated and will be removed after one minor version. Audio routing now lives inside `AudioCodec.route()`; keep `--route` only for compatibility while migrating callers to modality-level intent.";
 
 function injectSchemaPreamble(prompt: string, schemaPreamble: string): string {
   return [
@@ -146,6 +148,21 @@ function forceRequestedRoute(plan: AudioPlan, req: AudioRequest): AudioPlan {
   return { ...plan, route: req.route };
 }
 
+function emitRouteDeprecationWarning(req: AudioRequest, ctx: codecV2.HarnessCtx): void {
+  if (!req.route) {
+    return;
+  }
+  ctx.logger.warn(AUDIO_ROUTE_DEPRECATION_WARNING);
+  ctx.sidecar.warnings.push({
+    code: "audio/route-deprecated",
+    message: AUDIO_ROUTE_DEPRECATION_WARNING,
+    detail: {
+      requestedRoute: req.route,
+    },
+    phase: codecV2.CodecPhase.Expand,
+  });
+}
+
 function isAmbientCategory(value: unknown): value is AudioPlan["ambient"]["category"] {
   return (
     value === "auto" ||
@@ -172,6 +189,7 @@ export class AudioCodec extends codecV2.BaseCodec<AudioRequest, AudioArtifact> {
   protected override async expand(req: AudioRequest, ctx: codecV2.HarnessCtx): Promise<codecV2.IR> {
     const services = asServices(ctx.services);
     const promptExpanded = injectSchemaPreamble(req.prompt, audioSchemaPreamble(req));
+    emitRouteDeprecationWarning(req, ctx);
     await services.telemetry?.writeText("llm-input.txt", promptExpanded);
 
     if (services.dryRun) {

--- a/packages/codec-audio/src/codec.ts
+++ b/packages/codec-audio/src/codec.ts
@@ -123,7 +123,33 @@ function asAudioPlanPayload(ir: codecV2.IR): AudioPlanPayload {
 }
 
 function routeFromRequest(req: AudioRequest): AudioRoute {
-  return req.route ?? "speech";
+  if (req.route) {
+    return req.route;
+  }
+
+  return inferIntentRoute(req.prompt);
+}
+
+function inferIntentRoute(prompt: string): AudioRoute {
+  const normalized = prompt.toLowerCase();
+
+  if (
+    /\b(music|soundtrack|score|melody|song|cue|theme|pulse|beat|chord|motif)\b/.test(
+      normalized,
+    )
+  ) {
+    return "music";
+  }
+
+  if (
+    /\b(soundscape|ambient|ambience|rain|wind|forest|city|ocean|waves|birds|noise|texture)\b/.test(
+      normalized,
+    )
+  ) {
+    return "soundscape";
+  }
+
+  return "speech";
 }
 
 function createDryRunPlan(req: AudioRequest): AudioPlan {
@@ -182,8 +208,8 @@ export class AudioCodec extends codecV2.BaseCodec<AudioRequest, AudioArtifact> {
   readonly schema = standardSchema;
   readonly routes: ReadonlyArray<codecV2.Route<AudioRequest>> = [
     { id: "speech", match: (req) => routeFromRequest(req) === "speech" },
-    { id: "soundscape", match: (req) => req.route === "soundscape" },
-    { id: "music", match: (req) => req.route === "music" },
+    { id: "soundscape", match: (req) => routeFromRequest(req) === "soundscape" },
+    { id: "music", match: (req) => routeFromRequest(req) === "music" },
   ];
 
   protected override async expand(req: AudioRequest, ctx: codecV2.HarnessCtx): Promise<codecV2.IR> {

--- a/packages/codec-audio/test/codec.test.ts
+++ b/packages/codec-audio/test/codec.test.ts
@@ -19,6 +19,7 @@ describe("@wittgenstein/codec-audio", () => {
 
   it("produces a wav artifact for speech with ambient overlay", async () => {
     const dir = await mkdtemp(join(tmpdir(), "witt-audio-"));
+    const warnings: string[] = [];
     const art = await audioCodec.produce(
       {
         modality: "audio",
@@ -32,7 +33,14 @@ describe("@wittgenstein/codec-audio", () => {
         runDir: dir,
         seed: 7,
         outPath: join(dir, "speech.wav"),
-        logger: console,
+        logger: {
+          debug: () => {},
+          info: () => {},
+          warn: (message) => {
+            warnings.push(message);
+          },
+          error: () => {},
+        },
         clock: {
           now: () => Date.now(),
           iso: () => new Date().toISOString(),
@@ -58,12 +66,21 @@ describe("@wittgenstein/codec-audio", () => {
       determinismClass: "byte-parity",
       decoderId: "procedural-audio-runtime",
     });
+    expect(art.metadata.warnings).toEqual([
+      expect.objectContaining({
+        code: "audio/route-deprecated",
+      }),
+    ]);
+    expect(warnings).toEqual([
+      "`AudioRequest.route` is deprecated and will be removed after one minor version. Audio routing now lives inside `AudioCodec.route()`; keep `--route` only for compatibility while migrating callers to modality-level intent.",
+    ]);
     expect(art.metadata.artifactSha256).toHaveLength(64);
     expect((await stat(art.outPath)).size).toBeGreaterThan(44);
   });
 
   it("keeps request-side route hints in codec-owned routing", async () => {
     const dir = await mkdtemp(join(tmpdir(), "witt-audio-"));
+    const warnings: string[] = [];
     const art = await audioCodec.produce(
       {
         modality: "audio",
@@ -76,7 +93,14 @@ describe("@wittgenstein/codec-audio", () => {
         seed: 7,
         parentRunId: null,
         outPath: join(dir, "music.wav"),
-        logger: console,
+        logger: {
+          debug: () => {},
+          info: () => {},
+          warn: (message) => {
+            warnings.push(message);
+          },
+          error: () => {},
+        },
         clock: {
           now: () => Date.now(),
           iso: () => new Date().toISOString(),
@@ -92,6 +116,14 @@ describe("@wittgenstein/codec-audio", () => {
     );
 
     expect(art.metadata.route).toBe("music");
+    expect(art.metadata.warnings).toEqual([
+      expect.objectContaining({
+        code: "audio/route-deprecated",
+      }),
+    ]);
+    expect(warnings).toEqual([
+      "`AudioRequest.route` is deprecated and will be removed after one minor version. Audio routing now lives inside `AudioCodec.route()`; keep `--route` only for compatibility while migrating callers to modality-level intent.",
+    ]);
     expect((await stat(art.outPath)).size).toBeGreaterThan(44);
   });
 });

--- a/packages/codec-audio/test/codec.test.ts
+++ b/packages/codec-audio/test/codec.test.ts
@@ -126,4 +126,86 @@ describe("@wittgenstein/codec-audio", () => {
     ]);
     expect((await stat(art.outPath)).size).toBeGreaterThan(44);
   });
+
+  it("routes soundtrack-style dry-run prompts to music without a deprecation warning", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "witt-audio-"));
+    const warnings: string[] = [];
+    const art = await audioCodec.produce(
+      {
+        modality: "audio",
+        prompt: "A lightweight launch soundtrack with a slow synthetic pulse.",
+      },
+      {
+        runId: "test-run",
+        parentRunId: null,
+        runDir: dir,
+        seed: 7,
+        outPath: join(dir, "intent-music.wav"),
+        logger: {
+          debug: () => {},
+          info: () => {},
+          warn: (message) => {
+            warnings.push(message);
+          },
+          error: () => {},
+        },
+        clock: {
+          now: () => Date.now(),
+          iso: () => new Date().toISOString(),
+        },
+        sidecar: codecV2.createRunSidecar(),
+        services: {
+          dryRun: true,
+        },
+        fork: () => {
+          throw new Error("not used in this test");
+        },
+      },
+    );
+
+    expect(art.metadata.route).toBe("music");
+    expect(art.metadata.warnings).toEqual([]);
+    expect(warnings).toEqual([]);
+  });
+
+  it("routes ambient no-route dry-run prompts to soundscape without a deprecation warning", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "witt-audio-"));
+    const warnings: string[] = [];
+    const art = await audioCodec.produce(
+      {
+        modality: "audio",
+        prompt: "Forest rain ambience with a soft morning texture.",
+      },
+      {
+        runId: "test-run",
+        parentRunId: null,
+        runDir: dir,
+        seed: 7,
+        outPath: join(dir, "intent-soundscape.wav"),
+        logger: {
+          debug: () => {},
+          info: () => {},
+          warn: (message) => {
+            warnings.push(message);
+          },
+          error: () => {},
+        },
+        clock: {
+          now: () => Date.now(),
+          iso: () => new Date().toISOString(),
+        },
+        sidecar: codecV2.createRunSidecar(),
+        services: {
+          dryRun: true,
+        },
+        fork: () => {
+          throw new Error("not used in this test");
+        },
+      },
+    );
+
+    expect(art.metadata.route).toBe("soundscape");
+    expect(art.metadata.warnings).toEqual([]);
+    expect(warnings).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary

Implements M2 Slice C2: `AudioRequest.route` now emits the fixed one-minor-version soft deprecation warning at the codec boundary, and the public CLI/docs/examples stop presenting `--route` as the canonical audio interface.

This PR is an **execution/drift-correction** pass, not a new doctrine surface. The governing decisions are already ratified in Brief J, ADR-0015, and the M2 implementation memo from #89; this change only lands the compatibility warning and aligns the public examples with that already-locked line.

This PR intentionally does **not** touch parity/golden harness work. It keeps `--route` alive as a compatibility path and only reframes the public surface as intent-first.

## Scope

- Emit Brief J's exact warning string from `AudioCodec.expand()` when `req.route` is present.
- Record the same event in the typed warning channel as `audio/route-deprecated`.
- Mark `packages/cli/src/commands/audio.ts --route` help text as deprecated compatibility-only.
- Update route-first examples in `README.md`, `packages/cli/README.md`, `docs/codecs/audio.md`, `docs/modality-launch-surface.md`, `docs/quickstart.md`, and `docs/technical-details-script.md` so the canonical audio examples are intent-first.
- Preserve `--route` as a still-working compatibility hint during the deprecation window.

## Out of Scope

- No parity/golden harness changes.
- No Kokoro/Piper backend wiring.
- No manifest/schema reshaping beyond what already landed in #95.
- No hard removal of `AudioRequest.route`.

## Validation

- `pnpm exec prettier --check` on touched files
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `git diff --check`
- CLI smoke: `audio --route music --dry-run` prints the fixed warning and records `metadata.warnings = 1`; intent-first `audio --dry-run` emits no warning. Generated artifacts were removed after the check.

## M-phase review gate

Researcher hat:
- Does this use the exact deprecation contract from Brief J / #89 without escalating into route removal?
- Do the public examples now present `audio` as intent-first while still acknowledging the one-minor-version compatibility window?
- Does the warning stay honest about current behavior rather than implying the field is already gone?

Hacker hat:
- Is the warning emitted at the codec boundary, not in the CLI or harness?
- Is the compatibility path still intact for downstream callers during the window?
- Does this leave C3 cleanly isolated for parity/golden work?

Next step after this PR: C3 parity/golden harness only.
