### PR TITLE
fix(codec-audio): typed INTEGRITY_MISMATCH for Kokoro SHA mismatches (#170 partial)

### DIFF
--- a/packages/codec-audio/src/decoders/kokoro/index.ts
+++ b/packages/codec-audio/src/decoders/kokoro/index.ts
@@ -157,7 +157,7 @@ async function verifyCachedAssetIntegrity(
   ]);
 
   if (actualWeights !== KOKORO_MANIFEST.weightsSha256) {
-    throw new Error(
+    throw integrityError(
       `Kokoro weights SHA-256 mismatch at ${weightsPath}: expected ${KOKORO_MANIFEST.weightsSha256}, got ${actualWeights}. ` +
         `kokoro-js@${KOKORO_MANIFEST.kokoroJsVersion} does not pass \`revision\` through to transformers.js, so this check is the only catch for HuggingFace ${KOKORO_MANIFEST.repoId} 'main' drift away from commit ${KOKORO_MANIFEST.revision}. ` +
         `If main has moved intentionally, update manifest.json's revision + weightsSha256.`,
@@ -165,11 +165,24 @@ async function verifyCachedAssetIntegrity(
   }
 
   if (actualVoices !== KOKORO_MANIFEST.voicesSha256) {
-    throw new Error(
+    throw integrityError(
       `Kokoro voice file SHA-256 mismatch at ${voicesPath}: expected ${KOKORO_MANIFEST.voicesSha256}, got ${actualVoices}. ` +
         `kokoro-js bundles voice files in its npm package, so a mismatch here implies a corrupted \`node_modules\` or a kokoro-js version drift not reflected in pnpm-lock.`,
     );
   }
+}
+
+// Mirrors @wittgenstein/core's serializeError() duck-type contract:
+// an Error-shaped object with a string `code` is recognized and the
+// code is preserved in the run manifest. Codec packages do not import
+// @wittgenstein/core (boundary kept clean per scripts/check-codec-
+// boundaries.mjs). When/if error classes move to @wittgenstein/schemas
+// per the #170 architectural follow-up, this helper goes away.
+function integrityError(message: string): Error & { code: string } {
+  return Object.assign(new Error(message), {
+    name: "WittgensteinError",
+    code: "INTEGRITY_MISMATCH",
+  });
 }
 
 function resolveBundledVoicePath(): string {


### PR DESCRIPTION
## Summary

Narrowed slice of #170. Kokoro SHA-256 mismatch checks (weights + voices) previously threw bare `Error`, which `serializeError()` tagged as `UNEXPECTED_ERROR` in the run manifest. They are integrity violations; the manifest `code` field should say so.

Replaces the two `throw new Error(...)` sites in `packages/codec-audio/src/decoders/kokoro/index.ts:160,168` with `throw integrityError(...)` — produces an Error-shaped object with `code: "INTEGRITY_MISMATCH"`.

## Why narrowed (architectural finding for #170)

The agent audit on #170 said "Slice 1 — small PR, mechanical, replace 8 sites in codec-audio + 4 in codec-image with `ValidationError`/`NotImplementedError`." On verification this hits an architectural prerequisite:

- The error classes (`ValidationError`, `NotImplementedError`, `WittgensteinError`) live in `packages/core/src/runtime/errors.ts`.
- Codec packages **deliberately do not depend on `@wittgenstein/core`** (verified — only `@wittgenstein/schemas` + zod + modality-specific deps).
- `scripts/check-codec-boundaries.mjs` does not currently forbid codec→core imports, but the established codec pattern is duck-typed inline errors (`codec-sensor/src/codec.ts:38`, `codec-image/src/decoders/{seed,llamagen}.ts:5`).

Two ways to do the rest of Slice 1 cleanly:

1. **Move error classes to `@wittgenstein/schemas`** — then every codec can import them. This is the right architectural answer, but it's bigger than "mechanical" and benefits from explicit ratification (it touches the `@wittgenstein/schemas` doctrine surface PR #191 just added to the doctrine-guardrail).
2. **Keep duck-typed pattern, factor a per-codec helper** — uglier but no architectural change. This is what this PR does for the two Kokoro sites.

Posting a follow-up comment on #170 with the architectural finding so the next slice can pick the right path before more code is written.

## Diff

```diff
   if (actualWeights !== KOKORO_MANIFEST.weightsSha256) {
-    throw new Error(
+    throw integrityError(
       `Kokoro weights SHA-256 mismatch...`,
     );
   }
   if (actualVoices !== KOKORO_MANIFEST.voicesSha256) {
-    throw new Error(
+    throw integrityError(
       `Kokoro voice file SHA-256 mismatch...`,
     );
   }
 }
+
+// + 8-line helper with comment explaining the boundary contract
+function integrityError(message: string): Error & { code: string } { ... }
```

## Validation

`pnpm --filter @wittgenstein/codec-audio test` — 8 tests pass, 3 Kokoro determinism opt-in tests skipped (require `WITTGENSTEIN_AUDIO_BACKEND=kokoro` env var). No behavior change beyond manifest `code` field upgrade for these two integrity violations.

## What this PR is **not**

- **Not** the full #170 slice 1. The codec.ts ValidationError sites in codec-audio (8) and codec-image (4), the codec-sensor inline-error consolidation, and the sandbox NotImplementedError site are deferred pending the architectural decision.
- **Not** failure-path test coverage (Slice 3 in the agent audit). Stays as a separate post-v0.3 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)