### PR TITLE
fix(cli): execute workspace bin entrypoint

### DIFF
--- a/packages/cli/bin/wittgenstein.js
+++ b/packages/cli/bin/wittgenstein.js
@@ -6,16 +6,17 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const distEntry = resolve(here, "../dist/index.js");
-const srcEntry = resolve(here, "../src/index.ts");
+const distEntry = resolve(here, "../dist/cli-main.js");
+const srcEntry = resolve(here, "../src/cli-main.ts");
 const workspaceMarker = resolve(here, "../../../pnpm-workspace.yaml");
 
-const result = !existsSync(workspaceMarker) && existsSync(distEntry)
-  ? spawnSync(process.execPath, [distEntry, ...process.argv.slice(2)], {
-      stdio: "inherit",
-    })
-  : spawnSync(process.execPath, ["--import", "tsx", srcEntry, ...process.argv.slice(2)], {
-      stdio: "inherit",
-    });
+const result =
+  !existsSync(workspaceMarker) && existsSync(distEntry)
+    ? spawnSync(process.execPath, [distEntry, ...process.argv.slice(2)], {
+        stdio: "inherit",
+      })
+    : spawnSync(process.execPath, ["--import", "tsx", srcEntry, ...process.argv.slice(2)], {
+        stdio: "inherit",
+      });
 
 process.exit(result.status ?? 1);

--- a/packages/cli/test/bin.test.ts
+++ b/packages/cli/test/bin.test.ts
@@ -1,0 +1,19 @@
+import { spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+describe("@wittgenstein/cli bin", () => {
+  it("executes the CLI entrypoint from the workspace bin stub", () => {
+    const result = spawnSync(process.execPath, ["./bin/wittgenstein.js", "--version"], {
+      cwd: packageRoot,
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("0.1.0");
+    expect(result.stderr).toBe("");
+  });
+});


### PR DESCRIPTION
Follow-up to #120 cold-checkout verification.

Summary:
- points the workspace bin stub at cli-main instead of index so commands actually execute
- keeps index as the library surface and cli-main as the executable surface
- adds a regression test that runs ./bin/wittgenstein.js --version from the workspace package root

Why now:
The 2026-05-04 cold-checkout report found that workspace CLI commands and the smoke script were false greens: they exited 0 without producing artifacts because the bin stub imported an entrypoint that only exported functions.

Validation:
- pnpm exec prettier --check packages/cli/bin/wittgenstein.js packages/cli/test/bin.test.ts
- pnpm --filter @wittgenstein/cli test
- pnpm --filter @wittgenstein/cli run smoke
- pnpm test
- git diff --check