### PR TITLE
fix(polyglot-mini): emit dataset manifest for reproducibility (#114)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,10 @@ jobs:
         run: python -m pip install --upgrade pip && python -m pip install -r polyglot-mini/requirements.txt
 
       - name: Python compile
-        run: python -m compileall polyglot-mini/polyglot
+        run: python -m compileall polyglot-mini/polyglot polyglot-mini/train
+
+      - name: Python unit tests (polyglot-mini/train)
+        run: python -m unittest discover -s polyglot-mini/train -p 'test_*.py' -v
 
       - name: Python smoke (sensor + image + platform-aware tts)
         env:

--- a/docs/reproducibility.md
+++ b/docs/reproducibility.md
@@ -29,6 +29,10 @@ Every CLI invocation creates `artifacts/runs/<run-id>/manifest.json`.
 - Config can provide `runtime.defaultSeed`.
 - The resolved seed is written to the manifest even on failure.
 
+## Training-data sampling lock
+
+The `polyglot-mini` adapter-training data pipeline emits its own deterministic receipt: `polyglot-mini/train/data_manifest.json` records the seed, the requested sample count, the actual write count, the SHA-256 of the produced `data.jsonl`, and the SHA-256 of the canonical (sorted) prompt list. Re-running `build_dataset_coco.py` against the same Karpathy split with the same seed reproduces the same hashes. See `polyglot-mini/train/data_manifest.py` for the helper and Issue #114 for context.
+
 ## Why This Exists
 
 The manifest spine is the main quality bar in this scaffold. A failing run is still useful if it leaves a complete trace.

--- a/polyglot-mini/train/build_dataset_coco.py
+++ b/polyglot-mini/train/build_dataset_coco.py
@@ -147,6 +147,17 @@ def build(karpathy_path: str, out_path: str, n_images: int, workers: int, seed: 
                 print(f"PROGRESS {written}/{len(urls)} ({rate:.1f}/s)", flush=True)
     print(f"DONE wrote={written} out={out_path}", flush=True)
 
+    from data_manifest import build_manifest, write_manifest
+    manifest_path = os.path.join(os.path.dirname(out_path) or ".", "data_manifest.json")
+    manifest = build_manifest(
+        output_path=out_path,
+        seed=seed,
+        n_requested=n_images,
+        karpathy_input_path=karpathy_path,
+    )
+    write_manifest(manifest, manifest_path)
+    print(f"DONE manifest={manifest_path}", flush=True)
+
 
 if __name__ == "__main__":
     ap = argparse.ArgumentParser()

--- a/polyglot-mini/train/data_manifest.json
+++ b/polyglot-mini/train/data_manifest.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "generatedBy": "polyglot-mini/train/build_dataset_coco.py",
+  "generatedAt": "2026-05-04T13:26:40.742377+00:00",
+  "gitSha": "4fe9143139cb46b999c0b0e3c5014c0725ea6e5e",
+  "karpathyInput": {
+    "path": null,
+    "sha256": null
+  },
+  "seed": null,
+  "nRequested": null,
+  "nWritten": 781,
+  "output": {
+    "path": "data.jsonl",
+    "sha256": "eda25aae549918f942c73b8c6519639c26edbf7d82a7221fceda1f3829248f54"
+  },
+  "promptsSha256": "b5a7e352e2d4d66404055c040df9bc7280850dbb9eb806ec93db82f15f93a19f",
+  "note": "Backfill: data.jsonl was written before manifest emission landed (Issue #114). The original sampling seed and -n value were not recorded in the v0.1 sampling pass; both fields are null. Future runs of build_dataset_coco.py will emit a manifest with both populated."
+}

--- a/polyglot-mini/train/data_manifest.py
+++ b/polyglot-mini/train/data_manifest.py
@@ -1,0 +1,108 @@
+"""Dataset manifest helper — pins (input, seed, output) for reproducibility.
+
+Used by build_dataset_coco.py to emit `data_manifest.json` alongside `data.jsonl`.
+See docs/reproducibility.md and Issue #114.
+"""
+from __future__ import annotations
+
+import datetime
+import hashlib
+import json
+import os
+import subprocess
+from typing import Optional
+
+
+MANIFEST_VERSION = 1
+
+
+def _sha256_file(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _git_sha(cwd: Optional[str] = None) -> Optional[str]:
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True, text=True, check=True, cwd=cwd,
+        ).stdout.strip()
+        return out or None
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+
+def prompts_canonical_sha256(prompts: list[str]) -> str:
+    """SHA-256 over the sorted, newline-joined prompt list.
+
+    Sorting makes the hash invariant to write-order while still capturing
+    set membership. A different sample selection (different seed) produces
+    a different hash; the same selection re-emitted produces the same hash.
+    """
+    canonical = "\n".join(sorted(prompts))
+    return _sha256_text(canonical)
+
+
+def read_prompts_jsonl(path: str) -> list[str]:
+    prompts: list[str] = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            rec = json.loads(line)
+            prompts.append(rec["prompt"])
+    return prompts
+
+
+def build_manifest(
+    *,
+    output_path: str,
+    seed: Optional[int],
+    n_requested: Optional[int],
+    karpathy_input_path: Optional[str] = None,
+    note: Optional[str] = None,
+    repo_cwd: Optional[str] = None,
+) -> dict:
+    """Build the manifest dict from the freshly-written output_path.
+
+    Hashing happens here (not the caller) so the manifest is grounded
+    in the actual on-disk artifact, not the in-memory view of it.
+    """
+    output_sha256 = _sha256_file(output_path)
+    prompts = read_prompts_jsonl(output_path)
+    n_written = len(prompts)
+    prompts_sha = prompts_canonical_sha256(prompts)
+
+    karpathy: dict[str, Optional[str]] = {"path": karpathy_input_path, "sha256": None}
+    if karpathy_input_path and os.path.exists(karpathy_input_path):
+        karpathy["sha256"] = _sha256_file(karpathy_input_path)
+
+    manifest: dict = {
+        "version": MANIFEST_VERSION,
+        "generatedBy": "polyglot-mini/train/build_dataset_coco.py",
+        "generatedAt": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "gitSha": _git_sha(repo_cwd),
+        "karpathyInput": karpathy,
+        "seed": seed,
+        "nRequested": n_requested,
+        "nWritten": n_written,
+        "output": {"path": os.path.basename(output_path), "sha256": output_sha256},
+        "promptsSha256": prompts_sha,
+    }
+    if note:
+        manifest["note"] = note
+    return manifest
+
+
+def write_manifest(manifest: dict, manifest_path: str) -> None:
+    with open(manifest_path, "w") as f:
+        json.dump(manifest, f, indent=2)
+        f.write("\n")

--- a/polyglot-mini/train/test_data_manifest.py
+++ b/polyglot-mini/train/test_data_manifest.py
@@ -1,0 +1,103 @@
+"""Tests for data_manifest helper. Run via:
+    python -m unittest polyglot-mini.train.test_data_manifest
+or, from inside polyglot-mini/train:
+    python -m unittest test_data_manifest
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+# Allow running both from repo root (`python -m unittest discover polyglot-mini/train`)
+# and from inside polyglot-mini/train.
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+import data_manifest as dm  # noqa: E402
+
+
+def _write_jsonl(path: str, prompts: list[str]) -> None:
+    with open(path, "w") as f:
+        for p in prompts:
+            f.write(json.dumps({"prompt": p, "params": {}}) + "\n")
+
+
+class TestPromptsHash(unittest.TestCase):
+    def test_canonical_hash_is_order_invariant(self):
+        a = dm.prompts_canonical_sha256(["b", "a", "c"])
+        b = dm.prompts_canonical_sha256(["c", "a", "b"])
+        self.assertEqual(a, b)
+
+    def test_canonical_hash_changes_on_membership(self):
+        a = dm.prompts_canonical_sha256(["a", "b"])
+        b = dm.prompts_canonical_sha256(["a", "c"])
+        self.assertNotEqual(a, b)
+
+    def test_canonical_hash_known_value(self):
+        # Concrete fixture: "a\nb\nc" → SHA-256
+        expected = hashlib.sha256(b"a\nb\nc").hexdigest()
+        self.assertEqual(dm.prompts_canonical_sha256(["c", "a", "b"]), expected)
+
+
+class TestBuildManifest(unittest.TestCase):
+    def test_manifest_round_trip(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            jsonl = os.path.join(tmp, "data.jsonl")
+            _write_jsonl(jsonl, ["alpha", "beta", "gamma"])
+
+            m1 = dm.build_manifest(output_path=jsonl, seed=7, n_requested=3)
+            m2 = dm.build_manifest(output_path=jsonl, seed=7, n_requested=3)
+
+            # Hashes deterministic across rebuilds of the same file.
+            self.assertEqual(m1["output"]["sha256"], m2["output"]["sha256"])
+            self.assertEqual(m1["promptsSha256"], m2["promptsSha256"])
+            self.assertEqual(m1["nWritten"], 3)
+            self.assertEqual(m1["seed"], 7)
+            self.assertEqual(m1["nRequested"], 3)
+            self.assertEqual(m1["version"], dm.MANIFEST_VERSION)
+            self.assertEqual(m1["output"]["path"], "data.jsonl")
+
+    def test_different_seed_recorded(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            jsonl = os.path.join(tmp, "data.jsonl")
+            _write_jsonl(jsonl, ["alpha", "beta", "gamma"])
+
+            m_a = dm.build_manifest(output_path=jsonl, seed=7, n_requested=3)
+            m_b = dm.build_manifest(output_path=jsonl, seed=42, n_requested=3)
+            # Seed is honestly recorded — same file, different seed claim.
+            self.assertNotEqual(m_a["seed"], m_b["seed"])
+
+    def test_different_prompts_change_hashes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            a = os.path.join(tmp, "a.jsonl")
+            b = os.path.join(tmp, "b.jsonl")
+            _write_jsonl(a, ["alpha", "beta", "gamma"])
+            _write_jsonl(b, ["alpha", "beta", "delta"])
+
+            m_a = dm.build_manifest(output_path=a, seed=0, n_requested=3)
+            m_b = dm.build_manifest(output_path=b, seed=0, n_requested=3)
+            self.assertNotEqual(m_a["promptsSha256"], m_b["promptsSha256"])
+            self.assertNotEqual(m_a["output"]["sha256"], m_b["output"]["sha256"])
+
+    def test_write_manifest_emits_json(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            jsonl = os.path.join(tmp, "data.jsonl")
+            manifest_path = os.path.join(tmp, "data_manifest.json")
+            _write_jsonl(jsonl, ["alpha", "beta"])
+
+            m = dm.build_manifest(output_path=jsonl, seed=0, n_requested=2)
+            dm.write_manifest(m, manifest_path)
+
+            with open(manifest_path) as f:
+                loaded = json.load(f)
+            self.assertEqual(loaded["promptsSha256"], m["promptsSha256"])
+            self.assertEqual(loaded["nWritten"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #114.

## What

- Emit `polyglot-mini/train/data_manifest.json` alongside `data.jsonl` with seed / requested-count / actual-count / SHA-256 of `data.jsonl` / SHA-256 of the canonical sorted-prompts list / git SHA / generated-at.
- Backfilled manifest for the existing 781-row `data.jsonl` (seed + -n null with note; future runs populate both).
- New helper `polyglot-mini/train/data_manifest.py` + 7 unit tests in `test_data_manifest.py`.
- Wire `python -m unittest discover -s polyglot-mini/train` into CI; extend `compileall` to cover `polyglot-mini/train`.
- One-line cite in `docs/reproducibility.md` (drift correction).

## Why

Audit #103 called out "781 captions" as an unverifiable doctrine claim. The sampler was already seed-deterministic (`random.Random(seed).shuffle(imgs)`) but emitted no receipt — same diagnosis the sensor goldens (#125) just closed for sensor. The manifest closes the gap with the same SHA-256 + canonical-hash shape: two-pin receipt that distinguishes "same selection re-emitted" from "different upstream split / drift."

## Validation

- `python3 -m unittest discover -s polyglot-mini/train -p 'test_*.py'` → **7 / 7 green** (canonical hash order-invariance + membership-sensitivity, known-fixture hash, manifest round-trip, seed-recorded honestly, prompt-drift detection, JSON emission shape).
- `python3 -m compileall polyglot-mini/polyglot polyglot-mini/train` → green.
- `pnpm exec prettier --check` on json/md/yml → green (Python out of prettier's scope).
- `git diff --check` → clean.

## Receipt for the current `data.jsonl`

- `output.sha256`: `eda25aae549918f942c73b8c6519639c26edbf7d82a7221fceda1f3829248f54`
- `promptsSha256`: `b5a7e352e2d4d66404055c040df9bc7280850dbb9eb806ec93db82f15f93a19f`
- `nWritten`: 781

Anyone re-hashing `data.jsonl` reproduces these values; rebuilding the manifest with a different prompt set produces different hashes (the test exercises this).

## Out of scope (deferred follow-up)

#114's done-when item 3 is partial: wiring the manifest into the TS run-manifest spine transitively (`artifacts/runs/<id>/manifest.json` gaining a `trainingData.dataManifestSha256` field) requires a deeper change in `packages/core/src/runtime/manifest.ts` and is best paired with a real training run from `packages/codec-image`. Filed as a follow-up.

## Risk

- The backfilled manifest's `seed` is null because the original sampling seed wasn't recorded in v0.1. The first new sampling run overwrites the manifest with proper values. The backfill is a snapshot, not a reproducibility receipt for the original sampling pass.
- `generatedAt` and `gitSha` change on every regeneration even if hashes are stable. That's expected — the receipt is the SHA fields, not the timestamp.

## Per ADR-0013

`docs/reproducibility.md` is on the doctrine-bearing list (§1). This is a one-line cite for a now-existing artifact — drift correction per §3, not new doctrine.