### PR TITLE
ci(doctrine-guardrail): watch manifest.ts + modality.ts (closes #186)

### DIFF
--- a/.github/workflows/doctrine-guardrail.yml
+++ b/.github/workflows/doctrine-guardrail.yml
@@ -59,6 +59,8 @@ jobs:
               /^docs\/agent-guides\//,
               /^docs\/research\/briefs\//,
               /^packages\/schemas\/src\/codec\/v2\//,
+              /^packages\/schemas\/src\/manifest\.ts$/,
+              /^packages\/schemas\/src\/modality\.ts$/,
             ];
             const { data: files } = await github.rest.pulls.listFiles({
               owner: context.repo.owner,


### PR DESCRIPTION
## Summary

Adds two patterns to the doctrine-guardrail workflow's `doctrinePatterns` array so that PRs touching the reproducibility manifest schema or the modality enum trigger the gentle ADR/RFC reference nudge:

```diff
              /^docs\/research\/briefs\//,
              /^packages\/schemas\/src\/codec\/v2\//,
+              /^packages\/schemas\/src\/manifest\.ts$/,
+              /^packages\/schemas\/src\/modality\.ts$/,
            ];
```

Closes #186.

## Why

`docs/hard-constraints.md` calls the manifest spine "non-negotiable." A PR that quietly relaxes a manifest field — for example, marking `gitSha` as never-required, or removing `artifactSha256` — does not trip the doctrine nudge today. The codec-v2 schema directory was watched precisely because that's where the public protocol shape lives — the manifest schema is just as protocol-shaped (in fact more so, because it's the spine every codec writes to).

## What this is not

- Not a blocking gate. Per the workflow header comment ("Does NOT block merge — this is a nudge, not a gate"), this remains informational.
- Not new doctrine. Per ADR-0014, this is a governance-lane refinement; the underlying doctrine (manifest spine is non-negotiable) was already locked in `docs/hard-constraints.md`.
- Not a change to ADR-0013's surface list. The list there is the human-readable doctrine-bearing list; this workflow is the automated nudge that approximates it.

## Validation

- Verified `packages/schemas/src/manifest.ts` and `packages/schemas/src/modality.ts` exist at the cited paths.
- Pattern format matches the existing entries (`^.*\\.ts$` anchored, no `.git`/sibling matches).
- Two-line additive change; no risk of false-positive on unrelated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)