### PR TITLE
test(core, cli): budget + retry + shared invariant coverage (#108 deeper)

### DIFF
--- a/packages/cli/test/shared.test.ts
+++ b/packages/cli/test/shared.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { parseOptionalSeed, resolveExecutionRoot } from "../src/commands/shared.js";
+
+describe("parseOptionalSeed", () => {
+  it("returns undefined when no seed is provided (caller should fall through to default)", () => {
+    expect(parseOptionalSeed(undefined)).toBeUndefined();
+  });
+
+  it("parses '0' as the integer zero (NOT a missing value)", () => {
+    expect(parseOptionalSeed("0")).toBe(0);
+  });
+
+  it("parses positive integers", () => {
+    expect(parseOptionalSeed("7")).toBe(7);
+    expect(parseOptionalSeed("42")).toBe(42);
+  });
+
+  it("parses leading-numeric strings as the parseInt prefix", () => {
+    // parseInt("123abc", 10) → 123 — not ideal but the documented behavior
+    // of the existing implementation. If the contract changes (e.g. reject
+    // garbage), update this test alongside the change.
+    expect(parseOptionalSeed("123abc")).toBe(123);
+  });
+
+  it("returns NaN for non-numeric strings (not undefined; the caller can detect)", () => {
+    // The function returns undefined ONLY for undefined input. A bad seed
+    // string surfaces as NaN so the caller can choose to error rather
+    // than silently resolve to the default.
+    const result = parseOptionalSeed("not-a-number");
+    expect(Number.isNaN(result)).toBe(true);
+  });
+});
+
+describe("resolveExecutionRoot", () => {
+  it("walks up to the workspace root containing pnpm-workspace.yaml", () => {
+    // Vitest runs with cwd = the package's own dir (packages/cli) when
+    // invoked via `pnpm --filter`. The function should walk up to the
+    // monorepo root, where pnpm-workspace.yaml lives.
+    const root = resolveExecutionRoot();
+    expect(root.endsWith("/wittgenstein") || root.endsWith("\\wittgenstein")).toBe(true);
+  });
+
+  it("returns an absolute path", () => {
+    const root = resolveExecutionRoot();
+    // POSIX absolute or Windows drive prefix
+    expect(/^([A-Z]:|\/)/.test(root)).toBe(true);
+  });
+});

--- a/packages/core/test/budget.test.ts
+++ b/packages/core/test/budget.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { BudgetTracker } from "../src/runtime/budget.js";
+import { BudgetExceededError } from "../src/runtime/errors.js";
+
+const limits = { maxTokens: 100, maxCostUsd: 1.0 };
+
+describe("BudgetTracker.consume", () => {
+  it("returns the running snapshot when within limits", () => {
+    const tracker = new BudgetTracker(limits);
+    const snap = tracker.consume(40, 0.4);
+    expect(snap).toEqual({ tokens: 40, costUsd: 0.4 });
+  });
+
+  it("accumulates across consume calls", () => {
+    const tracker = new BudgetTracker(limits);
+    tracker.consume(30, 0.3);
+    const snap = tracker.consume(20, 0.2);
+    expect(snap).toEqual({ tokens: 50, costUsd: 0.5 });
+  });
+
+  it("throws BudgetExceededError when token total exceeds the limit", () => {
+    const tracker = new BudgetTracker(limits);
+    tracker.consume(80, 0);
+    expect(() => tracker.consume(30, 0)).toThrow(BudgetExceededError);
+  });
+
+  it("throws BudgetExceededError when cost total exceeds the limit", () => {
+    const tracker = new BudgetTracker(limits);
+    tracker.consume(0, 0.8);
+    expect(() => tracker.consume(0, 0.3)).toThrow(BudgetExceededError);
+  });
+
+  it("counts the budget-exceeding consume against the totals (snapshot must reflect what was charged)", () => {
+    // Consuming past the limit must NOT silently roll back the totals.
+    // The throw is the signal; the running totals are evidence.
+    const tracker = new BudgetTracker(limits);
+    tracker.consume(50, 0);
+    try {
+      tracker.consume(60, 0);
+    } catch {
+      // expected
+    }
+    expect(tracker.snapshot()).toEqual({ tokens: 110, costUsd: 0 });
+  });
+
+  it("treats consuming exactly at the limit as within budget (boundary == ok)", () => {
+    const tracker = new BudgetTracker(limits);
+    expect(() => tracker.consume(100, 1.0)).not.toThrow();
+  });
+
+  it("treats consuming one unit past the limit as over budget", () => {
+    const tracker = new BudgetTracker(limits);
+    expect(() => tracker.consume(101, 0)).toThrow(BudgetExceededError);
+  });
+});
+
+describe("BudgetTracker.snapshot", () => {
+  it("starts at zero before any consume", () => {
+    const tracker = new BudgetTracker(limits);
+    expect(tracker.snapshot()).toEqual({ tokens: 0, costUsd: 0 });
+  });
+
+  it("does not mutate the limits object after construction", () => {
+    const localLimits = { maxTokens: 50, maxCostUsd: 0.5 };
+    const tracker = new BudgetTracker(localLimits);
+    tracker.consume(10, 0.1);
+    expect(localLimits).toEqual({ maxTokens: 50, maxCostUsd: 0.5 });
+  });
+});

--- a/packages/core/test/retry.test.ts
+++ b/packages/core/test/retry.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from "vitest";
+import { retryWithPolicy } from "../src/runtime/retry.js";
+
+describe("retryWithPolicy", () => {
+  it("returns the task result when the first attempt succeeds (no retries)", async () => {
+    const task = vi.fn().mockResolvedValue("ok");
+    const result = await retryWithPolicy(task, { maxAttempts: 3, backoffMs: 0 });
+    expect(result).toBe("ok");
+    expect(task).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries until success and returns the eventual result", async () => {
+    let attempts = 0;
+    const task = vi.fn(async () => {
+      attempts += 1;
+      if (attempts < 3) {
+        throw new Error(`fail ${attempts}`);
+      }
+      return "third-time-lucky";
+    });
+
+    const result = await retryWithPolicy(task, { maxAttempts: 5, backoffMs: 0 });
+    expect(result).toBe("third-time-lucky");
+    expect(task).toHaveBeenCalledTimes(3);
+  });
+
+  it("passes the attempt number into the task", async () => {
+    const seen: number[] = [];
+    const task = vi.fn(async (attempt: number) => {
+      seen.push(attempt);
+      if (attempt < 3) {
+        throw new Error("retry");
+      }
+      return attempt;
+    });
+
+    await retryWithPolicy(task, { maxAttempts: 5, backoffMs: 0 });
+    expect(seen).toEqual([1, 2, 3]);
+  });
+
+  it("throws the last error when maxAttempts is exhausted", async () => {
+    let count = 0;
+    const task = vi.fn(async () => {
+      count += 1;
+      throw new Error(`fail-${count}`);
+    });
+
+    await expect(retryWithPolicy(task, { maxAttempts: 3, backoffMs: 0 })).rejects.toThrow("fail-3");
+    expect(task).toHaveBeenCalledTimes(3);
+  });
+
+  it("stops retrying immediately when shouldRetry returns false", async () => {
+    const task = vi.fn(async () => {
+      throw new Error("non-retryable");
+    });
+    const shouldRetry = vi.fn(() => false);
+
+    await expect(
+      retryWithPolicy(task, { maxAttempts: 5, backoffMs: 0 }, shouldRetry),
+    ).rejects.toThrow("non-retryable");
+    expect(task).toHaveBeenCalledTimes(1);
+    expect(shouldRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("scales backoff linearly with attempt number", async () => {
+    // Verify that backoff is `policy.backoffMs * attempt`. Use vi fake timers
+    // so the test is deterministic and the assertion does not depend on
+    // wall-clock variance.
+    vi.useFakeTimers();
+    try {
+      let attempts = 0;
+      const task = vi.fn(async () => {
+        attempts += 1;
+        if (attempts < 3) {
+          throw new Error("retry");
+        }
+        return "done";
+      });
+
+      const promise = retryWithPolicy(task, { maxAttempts: 5, backoffMs: 100 });
+
+      // Drive the event loop forward: first failure → backoff = 100 ms
+      await vi.advanceTimersByTimeAsync(100);
+      // Second failure → backoff = 200 ms
+      await vi.advanceTimersByTimeAsync(200);
+
+      const result = await promise;
+      expect(result).toBe("done");
+      expect(task).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not call shouldRetry on the final attempt (after the throw)", async () => {
+    // On attempt === maxAttempts, the function throws without consulting
+    // shouldRetry. Verifies the early-return short-circuit.
+    const task = vi.fn(async () => {
+      throw new Error("always fail");
+    });
+    const shouldRetry = vi.fn(() => true);
+
+    await expect(
+      retryWithPolicy(task, { maxAttempts: 2, backoffMs: 0 }, shouldRetry),
+    ).rejects.toThrow();
+    // shouldRetry called once (after attempt 1), not after attempt 2.
+    expect(shouldRetry).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Continues #108 with the runtime files PR #133 left out: \`budget.ts\`, \`retry.ts\`, and the \`cli/commands/shared.ts\` utilities.

## What

23 new tests over three files.

- **\`runtime/budget.ts\`** (9 tests): \`consume\` returns running snapshot; accumulation; token-budget exceeded throws \`BudgetExceededError\`; cost-budget exceeded throws same; over-limit consume still mutates totals (signal is the throw, **not silent rollback**); boundary cases (exactly-at-limit OK; one-past-limit throws); zero-state snapshot; limits object not mutated.
- **\`runtime/retry.ts\`** (7 tests): first-attempt success → no retries; retries until success; attempt counter monotonic; maxAttempts exhausted → throws lastError; \`shouldRetry === false\` → stops immediately; backoff scales linearly with attempt (verified with vi fake timers); shouldRetry not consulted on the final attempt.
- **\`cli/commands/shared.ts\`** (7 tests): \`parseOptionalSeed\` honours undefined / 0 / positive ints / leading-numeric strings / NaN fallback; \`resolveExecutionRoot\` walks up to monorepo root + returns absolute path.

## Why

Per PR #103 review + v0.3 roadmap indexer (PR #137), manifest-spine invariant coverage is gate ③ for v0.3. PR #133 closed manifest.ts / seed.ts / router.ts; this PR closes budget.ts / retry.ts / cli/shared.

## Test counts

- \`packages/core\`: **27 → 43** tests (+16)
- \`packages/cli\`: **2 → 9** tests (+7)

## Validation

- \`pnpm --filter @wittgenstein/core test\` → 43 / 43 green
- \`pnpm --filter @wittgenstein/cli test\` → 9 / 9 green
- \`pnpm typecheck\` → green workspace-wide
- lint + prettier → green

## Per ADR-0013

Tests under \`packages/*/test/\` are not on §1's doctrine-bearing list. Engineering.

#108 stays open until each cli command has at least a smoke arg-parsing test. Separate PR per "smallest effective change."