### PR TITLE
docs: clarify current status and CODEOWNERS routing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,31 +6,37 @@
 # independent ratification pass, not just self-review.
 #
 # Maintainer pair (per ADR-0013): @Jah-yee + @Moapacha.
-# Per-modality team handles are aspirational; if the team is not yet provisioned
-# in the org, the catchall pair still receives the review request.
+#
+# Per-modality team handles (@wittgenstein-image / -audio / -video / -sensor /
+# -core) were previously listed alongside the maintainer pair as aspirational
+# routing. Verified 2026-05-03 via `gh api orgs/p-to-q/teams` that no such
+# teams exist in the org; GitHub silently dropped those handles, so only the
+# maintainer pair was actually receiving review requests. Listing teams that
+# do not exist clutters CODEOWNERS validation without changing behavior.
+# Removed. When/if those teams are provisioned, re-add them in their own commit.
 
 # Default fallback — every PR auto-requests the maintainer pair.
 * @Jah-yee @Moapacha
 
 # ----- Code surfaces (per-modality, modality-team or fallback) -----
 
-/packages/core/src/runtime/ @Jah-yee @Moapacha @wittgenstein-core
-/packages/core/src/llm/ @Jah-yee @Moapacha @wittgenstein-core
-/packages/core/src/codecs/image.ts @Jah-yee @Moapacha @wittgenstein-image
-/packages/core/src/codecs/audio.ts @Jah-yee @Moapacha @wittgenstein-audio
-/packages/core/src/codecs/video.ts @Jah-yee @Moapacha @wittgenstein-video
-/packages/core/src/codecs/sensor.ts @Jah-yee @Moapacha @wittgenstein-sensor
-/packages/schemas/ @Jah-yee @Moapacha @wittgenstein-core
-/packages/sandbox/ @Jah-yee @Moapacha @wittgenstein-core
-/packages/codec-image/ @Jah-yee @Moapacha @wittgenstein-image
-/packages/codec-audio/ @Jah-yee @Moapacha @wittgenstein-audio
-/packages/codec-video/ @Jah-yee @Moapacha @wittgenstein-video
-/packages/codec-sensor/ @Jah-yee @Moapacha @wittgenstein-sensor
+/packages/core/src/runtime/ @Jah-yee @Moapacha
+/packages/core/src/llm/ @Jah-yee @Moapacha
+/packages/core/src/codecs/image.ts @Jah-yee @Moapacha
+/packages/core/src/codecs/audio.ts @Jah-yee @Moapacha
+/packages/core/src/codecs/video.ts @Jah-yee @Moapacha
+/packages/core/src/codecs/sensor.ts @Jah-yee @Moapacha
+/packages/schemas/ @Jah-yee @Moapacha
+/packages/sandbox/ @Jah-yee @Moapacha
+/packages/codec-image/ @Jah-yee @Moapacha
+/packages/codec-audio/ @Jah-yee @Moapacha
+/packages/codec-video/ @Jah-yee @Moapacha
+/packages/codec-sensor/ @Jah-yee @Moapacha
 /apps/site/ @Jah-yee @Moapacha
-/docs/codecs/image.md @Jah-yee @Moapacha @wittgenstein-image
-/docs/codecs/audio.md @Jah-yee @Moapacha @wittgenstein-audio
-/docs/codecs/video.md @Jah-yee @Moapacha @wittgenstein-video
-/docs/codecs/sensor.md @Jah-yee @Moapacha @wittgenstein-sensor
+/docs/codecs/image.md @Jah-yee @Moapacha
+/docs/codecs/audio.md @Jah-yee @Moapacha
+/docs/codecs/video.md @Jah-yee @Moapacha
+/docs/codecs/sensor.md @Jah-yee @Moapacha
 
 # ----- Doctrine surfaces (ADR-0013 §1) -----
 # These require independent ratification per ADR-0013. Always route to the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,7 @@ The RFC-0003 alternatives (Loom / Transducer / Score / Handoff) were rejected. U
 - `docs/exec-plans/active/` — live execution plans (M0 → M5b lives here)
 - `docs/agent-guides/` — per-port execution briefs (audio, sensor, image-to-audio)
 - `docs/rfcs/` and `docs/adrs/` — engineering decisions and ratified records
-- `docs/research/briefs/` — four-station research briefs (A–H)
+- `docs/research/briefs/` — four-station research briefs (A–J; see `docs/research/briefs/README.md`)
 
 ### Read Order — v0.2 supplement
 
@@ -148,9 +148,20 @@ Then return to the original Read Order above for engineering discipline, codec p
 
 ### What's currently active
 
-- **Doctrine:** locked at v0.2.0-alpha.1; M2 preflight closure is cut at v0.2.0-alpha.2.
-- **Code:** Codec Protocol v2 port — sequenced **M0 image → M1 image refinement → M2 audio → M3 sensor → M4 video stub → M5a/b benchmarks**. M0 and M1A are landed; M2 audio is the active execution line.
+- **Doctrine:** locked at v0.2.0-alpha.1; M2 preflight closure cut at v0.2.0-alpha.2; governance lane introduced in ADRs 0012–0014 (see below).
+- **Code:** Codec Protocol v2 port — sequenced **M0 image → M1 image refinement → M2 audio → M3 sensor → M4 video stub → M5a/b benchmarks**. M0 and M1A are landed; M2 audio is the active execution line (Slices A/B/C1/D merged; C2 Kokoro wiring + C3 parity tests pending).
 - **Out of scope until M5b:** new modalities, diffusion samplers, trained model weights, website rewrite, RFC-0003 renaming.
+
+### Two decision lanes (v0.2.0-alpha.2 governance addition)
+
+Operating-doc edits are now routed through two explicit lanes (introduced via ADR-0014):
+
+- **Engineering lane** — `Brief → RFC → ADR → exec-plan → code`. For codec / modality / protocol / runtime decisions. Canonical example: M1A landed via Brief A+G+H → RFC-0001 → ADR-0008 → exec-plan §M1 → PR #68.
+- **Governance lane** — `(optional Governance Note) → ADR → inline summary`. For review process, archive policy, label taxonomy, agency boundaries, surface classification.
+
+If you find yourself wanting to append a new section to `docs/engineering-discipline.md`, this file (`AGENTS.md`), `CONTRIBUTING.md`, `docs/labels.md`, or any other operating doc — **open an ADR first**. The inline summary is a pointer; the ADR is the doctrine. See ADR-0013 (independent ratification for doctrine PRs) and ADR-0014 (governance lane).
+
+This rule supersedes the unqualified "any task" framing earlier in this file. The earlier bullet "Put future architectural choices in ADRs instead of burying them in PR text" was correct but under-specified; the two lanes make the path explicit.
 
 ### Claude-specific style and working rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,7 +149,7 @@ Then return to the original Read Order above for engineering discipline, codec p
 ### What's currently active
 
 - **Doctrine:** locked at v0.2.0-alpha.1; M2 preflight closure cut at v0.2.0-alpha.2; governance lane introduced in ADRs 0012–0014 (see below).
-- **Code:** Codec Protocol v2 port — sequenced **M0 image → M1 image refinement → M2 audio → M3 sensor → M4 video stub → M5a/b benchmarks**. M0 and M1A are landed; M2 audio is the active execution line (Slices A/B/C1/D merged; C2 Kokoro wiring + C3 parity tests pending).
+- **Code:** Codec Protocol v2 port — sequenced **M0 image → M1 image refinement → M2 audio → M3 sensor → M4 video stub → M5a/b benchmarks**. M0 and M1A are landed; M2 audio is the active execution line. M2 Slices A/B/C1/C2 are merged; C3 audio parity/golden work is in review; Kokoro/Piper backend wiring remains a follow-up, not an already-landed behavior.
 - **Out of scope until M5b:** new modalities, diffusion samplers, trained model weights, website rewrite, RFC-0003 renaming.
 
 ### Two decision lanes (v0.2.0-alpha.2 governance addition)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,16 @@
 # Wittgenstein
 
 **The modality harness for text-first LLMs.**
+Give a text LLM a prompt → get a real `.png`, `.wav`, `.csv`, or `.svg` back, with a checked-in run manifest you can replay bit-exactly. No diffusion samplers, no fused multimodal model, no API key required for a 30-second demo.
+
+```bash
+git clone https://github.com/p-to-q/wittgenstein.git && cd wittgenstein
+cd polyglot-mini && pip install -r requirements.txt
+python3 -m polyglot.cli sensor "ECG 72 bpm resting" --dry-run --out /tmp/ecg.json
+open /tmp/ecg.html   # macOS; or xdg-open on Linux
+```
+
+You get a real ECG dashboard (`~117 KB` self-contained HTML), a 2,500-sample CSV, and a manifest tying every byte to a git SHA + seed. That's the smallest end-to-end shape; image, TTS, soundscape, music, and SVG routes work the same way.
 
 [![CI](https://img.shields.io/github/actions/workflow/status/p-to-q/wittgenstein/ci.yml?branch=main&label=CI)](./.github/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/p-to-q/wittgenstein?include_prereleases&label=release)](https://github.com/p-to-q/wittgenstein/releases)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@
 # Wittgenstein
 
 **The modality harness for text-first LLMs.**
-Give a text LLM a prompt → get a real `.png`, `.wav`, `.csv`, or `.svg` back, with a checked-in run manifest you can replay bit-exactly. No diffusion samplers, no fused multimodal model, no API key required for a 30-second demo.
+Give a text LLM a prompt and Wittgenstein turns the structured plan into real files:
+`.png`, `.wav`, `.csv`, `.html`, or `.svg`, with run manifests that record the seed,
+artifact hash, and model I/O. No fused multimodal model is required for the local
+30-second sensor demo.
 
 ```bash
 git clone https://github.com/p-to-q/wittgenstein.git && cd wittgenstein
@@ -12,7 +15,10 @@ python3 -m polyglot.cli sensor "ECG 72 bpm resting" --dry-run --out /tmp/ecg.jso
 open /tmp/ecg.html   # macOS; or xdg-open on Linux
 ```
 
-You get a real ECG dashboard (`~117 KB` self-contained HTML), a 2,500-sample CSV, and a manifest tying every byte to a git SHA + seed. That's the smallest end-to-end shape; image, TTS, soundscape, music, and SVG routes work the same way.
+You get a real ECG dashboard (`~117 KB` self-contained HTML), a 2,500-sample CSV, and
+a manifest tying the artifact to a git SHA + seed. That is the smallest end-to-end
+shape. Image, audio, and SVG follow the same harness/codec/manifest contract, with
+different maturity levels called out in `docs/implementation-status.md`.
 
 [![CI](https://img.shields.io/github/actions/workflow/status/p-to-q/wittgenstein/ci.yml?branch=main&label=CI)](./.github/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/p-to-q/wittgenstein?include_prereleases&label=release)](https://github.com/p-to-q/wittgenstein/releases)
@@ -31,13 +37,13 @@ of it can plan. Wittgenstein's response is to extend what the model can **expres
 files** — schemas, codec IR, latent codes — rather than what it can **say in tokens**. The
 expressive contract lives in code, not prompt copy.
 
-> **🧪 Project status — early-stage, doctrine-locked, pre-M2 implementation.**
+> **🧪 Project status — early-stage, doctrine-locked, M2 audio in progress.**
 > Wittgenstein is a prerelease (`v0.2.0-alpha.2`) with a working Python
 > surface, a production-shaped TypeScript harness, and a few intentionally
 > unfinished surfaces clearly flagged with ⚠️ or 🔴 in
 > [`docs/implementation-status.md`](docs/implementation-status.md). The v0.2
 > cut locks the thesis, vocabulary, and codec protocol (RFC-0001 / ADR-0008);
-> M0 and M1A have landed; M2 audio is the next implementation line against
+> M0 and M1A have landed; M2 audio is the active implementation line against
 > [`docs/exec-plans/active/codec-v2-port.md`](docs/exec-plans/active/codec-v2-port.md).
 > Breaking changes are still possible before a stable release. **We are
 > actively looking for early adopters and contributors** — see


### PR DESCRIPTION
## Summary

Completes the internal-perspective cleanup branch that was left without a PR.

- remove nonexistent aspirational modality team handles from CODEOWNERS after verifying `gh api orgs/p-to-q/teams` returns no provisioned teams
- make the README first screen answer what the project produces, while keeping maturity claims honest
- update AGENTS current-status wording so M2 C3 and Kokoro/Piper backend wiring are not conflated

## Why

This is a clarity/hygiene follow-up from the 2026-05-03 audit conversation. It does not add new doctrine; it corrects stale routing/status surfaces and makes the first reader path clearer.

## Validation

- `pnpm exec prettier --check README.md AGENTS.md`
- `git diff --check`
- `gh api orgs/p-to-q/teams` -> `[]`

## Review note

CODEOWNERS changes are intentionally conservative: until real org teams exist, the maintainer pair remains the only review-request target. If modality teams are provisioned later, re-add them in a separate commit.