### PR TITLE
docs: draft v0.3 release notes skeleton

### DIFF
--- a/docs/research/2026-05-06-v0.3-release-notes-draft.md
+++ b/docs/research/2026-05-06-v0.3-release-notes-draft.md
@@ -1,0 +1,112 @@
+# v0.3 Release Notes Draft — 2026-05-06
+
+**Status:** draft release surface for Issue #149. Not a tag plan, not a release
+artifact, and not a substitute for the final `CHANGELOG.md` entry.
+
+This note is the safe part of release-note work that can happen before the
+independent Docker/Linux Kokoro audit in Issue #164 returns. It keeps the
+release story ready without pretending the final M2 sweep verdict is known.
+
+## Release Boundary
+
+The next prerelease should describe the v0.3 execution line after the audio
+sweep verdict is known. The release should not be tagged until these receipts
+agree:
+
+- Issue #118 — M2 audio sweep-level verification.
+- Issue #151 — final truth-surface cold-checkout rerun.
+- Issue #164 — independent Docker/Linux Kokoro sweep audit.
+
+The current root package version is `0.2.0-alpha.2`. Do not bump
+`package.json` or add the final `CHANGELOG.md` section until the release
+version is chosen and the sweep verdict is settled.
+
+## Draft Headline
+
+v0.3 moves Wittgenstein from a codec-v2 image proof into a broader
+reproducibility-oriented harness: audio gains an opt-in frozen-decoder path,
+golden/parity receipts are CI-gated, and the repo's workflow now distinguishes
+execution, governance, fallback, and research-first lanes.
+
+## Candidate CHANGELOG Section
+
+Use this as the starting point for the final `CHANGELOG.md` entry. Replace
+`TBD` fields only after Issues #118, #151, and #164 close.
+
+```md
+## [0.3.0-alpha.1] — TBD — v0.3 audio sweep and reproducibility gates
+
+### Added
+
+- Added the Kokoro-82M family as an opt-in speech decoder backend for the audio
+  codec, gated behind `WITTGENSTEIN_AUDIO_BACKEND=kokoro`.
+- Added same-seed audio parity/golden tests for speech, soundscape, and music
+  routes.
+- Added `pnpm sweep:audio-kokoro`, a local receipt script that runs three
+  same-seed Kokoro speech renders and records artifact hashes plus manifest
+  evidence.
+- Added release-facing cold-checkout receipts for the v0.3 truth surface.
+- Added workflow/governance guidance for orchestration, explicit fallback
+  discipline, and research-first development.
+
+### Changed
+
+- Kept the default audio backend procedural until the M2 sweep verdict permits
+  a backend flip.
+- Updated README and status surfaces around the harness-first thesis and the
+  current maturity of image, audio, sensor, SVG, and video outputs.
+- Tightened reproducibility and evidence surfaces: README receipts, sensor
+  goldens, audio sweep receipts, and cold-checkout verification now point to
+  concrete commands or artifacts.
+
+### Fixed
+
+- Fixed the Kokoro opt-in test timeout so local decoder initialization can
+  complete before Vitest aborts.
+- Fixed release-gate drift by recording the current v0.3 gate state in an
+  explicit roadmap index.
+
+### Verification
+
+- `pnpm install --frozen-lockfile`
+- `pnpm typecheck`
+- `pnpm lint`
+- `pnpm test`
+- `pnpm test:golden`
+- `pnpm smoke:cli`
+- `pnpm sweep:audio-kokoro -- --out artifacts/tmp/kokoro-sweep-<platform>.json`
+
+### Known limits
+
+- Final audio backend verdict: TBD pending Issue #118 and Issue #164.
+- Default backend flip: TBD pending the sweep verdict.
+- Linux/Docker Kokoro receipt: TBD pending Issue #164.
+- This prerelease does not add neural soundscape, neural music, GPU inference,
+  voice cloning, or a new audio manifest schema.
+```
+
+## Evidence To Cite
+
+Release notes should cite the following receipts once they are final:
+
+- `docs/research/2026-05-06-v0.3-cold-checkout-rerun.md` — macOS cold-checkout
+  rehearsal on commit `df93c3ad8e6dc3c3a4898b7ea8526af77df0fc9f`.
+- Issue #164 — independent Linux/Docker Kokoro audit receipt.
+- Issue #118 — final M2 sweep verdict and backend decision.
+- PR #121 — audio C3 parity/golden harness.
+- PR #163 — Kokoro opt-in test timeout fix.
+- PR #165 — Kokoro sweep receipt script.
+- PR #166 — cold-checkout rerun receipt.
+
+## Release PR Checklist
+
+When the final release PR is opened:
+
+- choose the prerelease version,
+- bump the root `package.json` version to match the future tag,
+- add the matching `CHANGELOG.md` section,
+- replace every `TBD` with a concrete verdict or remove the line,
+- cite #118, #151, and #164 in the PR body,
+- run the release-facing validation commands from the candidate section,
+- do not publish a tag until the merged `CHANGELOG.md` section and package
+  version match the intended tag.


### PR DESCRIPTION
## Summary
- adds a release-note draft surface for Issue #149
- keeps the final CHANGELOG/package version work pending until #118/#151/#164 settle
- marks audio backend/default verdicts as TBD instead of speculating before the independent Linux/Docker audit

## Scope
This is a skeleton only. It does not bump `package.json`, does not add the final `CHANGELOG.md` section, and does not publish or imply a tag.

## Validation
- `pnpm exec prettier --check docs/research/2026-05-06-v0.3-release-notes-draft.md`
- `git diff --cached --check`

Closes part of #149.