### PR TITLE
test(core): manifest spine + seed + router invariant coverage (partial #108)

### DIFF
--- a/packages/core/test/manifest.test.ts
+++ b/packages/core/test/manifest.test.ts
@@ -1,0 +1,82 @@
+import { createHash } from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { collectRuntimeFingerprint, hashFile } from "../src/runtime/manifest.js";
+
+let tmp: string;
+
+beforeEach(async () => {
+  tmp = await mkdtemp(join(tmpdir(), "wittgenstein-manifest-test-"));
+});
+
+afterEach(async () => {
+  await rm(tmp, { recursive: true, force: true });
+});
+
+describe("hashFile", () => {
+  it("returns the SHA-256 hex digest of the file contents", async () => {
+    const path = join(tmp, "fixture.txt");
+    const content = "deterministic content";
+    await writeFile(path, content);
+
+    const expected = createHash("sha256").update(content).digest("hex");
+    expect(await hashFile(path)).toBe(expected);
+  });
+
+  it("is identical for two writes of the same content", async () => {
+    const a = join(tmp, "a.txt");
+    const b = join(tmp, "b.txt");
+    await writeFile(a, "same bytes");
+    await writeFile(b, "same bytes");
+
+    expect(await hashFile(a)).toBe(await hashFile(b));
+  });
+
+  it("differs when a single byte changes", async () => {
+    const a = join(tmp, "a.txt");
+    const b = join(tmp, "b.txt");
+    await writeFile(a, "same bytes");
+    await writeFile(b, "Same bytes"); // capitalized first letter
+
+    expect(await hashFile(a)).not.toBe(await hashFile(b));
+  });
+
+  it("returns null (not throws) for a missing file — failure must be inspectable, not silent", async () => {
+    const result = await hashFile(join(tmp, "does-not-exist.txt"));
+    expect(result).toBeNull();
+  });
+});
+
+describe("collectRuntimeFingerprint", () => {
+  it("returns the spine shape for a directory with no git or lockfile", async () => {
+    const fp = await collectRuntimeFingerprint(tmp);
+
+    // gitSha is null because tmpdir is not a git repo.
+    expect(fp.gitSha).toBeNull();
+    // lockfile is missing in tmpdir, so its hash is null too.
+    expect(fp.lockfileHash).toBeNull();
+    // wittgensteinVersion falls back to 0.0.0 when package.json is absent.
+    expect(fp.wittgensteinVersion).toBe("0.0.0");
+    // Node version is a real value, like "v20.x.y".
+    expect(fp.nodeVersion).toBe(process.version);
+    expect(fp.nodeVersion).toMatch(/^v\d+\.\d+\.\d+/);
+  });
+
+  it("reads version from package.json when present", async () => {
+    await writeFile(join(tmp, "package.json"), JSON.stringify({ version: "1.2.3" }));
+    const fp = await collectRuntimeFingerprint(tmp);
+    expect(fp.wittgensteinVersion).toBe("1.2.3");
+  });
+
+  it("reads lockfile hash when pnpm-lock.yaml is present", async () => {
+    const lockfilePath = join(tmp, "pnpm-lock.yaml");
+    await writeFile(lockfilePath, "lockfileVersion: '6.0'\n");
+
+    const fp = await collectRuntimeFingerprint(tmp);
+
+    const expected = createHash("sha256").update("lockfileVersion: '6.0'\n").digest("hex");
+    expect(fp.lockfileHash).toBe(expected);
+  });
+});

--- a/packages/core/test/router.test.ts
+++ b/packages/core/test/router.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import type { WittgensteinRequest } from "@wittgenstein/schemas";
+import { CodecRegistry } from "../src/runtime/registry.js";
+import { WittgensteinError } from "../src/runtime/errors.js";
+import { routeRequest } from "../src/runtime/router.js";
+
+function fakeCodec(modality: WittgensteinRequest["modality"]) {
+  return {
+    name: `fake-${modality}`,
+    modality,
+    schema: undefined as never,
+    expand: () => ({}) as never,
+    render: () => ({}) as never,
+  } as never;
+}
+
+describe("routeRequest", () => {
+  it("returns the registered codec for the request's modality", () => {
+    const registry = new CodecRegistry();
+    registry.register(fakeCodec("sensor"));
+    registry.register(fakeCodec("audio"));
+
+    const sensorReq = { modality: "sensor" } as WittgensteinRequest;
+    const audioReq = { modality: "audio" } as WittgensteinRequest;
+
+    expect((routeRequest(sensorReq, registry) as { name: string }).name).toBe("fake-sensor");
+    expect((routeRequest(audioReq, registry) as { name: string }).name).toBe("fake-audio");
+  });
+
+  it("throws WittgensteinError with UNKNOWN_MODALITY when the modality is not registered", () => {
+    const registry = new CodecRegistry();
+    registry.register(fakeCodec("sensor"));
+
+    const audioReq = { modality: "audio" } as WittgensteinRequest;
+
+    let caught: unknown;
+    try {
+      routeRequest(audioReq, registry);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(WittgensteinError);
+    expect((caught as WittgensteinError).code).toBe("UNKNOWN_MODALITY");
+  });
+
+  it("does not invoke the codec — routing is lookup-only", () => {
+    const registry = new CodecRegistry();
+    let renderCalls = 0;
+    const codec = {
+      name: "fake-image",
+      modality: "image" as const,
+      schema: undefined as never,
+      expand: () => ({}) as never,
+      render: () => {
+        renderCalls += 1;
+        return {} as never;
+      },
+    } as never;
+    registry.register(codec);
+
+    routeRequest({ modality: "image" } as WittgensteinRequest, registry);
+    expect(renderCalls).toBe(0);
+  });
+});

--- a/packages/core/test/seed.test.ts
+++ b/packages/core/test/seed.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { createDeterministicRandom, createRunId, resolveSeed } from "../src/runtime/seed.js";
+
+describe("resolveSeed", () => {
+  it("prefers an explicit requested seed over the default", () => {
+    expect(resolveSeed(7, 99)).toBe(7);
+  });
+
+  it("treats requested seed of 0 as a real value, not a missing one", () => {
+    expect(resolveSeed(0, 42)).toBe(0);
+  });
+
+  it("falls through to the default when no requested seed is provided", () => {
+    expect(resolveSeed(undefined, 42)).toBe(42);
+  });
+
+  it("returns null when neither requested nor default seed is present", () => {
+    expect(resolveSeed(undefined, undefined)).toBeNull();
+    expect(resolveSeed(undefined, null)).toBeNull();
+  });
+
+  it("treats an explicit null requested seed as the user asking for null", () => {
+    // The fallthrough is on undefined only; an explicit null is honored.
+    // This matters for "--seed=null" (or its programmatic equivalent) where
+    // the user is opting out of seeding rather than letting the default fire.
+    expect(resolveSeed(null, 42)).toBeNull();
+  });
+});
+
+describe("createRunId", () => {
+  it("starts with the ISO-8601 stamp with separators replaced", () => {
+    const fixed = new Date("2026-05-04T13:00:00.000Z");
+    const id = createRunId(fixed);
+    expect(id.startsWith("2026-05-04T13-00-00-000Z-")).toBe(true);
+  });
+
+  it("appends a 6-character random suffix", () => {
+    const id = createRunId(new Date("2026-05-04T13:00:00.000Z"));
+    const suffix = id.split("-").pop();
+    expect(suffix?.length).toBe(6);
+  });
+
+  it("produces unique ids when called rapidly with the same timestamp", () => {
+    const fixed = new Date("2026-05-04T13:00:00.000Z");
+    const ids = new Set<string>();
+    for (let i = 0; i < 50; i++) {
+      ids.add(createRunId(fixed));
+    }
+    // 50 random suffixes from a 36^6 space — collision probability is
+    // ~2e-7 per pair, so a clean run essentially never collides. If this
+    // ever flakes, the random source has changed in a non-trivial way.
+    expect(ids.size).toBe(50);
+  });
+});
+
+describe("createDeterministicRandom", () => {
+  it("is reproducible — same seed yields the same sequence", () => {
+    const a = createDeterministicRandom(42);
+    const b = createDeterministicRandom(42);
+    const sequenceA = [a(), a(), a(), a(), a()];
+    const sequenceB = [b(), b(), b(), b(), b()];
+    expect(sequenceA).toEqual(sequenceB);
+  });
+
+  it("differentiates seeds — different seeds yield different sequences", () => {
+    const a = createDeterministicRandom(7);
+    const b = createDeterministicRandom(8);
+    const sequenceA = [a(), a(), a()];
+    const sequenceB = [b(), b(), b()];
+    expect(sequenceA).not.toEqual(sequenceB);
+  });
+
+  it("returns values in the [0, 1) interval", () => {
+    const rand = createDeterministicRandom(123);
+    for (let i = 0; i < 100; i++) {
+      const v = rand();
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThan(1);
+    }
+  });
+
+  it("does not collapse to a fixed point — successive calls vary", () => {
+    const rand = createDeterministicRandom(999);
+    const samples = new Set<number>();
+    for (let i = 0; i < 32; i++) {
+      samples.add(rand());
+    }
+    // 32 outputs of a non-degenerate PRNG should produce more than a
+    // single distinct value. This catches the "lcg got stuck" failure mode.
+    expect(samples.size).toBeGreaterThan(20);
+  });
+});


### PR DESCRIPTION
Partial #108. The path agreed in PR #103 review: real invariant tests for the manifest-spine surfaces; **no ADR-0017, no test:src ratio gate**.

## What

22 new tests over three runtime files most directly implementing the reproducibility doctrine.

- **`runtime/seed.ts`** (12 tests): `resolveSeed` precedence including the honest "explicit null === user-asked-for-null" case + the "0 is not missing" case; `createRunId` ISO-8601 format + 6-char suffix + uniqueness; `createDeterministicRandom` reproducibility (same seed → same sequence), differentiation (different seeds → different sequences), [0,1) range, non-collapse.
- **`runtime/router.ts`** (3 tests): registered codec lookup; structured `WittgensteinError` with `UNKNOWN_MODALITY` code on miss (not a generic throw); routing is lookup-only (does not invoke render).
- **`runtime/manifest.ts`** (7 tests): `hashFile` produces SHA-256 hex digest; identical bytes → identical hashes; one-byte mutation → hash changes; missing file returns `null` (engineering-discipline §Robustness — failure must be inspectable, not silent); `collectRuntimeFingerprint` shape under absent-git / absent-lockfile / present-version / present-lockfile.

## Why

Audit (#103, §2.1) flagged the runtime files implementing reproducibility as effectively untested. These are the surfaces whose silent breakage would invalidate the manifest spine. Per my review on PR #103 + agreed in PR #103's close summary: the ratio threshold framing (`core ≥ 0.4`) is process-on-process; what matters is real invariant coverage of the load-bearing functions. This PR delivers the latter without bringing back the doctrine artifacts.

## Validation

```
pnpm --filter @wittgenstein/core test  →  Test Files 7 passed (7)  /  Tests 27 passed (27)
pnpm typecheck                          →  green
pnpm --filter @wittgenstein/core lint   →  green
pnpm exec prettier --check              →  green (on the three new files)
pnpm test:golden                        →  3/3 green (sensor unaffected)
```

Test count moved from 5 → 27 in `packages/core` (+22).

## Out of scope (#108 stays open)

- `runtime/budget.ts` and `runtime/retry.ts` — same shape can be added in follow-up PRs; this one stays scoped to the three files I read fully.
- `packages/cli` test coverage raise — separate PR per "smallest effective change."
- **ADR-0017 (test:src ratio threshold) — explicitly NOT opened.** The cure is process-on-process where the disease was too-much-process.

## Per ADR-0013

Tests under `packages/core/test/` are not on §1's doctrine-bearing list. Engineering.