### PR TITLE
chore(ci): guard codec package boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,9 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+      - name: Lint deps
+        run: pnpm lint:deps
+
       - name: Typecheck
         run: pnpm typecheck
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build": "pnpm -r build",
     "typecheck": "pnpm -r typecheck",
     "lint": "pnpm -r lint",
+    "lint:deps": "node scripts/check-codec-boundaries.mjs",
     "test": "pnpm -r test",
     "test:golden": "pnpm --filter @wittgenstein/codec-sensor run test:golden",
     "launch:check": "pnpm typecheck && pnpm --filter @wittgenstein/codec-audio test && pnpm --filter @wittgenstein/codec-sensor test",

--- a/scripts/check-codec-boundaries.mjs
+++ b/scripts/check-codec-boundaries.mjs
@@ -1,0 +1,120 @@
+import { readdir, readFile } from "node:fs/promises";
+import { dirname, extname, join, relative, resolve } from "node:path";
+import ts from "typescript";
+
+const repoRoot = resolve(dirname(new URL(import.meta.url).pathname), "..");
+const packagesDir = resolve(repoRoot, "packages");
+const codecDirs = (await readdir(packagesDir, { withFileTypes: true }))
+  .filter((entry) => entry.isDirectory() && entry.name.startsWith("codec-"))
+  .map((entry) => entry.name);
+
+const codecByPackageName = new Map(codecDirs.map((name) => [`@wittgenstein/${name}`, name]));
+const violations = [];
+
+for (const codecDir of codecDirs) {
+  for (const filePath of await collectSourceFiles(resolve(packagesDir, codecDir))) {
+    const sourceText = await readFile(filePath, "utf8");
+    const sourceFile = ts.createSourceFile(filePath, sourceText, ts.ScriptTarget.Latest, true);
+
+    for (const dependency of collectDependencies(sourceFile)) {
+      const targetCodec = resolveTargetCodec(codecDir, filePath, dependency);
+      if (!targetCodec || targetCodec === codecDir) {
+        continue;
+      }
+
+      const line = sourceFile.getLineAndCharacterOfPosition(dependency.start).line + 1;
+      violations.push(`${relative(repoRoot, filePath)}:${line} imports ${dependency.specifier}`);
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error("Cross-codec imports are forbidden. Found:");
+  for (const violation of violations) {
+    console.error(`- ${violation}`);
+  }
+  process.exit(1);
+}
+
+console.log(`Codec boundary check passed for ${codecDirs.length} codec packages.`);
+
+async function collectSourceFiles(rootDir) {
+  const files = [];
+  const entries = await readdir(rootDir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (entry.name === "dist" || entry.name === "node_modules") {
+      continue;
+    }
+
+    const fullPath = join(rootDir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await collectSourceFiles(fullPath)));
+      continue;
+    }
+
+    if ([".ts", ".mts", ".js", ".mjs"].includes(extname(entry.name))) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+function collectDependencies(sourceFile) {
+  const dependencies = [];
+
+  function visit(node) {
+    if (
+      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      dependencies.push({
+        specifier: node.moduleSpecifier.text,
+        start: node.moduleSpecifier.getStart(sourceFile),
+      });
+    }
+
+    if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+      node.arguments.length === 1 &&
+      ts.isStringLiteral(node.arguments[0])
+    ) {
+      dependencies.push({
+        specifier: node.arguments[0].text,
+        start: node.arguments[0].getStart(sourceFile),
+      });
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return dependencies;
+}
+
+function resolveTargetCodec(ownerCodec, filePath, dependency) {
+  const bareTarget = codecByPackageName.get(dependency.specifier);
+  if (bareTarget) {
+    return bareTarget;
+  }
+
+  if (!dependency.specifier.startsWith(".")) {
+    return null;
+  }
+
+  const resolvedPath = resolve(dirname(filePath), dependency.specifier);
+  const relativeToPackages = relative(packagesDir, resolvedPath);
+  if (relativeToPackages.startsWith("..")) {
+    return null;
+  }
+
+  const [targetCodec] = relativeToPackages.split("/");
+  if (!targetCodec || !targetCodec.startsWith("codec-")) {
+    return null;
+  }
+
+  return targetCodec === ownerCodec ? null : targetCodec;
+}


### PR DESCRIPTION
Closes #110.\n\n## Summary\n- adds a small repo-local codec boundary checker instead of introducing a new external dependency\n- fails when one codec package imports another codec package, including relative path escapes\n- wires the check into CI via a new root 
> wittgenstein-monorepo@0.2.0-alpha.2 lint:deps /Users/dujiayi/Desktop/Wittgenstein
> node scripts/check-codec-boundaries.mjs

Codec boundary check passed for 6 codec packages. command\n\n## Why this shape\nThe issue goal is to make the existing hard constraint executable. A small Node/TypeScript-based script keeps the surface tiny and avoids adding  or  just for one rule.\n\n## Validation\n- pnpm lint:deps\n- pnpm exec prettier --check scripts/check-codec-boundaries.mjs package.json .github/workflows/ci.yml\n- pnpm lint\n- pnpm typecheck\n- pnpm test\n- git diff --check