### PR TITLE
docs: record v0.3 cold-checkout rerun

### DIFF
--- a/docs/research/2026-05-06-v0.3-cold-checkout-rerun.md
+++ b/docs/research/2026-05-06-v0.3-cold-checkout-rerun.md
@@ -1,0 +1,142 @@
+# v0.3 Cold-checkout Rerun — 2026-05-06
+
+**Status:** pre-release rehearsal receipt for Issue #151  
+**Commit tested:** `df93c3ad8e6dc3c3a4898b7ea8526af77df0fc9f`  
+**Host:** macOS Darwin 25.5.0 arm64  
+**Node:** `v22.20.0`  
+**pnpm:** `9.12.0`
+
+This rerun verifies the current `main` branch after the M2 Kokoro opt-in backend
+and sweep receipt tooling landed. It is a release-facing cold-checkout receipt, but
+the final v0.3 audio verdict still waits on the independent Docker/Linux audit in
+Issue #164. If #164 changes the verdict, rerun this receipt before tagging.
+
+## Fresh Checkout
+
+```sh
+tmpdir=$(mktemp -d /tmp/witt-cold-151-XXXXXX)
+git clone https://github.com/p-to-q/wittgenstein.git "$tmpdir/wittgenstein"
+cd "$tmpdir/wittgenstein"
+git rev-parse HEAD
+node -v
+pnpm -v
+```
+
+Result:
+
+- checkout path: `/tmp/witt-cold-151-vlII27/wittgenstein`
+- commit: `df93c3ad8e6dc3c3a4898b7ea8526af77df0fc9f`
+- Node: `v22.20.0`
+- pnpm: `9.12.0`
+
+## Core Verification
+
+```sh
+pnpm install --frozen-lockfile
+pnpm typecheck
+pnpm lint
+pnpm test
+pnpm test:golden
+```
+
+Result: all passed.
+
+Notes:
+
+- `pnpm install --frozen-lockfile` completed from a fresh clone.
+- Workspace typecheck passed across 13 workspace projects.
+- Workspace lint passed across 13 workspace projects.
+- Workspace tests passed.
+- Sensor golden tests passed.
+- Kokoro determinism tests remained skipped in the default test run, as intended,
+  unless `WITTGENSTEIN_KOKORO_TEST=1` is set.
+
+## CLI Smoke
+
+```sh
+pnpm smoke:cli
+```
+
+Result: passed.
+
+Observed doctor output:
+
+```json
+{
+  "ok": true,
+  "nodeVersion": "v22.20.0",
+  "nodeSatisfied": true,
+  "hasApiKey": false,
+  "llmProvider": "minimax",
+  "llmModel": "minimax/minimax-01",
+  "artifactsDir": "artifacts"
+}
+```
+
+## Kokoro Sweep Receipt
+
+```sh
+pnpm sweep:audio-kokoro -- --out artifacts/tmp/kokoro-sweep-cold-checkout-macos.json
+```
+
+Result: passed.
+
+Receipt excerpt:
+
+```json
+{
+  "ok": true,
+  "platform": {
+    "os": "darwin",
+    "arch": "arm64",
+    "release": "25.5.0",
+    "node": "v22.20.0"
+  },
+  "packageVersions": {
+    "codecAudio": "0.0.0",
+    "kokoroJs": "1.2.1",
+    "transformers": "3.8.1"
+  },
+  "backend": "kokoro",
+  "seed": 7,
+  "runsRequested": 3,
+  "uniqueArtifactShaCount": 1
+}
+```
+
+All three Kokoro sweep runs produced:
+
+```text
+d67ff7e5a0a3773b034db3c7347f0bc98782e3b93d4b3e48b6eca1002e18d3cc
+```
+
+Manifest evidence from the sweep:
+
+```json
+{
+  "sampleRateHz": 24000,
+  "channels": 1,
+  "durationSec": 4.55,
+  "container": "wav",
+  "bitDepth": 32,
+  "determinismClass": "structural-parity",
+  "decoderId": "kokoro-82M:53a71ac22a70778d57162e4f92eafc62852d9e04a4460b20638d2424796e6037",
+  "decoderHash": "a13bb941e2560aaea824d1f6caf0fe3c509eb2d0c5c0b7b1f6b5c67e922bc143"
+}
+```
+
+## Verdict
+
+The fresh checkout is healthy on macOS arm64 for the current `main` branch:
+
+- install passes,
+- typecheck passes,
+- lint passes,
+- tests pass,
+- sensor goldens pass,
+- CLI smoke passes,
+- Kokoro sweep receipt passes locally with byte-identical same-seed artifacts.
+
+This supports moving toward release-note drafting, but it does not replace the
+independent Docker/Linux audit in Issue #164. Treat the audio verdict as provisional
+until that second receipt returns.


### PR DESCRIPTION
## What

Record a fresh-checkout v0.3 pre-release rehearsal receipt for Issue #151.

## Why

After #118 reached a provisional macOS Kokoro verdict and #165 added a sweep receipt command, we need a dated receipt that a new checkout can install, verify, run goldens, smoke the CLI, and produce a Kokoro sweep receipt. This is still marked provisional because the independent Docker/Linux audit in #164 can revise the final audio verdict.

## Validation

From a fresh clone at df93c3ad8e6dc3c3a4898b7ea8526af77df0fc9f:

- pnpm install --frozen-lockfile
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm test:golden
- pnpm smoke:cli
- pnpm sweep:audio-kokoro -- --out artifacts/tmp/kokoro-sweep-cold-checkout-macos.json
- pnpm exec prettier --check docs/research/2026-05-06-v0.3-cold-checkout-rerun.md
- git diff --check

## Risk

This is a release-facing receipt, not the final release tag. If #164 changes the audio verdict, rerun #151 before publishing the prerelease.

Refs #151, #118, #164.