### PR TITLE
fix(polyglot-mini): TTS is macOS-only; drop edge-tts fiction (closes #184)

### DIFF
--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -24,7 +24,7 @@ Everything below runs with `python3 -m polyglot.cli <cmd>`.
 | **Image — LLM code-as-painter**    | ✅ Ships | LLM → Python PIL/NumPy/SciPy → sandboxed subprocess → PNG                                          |
 | **Image — MLP fallback painter**   | ✅ Ships | text → hashed-BoW embed → MLP → palette+layout → procedural PNG                                    |
 | **Image — COCO training pipeline** | ✅ Ships | `train/build_dataset_coco.py` + `train/train.py`; 781 examples, 9 s                                |
-| **TTS — speech**                   | ✅ Ships | macOS `say` → AIFF → `afconvert` → M4A (zero deps)                                                 |
+| **TTS — speech**                   | ✅ Ships (macOS-only) | macOS `say` → AIFF → `afconvert` → M4A (zero deps). Linux / Windows have no fallback in this surface; cross-platform speech is in the TS `@wittgenstein/codec-audio` codec via the Kokoro backend (Issue #116 / PR #158). |
 | **TTS — procedural ambient**       | ✅ Ships | AudioMLP classifier → rain/wind/city/forest/electronic/white_noise → NumPy+SciPy synth → mixed M4A |
 | **Audio adapter training**         | ✅ Ships | `train/train_audio.py`; 369 examples, < 5 s                                                        |
 | **Sensor — dry-run expand**        | ✅ Ships | Built-in ECG/accelerometer/temperature specs → numpy arrays → CSV + PNG                            |

--- a/polyglot-mini/README.md
+++ b/polyglot-mini/README.md
@@ -38,8 +38,8 @@ trainable without touching the rest.
 |---|---|---|
 | **Image** | LLM → Python painter code → sandboxed subprocess | `.png` |
 | **Image (no-LLM)** | MLP adapter → procedural painter | `.png` |
-| **TTS** | macOS `say` → `afconvert` | `.m4a` (zero deps) |
-| **TTS + Ambient** | text → AudioMLP → procedural synth → mix | `.m4a` |
+| **TTS** (macOS-only) | macOS `say` → `afconvert` | `.m4a` (zero deps) |
+| **TTS + Ambient** (TTS macOS-only; ambient cross-platform) | text → AudioMLP → procedural synth → mix | `.m4a` |
 | **Sensor** | operator spec JSON → numpy expand → loupe dashboard | `.html` + `.csv` + `.png` |
 
 ---

--- a/polyglot-mini/polyglot/tts.py
+++ b/polyglot-mini/polyglot/tts.py
@@ -104,7 +104,11 @@ def generate_speech(
         script = prompt
 
     if not _have("say"):
-        raise RuntimeError("macOS `say` not found; TTS requires macOS or an `edge-tts` install.")
+        raise RuntimeError(
+            "macOS `say` not found; the polyglot-mini TTS path is macOS-only. "
+            "See polyglot-mini/README.md and docs/implementation-status.md for the platform matrix; "
+            "cross-platform speech is in the TypeScript `@wittgenstein/codec-audio` codec via the Kokoro backend (Issue #116 / PR #158)."
+        )
 
     voice = voice or MAC_VOICES.get(lang, MAC_VOICES["default"])
 


### PR DESCRIPTION
## Summary

The polyglot-mini TTS path raised:
```python
raise RuntimeError("macOS `say` not found; TTS requires macOS or an `edge-tts` install.")
```
but no edge-tts integration was ever wired. Three places implied cross-platform support that does not ship:

- `polyglot-mini/polyglot/tts.py:107` — the load-bearing fiction users hit on Linux
- `polyglot-mini/README.md` "What Ships" matrix
- `docs/implementation-status.md` TTS — speech row

Closes #184 (Option A — docs honesty subset).

## What changed

| File | Change |
|---|---|
| `polyglot-mini/polyglot/tts.py` | Error message now says "polyglot-mini TTS is macOS-only" and points at the TS `@wittgenstein/codec-audio` Kokoro backend for cross-platform speech |
| `polyglot-mini/README.md` | "TTS" row labelled `(macOS-only)`; "TTS + Ambient" row labelled `(TTS macOS-only; ambient cross-platform)` |
| `docs/implementation-status.md` | "TTS — speech" status changed to `✅ Ships (macOS-only)` with explicit pointer to `@wittgenstein/codec-audio` Kokoro for cross-platform |

## What this PR is **not**

- **Not a behavior change.** macOS `say` path works exactly as before. Linux users still hit the error — they just get a clear message pointing at the cross-platform alternative.
- **Not Option B from #184.** A real `edge-tts` / `pyttsx3` fallback is intentionally deferred. That's a research / dependency-budget decision that needs its own scope; this PR is the docs-honesty subset.
- **Not a CI matrix change.** Turning `.github/workflows/ci.yml:124-128`'s conditional `if command -v say` into a `runs-on: macos-latest` matrix job is the right move but has bigger blast radius (cost per CI run). Tracked under #173 (test-env audit).

## Why land this before v0.3 tag

Per the receipts framing on README, every "Ships ✅" claim is supposed to be reproducible from a clean checkout. A polyglot-mini TTS smoke that fails on Linux because of a fiction in the error string is exactly the kind of receipt-vs-claim drift the v0.3 tag should not preserve. This is the smallest correct fix.

Per round 2 audit on #149: recommended Option A as block-tag, deferred Options B and CI-matrix.

## Validation

- `python3 -c "from polyglot.polyglot import tts"` — imports cleanly (no syntax break)
- `git diff` — three small, contained edits
- No test changes needed; existing macOS smoke still asserts the same path

🤖 Generated with [Claude Code](https://claude.com/claude-code)