### PR TITLE
tools(audio): add Kokoro sweep receipt script

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lint:deps": "node scripts/check-codec-boundaries.mjs",
     "test": "pnpm -r test",
     "test:golden": "pnpm --filter @wittgenstein/codec-sensor run test:golden",
+    "sweep:audio-kokoro": "tsx scripts/audio-kokoro-sweep.ts",
     "launch:check": "pnpm typecheck && pnpm --filter @wittgenstein/codec-audio test && pnpm --filter @wittgenstein/codec-sensor test",
     "benchmark": "node --import tsx benchmarks/harness.ts",
     "format": "prettier --write \"**/*.{ts,tsx,js,json,md}\"",

--- a/scripts/audio-kokoro-sweep.ts
+++ b/scripts/audio-kokoro-sweep.ts
@@ -1,0 +1,193 @@
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { arch, platform, release } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { audioCodec } from "../packages/codec-audio/src/index.js";
+import { codecV2 } from "@wittgenstein/schemas";
+
+interface SweepRun {
+  readonly index: number;
+  readonly outPath: string;
+  readonly artifactSha256: string;
+  readonly audioRender: unknown;
+  readonly decoderHash: unknown;
+  readonly quality: unknown;
+}
+
+interface SweepReceipt {
+  readonly ok: boolean;
+  readonly generatedAt: string;
+  readonly platform: {
+    readonly os: NodeJS.Platform;
+    readonly arch: string;
+    readonly release: string;
+    readonly node: string;
+  };
+  readonly packageVersions: {
+    readonly codecAudio: string;
+    readonly kokoroJs: string;
+    readonly transformers: string;
+  };
+  readonly backend: "kokoro";
+  readonly seed: number;
+  readonly runsRequested: number;
+  readonly uniqueArtifactShaCount: number;
+  readonly runs: readonly SweepRun[];
+  readonly error?: {
+    readonly message: string;
+    readonly stack?: string;
+  };
+}
+
+const repoRoot = process.cwd();
+const seed = 7;
+const runsRequested = readRunsArg();
+const outPath = readOutArg();
+
+async function main(): Promise<void> {
+  process.env.WITTGENSTEIN_AUDIO_BACKEND = "kokoro";
+
+  try {
+    const runs = await produceRuns(runsRequested);
+    const receipt = await buildReceipt({
+      ok: new Set(runs.map((run) => run.artifactSha256)).size === 1,
+      runs,
+    });
+    await emitReceipt(receipt);
+    if (!receipt.ok) {
+      process.exitCode = 1;
+    }
+  } catch (error) {
+    const receipt = await buildReceipt({
+      ok: false,
+      runs: [],
+      error: error instanceof Error ? error : new Error(String(error)),
+    });
+    await emitReceipt(receipt);
+    process.exitCode = 1;
+  }
+}
+
+void main();
+
+async function produceRuns(count: number): Promise<SweepRun[]> {
+  const runs: SweepRun[] = [];
+  for (let index = 0; index < count; index += 1) {
+    const dir = await mkdtemp(join(tmpdir(), `witt-kokoro-sweep-${index}-`));
+    const art = await audioCodec.produce(
+      {
+        modality: "audio",
+        prompt: "Hello world. This is a Kokoro determinism check.",
+        ambient: "silence",
+      },
+      {
+        runId: `kokoro-sweep-${index}`,
+        parentRunId: null,
+        runDir: dir,
+        seed,
+        outPath: join(dir, "kokoro.wav"),
+        logger: {
+          debug: () => {},
+          info: () => {},
+          warn: () => {},
+          error: () => {},
+        },
+        clock: {
+          now: () => 1_900_000_000_000 + index,
+          iso: () => new Date(1_900_000_000_000 + index).toISOString(),
+        },
+        sidecar: codecV2.createRunSidecar(),
+        services: {
+          dryRun: true,
+        },
+        fork: () => {
+          throw new Error("not used in the Kokoro sweep");
+        },
+      },
+    );
+    const bytes = await readFile(art.outPath);
+    const artifactSha256 = createHash("sha256").update(bytes).digest("hex");
+    runs.push({
+      index,
+      outPath: art.outPath,
+      artifactSha256,
+      audioRender: art.metadata.audioRender,
+      decoderHash: art.metadata.decoderHash,
+      quality: art.metadata.quality,
+    });
+  }
+  return runs;
+}
+
+async function buildReceipt(input: {
+  readonly ok: boolean;
+  readonly runs: readonly SweepRun[];
+  readonly error?: Error;
+}): Promise<SweepReceipt> {
+  const codecAudioPackage = JSON.parse(
+    await readFile(resolve(repoRoot, "packages/codec-audio/package.json"), "utf8"),
+  ) as { version: string; dependencies?: Record<string, string> };
+
+  return {
+    ok: input.ok,
+    generatedAt: new Date().toISOString(),
+    platform: {
+      os: platform(),
+      arch: arch(),
+      release: release(),
+      node: process.version,
+    },
+    packageVersions: {
+      codecAudio: codecAudioPackage.version,
+      kokoroJs: codecAudioPackage.dependencies?.["kokoro-js"] ?? "unknown",
+      transformers: codecAudioPackage.dependencies?.["@huggingface/transformers"] ?? "unknown",
+    },
+    backend: "kokoro",
+    seed,
+    runsRequested,
+    uniqueArtifactShaCount: new Set(input.runs.map((run) => run.artifactSha256)).size,
+    runs: input.runs,
+    ...(input.error
+      ? {
+          error: {
+            message: input.error.message,
+            stack: input.error.stack,
+          },
+        }
+      : {}),
+  };
+}
+
+async function emitReceipt(receipt: SweepReceipt): Promise<void> {
+  const text = `${JSON.stringify(receipt, null, 2)}\n`;
+  if (outPath) {
+    await mkdir(dirname(outPath), { recursive: true });
+    await writeFile(outPath, text);
+  }
+  console.log(text);
+}
+
+function readOutArg(): string | null {
+  const index = process.argv.indexOf("--out");
+  if (index === -1) {
+    return null;
+  }
+  const value = process.argv[index + 1];
+  if (!value) {
+    throw new Error("--out requires a path");
+  }
+  return resolve(repoRoot, value);
+}
+
+function readRunsArg(): number {
+  const index = process.argv.indexOf("--runs");
+  if (index === -1) {
+    return 3;
+  }
+  const value = Number.parseInt(process.argv[index + 1] ?? "", 10);
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error("--runs requires a positive integer");
+  }
+  return value;
+}


### PR DESCRIPTION
## What

Add 
> wittgenstein-monorepo@0.2.0-alpha.2 sweep:audio-kokoro /Users/dujiayi/Desktop/Wittgenstein
> tsx scripts/audio-kokoro-sweep.ts

{
  "ok": true,
  "generatedAt": "2026-05-05T21:47:06.412Z",
  "platform": {
    "os": "darwin",
    "arch": "arm64",
    "release": "25.5.0",
    "node": "v22.20.0"
  },
  "packageVersions": {
    "codecAudio": "0.0.0",
    "kokoroJs": "1.2.1",
    "transformers": "3.8.1"
  },
  "backend": "kokoro",
  "seed": 7,
  "runsRequested": 3,
  "uniqueArtifactShaCount": 1,
  "runs": [
    {
      "index": 0,
      "outPath": "/var/folders/06/wl9jy4y51rdcrb6p2xy05sj80000gq/T/witt-kokoro-sweep-0-v5awRO/kokoro.wav",
      "artifactSha256": "d67ff7e5a0a3773b034db3c7347f0bc98782e3b93d4b3e48b6eca1002e18d3cc",
      "audioRender": {
        "sampleRateHz": 24000,
        "channels": 1,
        "durationSec": 4.55,
        "container": "wav",
        "bitDepth": 32,
        "determinismClass": "structural-parity",
        "decoderId": "kokoro-82M:53a71ac22a70778d57162e4f92eafc62852d9e04a4460b20638d2424796e6037",
        "decoderHash": "a13bb941e2560aaea824d1f6caf0fe3c509eb2d0c5c0b7b1f6b5c67e922bc143"
      },
      "decoderHash": {
        "value": "a13bb941e2560aaea824d1f6caf0fe3c509eb2d0c5c0b7b1f6b5c67e922bc143",
        "frozen": true,
        "slot": "Kokoro-82M-family-decoder"
      },
      "quality": {
        "structural": {
          "schemaValidated": true,
          "route": "speech",
          "determinismClass": "structural-parity"
        },
        "partial": {
          "reason": "kokoro-cross-platform-pending"
        }
      }
    },
    {
      "index": 1,
      "outPath": "/var/folders/06/wl9jy4y51rdcrb6p2xy05sj80000gq/T/witt-kokoro-sweep-1-1KvUCM/kokoro.wav",
      "artifactSha256": "d67ff7e5a0a3773b034db3c7347f0bc98782e3b93d4b3e48b6eca1002e18d3cc",
      "audioRender": {
        "sampleRateHz": 24000,
        "channels": 1,
        "durationSec": 4.55,
        "container": "wav",
        "bitDepth": 32,
        "determinismClass": "structural-parity",
        "decoderId": "kokoro-82M:53a71ac22a70778d57162e4f92eafc62852d9e04a4460b20638d2424796e6037",
        "decoderHash": "a13bb941e2560aaea824d1f6caf0fe3c509eb2d0c5c0b7b1f6b5c67e922bc143"
      },
      "decoderHash": {
        "value": "a13bb941e2560aaea824d1f6caf0fe3c509eb2d0c5c0b7b1f6b5c67e922bc143",
        "frozen": true,
        "slot": "Kokoro-82M-family-decoder"
      },
      "quality": {
        "structural": {
          "schemaValidated": true,
          "route": "speech",
          "determinismClass": "structural-parity"
        },
        "partial": {
          "reason": "kokoro-cross-platform-pending"
        }
      }
    },
    {
      "index": 2,
      "outPath": "/var/folders/06/wl9jy4y51rdcrb6p2xy05sj80000gq/T/witt-kokoro-sweep-2-WZ73AZ/kokoro.wav",
      "artifactSha256": "d67ff7e5a0a3773b034db3c7347f0bc98782e3b93d4b3e48b6eca1002e18d3cc",
      "audioRender": {
        "sampleRateHz": 24000,
        "channels": 1,
        "durationSec": 4.55,
        "container": "wav",
        "bitDepth": 32,
        "determinismClass": "structural-parity",
        "decoderId": "kokoro-82M:53a71ac22a70778d57162e4f92eafc62852d9e04a4460b20638d2424796e6037",
        "decoderHash": "a13bb941e2560aaea824d1f6caf0fe3c509eb2d0c5c0b7b1f6b5c67e922bc143"
      },
      "decoderHash": {
        "value": "a13bb941e2560aaea824d1f6caf0fe3c509eb2d0c5c0b7b1f6b5c67e922bc143",
        "frozen": true,
        "slot": "Kokoro-82M-family-decoder"
      },
      "quality": {
        "structural": {
          "schemaValidated": true,
          "route": "speech",
          "determinismClass": "structural-parity"
        },
        "partial": {
          "reason": "kokoro-cross-platform-pending"
        }
      }
    }
  ]
}, a small receipt-producing script for the #118 Kokoro sweep.

## Why

Stage B produced a useful macOS receipt, and #164 asks for an independent Docker/Linux fact check. The sweep should be runnable as one command and should emit machine-readable evidence: platform, Node/package versions, three artifact SHAs, and manifest fields. This keeps the Linux audit from becoming hand-copied shell state.

## Validation

- pnpm sweep:audio-kokoro -- --out artifacts/tmp/kokoro-sweep-macos.json
- pnpm exec prettier --check package.json scripts/audio-kokoro-sweep.ts
- pnpm lint
- pnpm typecheck
- git diff --check

## Risk

The script exercises real Kokoro and may download/load the 325 MB ONNX model. It does not run in CI by default and does not flip the audio backend default.

Refs #118, #164.