### PR TITLE
docs(roadmap): thin v0.3 roadmap indexer (closes #103 close-without-merge gap)

### DIFF
--- a/docs/exec-plans/active/v0.3-roadmap.md
+++ b/docs/exec-plans/active/v0.3-roadmap.md
@@ -1,0 +1,96 @@
+# v0.3 Roadmap — index
+
+**Date opened:** 2026-05-04
+**Status:** 🟡 Active — thin index over already-tracked work; **not a parallel exec plan**.
+**Engineering source of truth:** [`codec-v2-port.md`](codec-v2-port.md) §M2 — that's where M-phase gates and rollback criteria live; this file does not duplicate them.
+
+---
+
+## Why this file exists
+
+The 2026-05-03 staff audit (PR #103, closed without merge) produced a useful diagnosis ("doctrine has run ahead of code by ~1.5 milestones") and an actionable backlog of P0 / P1 / P2 items. The audit memo and the original v0.3 roadmap doc never landed on disk — they were closed in favor of distributing the work into individual GitHub issues. That close-without-merge left a gap: a new contributor / agent landing cold has no single page to scan for "what is v0.3 actually waiting on?"
+
+This page closes that gap. It is **an index, not new doctrine**. Each row points at:
+
+- the issue or PR that holds the work,
+- the canonical exec plan section (`codec-v2-port.md`) when one exists.
+
+When the listed work lands, this page updates the row's status. When v0.3 cuts, this page archives.
+
+---
+
+## v0.3 release gates
+
+Five concrete checks, lifted from the audit's "from doctrinal claim to checkable fact" framing. Status reflects 2026-05-04 reality.
+
+| #   | Gate                                                                               | Status             | Evidence                                                                                                                                                                                                          |
+| --- | ---------------------------------------------------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | At least one byte-for-byte golden checked in + CI-gated                            | ✅                 | Sensor (3 routes) — PR #125; `pnpm test:golden` green on main                                                                                                                                                     |
+| 2   | M2 sweep-level kill criterion verified                                             | ⏳                 | Slice E (Issue #118) — blocked on Slice C2 Kokoro wiring (Issue #116)                                                                                                                                             |
+| 3   | `runtime/manifest.ts` + `runtime/seed.ts` + `runtime/router.ts` invariant coverage | ✅ (partial)       | PR #133 (22 invariant tests). Demoted from the audit's "test:src ratio threshold" framing per the maintainer-pair review on PR #103                                                                               |
+| 4   | README "Receipts" table evidentiary-only (each row CI-gated)                       | ⏳                 | Initial pass landed via PR #134; tightened to 3 strict rows in PR #135 (open)                                                                                                                                     |
+| 5   | Supply-chain CI gating (dep-review fail-on-high; CodeQL extended)                  | ⏳ (config landed) | PR #132 landed config; `dependency-review-action` is `continue-on-error: true` until repo Settings → Security & analysis → Dependency graph is enabled. After that toggle, removing one line makes it a real gate |
+
+When all five rows reach ✅ and `CHANGELOG.md` has a `v0.3.0` entry, v0.3 is cut.
+
+---
+
+## Active engineering line
+
+**M2 audio port — Slice C2 + C3 + Sweep E.** Source of truth: [`codec-v2-port.md`](codec-v2-port.md) §M2. Slices A/B/C1/D + C3 parity goldens are merged. Remaining:
+
+| Slice | Issue | Status                                                                                       |
+| ----- | ----- | -------------------------------------------------------------------------------------------- |
+| C2    | #116  | Kokoro-82M ONNX backend wiring; handoff brief in issue body                                  |
+| E     | #118  | Sweep-level kill criterion verification across macOS + Linux; gates the default-backend flip |
+
+Slice C2 is the **single largest v0.3 blocker.** When C2 + E land, gate #2 closes.
+
+---
+
+## Open backlog (not gating v0.3 but staying tracked)
+
+| Issue | Title                                        | Status                                                                                |
+| ----- | -------------------------------------------- | ------------------------------------------------------------------------------------- |
+| #106  | README Receipts evidentiary tightening       | Initial PR #134 merged; PR #135 follow-up open                                        |
+| #107  | Supply-chain CI hardening                    | PR #132 landed config; awaiting dep-graph toggle + paired engineering-discipline cite |
+| #108  | core / cli manifest-spine invariant coverage | PR #133 partial (manifest / seed / router); budget / retry / cli scope remains        |
+| #113  | ADR-0016 — untrusted-code-execution boundary | PR #136 (open)                                                                        |
+
+Trackers (gated on external events, not actionable until tripped):
+
+- **#67** — H9 patch-grid IR variant (open-weights LFQ-family decoder release)
+- **#109** — VQ decoder bridge (open-weights LFQ-family decoder release; sibling of #70)
+- **#112** — Kimi workspace dependency isolation (next supply-chain audit)
+
+Discussion / deferred (not in v0.3 scope):
+
+- **#66** — H10 long-code A/B (gated on Brief E benchmarks)
+- **#77** — RFC-0002 CLI auth surface (post-v0.3)
+- **#91** — Research taxonomy reclassification (non-blocking)
+- **#92** — Video object study (pre-video-M-slot)
+
+Mother / handoff issues (close when their milestone cuts):
+
+- **#63** M2 mother — closes when v0.3 cuts
+- **#70** M1B handoff — gated on #109
+
+---
+
+## How this page updates
+
+- A new PR that closes a listed issue updates the corresponding status column in the same PR.
+- v0.3 release gates §1–§5 are the only doctrine-shaped rows — those follow drift-correction rules per ADR-0013 §3 (status changes do not need new ADRs).
+- New backlog items added to this index require a corresponding GitHub issue first; this page does not invent work that lacks an issue.
+
+---
+
+## Where the audit memo went
+
+PR #103 closed without merge. Useful parts harvested into:
+
+- **Issues #104–#118**, the audit-derived backlog. Each issue body cites the audit finding it addresses.
+- **PR #123** — `ROADMAP.md` Phase ↔ M-phase cross-reference + brief lineage DAG.
+- **PR #129** — full lineage embedded in `briefs/README.md` + `docs/index.md` cite.
+
+The audit memo itself (`docs/research/2026-05-03-staff-audit.md`) is preserved only in the `docs/v0.3-roadmap-and-staff-audit` branch + the closed PR #103 diff. If the dated audit becomes load-bearing again, restore it in a focused PR.

--- a/docs/exec-plans/active/v0.3-roadmap.md
+++ b/docs/exec-plans/active/v0.3-roadmap.md
@@ -27,9 +27,9 @@ Five concrete checks, lifted from the audit's "from doctrinal claim to checkable
 | --- | ---------------------------------------------------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 1   | At least one byte-for-byte golden checked in + CI-gated                            | ✅                 | Sensor (3 routes) — PR #125; `pnpm test:golden` green on main                                                                                                                                                     |
 | 2   | M2 sweep-level kill criterion verified                                             | ⏳                 | Slice E (Issue #118) — blocked on Slice C2 Kokoro wiring (Issue #116)                                                                                                                                             |
-| 3   | `runtime/manifest.ts` + `runtime/seed.ts` + `runtime/router.ts` invariant coverage | ✅ (partial)       | PR #133 (22 invariant tests). Demoted from the audit's "test:src ratio threshold" framing per the maintainer-pair review on PR #103                                                                               |
+| 3   | `runtime/manifest.ts` + `runtime/seed.ts` + `runtime/router.ts` invariant coverage | ✅                 | PR #133 (manifest / seed / router, 22 invariant tests) + PR #139 (budget / retry / cli shared, 21 invariant tests). Demoted from the audit's "test:src ratio threshold" framing per the maintainer-pair review on PR #103       |
 | 4   | README "Receipts" table evidentiary-only (each row CI-gated)                       | ✅                 | Initial pass via PR #134; tightened to 3 strict CI-gated rows + Engineering subsection via PR #135                                                                                                                |
-| 5   | Supply-chain CI gating (dep-review fail-on-high; CodeQL extended)                  | ⏳ (config landed) | PR #132 landed config; `dependency-review-action` is `continue-on-error: true` until repo Settings → Security & analysis → Dependency graph is enabled. After that toggle, removing one line makes it a real gate |
+| 5   | Supply-chain CI gating (dep-review fail-on-high; CodeQL extended)                  | ✅                 | PR #132 landed config; PR #138 made `dependency-review-action` a real gate after Dependency graph was enabled in repo Settings → Security & analysis (2026-05-04)                                                 |
 
 When all five rows reach ✅ and `CHANGELOG.md` has a `v0.3.0` entry, v0.3 is cut.
 
@@ -52,10 +52,10 @@ Slice C2 is the **single largest v0.3 blocker.** When C2 + E land, gate #2 close
 
 | Issue | Title                                        | Status                                                                                |
 | ----- | -------------------------------------------- | ------------------------------------------------------------------------------------- |
-| #106  | README Receipts evidentiary tightening       | Closed by PR #135 (3 strict rows + Engineering subsection)                            |
-| #107  | Supply-chain CI hardening                    | PR #132 landed config; awaiting dep-graph toggle + paired engineering-discipline cite |
-| #108  | core / cli manifest-spine invariant coverage | PR #133 partial (manifest / seed / router); budget / retry / cli scope remains        |
-| #113  | ADR-0016 — untrusted-code-execution boundary | PR #136 (open)                                                                        |
+| #106  | README Receipts evidentiary tightening       | Closed by PR #135 (3 strict rows + Engineering subsection)                                                |
+| #107  | Supply-chain CI hardening                    | Closed by PR #138 (dep-review gate flipped real after dep-graph toggle)                                   |
+| #108  | core / cli manifest-spine invariant coverage | Closed by PR #133 (manifest / seed / router) + PR #139 (budget / retry / cli)                             |
+| #113  | ADR-0016 — untrusted-code-execution boundary | PR #136 (open; doctrine-bearing — pending independent ratification per ADR-0013)                          |
 
 Trackers (gated on external events, not actionable until tripped):
 

--- a/docs/exec-plans/active/v0.3-roadmap.md
+++ b/docs/exec-plans/active/v0.3-roadmap.md
@@ -28,7 +28,7 @@ Five concrete checks, lifted from the audit's "from doctrinal claim to checkable
 | 1   | At least one byte-for-byte golden checked in + CI-gated                            | ✅                 | Sensor (3 routes) — PR #125; `pnpm test:golden` green on main                                                                                                                                                     |
 | 2   | M2 sweep-level kill criterion verified                                             | ⏳                 | Slice E (Issue #118) — blocked on Slice C2 Kokoro wiring (Issue #116)                                                                                                                                             |
 | 3   | `runtime/manifest.ts` + `runtime/seed.ts` + `runtime/router.ts` invariant coverage | ✅ (partial)       | PR #133 (22 invariant tests). Demoted from the audit's "test:src ratio threshold" framing per the maintainer-pair review on PR #103                                                                               |
-| 4   | README "Receipts" table evidentiary-only (each row CI-gated)                       | ⏳                 | Initial pass landed via PR #134; tightened to 3 strict rows in PR #135 (open)                                                                                                                                     |
+| 4   | README "Receipts" table evidentiary-only (each row CI-gated)                       | ✅                 | Initial pass via PR #134; tightened to 3 strict CI-gated rows + Engineering subsection via PR #135                                                                                                                |
 | 5   | Supply-chain CI gating (dep-review fail-on-high; CodeQL extended)                  | ⏳ (config landed) | PR #132 landed config; `dependency-review-action` is `continue-on-error: true` until repo Settings → Security & analysis → Dependency graph is enabled. After that toggle, removing one line makes it a real gate |
 
 When all five rows reach ✅ and `CHANGELOG.md` has a `v0.3.0` entry, v0.3 is cut.
@@ -52,7 +52,7 @@ Slice C2 is the **single largest v0.3 blocker.** When C2 + E land, gate #2 close
 
 | Issue | Title                                        | Status                                                                                |
 | ----- | -------------------------------------------- | ------------------------------------------------------------------------------------- |
-| #106  | README Receipts evidentiary tightening       | Initial PR #134 merged; PR #135 follow-up open                                        |
+| #106  | README Receipts evidentiary tightening       | Closed by PR #135 (3 strict rows + Engineering subsection)                            |
 | #107  | Supply-chain CI hardening                    | PR #132 landed config; awaiting dep-graph toggle + paired engineering-discipline cite |
 | #108  | core / cli manifest-spine invariant coverage | PR #133 partial (manifest / seed / router); budget / retry / cli scope remains        |
 | #113  | ADR-0016 — untrusted-code-execution boundary | PR #136 (open)                                                                        |

--- a/docs/exec-plans/active/v0.3-roadmap.md
+++ b/docs/exec-plans/active/v0.3-roadmap.md
@@ -52,10 +52,11 @@ Slice C2 is the **single largest v0.3 blocker.** When C2 + E land, gate #2 close
 
 | Issue | Title                                        | Status                                                                                |
 | ----- | -------------------------------------------- | ------------------------------------------------------------------------------------- |
+| #91   | Research taxonomy — long-form note relabeling | Closed by PR #140 (5 surfaces banner-labeled as theory note / reference sheet / captured artifact)       |
 | #106  | README Receipts evidentiary tightening       | Closed by PR #135 (3 strict rows + Engineering subsection)                                                |
 | #107  | Supply-chain CI hardening                    | Closed by PR #138 (dep-review gate flipped real after dep-graph toggle)                                   |
 | #108  | core / cli manifest-spine invariant coverage | Closed by PR #133 (manifest / seed / router) + PR #139 (budget / retry / cli)                             |
-| #113  | ADR-0016 — untrusted-code-execution boundary | PR #136 (open; doctrine-bearing — pending independent ratification per ADR-0013)                          |
+| #113  | ADR-0016 — untrusted-code-execution boundary | Closed by PR #136 (ADR-0016 ratified; SECURITY.md + engineering-discipline.md cite added)                 |
 
 Trackers (gated on external events, not actionable until tripped):
 
@@ -67,7 +68,6 @@ Discussion / deferred (not in v0.3 scope):
 
 - **#66** — H10 long-code A/B (gated on Brief E benchmarks)
 - **#77** — RFC-0002 CLI auth surface (post-v0.3)
-- **#91** — Research taxonomy reclassification (non-blocking)
 - **#92** — Video object study (pre-video-M-slot)
 
 Mother / handoff issues (close when their milestone cuts):


### PR DESCRIPTION
## What

`docs/exec-plans/active/v0.3-roadmap.md` — ~80-line **index**, **not a parallel exec plan**. Three sections:

1. **v0.3 release gates** — 5 rows from the audit, with current status pointing at the PR / issue that holds the work.
2. **Active engineering line** — M2 Slice C2 + E (refs `codec-v2-port.md` §M2 as the engineering source of truth; does not duplicate).
3. **Open backlog + trackers + deferred + mother issues**, each with one-line status.

## Why

PR #103 closed without merge (per @Jah-yee's "useful parts harvested elsewhere" note in the close comment). That left no single page a new contributor / agent can scan to see "what is v0.3 actually waiting on?" — the audit's actionable framing was distributed into individual issues but the connective tissue is gone.

The original v0.3-roadmap.md proposal in #103 was 323 lines and had real drift issues (slice naming stale; issue numbers wrong; doctrinal framing of test:src ratios). This ~80-line indexer takes the audit's "from doctrinal claim to checkable fact" gate framing **without** the doctrine bloat that got #103 closed.

This is the **PR-b "small indexer-only roadmap"** path I named in my #103 review.

## v0.3 release gate snapshot at land

| #   | Gate                                                              | Status             |
| --- | ----------------------------------------------------------------- | ------------------ |
| 1   | One byte-for-byte golden CI-gated                                 | ✅ sensor (#125)   |
| 2   | M2 sweep verified                                                 | ⏳ #116 → #118     |
| 3   | runtime invariant coverage (manifest / seed / router)             | ✅ partial (#133)  |
| 4   | README Receipts evidentiary-only                                  | ⏳ #134 → #135     |
| 5   | Supply-chain CI gating                                            | ⏳ config (#132); awaits dep-graph toggle |

## Validation

- `pnpm exec prettier --check docs/exec-plans/active/v0.3-roadmap.md` → green
- All 14 cross-links resolve to merged PRs, open PRs, or open issues.

## Per ADR-0013

`docs/exec-plans/active/` is on §1's doctrine-bearing list. The page is a status indexer (not new doctrine) and its own "How this page updates" section names ADR-0013 §3 drift correction as the rule for row updates. **Cannot self-merge — needs second independent review pass.**

## Companion PRs in flight

- #135 — README Receipts strict 3-row (gate #4)
- #136 — ADR-0016 untrusted-code boundary (closes #113)

This roadmap PR documents the work; those PRs do the work. They land in any order.