### PR TITLE
docs(readme): tighten Receipts to 3 strict CI-gated rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,28 +84,21 @@ Wittgenstein makes three architectural bets instead:
 
 ## Receipts (not claims)
 
-Every row below is byte-reproducible from a clean checkout. Run the command in the **Verify** column and you will get the same numbers, or the build will fail. Single-run hackathon-phase metrics (training loss, manual spot checks, illustrative ratios) live in [Demos](#demos--illustrative-not-benchmarks) below, clearly labeled as not-a-benchmark.
+Three byte-precise CI gates. Every row is reproducible from a clean checkout via the command in the **Verify** column, and CI fails if any of them drifts. Single-run hackathon-phase numbers (training loss, manual spot checks, illustrative ratios) used to live here; they are not receipts and have been removed in favor of these three.
 
-| What                                      | Number                                         | Verify                                                                                                                                                                                                                                     |
-| ----------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Sensor goldens (ECG / temperature / gyro) | <strong>3 / 3 byte-for-byte</strong>           | `pnpm test:golden` against [`fixtures/golden/sensor/manifest.json`](fixtures/golden/sensor/manifest.json) (SHA-256 pinned per signal; CI-gated)                                                                                            |
-| Codec independence                        | <strong>6 / 6 packages clean</strong>          | `pnpm lint:deps` runs [`scripts/check-codec-boundaries.mjs`](scripts/check-codec-boundaries.mjs) — fails if any `packages/codec-X/` imports `packages/codec-Y/` (CI-gated)                                                                 |
-| Self-contained loupe HTML dashboard       | <strong>~ 117 KB</strong>                      | Run the [Quickstart](#quickstart-30-seconds-no-api-key) below, then `wc -c /tmp/ecg.html` (zero external CDN deps; single self-contained file)                                                                                             |
-| Workspace gates from a clean checkout     | <strong>typecheck + lint + test green</strong> | `git clone … && pnpm install && pnpm typecheck && pnpm lint && pnpm test` — the 2026-05-04 fresh-clone run is logged in [`docs/research/2026-05-04-cold-checkout-verification.md`](docs/research/2026-05-04-cold-checkout-verification.md) |
+| What                                       | Number                                                  | Verify (CI gate)                                                                                                                                                                                                                                                    |
+| ------------------------------------------ | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Sensor parity (ECG / temperature / gyro)   | <strong>3 / 3 routes byte-for-byte</strong>             | `pnpm test:golden` against [`fixtures/golden/sensor/manifest.json`](fixtures/golden/sensor/manifest.json) (SHA-256 pinned per signal; landed in [PR #125](https://github.com/p-to-q/wittgenstein/pull/125))                                                         |
+| Audio parity (speech / soundscape / music) | <strong>3 / 3 routes byte + structural</strong>         | `pnpm --filter @wittgenstein/codec-audio test` exercises [`packages/codec-audio/test/parity.test.ts`](packages/codec-audio/test/parity.test.ts) (procedural backend SHA-256 pinned; landed in [PR #121](https://github.com/p-to-q/wittgenstein/pull/121))           |
+| Training-data lock                         | <strong>SHA-256 over selection + output sealed</strong> | `python -m unittest discover -s polyglot-mini/train` against [`polyglot-mini/train/data_manifest.json`](polyglot-mini/train/data_manifest.json) (caption-set hash + `data.jsonl` hash pinned; landed in [PR #130](https://github.com/p-to-q/wittgenstein/pull/130)) |
 
 The receipt set is intentionally narrow. Adding a row requires a script + a CI gate, not a number in a slide.
 
-## Demos — illustrative, not benchmarks
+### Engineering
 
-These are single-run snapshots from hackathon-phase work. They demonstrate that the pipelines produce real outputs but are **not** statistical claims — no holdout sets, no cross-validation, no baselines. Treat them as evidence that the path runs end-to-end, not as quality measurements.
-
-| What                          | Number                       | Provenance                                                                                                                                                                                         |
-| ----------------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Image style MLP training loss | 0.7698 BCE                   | Single training run, 600 epochs, 781 COCO captions; no holdout split. Reproduce: `cd polyglot-mini && python3 train/train.py`                                                                      |
-| Audio ambient classifier      | 5 / 5 manual spot checks     | 5 hand-picked prompts logged in [`docs/benchmark-standards.md`](docs/benchmark-standards.md) §"Audio ambient classifier baseline"; no confusion matrix, no cross-validation, no held-out test set. |
-| Sensor expand latency         | sub-2 ms on a single machine | Pure numpy expand of a 250 Hz × 10 s ECG operator spec; no baseline (e.g. pandas → resample → matplotlib) is measured against it.                                                                  |
-
-The full hackathon-phase artifact pack (35 outputs) lives in [Showcase](#showcase--35-real-artifacts-you-can-open-right-now) below.
+- Workspace gates from a clean checkout: `pnpm install && pnpm typecheck && pnpm lint && pnpm test` — 10 / 10 packages green. Verified 2026-05-04 in [`docs/research/2026-05-04-cold-checkout-verification.md`](docs/research/2026-05-04-cold-checkout-verification.md).
+- Codec independence: `pnpm lint:deps` enforces no cross-codec imports across 6 codec packages ([PR #126](https://github.com/p-to-q/wittgenstein/pull/126)).
+- Self-contained loupe HTML dashboard: ~ 117 KB, zero external CDN dependencies (run the [Quickstart](#quickstart-30-seconds-no-api-key) below, then `wc -c /tmp/ecg.html`).
 
 ---
 


### PR DESCRIPTION
Follow-up to PR #134 / Issue #106. The maintainer pair agreed offline that the 4-row + Demos compromise still left audit-flagged claims visible on the front page; this PR removes the Demos section entirely and trims Receipts to the **three rows that share one theme**: each is a byte-precise CI gate that came out of an audit-named gap.

## What changes vs #134

| Section | #134 (just merged) | This PR |
|---|---|---|
| Receipts rows | 4 (sensor goldens / codec independence / loupe HTML / workspace gates) | **3** (sensor parity / audio parity / training-data lock) |
| Demos section | Present (3 demoted hackathon-phase rows with "illustrative" label) | **Removed** |
| Diagnostic facts | mixed into Receipts | new **Engineering** subsection (workspace gates / codec-cruiser / loupe HTML) |

The hackathon-phase claims (BCE 0.7698, 5/5 spot checks, sub-2 ms sensor latency) are **deleted**, not demoted. Auditing them as "illustrative" still left audit-flagged numbers visible on the front page; deletion is honest.

## Why

Per the audit memo (#103) + my own #103 review answer to open-question 3: every Receipts row should be a byte-precise CI gate. Anything diagnostic goes elsewhere. Loupe HTML's ~117 KB is a real reproducible measurement but not a CI-gated parity check — so it lives under Engineering, not Receipts.

The three new Receipts rows directly answer specific audit findings:

| Audit finding | Closed by |
|---|---|
| "fixtures/golden/sensor empty" | sensor parity row → PR #125 |
| "audio M2 has no parity test" | audio parity row → PR #121 |
| "781 captions is not a reproducible selection" | training-data lock → PR #130 |

That alignment makes the table re-readable as "audit gaps that grew teeth."

## Validation

- `pnpm exec prettier --check README.md` → green
- `git diff --check` → clean
- All four PR cross-links resolve to merged PRs: #121, #125, #126, #130.

## Per ADR-0013

README.md is doctrine-bearing per §1; this is drift correction tightening the gap between what's claimed and what CI gates prove. **Cannot self-merge — needs an independent review pass from @Jah-yee or your second-reviewer call.**