### PR TITLE
chore(ci): make dep-review gating (closes #107)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,21 +191,13 @@ jobs:
         uses: reviewdog/action-actionlint@v1
 
       - name: Dependency review (PR)
-        # Configures dependency-review for HIGH-or-CRITICAL severity gating
-        # and GPL-3.0 / AGPL-3.0 license denial (Apache-2.0 incompatibility
-        # per the audit memo § supply-chain). Existing tree is not re-scanned;
-        # only NEW deps introduced by a PR are checked.
-        #
-        # `continue-on-error: true` is kept for now because the action
-        # requires GitHub's Dependency graph to be enabled in
-        # Settings → Security & analysis. Until a maintainer flips that
-        # toggle, the action returns "Dependency review is not supported
-        # on this repository" and we don't want that to block merge.
-        # Once dep-graph is enabled, REMOVE this line to make the gate real.
-        # Tracking: Issue #107.
+        # Real gate: any PR introducing a HIGH or CRITICAL severity
+        # advisory, or a GPL-3.0 / AGPL-3.0 dependency (Apache-2.0
+        # incompatible) is rejected. Only NEW deps introduced by the PR
+        # are checked — the existing pnpm-lock is not re-scanned.
+        # Closes the last bullet of Issue #107.
         if: github.event_name == 'pull_request'
         uses: actions/dependency-review-action@v4
-        continue-on-error: true
         with:
           fail-on-severity: high
           deny-licenses: GPL-3.0, AGPL-3.0


### PR DESCRIPTION
Removes \`continue-on-error: true\` from the dependency-review step that PR #132 left in place. Final close-out for #107 (gate ⑤).

## Why

Prior CI run on PR #132 (with \`continue-on-error\` removed) failed with "Dependency review is not supported on this repository. Please ensure that Dependency graph is enabled." This was the trigger for masking the step. \`p-to-q/wittgenstein\` is a public repo, so GitHub's Dependency graph is enabled by default — the prior failure may have been a transient action / runner issue, or the repo Settings have since been confirmed.

## Validation strategy

Push this PR and let CI run. **Two outcomes:**
- ✅ Dep-review passes → gate is real, merge → #107 closes.
- ❌ Dep-review fails again with "not supported" → flip Settings → Security & analysis → Dependency graph in the repo (admin), do NOT re-add \`continue-on-error\`, then re-run.

The point is that \`continue-on-error: true\` is a permanent mask that defeats the gate. Removing it forces the real status to surface.

## Per ADR-0013

`.github/workflows/ci.yml` is CI infrastructure, not on §1's doctrine-bearing list. Engineering.