### PR TITLE
ci: include manifest evidence in Kokoro sweep summary

### DIFF
--- a/.github/workflows/kokoro-sweep.yml
+++ b/.github/workflows/kokoro-sweep.yml
@@ -68,7 +68,7 @@ jobs:
           if [ -f artifacts/tmp/kokoro-sweep-linux.json ]; then
             echo "## Kokoro sweep receipt (Linux)" >> "$GITHUB_STEP_SUMMARY"
             echo '```json' >> "$GITHUB_STEP_SUMMARY"
-            jq '{ok, platform, packageVersions, backend, seed, runsRequested, uniqueArtifactShaCount, runs: [.runs[] | {index, artifactSha256}]}' \
+            jq '{ok, platform, packageVersions, backend, seed, runsRequested, uniqueArtifactShaCount, runs: [.runs[] | {index, artifactSha256, audioRender, decoderHash, quality}]}' \
               artifacts/tmp/kokoro-sweep-linux.json >> "$GITHUB_STEP_SUMMARY"
             echo '```' >> "$GITHUB_STEP_SUMMARY"
           else


### PR DESCRIPTION
## Summary
- updates the manual Linux Kokoro sweep workflow summary to show each run's audioRender, decoderHash, and quality evidence
- fixes the post-#181 observation that the full artifact was correct but the inline summary omitted nested manifest evidence

## Scope
Tiny workflow-summary cleanup only. No change to the sweep command, artifact upload, or release verdict.

## Validation
- `pnpm exec prettier --check .github/workflows/kokoro-sweep.yml`
- `git diff --check`

Refs #164 and #118.