### PR TITLE
refactor(test): generalize test:golden across codec-* (closes #188)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint": "pnpm -r lint",
     "lint:deps": "node scripts/check-codec-boundaries.mjs",
     "test": "pnpm -r test",
-    "test:golden": "pnpm --filter @wittgenstein/codec-sensor run test:golden",
+    "test:golden": "pnpm -r --filter \"./packages/codec-*\" --if-present run test:golden",
     "sweep:audio-kokoro": "tsx scripts/audio-kokoro-sweep.ts",
     "launch:check": "pnpm typecheck && pnpm --filter @wittgenstein/codec-audio test && pnpm --filter @wittgenstein/codec-sensor test",
     "benchmark": "node --import tsx benchmarks/harness.ts",

--- a/packages/codec-audio/package.json
+++ b/packages/codec-audio/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc -b",
     "lint": "eslint src test --ext .ts",
     "test": "vitest run",
+    "test:golden": "vitest run test/parity.test.ts",
     "build": "tsc"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

The root \`test:golden\` script only ran codec-sensor's goldens. The audio \`parity.test.ts\` (PR #121) asserts byte-for-byte determinism but lived under the generic \`test\` umbrella, so the README receipts-table claim \"test:golden covers byte-parity goldens\" overpromised.

Closes #188.

## Diff

```diff
# package.json
-    "test:golden": "pnpm --filter @wittgenstein/codec-sensor run test:golden",
+    "test:golden": "pnpm -r --filter \"./packages/codec-*\" --if-present run test:golden",

# packages/codec-audio/package.json
     "test": "vitest run",
+    "test:golden": "vitest run test/parity.test.ts",
     "build": "tsc"
```

The \`--if-present\` flag means packages without a \`test:golden\` script (codec-image / codec-svg / codec-asciipng / codec-video) don't error.

## Validation

\`pnpm test:golden\` from a clean checkout now runs:

- **codec-sensor** — \`test/golden.test.ts\` (3 tests, 118ms)
- **codec-audio** — \`test/parity.test.ts\` (3 tests, 110ms)

Total 6 tests, all green. Verified locally on this branch.

## Out of scope (deferred)

- Mandating \`test:golden\` for codecs that declare \`determinismClass: byte-parity\` (Option B in #188 — needs a separate decision since not every codec has the metadata yet).
- Adding goldens for codec-asciipng / codec-svg (deterministic by construction) — separate decision per their codec maturity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)