### PR TITLE
docs(links): fix #102 — replace machine-absolute paths + skip vendored node_modules

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -29,6 +29,7 @@ jobs:
             --max-concurrency 4
             --exclude-mail
             --exclude-loopback
+            --exclude-path '.*node_modules.*'
             --accept 200..=299,403,429
             'docs/**/*.md'
             'README.md'

--- a/docs/research/2026-05-04-cold-checkout-verification.md
+++ b/docs/research/2026-05-04-cold-checkout-verification.md
@@ -42,9 +42,9 @@ That means the repo reaches "all checks green" from scratch in roughly 40 second
 
 The key evidence is in the CLI entrypoint shape:
 
-- [packages/cli/bin/wittgenstein.js](/Users/dujiayi/Desktop/Wittgenstein/packages/cli/bin/wittgenstein.js:1) detects a workspace checkout via `pnpm-workspace.yaml` and, in that case, runs the source entrypoint with `node --import tsx .../src/index.ts`.
-- [packages/cli/src/index.ts](/Users/dujiayi/Desktop/Wittgenstein/packages/cli/src/index.ts:1) exports `createProgram()` and `runCli()` but does **not** invoke `runCli()` at module top level.
-- The built file at [packages/cli/dist/index.js](/Users/dujiayi/Desktop/Wittgenstein/packages/cli/dist/index.js:1) has the same shape.
+- [`packages/cli/bin/wittgenstein.js`](../../packages/cli/bin/wittgenstein.js) detects a workspace checkout via `pnpm-workspace.yaml` and, in that case, runs the source entrypoint with `node --import tsx .../src/index.ts`.
+- [`packages/cli/src/index.ts`](../../packages/cli/src/index.ts) exports `createProgram()` and `runCli()` but does **not** invoke `runCli()` at module top level.
+- The built file at `packages/cli/dist/index.js` (gitignored; produced by `pnpm build`) has the same shape.
 
 As a result, workspace CLI invocations and the package smoke script:
 


### PR DESCRIPTION
Closes #102.

## What

1. Replace three `/Users/dujiayi/Desktop/Wittgenstein/...` machine-absolute path references in `docs/research/2026-05-04-cold-checkout-verification.md` with repo-relative paths (`../../packages/cli/...`). The `dist/index.js` reference becomes prose-only since `dist/` is gitignored.
2. Add `--exclude-path '.*node_modules.*'` to the monthly lychee link-check so it stops failing on internal links inside vendored playwright README under `docs/research/www.aquin.app/node_modules/`.

## Why

The monthly link-check has been filing on #102 since at least 2026-05-01. Two distinct sources:

- **Author-machine absolute paths** leaked into PR #127. The link-checker can't resolve them as files; GitHub renders them but they confuse readers.
- **Vendored third-party `node_modules`** inside a research artifact directory contain their own internal cross-refs that lychee tries (and fails) to resolve. Reclassifying `docs/research/www.aquin.app/` is out of scope for #102 and tracked separately under #91.

## Validation

```
lychee --no-progress --max-concurrency 4 --offline \
  --exclude-path '.*node_modules.*' \
  'docs/**/*.md' 'README.md' 'AGENTS.md' 'PROMPT.md' 'CONTRIBUTING.md' 'CHANGELOG.md'
→ 🔍 557 Total · ✅ 308 OK · 🚫 0 Errors
```

Down from 4 errors (3 absolute paths + 1 vendored playwright internal ref). `pnpm exec prettier --check` and `git diff --check` clean.

## Risk

CI's lychee version may differ from local 0.24.2; `--exclude-path` is supported across recent versions and the `.*` regex is portable. If CI behavior surprises, the next monthly run flags it.

## Per ADR-0013

Neither file is on §1's doctrine-bearing list. Engineering / drift correction.