### PR TITLE
docs(research): add v0.3 stage closeout + next-phase sync note

### DIFF
--- a/docs/research/2026-05-05-v0.3-stage-closeout-and-next-phase.md
+++ b/docs/research/2026-05-05-v0.3-stage-closeout-and-next-phase.md
@@ -1,0 +1,185 @@
+# v0.3 stage closeout and next-phase launch
+
+**Date:** 2026-05-05  
+**Status:** Active sync note for maintainers. Not a brief, RFC, ADR, or exec-plan.
+
+This note closes the "what still matters before we start the next real slice?" gap after the WORKFLOW / ADR-0017 landing and the follow-up hygiene work on 2026-05-04 to 2026-05-05.
+
+It does three things:
+
+1. records what is now actually true on `main`,
+2. separates "ready to execute now" from "worth keeping open but not now",
+3. provides one updated maintainer-agent prompt for the next dispatch.
+
+The engineering source of truth for audio remains [`docs/exec-plans/active/codec-v2-port.md`](../exec-plans/active/codec-v2-port.md) §M2. This note does not replace it.
+
+---
+
+## 1. What this stage closes
+
+As of 2026-05-05, the repo has already absorbed the high-leverage pre-M2 hygiene work that was worth doing before the next implementation slice:
+
+- byte-for-byte goldens are on disk and CI-gated for sensor and audio parity surfaces,
+- cold-checkout verification was rerun and the CLI entrypoint no-op bug was fixed,
+- codec package boundary checking is live in CI,
+- `WORKFLOW.md` + ADR-0017 landed, so the orchestration contract is now explicit,
+- the Kokoro Slice C2 handoff brief lives on `main` under [`docs/handoff/m2-slice-c2-kokoro.md`](../handoff/m2-slice-c2-kokoro.md).
+
+The result: there is no longer a missing-context excuse for delaying M2 backend work.
+
+---
+
+## 2. What is true on `main` right now
+
+### v0.3 gates
+
+Per [`docs/exec-plans/active/v0.3-roadmap.md`](../exec-plans/active/v0.3-roadmap.md), **4 of the 5 v0.3 gates are already green**:
+
+1. byte-for-byte golden surface — ✅
+2. M2 sweep-level kill criterion verified — ⏳ blocked on `#116` then `#118`
+3. manifest / seed / router invariant coverage — ✅
+4. README receipts evidentiary purity — ✅
+5. supply-chain CI gating — ✅
+
+So the remaining release-critical engineering line is narrow: **finish audio C2, then run audio sweep E**.
+
+### Open PR queue
+
+Only one open PR remains:
+
+- **#152** `docs(briefs): add Brief L — sensor codec landscape (chaos / TimesFM / metrics)`
+  - checks green,
+  - not an M2 blocker,
+  - doctrine-bearing because it lands a research brief,
+  - should merge only after an **independent content review** per ADR-0013.
+
+### Re-check of merged PRs #142 / #143 / #144
+
+These were re-audited after merge:
+
+- **#142** (`actions/checkout` v4 -> v6 in `link-check.yml`) is a routine workflow dependency bump with no repo-local semantic change.
+- **#143** (`postcss` patch bump) is a low-risk dependency refresh; the diff is almost entirely lockfile churn and the checks were green.
+- **#144** (`globals` major bump in `apps/wittgenstein-kimi`) is isolated to the Kimi app surface and passed CI. It does not block M2.
+
+No rollback or follow-up issue is warranted from those three merges.
+
+---
+
+## 3. Issue triage before the next phase
+
+### Ready to execute now
+
+- **#116** — M2 backend wiring. This is the next implementation slice. The issue is now fully pick-up-able cold because the handoff brief is on `main`.
+- **#118** — M2 sweep verification. This follows immediately after `#116`; do not start it first.
+
+### Useful, but only after `#116` / `#118`
+
+- **#151** — rerun cold-checkout before the v0.3 tag. Valuable release receipt, but not needed before Kokoro wiring exists.
+- **#149** — release notes draft + `CHANGELOG` entry. End-of-cycle work, not pre-C2 work.
+
+### Keep open, but do not spend this sprint here
+
+- **#150** — WORKFLOW consumption audit tracker. Let at least one real engineering slice (`#116`) run through the workflow contract first.
+- **#153 / #154 / #155** — sensor v0.4+ / horizon work from Brief L; correct to track, wrong to prioritize now.
+- **#109 / #67** — external-event trackers.
+- **#66 / #92 / #70 / #77** — valid but not v0.3-critical.
+- **#63** — mother issue; closes when the v0.3 audio line closes, not before.
+
+### New issues
+
+None are required right now. The queue is already sufficient for the next stage.
+
+---
+
+## 4. Branch and merge guidance
+
+- **Mergeable now:** `docs/handoff-m2-slice-c2-kokoro` already merged as PR #148.
+- **Needs independent review before merge:** `docs/brief-l-sensor-codec-landscape` / PR #152.
+- **Local hygiene only:** old merged local branches such as `codex/cold-checkout-verification` and `codex/fix-cli-entrypoint` can be deleted opportunistically; they are not blocking anything.
+
+---
+
+## 5. Recommended next-phase order
+
+1. Implement **#116** from [`docs/handoff/m2-slice-c2-kokoro.md`](../handoff/m2-slice-c2-kokoro.md).
+2. Run **#118** sweep verification across the target matrix.
+3. If sweep passes, prepare **#151** and **#149** as the release-closeout pair.
+4. Keep #152 moving in parallel through maintainer review; it is not on the audio critical path.
+
+This order is deliberately small. v0.3 does not need another round of repo-wide hygiene before M2 resumes.
+
+---
+
+## 6. Maintainer-agent prompt (updated, 2026-05-05)
+
+Use this as the cold-start prompt for a maintainer-facing agent joining the repo at this stage:
+
+> You are joining the Wittgenstein project ([https://github.com/p-to-q/wittgenstein](https://github.com/p-to-q/wittgenstein)).  
+> This is a TypeScript monorepo with a small Python surface: a harness-first multimodal system for text-first LLMs.  
+> Reproducibility is load-bearing: every artifact must replay from a manifest, and failures still preserve receipts.
+>
+> ## Where the project is right now (2026-05-05)
+>
+> `v0.2.0-alpha.2` has shipped. `v0.3` is in flight. The release-gate picture is:
+>
+> - ✅ byte-for-byte goldens are CI-gated
+> - ⏳ M2 audio sweep kill criterion remains open (`#116` then `#118`)
+> - ✅ manifest / seed / router invariant coverage is landed
+> - ✅ README receipts are evidentiary-only
+> - ✅ supply-chain CI gating is landed
+>
+> So the next engineering line is narrow: finish M2 audio backend wiring, then verify the sweep.
+>
+> ## Read these and stop
+>
+> 1. `AGENTS.md`
+> 2. `WORKFLOW.md`
+> 3. `docs/engineering-discipline.md`
+> 4. The handoff brief that matches your assigned issue:
+>    - `#116` -> `docs/handoff/m2-slice-c2-kokoro.md`
+>    - otherwise -> if `docs/handoff/<slice>.md` exists, read it; if not, use the issue body
+>
+> If you drift outside this list at first contact, stop and re-anchor.
+>
+> ## Doctrine you cannot violate
+>
+> - Manifest spine is non-negotiable: git SHA, lockfile hash, seed, artifact SHA-256, and failure receipts stay recorded.
+> - Two decision lanes are locked (ADR-0014):
+>   - Engineering: Brief -> RFC -> ADR -> exec-plan -> code
+>   - Governance: (Governance Note ->) ADR -> inline summary
+> - Independent ratification for doctrine-bearing PRs is locked by ADR-0013.
+> - Locked vocabulary is Harness / Codec / Spec / IR / Decoder / Adapter / Packaging (ADR-0011).
+> - `WORKFLOW.md` excluded labels are real: do not auto-dispatch `tracker`, `discussion`, `horizon-spike`, or `blocked`.
+>
+> ## Priority order
+>
+> 1. **Issue #116** — wire the Kokoro backend exactly as the handoff brief specifies.
+> 2. **Issue #118** — run the sweep verification only after `#116` lands.
+> 3. **Issue #151** and **#149** — release-closeout work after the sweep.
+> 4. Keep **PR #152** separate; it is a research-brief review task, not part of the audio critical path.
+>
+> ## What you are not allowed to do
+>
+> - Do not flip the default audio backend in `#116`; sweep verification owns that gate.
+> - Do not silently fall back from Kokoro to procedural if Kokoro fails.
+> - Do not reshape the `audioRender` manifest schema.
+> - Do not add doctrine to `AGENTS.md`, `WORKFLOW.md`, `README.md`, or `docs/engineering-discipline.md` without a paired ADR.
+> - Do not reopen already-ratified decoder-family arguments from Brief I / ADR-0015 unless you have a new doctrine-track artifact.
+>
+> ## Reporting
+>
+> Follow `docs/engineering-discipline.md` §Reporting: what / why / validation / remaining risk, in under 150 words.
+>
+> You are done when the assigned slice is actually done, not when you have a nice theory about it.
+
+---
+
+## 7. Recommendation to the maintainer pair
+
+Treat this note as the stage-closeout receipt:
+
+- the repo is clear enough to resume implementation,
+- the only live engineering blocker is `#116`,
+- the only open PR needing independent content review is `#152`.
+
+That is enough clarity to move from preflight / hygiene back into execution.


### PR DESCRIPTION
## Summary
- add a dated maintainer sync note for the 2026-05-05 stage closeout
- record what is now true on main after WORKFLOW / ADR-0017 and the pre-M2 hygiene pass
- separate immediate M2 work from later release and horizon work, and include an updated maintainer-agent prompt

## Why
We had enough drift between chat context, open issues, and the actual state of main that the next maintainer or agent would otherwise have to reconstruct the picture by hand. This note is a receipt and a launchpad, not new doctrine.

## Validation
- `pnpm exec prettier --check docs/research/2026-05-05-v0.3-stage-closeout-and-next-phase.md`
- `git diff --check`

## Scope
Non-doctrine sync note only. No change to exec-plan, ADRs, or workflow contract.
