### PR TITLE
test(audio): allow Kokoro opt-in probe to finish

### DIFF
--- a/packages/codec-audio/test/kokoro-determinism.test.ts
+++ b/packages/codec-audio/test/kokoro-determinism.test.ts
@@ -24,34 +24,43 @@ const SHOULD_SKIP =
   process.env.CI === "true" ||
   process.env.CI === "1" ||
   process.env.WITTGENSTEIN_KOKORO_TEST !== "1";
+const KOKORO_TEST_TIMEOUT_MS = 180_000;
 
 describe.skipIf(SHOULD_SKIP)(
   "@wittgenstein/codec-audio Kokoro determinism (local-only, opt-in via cached weights)",
   () => {
-    it("produces byte-identical WAV across 3 back-to-back same-seed invocations", async () => {
-      const restore = withEnv("WITTGENSTEIN_AUDIO_BACKEND", "kokoro");
-      try {
-        const shas = await produceKokoroRunShas(3);
-        expect(new Set(shas).size).toBe(1);
-      } finally {
-        restore();
-      }
-    });
+    it(
+      "produces byte-identical WAV across 3 back-to-back same-seed invocations",
+      async () => {
+        const restore = withEnv("WITTGENSTEIN_AUDIO_BACKEND", "kokoro");
+        try {
+          const shas = await produceKokoroRunShas(3);
+          expect(new Set(shas).size).toBe(1);
+        } finally {
+          restore();
+        }
+      },
+      KOKORO_TEST_TIMEOUT_MS,
+    );
 
-    it("writes honest manifest evidence — kokoro-82M decoderId, 24 kHz, structural-parity", async () => {
-      const restore = withEnv("WITTGENSTEIN_AUDIO_BACKEND", "kokoro");
-      try {
-        const dir = await mkdtemp(join(tmpdir(), "witt-kokoro-manifest-"));
-        const art = await audioCodec.produce(buildSpeechRequest(), buildCtx(dir, 0));
-        expect(art.metadata.audioRender.decoderId).toMatch(/^kokoro-82M:[0-9a-f]{64}$/);
-        expect(art.metadata.audioRender.determinismClass).toBe("structural-parity");
-        expect(art.metadata.audioRender.sampleRateHz).toBe(24_000);
-        expect(art.metadata.quality.partial.reason).toBe("kokoro-cross-platform-pending");
-        expect(art.metadata.decoderHash.slot).toBe("Kokoro-82M-family-decoder");
-      } finally {
-        restore();
-      }
-    });
+    it(
+      "writes honest manifest evidence — kokoro-82M decoderId, 24 kHz, structural-parity",
+      async () => {
+        const restore = withEnv("WITTGENSTEIN_AUDIO_BACKEND", "kokoro");
+        try {
+          const dir = await mkdtemp(join(tmpdir(), "witt-kokoro-manifest-"));
+          const art = await audioCodec.produce(buildSpeechRequest(), buildCtx(dir, 0));
+          expect(art.metadata.audioRender.decoderId).toMatch(/^kokoro-82M:[0-9a-f]{64}$/);
+          expect(art.metadata.audioRender.determinismClass).toBe("structural-parity");
+          expect(art.metadata.audioRender.sampleRateHz).toBe(24_000);
+          expect(art.metadata.quality.partial.reason).toBe("kokoro-cross-platform-pending");
+          expect(art.metadata.decoderHash.slot).toBe("Kokoro-82M-family-decoder");
+        } finally {
+          restore();
+        }
+      },
+      KOKORO_TEST_TIMEOUT_MS,
+    );
 
     it("emits audio/kokoro-backend-not-applicable warning when route is non-speech", async () => {
       const restore = withEnv("WITTGENSTEIN_AUDIO_BACKEND", "kokoro");


### PR DESCRIPTION
## What

Give the local opt-in Kokoro determinism tests an explicit 180s timeout.

## Why

During #118 Stage B, the documented opt-in command exercised the real Kokoro backend but hit Vitest's default 5s timeout before model load / synthesis could finish. The probe is intentionally local-only and may download/load ~325 MB of weights, so the test itself should carry the timeout instead of requiring callers to remember a CLI flag.

## Validation

- pnpm --filter @wittgenstein/codec-audio exec vitest run test/kokoro-determinism.test.ts --reporter=verbose
- WITTGENSTEIN_KOKORO_TEST=1 pnpm --filter @wittgenstein/codec-audio exec vitest run test/kokoro-determinism.test.ts --reporter=verbose
- pnpm --filter @wittgenstein/codec-audio typecheck
- pnpm --filter @wittgenstein/codec-audio lint
- pnpm exec prettier --check packages/codec-audio/test/kokoro-determinism.test.ts
- git diff --check

## Risk

This does not change default CI behavior; tests remain skipped unless WITTGENSTEIN_KOKORO_TEST=1 is set. It only makes the documented local probe runnable without an extra timeout flag.

Refs #118.