### PR TITLE
scaffold(benchmarks/tools): Phase-4 metric runner skeletons (closes #187)

### DIFF
--- a/benchmarks/tools/README.md
+++ b/benchmarks/tools/README.md
@@ -1,0 +1,79 @@
+# benchmarks/tools/
+
+Phase-4 quality-metric runners (per `ROADMAP.md` Phase 4). Today every entrypoint here is a typed Python skeleton that raises `NotImplementedError` — landing the contract first so that wiring CLIP / Whisper / discriminative classifiers can happen one PR at a time without rediscovering the file layout.
+
+## Contract
+
+Every runner is invoked as:
+
+```bash
+python benchmarks/tools/<runner>.py \
+  --artifact <artifact-path> \
+  --manifest <run-manifest.json> \
+  --out <score-receipt.json>
+```
+
+- `--artifact` — path to a single artifact (e.g. `.png`, `.wav`, `.csv`) under `artifacts/runs/<run-id>/`.
+- `--manifest` — path to the run manifest at `artifacts/runs/<run-id>/manifest.json` (the runner inspects modality / route / seed for context).
+- `--out` — path to write a structured **score receipt** JSON. If the runner is not yet implemented it raises `NotImplementedError` and writes nothing; the caller can detect this from the missing file and fall back to the structural smoke proxy.
+
+## Score receipt shape
+
+When a runner is implemented, the receipt JSON has this shape (tighter typing TBD when the first real runner lands):
+
+```json
+{
+  "tool": "clipscore",
+  "version": "0.0.1",
+  "metric": {
+    "name": "CLIPScore",
+    "value": 0.832,
+    "unit": "cosine"
+  },
+  "model": {
+    "id": "openai/clip-vit-base-patch32",
+    "deterministic": true
+  },
+  "inputs": {
+    "artifact": "artifacts/runs/2026-04-20T14-52-33_a3f9b2/artifact.png",
+    "manifest": "artifacts/runs/2026-04-20T14-52-33_a3f9b2/manifest.json",
+    "prompt": "stormy ocean at midnight"
+  },
+  "generatedAt": "2026-05-06T12:34:56Z"
+}
+```
+
+The shape is **not yet a zod-validated boundary** — it solidifies when the first runner lands and the actual data shape is known.
+
+## Runners
+
+| File | Modality | Metric | Status |
+| --- | --- | --- | --- |
+| `clipscore.py` | image | CLIPScore (image-text cosine) | 🔴 Stub |
+| `wer.py` | audio (speech) | Whisper WER | 🔴 Stub |
+| `disc_score.py` | sensor | discriminative-score classifier | 🔴 Stub |
+| `chart.py` | all | aggregate score chart from `artifacts/benchmarks/<tag>/*.json` | 🔴 Stub |
+
+## Why scaffolding-only first
+
+Per ROADMAP.md Phase 4 plan: the metric runners land at v0.4. Without scaffolding, the first contributor to wire CLIP has to discover the file layout, dependency choice, manifest contract, and CI integration from scratch. With scaffolding, that contributor only has to fill in the model call.
+
+Each stub:
+
+- Validates argparse inputs.
+- Reads the run manifest and asserts the modality matches what the runner expects.
+- Raises `NotImplementedError` with a one-line "wire X here" message.
+- A test under `benchmarks/tools/test_*` asserts the `NotImplementedError` fires (so that "still a stub" is itself a checked invariant — silent success here would be the worst failure mode).
+
+## Out of scope
+
+- Real model dependencies (`transformers` / `openai-whisper` / `torch`) are NOT added to `polyglot-mini/requirements.txt`. They land per-runner when the first implementation PR lands.
+- CI integration. The runners are runnable from shell today; whether they become a CI gate is a separate decision tied to model-cost / runtime budgets.
+- Backfilling historical receipts. The score receipts are forward-looking — runs after v0.4 land get them; pre-v0.4 runs do not.
+
+## Related
+
+- `ROADMAP.md` Phase 4 — metric runner list
+- `benchmarks/harness.ts` — the structural smoke proxy that runs today
+- Issue #187 — this scaffolding's filing
+- Issue #189 — manifest schema discriminated union (coordinates with the score-receipt shape lock)

--- a/benchmarks/tools/chart.py
+++ b/benchmarks/tools/chart.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Aggregate score chart generator (Phase 4 stub).
+
+Reads a directory of score-receipt JSON files (produced by clipscore /
+wer / disc_score) and writes a single chart summarizing the aggregate
+quality picture for a release tag. Today this is a typed skeleton that
+raises NotImplementedError so the contract is locked before a chart
+library and aggregation rule are committed to.
+
+Per ROADMAP.md Phase 4: "Chart generator producing
+artifacts/benchmarks/<tag>.png".
+
+To implement:
+    1. Pick a chart library (matplotlib, since polyglot-mini already
+       depends on it; no new dependency).
+    2. Decide aggregation: per-modality scatter, per-runner box, or
+       single multi-panel figure. Pick one.
+    3. Replace the NotImplementedError with the read + render pass.
+    4. Write the PNG to args.out.
+    5. Drop the test that asserts NotImplementedError fires.
+
+See benchmarks/tools/README.md for the full contract.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def _read_score_receipts(receipts_dir: Path) -> list[dict]:
+    if not receipts_dir.is_dir():
+        raise FileNotFoundError(f"Score-receipts directory not found: {receipts_dir}")
+    receipts: list[dict] = []
+    for path in sorted(receipts_dir.glob("*.json")):
+        receipts.append(json.loads(path.read_text()))
+    return receipts
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="chart",
+        description="Aggregate score chart generator (Phase 4 stub).",
+    )
+    parser.add_argument(
+        "--receipts-dir",
+        type=Path,
+        required=True,
+        help="Directory of *.json score receipts produced by clipscore/wer/disc_score.",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        required=True,
+        help="Where to write the aggregate chart PNG.",
+    )
+    parser.add_argument(
+        "--tag",
+        type=str,
+        required=False,
+        default="unreleased",
+        help="Release tag label for the chart title (e.g. 'v0.3.0-alpha.1').",
+    )
+    args = parser.parse_args(argv)
+
+    receipts = _read_score_receipts(args.receipts_dir)
+    if not receipts:
+        print(f"chart: no score receipts found in {args.receipts_dir}", file=sys.stderr)
+        return 1
+
+    raise NotImplementedError(
+        "chart: chart rendering is not yet implemented. "
+        "Pick a chart shape (per-modality scatter / per-runner box / multi-panel) "
+        "and replace this stub with matplotlib calls. "
+        "See benchmarks/tools/README.md."
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/tools/clipscore.py
+++ b/benchmarks/tools/clipscore.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""CLIPScore — image-text cosine similarity (Phase 4 stub).
+
+Wires `openai/clip-vit-base-patch32` (or compatible) to produce a single
+scalar quality score per image artifact. Today this is a typed skeleton
+that raises NotImplementedError so the contract — argparse shape,
+manifest read, score receipt path — is locked before a real CLIP load
+is wired.
+
+To implement:
+    1. pip install transformers torch (or use a pinned local copy)
+    2. Replace the NotImplementedError with the CLIP cosine call
+    3. Write the score receipt JSON to args.out
+    4. Drop the test that asserts NotImplementedError fires
+
+See benchmarks/tools/README.md for the full contract.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def _read_manifest(manifest_path: Path) -> dict:
+    if not manifest_path.exists():
+        raise FileNotFoundError(f"Run manifest not found: {manifest_path}")
+    return json.loads(manifest_path.read_text())
+
+
+def _assert_image_modality(manifest: dict) -> None:
+    modality = manifest.get("codec", "")
+    if not modality.startswith("image"):
+        raise ValueError(
+            f"clipscore expects an image-modality manifest; got codec={modality!r}"
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="clipscore",
+        description="CLIPScore image-text cosine similarity (Phase 4 stub).",
+    )
+    parser.add_argument(
+        "--artifact",
+        type=Path,
+        required=True,
+        help="Path to image artifact (.png / .jpg) produced by an image codec run.",
+    )
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        required=True,
+        help="Path to artifacts/runs/<run-id>/manifest.json for the same run.",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        required=True,
+        help="Where to write the score receipt JSON.",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.artifact.exists():
+        print(f"clipscore: artifact not found: {args.artifact}", file=sys.stderr)
+        return 1
+
+    manifest = _read_manifest(args.manifest)
+    _assert_image_modality(manifest)
+
+    raise NotImplementedError(
+        "clipscore: CLIP model wiring is not yet implemented. "
+        "Install transformers + torch and replace this stub with a CLIP "
+        "image-text cosine call. See benchmarks/tools/README.md."
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/tools/disc_score.py
+++ b/benchmarks/tools/disc_score.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Discriminative-score classifier for sensor artifacts (Phase 4 stub).
+
+Trains (or loads) a small classifier that distinguishes real-recording
+sensor traces from generated traces; the score is the classifier's
+accuracy in distinguishing — lower is better (closer to 0.5 = generated
+is indistinguishable from real). Today this is a typed skeleton that
+raises NotImplementedError so the contract is locked before a model
+choice and dataset are committed to.
+
+To implement:
+    1. Pick a small classifier architecture (e.g. 1D-CNN or random forest
+       over a few HRV / spectral-entropy features). Document the choice.
+    2. Pick a real-recording dataset (PhysioNet MIT-BIH for ECG, etc.)
+       — coordinate with #155 dataset-lock decision.
+    3. Replace the NotImplementedError with the train + eval pass.
+    4. Write the score receipt JSON to args.out.
+    5. Drop the test that asserts NotImplementedError fires.
+
+See benchmarks/tools/README.md for the full contract.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def _read_manifest(manifest_path: Path) -> dict:
+    if not manifest_path.exists():
+        raise FileNotFoundError(f"Run manifest not found: {manifest_path}")
+    return json.loads(manifest_path.read_text())
+
+
+def _assert_sensor_modality(manifest: dict) -> None:
+    codec = manifest.get("codec", "")
+    if codec != "sensor":
+        raise ValueError(
+            f"disc_score expects a sensor manifest; got codec={codec!r}"
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="disc_score",
+        description="Discriminative-score classifier for sensor artifacts (Phase 4 stub).",
+    )
+    parser.add_argument(
+        "--artifact",
+        type=Path,
+        required=True,
+        help="Path to sensor .csv artifact produced by sensor codec.",
+    )
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        required=True,
+        help="Path to artifacts/runs/<run-id>/manifest.json for the same run.",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        required=True,
+        help="Where to write the score receipt JSON.",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.artifact.exists():
+        print(f"disc_score: artifact not found: {args.artifact}", file=sys.stderr)
+        return 1
+
+    manifest = _read_manifest(args.manifest)
+    _assert_sensor_modality(manifest)
+
+    raise NotImplementedError(
+        "disc_score: classifier training/inference is not yet implemented. "
+        "Pick a real-recording dataset (coordinate with #155) and a small "
+        "classifier architecture, then replace this stub. "
+        "See benchmarks/tools/README.md."
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/tools/test_stubs.py
+++ b/benchmarks/tools/test_stubs.py
@@ -1,0 +1,95 @@
+"""Asserts every Phase 4 runner stub raises NotImplementedError.
+
+Drop the relevant block (and add real coverage) when each runner gets
+its real implementation. Until then, "this is a stub" is itself an
+invariant — silent success here would be the worst failure mode.
+
+Run with:
+    python -m unittest discover -s benchmarks/tools -p 'test_*.py' -v
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+THIS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(THIS_DIR))
+
+import chart  # noqa: E402
+import clipscore  # noqa: E402
+import disc_score  # noqa: E402
+import wer  # noqa: E402
+
+
+def _write_dummy(path: Path, content: str = "") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def _write_manifest(path: Path, codec: str, route: str | None = None) -> None:
+    payload = {"codec": codec}
+    if route is not None:
+        payload["route"] = route
+    _write_dummy(path, json.dumps(payload))
+
+
+class StubsRaiseNotImplementedTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.mkdtemp(prefix="benchmarks-tools-stubs-")
+
+    def tearDown(self) -> None:
+        for root, _, files in os.walk(self.tmp, topdown=False):
+            for name in files:
+                Path(root, name).unlink()
+            Path(root).rmdir()
+
+    def test_clipscore_stub_raises(self) -> None:
+        artifact = Path(self.tmp, "artifact.png")
+        manifest = Path(self.tmp, "manifest.json")
+        out = Path(self.tmp, "score.json")
+        _write_dummy(artifact, "fake-png")
+        _write_manifest(manifest, codec="image")
+        with self.assertRaises(NotImplementedError):
+            clipscore.main(
+                ["--artifact", str(artifact), "--manifest", str(manifest), "--out", str(out)]
+            )
+
+    def test_wer_stub_raises(self) -> None:
+        artifact = Path(self.tmp, "speech.wav")
+        manifest = Path(self.tmp, "manifest.json")
+        out = Path(self.tmp, "score.json")
+        _write_dummy(artifact, "fake-wav")
+        _write_manifest(manifest, codec="audio", route="speech")
+        with self.assertRaises(NotImplementedError):
+            wer.main(
+                ["--artifact", str(artifact), "--manifest", str(manifest), "--out", str(out)]
+            )
+
+    def test_disc_score_stub_raises(self) -> None:
+        artifact = Path(self.tmp, "trace.csv")
+        manifest = Path(self.tmp, "manifest.json")
+        out = Path(self.tmp, "score.json")
+        _write_dummy(artifact, "t,v\n0,0\n")
+        _write_manifest(manifest, codec="sensor")
+        with self.assertRaises(NotImplementedError):
+            disc_score.main(
+                ["--artifact", str(artifact), "--manifest", str(manifest), "--out", str(out)]
+            )
+
+    def test_chart_stub_raises(self) -> None:
+        receipts_dir = Path(self.tmp, "receipts")
+        receipts_dir.mkdir()
+        _write_dummy(receipts_dir / "one.json", json.dumps({"tool": "clipscore"}))
+        out = Path(self.tmp, "chart.png")
+        with self.assertRaises(NotImplementedError):
+            chart.main(
+                ["--receipts-dir", str(receipts_dir), "--out", str(out)]
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/tools/wer.py
+++ b/benchmarks/tools/wer.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Whisper WER — word error rate for TTS speech artifacts (Phase 4 stub).
+
+Wires `openai/whisper-small` (or compatible) to transcribe a `.wav`
+artifact and compute WER against the requested speech text. Today this
+is a typed skeleton that raises NotImplementedError so the contract —
+argparse shape, manifest read, score receipt path — is locked before
+a real Whisper load is wired.
+
+To implement:
+    1. pip install openai-whisper (or use faster-whisper)
+    2. Replace the NotImplementedError with the transcription + WER calc
+    3. Write the score receipt JSON to args.out
+    4. Drop the test that asserts NotImplementedError fires
+
+See benchmarks/tools/README.md for the full contract.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def _read_manifest(manifest_path: Path) -> dict:
+    if not manifest_path.exists():
+        raise FileNotFoundError(f"Run manifest not found: {manifest_path}")
+    return json.loads(manifest_path.read_text())
+
+
+def _assert_speech_route(manifest: dict) -> None:
+    codec = manifest.get("codec", "")
+    route = manifest.get("route", "")
+    if codec != "audio" or route != "speech":
+        raise ValueError(
+            f"wer expects an audio-speech manifest; got codec={codec!r}, route={route!r}"
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="wer",
+        description="Whisper WER for TTS speech artifacts (Phase 4 stub).",
+    )
+    parser.add_argument(
+        "--artifact",
+        type=Path,
+        required=True,
+        help="Path to speech .wav artifact produced by audio codec speech route.",
+    )
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        required=True,
+        help="Path to artifacts/runs/<run-id>/manifest.json for the same run.",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        required=True,
+        help="Where to write the score receipt JSON.",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.artifact.exists():
+        print(f"wer: artifact not found: {args.artifact}", file=sys.stderr)
+        return 1
+
+    manifest = _read_manifest(args.manifest)
+    _assert_speech_route(manifest)
+
+    raise NotImplementedError(
+        "wer: Whisper model wiring is not yet implemented. "
+        "Install openai-whisper (or faster-whisper) and replace this stub "
+        "with a transcription + WER call. See benchmarks/tools/README.md."
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Lands the typed Python skeletons promised by `ROADMAP.md` Phase 4 so the "stub vs minimum viable" gap is scoped before any model wiring happens. The first contributor to wire CLIP / Whisper / a discriminative classifier no longer has to invent file layout, CLI contract, manifest read, or score-receipt shape — they only need to fill in the model call.

Closes #187.

## What landed

```
benchmarks/tools/
├── README.md         — contract: CLI shape, score-receipt JSON, runner table
├── clipscore.py      — image CLIP cosine
├── wer.py            — speech Whisper WER
├── disc_score.py     — sensor discriminative classifier
├── chart.py          — aggregate score chart from a directory of receipts
└── test_stubs.py     — asserts every stub raises NotImplementedError
```

Every entrypoint has the same shape:

```bash
python benchmarks/tools/<runner>.py \
  --artifact <artifact-path> \
  --manifest <run-manifest.json> \
  --out <score-receipt.json>
```

Each:
1. parses argparse with consistent flags
2. validates the artifact exists
3. reads the run manifest and asserts the modality matches what the runner expects
4. raises `NotImplementedError` with a one-line "wire X here" message

## Why scaffolding-only first

`ROADMAP.md` Phase 4 lists these runners as v0.4 work. Without scaffolding, the first contributor to wire CLIP has to discover everything — file layout, dependency choice, manifest contract, CI integration — from scratch. With scaffolding:

- The CLI shape is locked once.
- The manifest-read pattern is locked once.
- The "what modality does this runner expect" check is locked once.
- "This is a stub" becomes a tested invariant (`test_stubs.py`) — silent success is the worst failure mode for an unimplemented metric.

## Out of scope (deliberately deferred)

- **Real model dependencies** (`transformers` / `openai-whisper` / `torch`) are NOT added to `polyglot-mini/requirements.txt`. They land per-runner when the first implementation PR lands.
- **CI integration.** The runners are runnable from shell today; whether they become a CI gate is a separate decision tied to model-cost / runtime budgets.
- **Backfilling historical receipts.** Score receipts are forward-looking — runs after v0.4 land get them; pre-v0.4 runs do not.
- **Locking the score-receipt JSON shape via zod.** The shape is documented in README.md and example-shaped, but the actual zod boundary lives in `@wittgenstein/schemas` and waits for the first real runner so the data shape is concrete (per issue #189 manifest discriminated union).

## Validation

`python3 -m unittest discover -s benchmarks/tools -p 'test_*.py' -v` — 4 tests, all green:

```
test_chart_stub_raises ... ok
test_clipscore_stub_raises ... ok
test_disc_score_stub_raises ... ok
test_wer_stub_raises ... ok
```

## Related

- ROADMAP.md Phase 4
- benchmarks/harness.ts — the existing structural smoke proxy (unchanged by this PR)
- #189 — manifest schema discriminated union (coordinates with score-receipt shape lock)
- #155 — sensor downstream measurement (future input to disc_score.py implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)