### PR TITLE
docs(research): add role banners to long-form notes (closes #91)

### DIFF
--- a/docs/research/compression-view-of-llms.md
+++ b/docs/research/compression-view-of-llms.md
@@ -1,5 +1,9 @@
 # Compression View of LLMs
 
+> **Status:** Theory note (background reading; not active execution guidance, not ratified doctrine).
+> Cited from briefs (e.g. Brief A — VQ/VLM lineage) that route ratifying decisions through `Brief → RFC → ADR`. Do not promote prose from this page directly into operating docs; new doctrine derived here must follow the lane (ADR-0014 §2).
+> _Tracker: #91 (research taxonomy reclassification pass)._
+
 ## Core Argument
 
 Language models are implicit neural compressors. Wittgenstein is architected around this fact: the LLM compresses intent into a compact symbolic IR, and the codec expands that IR into a real file. This is not a metaphor — it is an architectural decision with measurable cost consequences.

--- a/docs/research/frozen-llm-multimodality.md
+++ b/docs/research/frozen-llm-multimodality.md
@@ -1,5 +1,9 @@
 # Frozen LLM Multimodality
 
+> **Status:** Theory note (background reading; not active execution guidance, not ratified doctrine).
+> Cited from briefs (e.g. Brief G — image-network clues) that route ratifying decisions through `Brief → RFC → ADR`. Do not promote prose from this page directly into operating docs; new doctrine derived here must follow the lane (ADR-0014 §2).
+> _Tracker: #91 (research taxonomy reclassification pass)._
+
 ## Core Argument
 
 A frozen text LLM paired with modality-specific codecs and small adapter heads is a better architecture for Wittgenstein's use case than an end-to-end trained multimodal giant. This is not a resource constraint — it is a principled design choice with implications for cost, reproducibility, debuggability, and modularity.

--- a/docs/research/neural-codec-references.md
+++ b/docs/research/neural-codec-references.md
@@ -1,5 +1,9 @@
 # Neural Codec References
 
+> **Status:** Reference sheet (annotated bibliography; not active execution guidance, not ratified doctrine).
+> Use to look up papers cited from briefs / ADRs (e.g. Brief A — VQ/VLM lineage; ADR-0005). Do not treat any single citation here as load-bearing on its own; new doctrine still routes through `Brief → RFC → ADR` (ADR-0014 §2).
+> _Tracker: #91 (research taxonomy reclassification pass)._
+
 Annotated reference sheet for the image path's theoretical foundation. Organized by theme in the order the ideas build on each other.
 
 ---

--- a/docs/research/vq-tokens-as-interface.md
+++ b/docs/research/vq-tokens-as-interface.md
@@ -1,5 +1,9 @@
 # VQ Tokens as the LLM–Decoder Interface
 
+> **Status:** Theory note (background reading; not active execution guidance, not ratified doctrine).
+> Cited from briefs (e.g. Brief A — VQ/VLM lineage) and ADR-0005 (decoder-not-generator). Ratifying decisions route through `Brief → RFC → ADR`; do not promote prose from this page directly into operating docs (ADR-0014 §2).
+> _Tracker: #91 (research taxonomy reclassification pass)._
+
 ## The Interface Problem
 
 When a text LLM is asked to produce an image, something has to cross the boundary between

--- a/docs/research/www.aquin.app/README.md
+++ b/docs/research/www.aquin.app/README.md
@@ -1,5 +1,9 @@
 # www.aquin.app — clone bootstrap
 
+> **Status:** Captured research artifact (site-clone snapshot; evidence preserved as-is, not active execution guidance, not ratified doctrine).
+> Captured via the `site-clone` skill on the date below. Re-running the capture replaces these files; treat them as a frozen snapshot rather than a live source.
+> _Tracker: #91 (research taxonomy reclassification pass)._
+
 ## Last capture
 
 - **URL:** [https://www.aquin.app/](https://www.aquin.app/)


### PR DESCRIPTION
Closes #91.

## What

Per Issue #91 ("research taxonomy reclassification") done criteria — give the five listed surfaces explicit role labels so a new contributor / agent does not mistake background theory for active execution guidance or ratified doctrine.

Per-file decision (pinned in the banner of each file):

| File | Role |
| --- | --- |
| `docs/research/compression-view-of-llms.md` | Theory note (cited from Brief A) |
| `docs/research/frozen-llm-multimodality.md` | Theory note (cited from Brief G) |
| `docs/research/vq-tokens-as-interface.md` | Theory note (cited from Brief A + ADR-0005) |
| `docs/research/neural-codec-references.md` | Reference sheet (annotated bibliography) |
| `docs/research/www.aquin.app/README.md` | Captured research artifact (site-clone snapshot) |

Each banner restates: **not active execution guidance, not ratified doctrine, new doctrine derived here must route through `Brief → RFC → ADR`** (ADR-0014 §2).

## Why

`docs/research/program.md` "What is not closed before M2" already names "Long-form theory notes — Need clearer labels over time, but are not active execution guidance." This PR closes that small gap by labeling the surfaces in-place. Aligned with `docs/index.md` "Long-form research notes (predate the briefs)" classification.

## Out of scope

Per #91 non-goals:

- Did **not** rewrite the substance of any note.
- Did **not** promote any note to doctrine (no Brief / RFC / ADR derived in this PR).
- Did **not** archive anything.
- Did **not** create a new research-taxonomy layer.

If any note later becomes load-bearing for a new RFC/ADR, the promotion-worthy finding splits into its own follow-up per #91 boundaries.

## Per ADR-0013

`docs/research/` is **not** on ADR-0013 §1's doctrine-bearing list. Banners are explicit non-promotion (each banner says "not ratified doctrine"). Self-mergeable.

## Validation

- `pnpm exec prettier --check docs/research/{compression-view-of-llms,frozen-llm-multimodality,vq-tokens-as-interface,neural-codec-references,www.aquin.app/README}.md` → green
- `git diff --check` → clean
- 5 files, +20 lines, zero substance changes