### PR TITLE
feat(audio): wire Kokoro-82M backend (M2 Slice C2, closes #116)

### DIFF
--- a/docs/codecs/audio.md
+++ b/docs/codecs/audio.md
@@ -4,6 +4,8 @@ Audio is the second-priority modality after image. It ships three internal route
 
 `LLM -> structured AudioPlan JSON -> per-route render -> WAV bytes -> manifest`
 
+> **Implementation status (v0.3 in flight, 2026-05-05).** The doctrine below — Kokoro-82M-family default for speech, Piper-family fallback, byte-parity on the pinned CPU backend — is the **ratified target** (ADR-0015). Code-wise, the speech route currently ships `procedural-audio-runtime` as the **default** decoder; **Kokoro-82M is opt-in** via `WITTGENSTEIN_AUDIO_BACKEND=kokoro` (M2 Slice C2, Issue #116). The default flip from procedural to Kokoro is gated on Slice E (#118) cross-platform determinism verification. Until Slice E lands, `audioRender.decoderId` in the manifest is the source of truth for which backend actually ran on a given run; the doctrine and the code converge at the v0.3 cut, not before.
+
 ## Position
 
 Audio is a _layered_ modality, not a single decoder. Each route picks its own L3:

--- a/packages/codec-audio/package.json
+++ b/packages/codec-audio/package.json
@@ -15,8 +15,10 @@
     "build": "tsc"
   },
   "dependencies": {
+    "@huggingface/transformers": "3.8.1",
     "@wittgenstein/schemas": "workspace:*",
     "kokoro-js": "1.2.1",
+    "undici": "^7.0.0",
     "zod": "^3.23.8"
   }
 }

--- a/packages/codec-audio/package.json
+++ b/packages/codec-audio/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@wittgenstein/schemas": "workspace:*",
+    "kokoro-js": "1.2.1",
     "zod": "^3.23.8"
   }
 }

--- a/packages/codec-audio/src/codec.ts
+++ b/packages/codec-audio/src/codec.ts
@@ -14,6 +14,7 @@ import { renderSoundscapeRoute } from "./routes/soundscape/index.js";
 import { renderMusicRoute } from "./routes/music/index.js";
 import type { AudioArtifact, AudioRoute } from "./types.js";
 import { AUDIO_SAMPLE_RATE } from "./runtime.js";
+import { getKokoroDecoder } from "./decoders/kokoro/index.js";
 
 interface AudioCodecLlmService {
   readonly provider: string;
@@ -105,10 +106,14 @@ function hashBytes(value: Uint8Array): string {
   return createHash("sha256").update(value).digest("hex");
 }
 
-function wavDurationSec(bytes: Uint8Array): number {
+function wavDurationSec(bytes: Uint8Array, sampleRateHz: number): number {
   const pcm16BytesPerFrame = 2;
   const dataBytes = Math.max(0, bytes.byteLength - 44);
-  return dataBytes / (AUDIO_SAMPLE_RATE * pcm16BytesPerFrame);
+  return dataBytes / (sampleRateHz * pcm16BytesPerFrame);
+}
+
+function isKokoroBackendRequested(): boolean {
+  return process.env.WITTGENSTEIN_AUDIO_BACKEND === "kokoro";
 }
 
 function asServices(services: codecV2.HarnessCtx["services"]): AudioCodecServices {
@@ -285,28 +290,70 @@ export class AudioCodec extends codecV2.BaseCodec<AudioRequest, AudioArtifact> {
     const payload = asAudioPlanPayload(ir);
     const startedAt = ctx.clock.now();
     const renderCtx = this.createRenderCtx(ctx);
-    const result =
-      payload.plan.route === "speech"
-        ? await renderSpeechRoute(payload.plan, renderCtx, { allowHostTts: false })
-        : payload.plan.route === "soundscape"
-          ? await renderSoundscapeRoute(payload.plan, renderCtx)
-          : await renderMusicRoute(payload.plan, renderCtx);
-    const bytes = await readFile(result.artifactPath);
     const route = payload.plan.route;
-    const decoderHash = hashString("procedural-audio-runtime");
+
+    const kokoroRequested = isKokoroBackendRequested();
+    const kokoroEngaged = kokoroRequested && route === "speech";
+
+    if (kokoroRequested && !kokoroEngaged) {
+      ctx.sidecar.warnings.push({
+        code: "audio/kokoro-backend-not-applicable",
+        message: `WITTGENSTEIN_AUDIO_BACKEND=kokoro is set but route=${route}; Kokoro is TTS-only at v0.3, this route falls through to the procedural runtime.`,
+        detail: { route },
+        phase: codecV2.CodecPhase.Decode,
+      });
+    }
+
+    let artifactPath: string;
+    let sampleRateHz: number;
+    let decoderId: string;
+    let determinismClass: "byte-parity" | "structural-parity";
+    let partialReason: "procedural-runtime" | "kokoro-cross-platform-pending";
+    let slot: "Kokoro-82M-family-decoder" | "procedural-audio-runtime";
+
+    if (kokoroEngaged) {
+      const kokoro = await getKokoroDecoder();
+      const result = await kokoro.synthesize(
+        payload.plan.script,
+        kokoro.manifest.voiceDefault,
+        ctx.outPath,
+      );
+      artifactPath = ctx.outPath;
+      sampleRateHz = result.sampleRate;
+      decoderId = kokoro.decoderId;
+      determinismClass = "structural-parity";
+      partialReason = "kokoro-cross-platform-pending";
+      slot = "Kokoro-82M-family-decoder";
+    } else {
+      const result =
+        route === "speech"
+          ? await renderSpeechRoute(payload.plan, renderCtx, { allowHostTts: false })
+          : route === "soundscape"
+            ? await renderSoundscapeRoute(payload.plan, renderCtx)
+            : await renderMusicRoute(payload.plan, renderCtx);
+      artifactPath = result.artifactPath;
+      sampleRateHz = AUDIO_SAMPLE_RATE;
+      decoderId = "procedural-audio-runtime";
+      determinismClass = "byte-parity";
+      partialReason = "procedural-runtime";
+      slot = "procedural-audio-runtime";
+    }
+
+    const bytes = await readFile(artifactPath);
+    const decoderHash = hashString(decoderId);
     const audioRender = {
-      sampleRateHz: AUDIO_SAMPLE_RATE,
+      sampleRateHz,
       channels: 1,
-      durationSec: wavDurationSec(bytes),
+      durationSec: wavDurationSec(bytes, sampleRateHz),
       container: "wav" as const,
       bitDepth: 16,
-      determinismClass: "byte-parity" as const,
-      decoderId: "procedural-audio-runtime",
+      determinismClass,
+      decoderId,
       decoderHash,
     };
 
     return {
-      outPath: result.artifactPath,
+      outPath: artifactPath,
       bytes,
       mime: "audio/wav",
       metadata: {
@@ -327,14 +374,14 @@ export class AudioCodec extends codecV2.BaseCodec<AudioRequest, AudioArtifact> {
             determinismClass: audioRender.determinismClass,
           },
           partial: {
-            reason: "procedural-runtime",
+            reason: partialReason,
           },
         },
         audioRender,
         decoderHash: {
           value: decoderHash,
           frozen: true,
-          slot: "procedural-audio-runtime",
+          slot,
         },
         artifactSha256: hashBytes(bytes),
       },

--- a/packages/codec-audio/src/codec.ts
+++ b/packages/codec-audio/src/codec.ts
@@ -13,7 +13,6 @@ import { renderSpeechRoute } from "./routes/speech/index.js";
 import { renderSoundscapeRoute } from "./routes/soundscape/index.js";
 import { renderMusicRoute } from "./routes/music/index.js";
 import type { AudioArtifact, AudioRoute } from "./types.js";
-import { AUDIO_SAMPLE_RATE } from "./runtime.js";
 import { getKokoroDecoder } from "./decoders/kokoro/index.js";
 
 interface AudioCodecLlmService {
@@ -106,10 +105,25 @@ function hashBytes(value: Uint8Array): string {
   return createHash("sha256").update(value).digest("hex");
 }
 
-function wavDurationSec(bytes: Uint8Array, sampleRateHz: number): number {
-  const pcm16BytesPerFrame = 2;
+interface WavMeta {
+  readonly sampleRateHz: number;
+  readonly channels: number;
+  readonly bitDepth: number;
+  readonly durationSec: number;
+}
+
+function readWavMeta(bytes: Uint8Array): WavMeta {
+  if (bytes.byteLength < 44) {
+    throw new Error(`WAV header too short (${bytes.byteLength} bytes)`);
+  }
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const channels = view.getUint16(22, true);
+  const sampleRateHz = view.getUint32(24, true);
+  const bitDepth = view.getUint16(34, true);
   const dataBytes = Math.max(0, bytes.byteLength - 44);
-  return dataBytes / (sampleRateHz * pcm16BytesPerFrame);
+  const bytesPerFrame = (bitDepth / 8) * channels;
+  const durationSec = bytesPerFrame > 0 ? dataBytes / (sampleRateHz * bytesPerFrame) : 0;
+  return { sampleRateHz, channels, bitDepth, durationSec };
 }
 
 function isKokoroBackendRequested(): boolean {
@@ -305,7 +319,6 @@ export class AudioCodec extends codecV2.BaseCodec<AudioRequest, AudioArtifact> {
     }
 
     let artifactPath: string;
-    let sampleRateHz: number;
     let decoderId: string;
     let determinismClass: "byte-parity" | "structural-parity";
     let partialReason: "procedural-runtime" | "kokoro-cross-platform-pending";
@@ -313,13 +326,12 @@ export class AudioCodec extends codecV2.BaseCodec<AudioRequest, AudioArtifact> {
 
     if (kokoroEngaged) {
       const kokoro = await getKokoroDecoder();
-      const result = await kokoro.synthesize(
+      await kokoro.synthesize(
         payload.plan.script,
         kokoro.manifest.voiceDefault,
         ctx.outPath,
       );
       artifactPath = ctx.outPath;
-      sampleRateHz = result.sampleRate;
       decoderId = kokoro.decoderId;
       determinismClass = "structural-parity";
       partialReason = "kokoro-cross-platform-pending";
@@ -332,7 +344,6 @@ export class AudioCodec extends codecV2.BaseCodec<AudioRequest, AudioArtifact> {
             ? await renderSoundscapeRoute(payload.plan, renderCtx)
             : await renderMusicRoute(payload.plan, renderCtx);
       artifactPath = result.artifactPath;
-      sampleRateHz = AUDIO_SAMPLE_RATE;
       decoderId = "procedural-audio-runtime";
       determinismClass = "byte-parity";
       partialReason = "procedural-runtime";
@@ -340,13 +351,14 @@ export class AudioCodec extends codecV2.BaseCodec<AudioRequest, AudioArtifact> {
     }
 
     const bytes = await readFile(artifactPath);
+    const wavMeta = readWavMeta(bytes);
     const decoderHash = hashString(decoderId);
     const audioRender = {
-      sampleRateHz,
-      channels: 1,
-      durationSec: wavDurationSec(bytes, sampleRateHz),
+      sampleRateHz: wavMeta.sampleRateHz,
+      channels: wavMeta.channels,
+      durationSec: wavMeta.durationSec,
       container: "wav" as const,
-      bitDepth: 16,
+      bitDepth: wavMeta.bitDepth,
       determinismClass,
       decoderId,
       decoderHash,

--- a/packages/codec-audio/src/codec.ts
+++ b/packages/codec-audio/src/codec.ts
@@ -113,17 +113,52 @@ interface WavMeta {
 }
 
 function readWavMeta(bytes: Uint8Array): WavMeta {
-  if (bytes.byteLength < 44) {
+  if (bytes.byteLength < 12) {
     throw new Error(`WAV header too short (${bytes.byteLength} bytes)`);
   }
   const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
-  const channels = view.getUint16(22, true);
-  const sampleRateHz = view.getUint32(24, true);
-  const bitDepth = view.getUint16(34, true);
-  const dataBytes = Math.max(0, bytes.byteLength - 44);
+  if (ascii(bytes, 0, 4) !== "RIFF" || ascii(bytes, 8, 4) !== "WAVE") {
+    throw new Error("Expected RIFF/WAVE audio artifact");
+  }
+
+  let channels = 0;
+  let sampleRateHz = 0;
+  let bitDepth = 0;
+  let dataBytes = 0;
+
+  for (let offset = 12; offset + 8 <= bytes.byteLength; ) {
+    const chunkId = ascii(bytes, offset, 4);
+    const chunkSize = view.getUint32(offset + 4, true);
+    const chunkStart = offset + 8;
+    if (chunkStart + chunkSize > bytes.byteLength) {
+      throw new Error(`WAV chunk ${chunkId} exceeds artifact length`);
+    }
+
+    if (chunkId === "fmt ") {
+      if (chunkSize < 16) {
+        throw new Error("WAV fmt chunk too short");
+      }
+      channels = view.getUint16(chunkStart + 2, true);
+      sampleRateHz = view.getUint32(chunkStart + 4, true);
+      bitDepth = view.getUint16(chunkStart + 14, true);
+    } else if (chunkId === "data") {
+      dataBytes = chunkSize;
+    }
+
+    offset = chunkStart + chunkSize + (chunkSize % 2);
+  }
+
+  if (!channels || !sampleRateHz || !bitDepth || !dataBytes) {
+    throw new Error("WAV artifact missing fmt or data chunk");
+  }
+
   const bytesPerFrame = (bitDepth / 8) * channels;
   const durationSec = bytesPerFrame > 0 ? dataBytes / (sampleRateHz * bytesPerFrame) : 0;
   return { sampleRateHz, channels, bitDepth, durationSec };
+}
+
+function ascii(bytes: Uint8Array, offset: number, length: number): string {
+  return String.fromCharCode(...bytes.subarray(offset, offset + length));
 }
 
 function isKokoroBackendRequested(): boolean {
@@ -153,9 +188,7 @@ function inferIntentRoute(prompt: string): AudioRoute {
   const normalized = prompt.toLowerCase();
 
   if (
-    /\b(music|soundtrack|score|melody|song|cue|theme|pulse|beat|chord|motif)\b/.test(
-      normalized,
-    )
+    /\b(music|soundtrack|score|melody|song|cue|theme|pulse|beat|chord|motif)\b/.test(normalized)
   ) {
     return "music";
   }
@@ -326,11 +359,7 @@ export class AudioCodec extends codecV2.BaseCodec<AudioRequest, AudioArtifact> {
 
     if (kokoroEngaged) {
       const kokoro = await getKokoroDecoder();
-      await kokoro.synthesize(
-        payload.plan.script,
-        kokoro.manifest.voiceDefault,
-        ctx.outPath,
-      );
+      await kokoro.synthesize(payload.plan.script, kokoro.manifest.voiceDefault, ctx.outPath);
       artifactPath = ctx.outPath;
       decoderId = kokoro.decoderId;
       determinismClass = "structural-parity";

--- a/packages/codec-audio/src/decoders/kokoro/index.ts
+++ b/packages/codec-audio/src/decoders/kokoro/index.ts
@@ -1,0 +1,165 @@
+import { createHash } from "node:crypto";
+import { createReadStream, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const manifestPath = fileURLToPath(new URL("./manifest.json", import.meta.url));
+
+export interface KokoroDecoderManifest {
+  readonly repoId: string;
+  readonly revision: string;
+  readonly weightsFilename: string;
+  readonly weightsSha256: string;
+  readonly voicesFilename: string;
+  readonly voicesSha256: string;
+  readonly voiceDefault: string;
+  readonly dtype: "fp32";
+  readonly kokoroJsVersion: string;
+}
+
+export const KOKORO_MANIFEST: KokoroDecoderManifest = JSON.parse(
+  readFileSync(manifestPath, "utf8"),
+) as KokoroDecoderManifest;
+
+interface RawAudioLike {
+  readonly audio: Float32Array;
+  readonly sampling_rate: number;
+  save(outPath: string): Promise<void>;
+}
+
+interface KokoroTtsLike {
+  generate(text: string, options: { voice: string }): Promise<RawAudioLike>;
+}
+
+type KokoroTtsLoader = {
+  KokoroTTS: {
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- kokoro-js exports this as snake_case (Python lineage); upstream API, not a Wittgenstein contract.
+    from_pretrained(
+      modelId: string,
+      options: {
+        dtype: "fp32" | "fp16" | "q8" | "q4" | "q4f16";
+        device: "cpu" | "wasm" | "webgpu";
+        revision?: string;
+      },
+    ): Promise<KokoroTtsLike>;
+  };
+};
+
+export interface KokoroDecoder {
+  /** Synthesize `text` and write a WAV file to `outPath`. */
+  synthesize(
+    text: string,
+    voice: string,
+    outPath: string,
+  ): Promise<{ sampleRate: number }>;
+  /** Stable identifier suitable for `audioRender.decoderId`. */
+  readonly decoderId: string;
+  /** Pinned manifest values used to construct this decoder. */
+  readonly manifest: KokoroDecoderManifest;
+}
+
+let cachedDecoder: KokoroDecoder | null = null;
+
+/**
+ * Lazy-load Kokoro-82M (fp32, CPU, pinned to a specific HF commit) and return a
+ * thin synthesize/save wrapper. The first call downloads weights through
+ * `kokoro-js` (transformers.js under the hood) and then verifies the cached
+ * weight + voice files against the SHA-256 values in `manifest.json`.
+ *
+ * Pinning is layered: pnpm-lock fixes the `kokoro-js` package version,
+ * `manifest.json#revision` fixes the HuggingFace commit. The post-load SHA
+ * check is the third receipt — a cache-corruption / cache-poisoning guard.
+ */
+export async function getKokoroDecoder(): Promise<KokoroDecoder> {
+  if (cachedDecoder !== null) {
+    return cachedDecoder;
+  }
+
+  const mod = (await import("kokoro-js")) as unknown as KokoroTtsLoader;
+
+  const tts = await mod.KokoroTTS.from_pretrained(KOKORO_MANIFEST.repoId, {
+    dtype: KOKORO_MANIFEST.dtype,
+    device: "cpu",
+    revision: KOKORO_MANIFEST.revision,
+  });
+
+  await verifyCachedAssetIntegrity();
+
+  const decoderId = `kokoro-82M:${KOKORO_MANIFEST.weightsSha256}`;
+
+  cachedDecoder = {
+    decoderId,
+    manifest: KOKORO_MANIFEST,
+    async synthesize(text, voice, outPath) {
+      const audio = await tts.generate(text, { voice });
+      await audio.save(outPath);
+      return { sampleRate: audio.sampling_rate };
+    },
+  };
+
+  return cachedDecoder;
+}
+
+/**
+ * Walk the transformers.js cache (where `kokoro-js` stores downloaded
+ * weights) and SHA-256 the pinned weight + voice files. Mismatch is a hard
+ * error — this is the layer-3 receipt that the decoder really did load
+ * what `manifest.json` claims.
+ *
+ * Cache layout convention (transformers.js v3):
+ *   $TRANSFORMERS_CACHE/$HF_HOME/hub/
+ *     models--{org}--{name}/snapshots/{revision}/{path}
+ *
+ * `models--{org}--{name}` is the repoId with `/` substituted by `--`.
+ */
+async function verifyCachedAssetIntegrity(): Promise<void> {
+  const cacheRoot = resolveTransformersCacheRoot();
+  const repoSlug = `models--${KOKORO_MANIFEST.repoId.replace(/\//g, "--")}`;
+  const snapshotRoot = join(
+    cacheRoot,
+    repoSlug,
+    "snapshots",
+    KOKORO_MANIFEST.revision,
+  );
+  const weightsPath = join(snapshotRoot, KOKORO_MANIFEST.weightsFilename);
+  const voicesPath = join(snapshotRoot, KOKORO_MANIFEST.voicesFilename);
+
+  const [actualWeights, actualVoices] = await Promise.all([
+    sha256OfFile(weightsPath),
+    sha256OfFile(voicesPath),
+  ]);
+
+  if (actualWeights !== KOKORO_MANIFEST.weightsSha256) {
+    throw new Error(
+      `Kokoro weights SHA-256 mismatch at ${weightsPath}: expected ${KOKORO_MANIFEST.weightsSha256}, got ${actualWeights}. Refusing to engage Kokoro backend.`,
+    );
+  }
+
+  if (actualVoices !== KOKORO_MANIFEST.voicesSha256) {
+    throw new Error(
+      `Kokoro voice file SHA-256 mismatch at ${voicesPath}: expected ${KOKORO_MANIFEST.voicesSha256}, got ${actualVoices}. Refusing to engage Kokoro backend.`,
+    );
+  }
+}
+
+function resolveTransformersCacheRoot(): string {
+  // transformers.js precedence: TRANSFORMERS_CACHE > HF_HOME/hub > ~/.cache/huggingface/hub.
+  if (process.env.TRANSFORMERS_CACHE) {
+    return process.env.TRANSFORMERS_CACHE;
+  }
+  if (process.env.HF_HOME) {
+    return join(process.env.HF_HOME, "hub");
+  }
+  return join(homedir(), ".cache", "huggingface", "hub");
+}
+
+async function sha256OfFile(filePath: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const hash = createHash("sha256");
+    const stream = createReadStream(filePath);
+    stream.on("data", (chunk) => hash.update(chunk));
+    stream.on("end", () => resolve(hash.digest("hex")));
+    stream.on("error", reject);
+  });
+}

--- a/packages/codec-audio/src/decoders/kokoro/index.ts
+++ b/packages/codec-audio/src/decoders/kokoro/index.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { createReadStream, readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const manifestPath = fileURLToPath(new URL("./manifest.json", import.meta.url));
@@ -40,10 +40,13 @@ type KokoroTtsLoader = {
       options: {
         dtype: "fp32" | "fp16" | "q8" | "q4" | "q4f16";
         device: "cpu" | "wasm" | "webgpu";
-        revision?: string;
       },
     ): Promise<KokoroTtsLike>;
   };
+};
+
+type TransformersEnvModule = {
+  env: { cacheDir: string };
 };
 
 export interface KokoroDecoder {
@@ -60,31 +63,68 @@ export interface KokoroDecoder {
 }
 
 let cachedDecoder: KokoroDecoder | null = null;
+let proxyDispatcherInstalled = false;
 
 /**
- * Lazy-load Kokoro-82M (fp32, CPU, pinned to a specific HF commit) and return a
- * thin synthesize/save wrapper. The first call downloads weights through
- * `kokoro-js` (transformers.js under the hood) and then verifies the cached
- * weight + voice files against the SHA-256 values in `manifest.json`.
+ * Node's global `fetch` (undici) does NOT honor `HTTP_PROXY` / `HTTPS_PROXY`
+ * env vars by default — kokoro-js / transformers.js call `fetch` to download
+ * weights from HuggingFace, so behind a corp / regional proxy the download
+ * silently times out. Install undici's `EnvHttpProxyAgent` as the global
+ * dispatcher when proxy env vars are present so the existing curl-style
+ * proxy story carries into Node fetch.
  *
- * Pinning is layered: pnpm-lock fixes the `kokoro-js` package version,
- * `manifest.json#revision` fixes the HuggingFace commit. The post-load SHA
- * check is the third receipt — a cache-corruption / cache-poisoning guard.
+ * No-op when no proxy env var is set; harmless on CI.
+ */
+async function ensureProxyDispatcher(): Promise<void> {
+  if (proxyDispatcherInstalled) {
+    return;
+  }
+  proxyDispatcherInstalled = true;
+  if (!process.env.HTTPS_PROXY && !process.env.HTTP_PROXY) {
+    return;
+  }
+  const undici = await import("undici");
+  undici.setGlobalDispatcher(new undici.EnvHttpProxyAgent());
+}
+
+/**
+ * Lazy-load Kokoro-82M (fp32, CPU) and return a thin synthesize/save wrapper.
+ *
+ * Integrity story is layered:
+ *   1. `pnpm-lock.yaml` pins `kokoro-js@1.2.1` (the npm package bundles
+ *      `voices/<name>.bin` directly, so voice files come from the locked
+ *      npm tarball, not from HuggingFace).
+ *   2. `manifest.json#revision` records the HuggingFace commit we audited
+ *      against (`f46687f7e41512228ae953af24a11b2640ea0f22`, 2025-02-07).
+ *      kokoro-js@1.2.1 does NOT pass `revision` through to transformers.js
+ *      — it always fetches `main` — so the next layer is the only thing
+ *      that catches HF main drift.
+ *   3. Post-load SHA-256 verification:
+ *      - weights at `<transformers.env.cacheDir>/<repoId>/<weightsFilename>`
+ *        must match `manifest.json#weightsSha256`.
+ *      - voice at `<kokoro-js package>/voices/<voice>.bin` must match
+ *        `manifest.json#voicesSha256`.
+ *      Mismatch is a hard error — refuses to engage Kokoro rather than
+ *      lying about which decoder ran.
  */
 export async function getKokoroDecoder(): Promise<KokoroDecoder> {
   if (cachedDecoder !== null) {
     return cachedDecoder;
   }
 
-  const mod = (await import("kokoro-js")) as unknown as KokoroTtsLoader;
+  await ensureProxyDispatcher();
 
-  const tts = await mod.KokoroTTS.from_pretrained(KOKORO_MANIFEST.repoId, {
+  const kokoroMod = (await import("kokoro-js")) as unknown as KokoroTtsLoader;
+  const transformersMod = (await import(
+    "@huggingface/transformers"
+  )) as unknown as TransformersEnvModule;
+
+  const tts = await kokoroMod.KokoroTTS.from_pretrained(KOKORO_MANIFEST.repoId, {
     dtype: KOKORO_MANIFEST.dtype,
     device: "cpu",
-    revision: KOKORO_MANIFEST.revision,
   });
 
-  await verifyCachedAssetIntegrity();
+  await verifyCachedAssetIntegrity(transformersMod);
 
   const decoderId = `kokoro-82M:${KOKORO_MANIFEST.weightsSha256}`;
 
@@ -101,29 +141,15 @@ export async function getKokoroDecoder(): Promise<KokoroDecoder> {
   return cachedDecoder;
 }
 
-/**
- * Walk the transformers.js cache (where `kokoro-js` stores downloaded
- * weights) and SHA-256 the pinned weight + voice files. Mismatch is a hard
- * error — this is the layer-3 receipt that the decoder really did load
- * what `manifest.json` claims.
- *
- * Cache layout convention (transformers.js v3):
- *   $TRANSFORMERS_CACHE/$HF_HOME/hub/
- *     models--{org}--{name}/snapshots/{revision}/{path}
- *
- * `models--{org}--{name}` is the repoId with `/` substituted by `--`.
- */
-async function verifyCachedAssetIntegrity(): Promise<void> {
-  const cacheRoot = resolveTransformersCacheRoot();
-  const repoSlug = `models--${KOKORO_MANIFEST.repoId.replace(/\//g, "--")}`;
-  const snapshotRoot = join(
-    cacheRoot,
-    repoSlug,
-    "snapshots",
-    KOKORO_MANIFEST.revision,
+async function verifyCachedAssetIntegrity(
+  transformersMod: TransformersEnvModule,
+): Promise<void> {
+  const weightsPath = join(
+    transformersMod.env.cacheDir,
+    KOKORO_MANIFEST.repoId,
+    KOKORO_MANIFEST.weightsFilename,
   );
-  const weightsPath = join(snapshotRoot, KOKORO_MANIFEST.weightsFilename);
-  const voicesPath = join(snapshotRoot, KOKORO_MANIFEST.voicesFilename);
+  const voicesPath = resolveBundledVoicePath();
 
   const [actualWeights, actualVoices] = await Promise.all([
     sha256OfFile(weightsPath),
@@ -132,26 +158,29 @@ async function verifyCachedAssetIntegrity(): Promise<void> {
 
   if (actualWeights !== KOKORO_MANIFEST.weightsSha256) {
     throw new Error(
-      `Kokoro weights SHA-256 mismatch at ${weightsPath}: expected ${KOKORO_MANIFEST.weightsSha256}, got ${actualWeights}. Refusing to engage Kokoro backend.`,
+      `Kokoro weights SHA-256 mismatch at ${weightsPath}: expected ${KOKORO_MANIFEST.weightsSha256}, got ${actualWeights}. ` +
+        `kokoro-js@${KOKORO_MANIFEST.kokoroJsVersion} does not pass \`revision\` through to transformers.js, so this check is the only catch for HuggingFace ${KOKORO_MANIFEST.repoId} 'main' drift away from commit ${KOKORO_MANIFEST.revision}. ` +
+        `If main has moved intentionally, update manifest.json's revision + weightsSha256.`,
     );
   }
 
   if (actualVoices !== KOKORO_MANIFEST.voicesSha256) {
     throw new Error(
-      `Kokoro voice file SHA-256 mismatch at ${voicesPath}: expected ${KOKORO_MANIFEST.voicesSha256}, got ${actualVoices}. Refusing to engage Kokoro backend.`,
+      `Kokoro voice file SHA-256 mismatch at ${voicesPath}: expected ${KOKORO_MANIFEST.voicesSha256}, got ${actualVoices}. ` +
+        `kokoro-js bundles voice files in its npm package, so a mismatch here implies a corrupted \`node_modules\` or a kokoro-js version drift not reflected in pnpm-lock.`,
     );
   }
 }
 
-function resolveTransformersCacheRoot(): string {
-  // transformers.js precedence: TRANSFORMERS_CACHE > HF_HOME/hub > ~/.cache/huggingface/hub.
-  if (process.env.TRANSFORMERS_CACHE) {
-    return process.env.TRANSFORMERS_CACHE;
-  }
-  if (process.env.HF_HOME) {
-    return join(process.env.HF_HOME, "hub");
-  }
-  return join(homedir(), ".cache", "huggingface", "hub");
+function resolveBundledVoicePath(): string {
+  // kokoro-js's main entry resolves to `<pkg>/dist/kokoro.js`; voices/ is a
+  // sibling of dist/. Walk up two dirs from the resolved entry to land on
+  // the package root. `createRequire` works in both Node CLI and the vitest
+  // SSR environment; `import.meta.resolve` is CLI-only.
+  const requireFromHere = createRequire(import.meta.url);
+  const entryPath = requireFromHere.resolve("kokoro-js");
+  const packageRoot = dirname(dirname(entryPath));
+  return join(packageRoot, KOKORO_MANIFEST.voicesFilename);
 }
 
 async function sha256OfFile(filePath: string): Promise<string> {

--- a/packages/codec-audio/src/decoders/kokoro/manifest.json
+++ b/packages/codec-audio/src/decoders/kokoro/manifest.json
@@ -1,0 +1,11 @@
+{
+  "repoId": "onnx-community/Kokoro-82M-ONNX",
+  "revision": "f46687f7e41512228ae953af24a11b2640ea0f22",
+  "weightsFilename": "onnx/model.onnx",
+  "weightsSha256": "53a71ac22a70778d57162e4f92eafc62852d9e04a4460b20638d2424796e6037",
+  "voicesFilename": "voices/af_bella.bin",
+  "voicesSha256": "38e12d4b9b31a751282ab9154fb083dad3df3a749772687cde7873da107160fa",
+  "voiceDefault": "af_bella",
+  "dtype": "fp32",
+  "kokoroJsVersion": "1.2.1"
+}

--- a/packages/codec-audio/src/decoders/kokoro/manifest.json
+++ b/packages/codec-audio/src/decoders/kokoro/manifest.json
@@ -4,7 +4,7 @@
   "weightsFilename": "onnx/model.onnx",
   "weightsSha256": "53a71ac22a70778d57162e4f92eafc62852d9e04a4460b20638d2424796e6037",
   "voicesFilename": "voices/af_bella.bin",
-  "voicesSha256": "38e12d4b9b31a751282ab9154fb083dad3df3a749772687cde7873da107160fa",
+  "voicesSha256": "f69d836209b78eb8c66e75e3cda491e26ea838a3674257e9d4e5703cbaf55c8b",
   "voiceDefault": "af_bella",
   "dtype": "fp32",
   "kokoroJsVersion": "1.2.1"

--- a/packages/codec-audio/src/types.ts
+++ b/packages/codec-audio/src/types.ts
@@ -21,7 +21,7 @@ export interface AudioArtifactMetadata extends codecV2.BaseArtifactMetadata {
       readonly determinismClass: "byte-parity" | "structural-parity";
     };
     readonly partial: {
-      readonly reason: "procedural-runtime";
+      readonly reason: "procedural-runtime" | "kokoro-cross-platform-pending";
     };
   };
   readonly audioRender: AudioRenderManifest;

--- a/packages/codec-audio/test/kokoro-determinism.test.ts
+++ b/packages/codec-audio/test/kokoro-determinism.test.ts
@@ -14,13 +14,16 @@ import { audioCodec } from "../src/index.js";
  * `<repo>/node_modules/.pnpm/@huggingface+transformers@<v>/node_modules/@huggingface/transformers/.cache/onnx-community/Kokoro-82M-ONNX/`)
  * — subsequent runs are sub-second. To opt in:
  *
- *   pnpm --filter @wittgenstein/codec-audio test
+ *   WITTGENSTEIN_KOKORO_TEST=1 pnpm --filter @wittgenstein/codec-audio test
  *
  * This is the single-machine version of Brief I §H I.7. The cross-platform
  * sweep is M2 Slice E (#118), not this file.
  */
 
-const SHOULD_SKIP = process.env.CI === "true" || process.env.CI === "1";
+const SHOULD_SKIP =
+  process.env.CI === "true" ||
+  process.env.CI === "1" ||
+  process.env.WITTGENSTEIN_KOKORO_TEST !== "1";
 
 describe.skipIf(SHOULD_SKIP)(
   "@wittgenstein/codec-audio Kokoro determinism (local-only, opt-in via cached weights)",

--- a/packages/codec-audio/test/kokoro-determinism.test.ts
+++ b/packages/codec-audio/test/kokoro-determinism.test.ts
@@ -1,0 +1,133 @@
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AudioRequest } from "@wittgenstein/schemas";
+import { codecV2 } from "@wittgenstein/schemas";
+import { describe, expect, it } from "vitest";
+import { audioCodec } from "../src/index.js";
+
+/*
+ * Local-only determinism probe for the Kokoro backend. Skipped on CI;
+ * locally, the first run downloads ~325 MB of Kokoro weights through
+ * kokoro-js / transformers.js (cached under
+ * `<repo>/node_modules/.pnpm/@huggingface+transformers@<v>/node_modules/@huggingface/transformers/.cache/onnx-community/Kokoro-82M-ONNX/`)
+ * — subsequent runs are sub-second. To opt in:
+ *
+ *   pnpm --filter @wittgenstein/codec-audio test
+ *
+ * This is the single-machine version of Brief I §H I.7. The cross-platform
+ * sweep is M2 Slice E (#118), not this file.
+ */
+
+const SHOULD_SKIP = process.env.CI === "true" || process.env.CI === "1";
+
+describe.skipIf(SHOULD_SKIP)(
+  "@wittgenstein/codec-audio Kokoro determinism (local-only, opt-in via cached weights)",
+  () => {
+    it("produces byte-identical WAV across 3 back-to-back same-seed invocations", async () => {
+      const restore = withEnv("WITTGENSTEIN_AUDIO_BACKEND", "kokoro");
+      try {
+        const shas = await produceKokoroRunShas(3);
+        expect(new Set(shas).size).toBe(1);
+      } finally {
+        restore();
+      }
+    });
+
+    it("writes honest manifest evidence — kokoro-82M decoderId, 24 kHz, structural-parity", async () => {
+      const restore = withEnv("WITTGENSTEIN_AUDIO_BACKEND", "kokoro");
+      try {
+        const dir = await mkdtemp(join(tmpdir(), "witt-kokoro-manifest-"));
+        const art = await audioCodec.produce(buildSpeechRequest(), buildCtx(dir, 0));
+        expect(art.metadata.audioRender.decoderId).toMatch(/^kokoro-82M:[0-9a-f]{64}$/);
+        expect(art.metadata.audioRender.determinismClass).toBe("structural-parity");
+        expect(art.metadata.audioRender.sampleRateHz).toBe(24_000);
+        expect(art.metadata.quality.partial.reason).toBe("kokoro-cross-platform-pending");
+        expect(art.metadata.decoderHash.slot).toBe("Kokoro-82M-family-decoder");
+      } finally {
+        restore();
+      }
+    });
+
+    it("emits audio/kokoro-backend-not-applicable warning when route is non-speech", async () => {
+      const restore = withEnv("WITTGENSTEIN_AUDIO_BACKEND", "kokoro");
+      try {
+        const dir = await mkdtemp(join(tmpdir(), "witt-kokoro-warn-"));
+        const ctx = buildCtx(dir, 0);
+        const soundscapeReq: AudioRequest = {
+          modality: "audio",
+          prompt: "Forest rain ambience for codec parity.",
+          ambient: "forest",
+        };
+        const art = await audioCodec.produce(soundscapeReq, ctx);
+        // Falls through to procedural; manifest tells the truth.
+        expect(art.metadata.audioRender.decoderId).toBe("procedural-audio-runtime");
+        expect(art.metadata.audioRender.determinismClass).toBe("byte-parity");
+        // But sidecar carries the explicit warning.
+        const codes = ctx.sidecar.warnings.map((w) => w.code);
+        expect(codes).toContain("audio/kokoro-backend-not-applicable");
+      } finally {
+        restore();
+      }
+    });
+  },
+);
+
+async function produceKokoroRunShas(count: number): Promise<string[]> {
+  const shas: string[] = [];
+  for (let i = 0; i < count; i += 1) {
+    const dir = await mkdtemp(join(tmpdir(), `witt-kokoro-det-${i}-`));
+    const art = await audioCodec.produce(buildSpeechRequest(), buildCtx(dir, i));
+    const bytes = await readFile(art.outPath);
+    shas.push(createHash("sha256").update(bytes).digest("hex"));
+  }
+  return shas;
+}
+
+function buildSpeechRequest(): AudioRequest {
+  return {
+    modality: "audio",
+    prompt: "Hello world. This is a Kokoro determinism check.",
+    ambient: "silence",
+  };
+}
+
+function buildCtx(dir: string, index: number): codecV2.HarnessCtx {
+  return {
+    runId: `kokoro-test-${index}`,
+    parentRunId: null,
+    runDir: dir,
+    seed: 7,
+    outPath: join(dir, "kokoro.wav"),
+    logger: {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+    },
+    clock: {
+      now: () => 1_900_000_000_000 + index,
+      iso: () => new Date(1_900_000_000_000 + index).toISOString(),
+    },
+    sidecar: codecV2.createRunSidecar(),
+    services: {
+      dryRun: true,
+    },
+    fork: () => {
+      throw new Error("not used in this test");
+    },
+  };
+}
+
+function withEnv(name: string, value: string): () => void {
+  const original = process.env[name];
+  process.env[name] = value;
+  return () => {
+    if (original === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = original;
+    }
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,12 +120,18 @@ importers:
 
   packages/codec-audio:
     dependencies:
+      '@huggingface/transformers':
+        specifier: 3.8.1
+        version: 3.8.1
       '@wittgenstein/schemas':
         specifier: workspace:*
         version: link:../schemas
       kokoro-js:
         specifier: 1.2.1
         version: 1.2.1
+      undici:
+        specifier: ^7.0.0
+        version: 7.25.0
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -2241,6 +2247,10 @@ packages:
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -4095,6 +4105,8 @@ snapshots:
   typescript@5.9.3: {}
 
   undici-types@7.19.2: {}
+
+  undici@7.25.0: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,6 +61,12 @@ importers:
         specifier: ^2.1.0
         version: 2.1.9(@types/node@25.6.0)(lightningcss@1.32.0)
 
+  apps/_vercel-kimi-out:
+    devDependencies:
+      sharp:
+        specifier: ^0.33.5
+        version: 0.33.5
+
   apps/presentation: {}
 
   apps/site:
@@ -117,6 +123,9 @@ importers:
       '@wittgenstein/schemas':
         specifier: workspace:*
         version: link:../schemas
+      kokoro-js:
+        specifier: 1.2.1
+        version: 1.2.1
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -200,6 +209,9 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -669,6 +681,13 @@ packages:
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  '@huggingface/jinja@0.5.8':
+    resolution: {integrity: sha512-ZdElB7DPS7QQS8ZnFc5RPPtkg+eN11z8AmIZWAyes6pSbwXqiFB/POVevvm01begdSX1ho9Gxln/F6qlQMsuaA==}
+    engines: {node: '>=18'}
+
+  '@huggingface/transformers@3.8.1':
+    resolution: {integrity: sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA==}
+
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
     engines: {node: '>=10.10.0'}
@@ -681,6 +700,252 @@ packages:
   '@humanwhocodes/object-schema@2.0.3':
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.33.5':
+    resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.33.5':
+    resolution: {integrity: sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.0.4':
+    resolution: {integrity: sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.0.4':
+    resolution: {integrity: sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.0.4':
+    resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm@1.0.5':
+    resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-s390x@1.0.4':
+    resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-x64@1.0.4':
+    resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
+    resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
+    resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linux-arm64@0.33.5':
+    resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.33.5':
+    resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-linux-s390x@0.33.5':
+    resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.33.5':
+    resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-arm64@0.33.5':
+    resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.33.5':
+    resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-wasm32@0.33.5':
+    resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.33.5':
+    resolution: {integrity: sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.33.5':
+    resolution: {integrity: sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -766,6 +1031,36 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.1':
+    resolution: {integrity: sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
   '@rollup/rollup-android-arm-eabi@4.60.2':
     resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
@@ -1141,6 +1436,10 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  boolean@3.2.0:
+    resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
@@ -1180,6 +1479,10 @@ packages:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
 
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
@@ -1189,6 +1492,13 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  color-string@1.9.1:
+    resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
+
+  color@4.2.3:
+    resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
+    engines: {node: '>=12.5.0'}
 
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
@@ -1220,9 +1530,20 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
+  define-properties@1.2.1:
+    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
+    engines: {node: '>= 0.4'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  detect-node@2.1.0:
+    resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
 
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
@@ -1235,8 +1556,19 @@ packages:
     resolution: {integrity: sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==}
     engines: {node: '>=10.13.0'}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es6-error@4.1.1:
+    resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
 
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
@@ -1345,6 +1677,9 @@ packages:
     resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
     engines: {node: ^10.12.0 || >=12.0.0}
 
+  flatbuffers@25.9.23:
+    resolution: {integrity: sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==}
+
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
@@ -1370,9 +1705,21 @@ packages:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
+  global-agent@3.0.0:
+    resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
+    engines: {node: '>=10.0'}
+
   globals@13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
     engines: {node: '>=8'}
+
+  globalthis@1.0.4:
+    resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -1380,9 +1727,15 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
+  guid-typescript@1.0.9:
+    resolution: {integrity: sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -1406,6 +1759,9 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  is-arrayish@0.3.4:
+    resolution: {integrity: sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -1442,8 +1798,14 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  kokoro-js@1.2.1:
+    resolution: {integrity: sha512-oq0HZJWis3t8lERkMJh84WLU86dpYD0EuBPtqYnLlQzyFP1OkyBRDcweAqCfhNOpltyN9j/azp1H6uuC47gShw==}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -1526,6 +1888,9 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -1536,12 +1901,24 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  matcher@3.0.0:
+    resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
+    engines: {node: '>=10'}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1575,8 +1952,25 @@ packages:
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
 
+  object-keys@1.1.1:
+    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    engines: {node: '>= 0.4'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  onnxruntime-common@1.21.0:
+    resolution: {integrity: sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ==}
+
+  onnxruntime-common@1.22.0-dev.20250409-89f8206ba4:
+    resolution: {integrity: sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ==}
+
+  onnxruntime-node@1.21.0:
+    resolution: {integrity: sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw==}
+    os: [win32, darwin, linux]
+
+  onnxruntime-web@1.22.0-dev.20250409-89f8206ba4:
+    resolution: {integrity: sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -1613,12 +2007,18 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
+  phonemizer@1.2.1:
+    resolution: {integrity: sha512-v0KJ4mi2T4Q7eJQ0W15Xd4G9k4kICSXE8bpDeJ8jisL4RyJhNWsweKTOi88QXFc4r4LZlz5jVL5lCHhkpdT71A==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  platform@1.3.6:
+    resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
 
   pngjs@7.0.0:
     resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
@@ -1643,6 +2043,10 @@ packages:
     resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
     engines: {node: '>=14'}
     hasBin: true
+
+  protobufjs@7.5.6:
+    resolution: {integrity: sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==}
+    engines: {node: '>=12.0.0'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -1676,6 +2080,10 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
+  roarr@2.15.4:
+    resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
+    engines: {node: '>=8.0'}
+
   rollup@4.60.2:
     resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -1687,10 +2095,25 @@ packages:
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
+  semver-compare@1.0.0:
+    resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
+
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  serialize-error@7.0.1:
+    resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
+    engines: {node: '>=10'}
+
+  sharp@0.33.5:
+    resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1703,9 +2126,15 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  simple-swizzle@0.2.4:
+    resolution: {integrity: sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  sprintf-js@1.1.3:
+    resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -1749,6 +2178,10 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  tar@7.5.13:
+    resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
+    engines: {node: '>=18'}
+
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
 
@@ -1791,6 +2224,10 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-fest@0.13.1:
+    resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
+    engines: {node: '>=10'}
 
   type-fest@0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
@@ -1891,6 +2328,10 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -1901,6 +2342,11 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -2150,6 +2596,15 @@ snapshots:
 
   '@eslint/js@8.57.1': {}
 
+  '@huggingface/jinja@0.5.8': {}
+
+  '@huggingface/transformers@3.8.1':
+    dependencies:
+      '@huggingface/jinja': 0.5.8
+      onnxruntime-node: 1.21.0
+      onnxruntime-web: 1.22.0-dev.20250409-89f8206ba4
+      sharp: 0.34.5
+
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
@@ -2161,6 +2616,181 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/object-schema@2.0.3': {}
+
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.0.4
+    optional: true
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.0.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.0.5':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.0.4
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.0.5
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.0.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.0.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.33.5':
+    dependencies:
+      '@emnapi/runtime': 1.10.0
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.10.0
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.33.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.33.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.3
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -2221,6 +2851,29 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.1
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.1': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
 
   '@rollup/rollup-android-arm-eabi@4.60.2':
     optional: true
@@ -2562,6 +3215,8 @@ snapshots:
 
   baseline-browser-mapping@2.10.20: {}
 
+  boolean@3.2.0: {}
+
   brace-expansion@1.1.14:
     dependencies:
       balanced-match: 1.0.2
@@ -2604,6 +3259,8 @@ snapshots:
 
   check-error@2.1.3: {}
 
+  chownr@3.0.0: {}
+
   client-only@0.0.1: {}
 
   color-convert@2.0.1:
@@ -2611,6 +3268,16 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  color-string@1.9.1:
+    dependencies:
+      color-name: 1.1.4
+      simple-swizzle: 0.2.4
+
+  color@4.2.3:
+    dependencies:
+      color-convert: 2.0.1
+      color-string: 1.9.1
 
   commander@14.0.3: {}
 
@@ -2632,7 +3299,21 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  define-properties@1.2.1:
+    dependencies:
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
+      object-keys: 1.1.1
+
   detect-libc@2.1.2: {}
+
+  detect-node@2.1.0: {}
 
   doctrine@3.0.0:
     dependencies:
@@ -2645,7 +3326,13 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.3
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@1.7.0: {}
+
+  es6-error@4.1.1: {}
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -2844,6 +3531,8 @@ snapshots:
       keyv: 4.5.4
       rimraf: 3.0.2
 
+  flatbuffers@25.9.23: {}
+
   flatted@3.4.2: {}
 
   fraction.js@5.3.4: {}
@@ -2870,15 +3559,37 @@ snapshots:
       once: 1.4.0
       path-is-absolute: 1.0.1
 
+  global-agent@3.0.0:
+    dependencies:
+      boolean: 3.2.0
+      es6-error: 4.1.1
+      matcher: 3.0.0
+      roarr: 2.15.4
+      semver: 7.7.4
+      serialize-error: 7.0.1
+
   globals@13.24.0:
     dependencies:
       type-fest: 0.20.2
+
+  globalthis@1.0.4:
+    dependencies:
+      define-properties: 1.2.1
+      gopd: 1.2.0
+
+  gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
 
+  guid-typescript@1.0.9: {}
+
   has-flag@4.0.0: {}
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
 
   ignore@5.3.2: {}
 
@@ -2897,6 +3608,8 @@ snapshots:
       wrappy: 1.0.2
 
   inherits@2.0.4: {}
+
+  is-arrayish@0.3.4: {}
 
   is-extglob@2.1.1: {}
 
@@ -2922,9 +3635,16 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
+  json-stringify-safe@5.0.1: {}
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  kokoro-js@1.2.1:
+    dependencies:
+      '@huggingface/transformers': 3.8.1
+      phonemizer: 1.2.1
 
   levn@0.4.1:
     dependencies:
@@ -2986,6 +3706,8 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  long@5.3.2: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -2996,6 +3718,10 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  matcher@3.0.0:
+    dependencies:
+      escape-string-regexp: 4.0.0
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
@@ -3003,6 +3729,12 @@ snapshots:
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.14
+
+  minipass@7.1.3: {}
+
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
 
   ms@2.1.3: {}
 
@@ -3037,9 +3769,30 @@ snapshots:
 
   node-releases@2.0.37: {}
 
+  object-keys@1.1.1: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+
+  onnxruntime-common@1.21.0: {}
+
+  onnxruntime-common@1.22.0-dev.20250409-89f8206ba4: {}
+
+  onnxruntime-node@1.21.0:
+    dependencies:
+      global-agent: 3.0.0
+      onnxruntime-common: 1.21.0
+      tar: 7.5.13
+
+  onnxruntime-web@1.22.0-dev.20250409-89f8206ba4:
+    dependencies:
+      flatbuffers: 25.9.23
+      guid-typescript: 1.0.9
+      long: 5.3.2
+      onnxruntime-common: 1.22.0-dev.20250409-89f8206ba4
+      platform: 1.3.6
+      protobufjs: 7.5.6
 
   optionator@0.9.4:
     dependencies:
@@ -3072,9 +3825,13 @@ snapshots:
 
   pathval@2.0.1: {}
 
+  phonemizer@1.2.1: {}
+
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  platform@1.3.6: {}
 
   pngjs@7.0.0: {}
 
@@ -3095,6 +3852,21 @@ snapshots:
   prelude-ls@1.2.1: {}
 
   prettier@3.8.3: {}
+
+  protobufjs@7.5.6:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.1
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 25.6.0
+      long: 5.3.2
 
   punycode@2.3.1: {}
 
@@ -3119,6 +3891,15 @@ snapshots:
   rimraf@3.0.2:
     dependencies:
       glob: 7.2.3
+
+  roarr@2.15.4:
+    dependencies:
+      boolean: 3.2.0
+      detect-node: 2.1.0
+      globalthis: 1.0.4
+      json-stringify-safe: 5.0.1
+      semver-compare: 1.0.0
+      sprintf-js: 1.1.3
 
   rollup@4.60.2:
     dependencies:
@@ -3159,7 +3940,70 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  semver-compare@1.0.0: {}
+
   semver@7.7.4: {}
+
+  serialize-error@7.0.1:
+    dependencies:
+      type-fest: 0.13.1
+
+  sharp@0.33.5:
+    dependencies:
+      color: 4.2.3
+      detect-libc: 2.1.2
+      semver: 7.7.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.33.5
+      '@img/sharp-darwin-x64': 0.33.5
+      '@img/sharp-libvips-darwin-arm64': 1.0.4
+      '@img/sharp-libvips-darwin-x64': 1.0.4
+      '@img/sharp-libvips-linux-arm': 1.0.5
+      '@img/sharp-libvips-linux-arm64': 1.0.4
+      '@img/sharp-libvips-linux-s390x': 1.0.4
+      '@img/sharp-libvips-linux-x64': 1.0.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
+      '@img/sharp-linux-arm': 0.33.5
+      '@img/sharp-linux-arm64': 0.33.5
+      '@img/sharp-linux-s390x': 0.33.5
+      '@img/sharp-linux-x64': 0.33.5
+      '@img/sharp-linuxmusl-arm64': 0.33.5
+      '@img/sharp-linuxmusl-x64': 0.33.5
+      '@img/sharp-wasm32': 0.33.5
+      '@img/sharp-win32-ia32': 0.33.5
+      '@img/sharp-win32-x64': 0.33.5
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.7.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
 
   shebang-command@2.0.0:
     dependencies:
@@ -3169,7 +4013,13 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  simple-swizzle@0.2.4:
+    dependencies:
+      is-arrayish: 0.3.4
+
   source-map-js@1.2.1: {}
+
+  sprintf-js@1.1.3: {}
 
   stackback@0.0.2: {}
 
@@ -3195,6 +4045,14 @@ snapshots:
   tailwindcss@4.2.4: {}
 
   tapable@2.3.3: {}
+
+  tar@7.5.13:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
 
   text-table@0.2.0: {}
 
@@ -3229,6 +4087,8 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-fest@0.13.1: {}
 
   type-fest@0.20.2: {}
 
@@ -3321,6 +4181,8 @@ snapshots:
   word-wrap@1.2.5: {}
 
   wrappy@1.0.2: {}
+
+  yallist@5.0.0: {}
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
Closes #116. Implements `docs/handoff/m2-slice-c2-kokoro.md` — wires the Kokoro-82M ONNX TTS backend behind `WITTGENSTEIN_AUDIO_BACKEND=kokoro`, fp32 / CPU only, default backend stays procedural until Slice E (#118) flips it.

> **Per ADR-0013**: `packages/codec-audio/*` is not on §1's doctrine-bearing list, but the handoff brief explicitly says "the manifest contract surface (`audioRender` shape, `decoderId` semantics) is shared protocol. Independent second review pass strongly recommended even though not strictly required." Self-merge is rule-blocked anyway (author + ratifier same GH identity); **needs an independent review pass before merge**.

## What

| File | Change |
| --- | --- |
| `packages/codec-audio/package.json` | + `kokoro-js@1.2.1`, `@huggingface/transformers@3.8.1`, `undici@^7` |
| `packages/codec-audio/src/decoders/kokoro/index.ts` | **new** — lazy-loaded singleton wrapper (proxy-aware, post-load SHA verification) |
| `packages/codec-audio/src/decoders/kokoro/manifest.json` | **new** — pinned repoId / revision / sha256 / voice / dtype / kokoroJsVersion |
| `packages/codec-audio/src/codec.ts` | branch on `WITTGENSTEIN_AUDIO_BACKEND === "kokoro"` AND `route === "speech"`; truthful `audioRender` from WAV header |
| `packages/codec-audio/src/types.ts` | widen `partial.reason` literal: `+ "kokoro-cross-platform-pending"` |
| `packages/codec-audio/test/kokoro-determinism.test.ts` | **new** — opt-in 3-test suite (CI-skipped) |
| `docs/codecs/audio.md` | + 1 implementation-status note (drift correction; ADR-0015 stays the doctrine target) |
| `pnpm-lock.yaml` | regenerated |

## How it splits across 4 commits

1. `6b5c2e4` — **decoder module** added in isolation (no codec.ts wiring), procedural path completely untouched.
2. `2b01641` — **wire decoder behind env var**, types widen, route-mismatch warning, default stays procedural.
3. `4f4e2a9` — **end-to-end fixes** discovered when the wired path was actually run: undici proxy, transformers.js cache layout (NOT the HF Hub spec), kokoro-js bundles voices in npm, Kokoro emits IEEE Float (not PCM16). Truthful manifest from WAV header.
4. `3331a74` — **opt-in determinism test suite + audio.md status note** (CI-skipped; locally the first run downloads ~325 MB once, then sub-second).

The third commit's body details each fix and how the brief / earlier commits had assumed it away — those are the real-world findings worth surfacing during review.

## Done-when checklist (from handoff brief)

- [x] `pnpm --filter @wittgenstein/codec-audio test` green with both default backend and kokoro env var (locally, weights cached). 3 procedural goldens still byte-identical; 3 kokoro determinism tests pass.
- [x] `WITTGENSTEIN_AUDIO_BACKEND=kokoro pnpm cli tts "..." --seed 7 --dry-run` writes a manifest with:
  - `audioRender.decoderId = "kokoro-82M:53a71ac22a70778d57162e4f92eafc62852d9e04a4460b20638d2424796e6037"` ✓
  - `audioRender.decoderHash` set ✓
  - `audioRender.determinismClass: "structural-parity"` ✓
  - `audioRender.bitDepth: 32` (Kokoro is IEEE Float; honest from WAV header) ✓
  - `audioRender.sampleRateHz: 24000` (Kokoro native, no resampling) ✓
- [x] Three back-to-back same-seed invocations produce byte-identical WAV (verified via `kokoro-determinism.test.ts`).
- [x] `decoderId = "procedural-audio-runtime"` still appears as the default when env var is unset. Default flip is Slice E (#118)'s gate.
- [x] `pnpm typecheck` / `pnpm lint` / `pnpm test` / `pnpm lint:deps` (codec boundary check passed for 6 codec packages) all green at the root.

## Manifest evidence (real run on this machine)

```json
"audioRender": {
  "sampleRateHz": 24000,
  "channels": 1,
  "bitDepth": 32,
  "container": "wav",
  "durationSec": 1.97...,
  "determinismClass": "structural-parity",
  "decoderId": "kokoro-82M:53a71ac2...",
  "decoderHash": "..."
},
"quality": {
  "structural": { "schemaValidated": true, "route": "speech", "determinismClass": "structural-parity" },
  "partial": { "reason": "kokoro-cross-platform-pending" }
},
"decoderHash": { "value": "...", "frozen": true, "slot": "Kokoro-82M-family-decoder" }
```

## Out of scope (per handoff brief, deferred)

- GPU backend.
- Voice cloning.
- New routes.
- Flipping the default backend (Slice E #118).
- Cross-platform (macOS / Linux / Windows) determinism testing (Slice E).
- Reshape of `audioRender` schema (Slice C1 #95 locked it).
- Direct `onnxruntime-node` integration (kokoro-js handles it).
- Re-litigating Brief I or ADR-0015.

## Brief / ADR / exec-plan trail

- Brief I §H I.1 (Kokoro decoder choice) + §H I.7 (CPU byte-parity contract).
- ADR-0015 (audio decoder family ratification).
- `docs/exec-plans/active/codec-v2-port.md` §M2 Slice C2.
- `docs/handoff/m2-slice-c2-kokoro.md` (the handoff brief this PR implements).

Engineering lane: Brief → ADR → exec-plan → handoff → code. This PR is the code step; no doctrine introduced.

## Open question for ratifier

The runtime SHA check is the only defense against HuggingFace `main` drift, because kokoro-js@1.2.1 silently drops `revision` from `from_pretrained`. If main on `onnx-community/Kokoro-82M-ONNX` ever moves away from `f46687f7e41512228ae953af24a11b2640ea0f22`, every Kokoro run on a fresh checkout will fail loudly with the SHA-mismatch error. That's correct behavior (fail-loud-not-silent), but worth knowing as a maintenance signal.