### PR TITLE
docs: record M2 Slice E Kokoro sweep verdict

### DIFF
--- a/docs/codecs/audio.md
+++ b/docs/codecs/audio.md
@@ -4,7 +4,7 @@ Audio is the second-priority modality after image. It ships three internal route
 
 `LLM -> structured AudioPlan JSON -> per-route render -> WAV bytes -> manifest`
 
-> **Implementation status (v0.3 in flight, 2026-05-05).** The doctrine below — Kokoro-82M-family default for speech, Piper-family fallback, byte-parity on the pinned CPU backend — is the **ratified target** (ADR-0015). Code-wise, the speech route currently ships `procedural-audio-runtime` as the **default** decoder; **Kokoro-82M is opt-in** via `WITTGENSTEIN_AUDIO_BACKEND=kokoro` (M2 Slice C2, Issue #116). The default flip from procedural to Kokoro is gated on Slice E (#118) cross-platform determinism verification. Until Slice E lands, `audioRender.decoderId` in the manifest is the source of truth for which backend actually ran on a given run; the doctrine and the code converge at the v0.3 cut, not before.
+> **Implementation status (v0.3 in flight, 2026-05-06).** The doctrine below — Kokoro-82M-family default target for speech, Piper-family fallback, byte-parity on a pinned CPU backend — remains the ratified target (ADR-0015), but Slice E found that Kokoro is same-platform deterministic and **not** byte-identical across macOS arm64 and Linux x64. Code-wise, `procedural-audio-runtime` remains the **default** decoder for v0.3; **Kokoro-82M is opt-in** via `WITTGENSTEIN_AUDIO_BACKEND=kokoro` and records `determinismClass: "structural-parity"`. `audioRender.decoderId` in the manifest is the source of truth for which backend actually ran.
 
 ## Position
 
@@ -49,16 +49,18 @@ The LLM does not emit raw audio, MIDI bytes, or sample arrays. It emits a _plan_
 
 ### Speech route
 
-- `Kokoro-82M-family` decoder by default, with `Piper-family` as the fallback speech
-  path only when the Kokoro path is unavailable, cannot initialize, or fails the
-  pinned deterministic CPU gate.
+- Current v0.3 default: `procedural-audio-runtime`.
+- Opt-in neural speech path: `Kokoro-82M-family` via `WITTGENSTEIN_AUDIO_BACKEND=kokoro`.
+- Ratified fallback family: `Piper-family`, not wired at v0.3.
 - Optional ambient layer mixed at a fixed gain.
-- Output: 16-bit mono WAV at 22050 Hz (configurable via the AudioPlan).
+- Output is backend-specific and recorded in `audioRender`. Procedural speech emits
+  16-bit WAV; Kokoro emits 24 kHz float WAV with `determinismClass:
+"structural-parity"`.
 
-Fallback to Piper must leave manifest evidence of the concrete decoder actually used
-(`decoderId`, `determinismClass`). If the Kokoro path was present but rejected by the
-CPU reproducibility gate, the codec should also preserve a structured partial/failure
-reason rather than silently presenting the run as a normal Kokoro render.
+Any future fallback to Piper must leave manifest evidence of the concrete decoder
+actually used (`decoderId`, `determinismClass`). The v0.3 decision is simpler:
+Kokoro does not flip to default because its same-seed WAV bytes differ across the
+tested macOS and Linux targets.
 
 ### Soundscape route
 
@@ -107,10 +109,8 @@ waveform-direct.
 
 - The LLM emits an AudioPlan with an out-of-range route — caught by zod parse, surfaced as a structured error.
 - The TTS engine is unavailable on the host — codec writes `quality.partial: { reason: "tts_engine_missing" }` and a manifest row noting the failure; no silent fallback.
-- The Kokoro path is present but fails the pinned deterministic CPU gate — codec may
-  fall back to Piper, but must record the fallback in manifest evidence and preserve a
-  structured partial/failure reason if the render no longer satisfies the Kokoro path's
-  byte-parity contract.
+- The Kokoro path is present but does not satisfy cross-platform byte identity —
+  the codec keeps it opt-in and reports `structural-parity`; no silent default flip.
 - The music plan specifies a key/tempo combination the synth cannot render — error surfaced to the user with the offending plan field; no down-tuning happens silently.
 - An ambient layer file is missing — fall back to silence with a structured warning, never to a different ambient.
 

--- a/docs/exec-plans/active/v0.3-roadmap.md
+++ b/docs/exec-plans/active/v0.3-roadmap.md
@@ -21,15 +21,15 @@ When the listed work lands, this page updates the row's status. When v0.3 cuts, 
 
 ## v0.3 release gates
 
-Five concrete checks, lifted from the audit's "from doctrinal claim to checkable fact" framing. Status reflects 2026-05-04 reality.
+Five concrete checks, lifted from the audit's "from doctrinal claim to checkable fact" framing. Status reflects 2026-05-06 reality.
 
-| #   | Gate                                                                               | Status             | Evidence                                                                                                                                                                                                          |
-| --- | ---------------------------------------------------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1   | At least one byte-for-byte golden checked in + CI-gated                            | ✅                 | Sensor (3 routes) — PR #125; `pnpm test:golden` green on main                                                                                                                                                     |
-| 2   | M2 sweep-level kill criterion verified                                             | ⏳                 | Slice E (Issue #118) — blocked on Slice C2 Kokoro wiring (Issue #116)                                                                                                                                             |
-| 3   | `runtime/manifest.ts` + `runtime/seed.ts` + `runtime/router.ts` invariant coverage | ✅                 | PR #133 (manifest / seed / router, 22 invariant tests) + PR #139 (budget / retry / cli shared, 21 invariant tests). Demoted from the audit's "test:src ratio threshold" framing per the maintainer-pair review on PR #103       |
-| 4   | README "Receipts" table evidentiary-only (each row CI-gated)                       | ✅                 | Initial pass via PR #134; tightened to 3 strict CI-gated rows + Engineering subsection via PR #135                                                                                                                |
-| 5   | Supply-chain CI gating (dep-review fail-on-high; CodeQL extended)                  | ✅                 | PR #132 landed config; PR #138 made `dependency-review-action` a real gate after Dependency graph was enabled in repo Settings → Security & analysis (2026-05-04)                                                 |
+| #   | Gate                                                                               | Status | Evidence                                                                                                                                                                                                                  |
+| --- | ---------------------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | At least one byte-for-byte golden checked in + CI-gated                            | ✅     | Sensor (3 routes) — PR #125; `pnpm test:golden` green on main                                                                                                                                                             |
+| 2   | M2 sweep-level kill criterion verified                                             | ✅     | Slice E (Issue #118) recorded in `docs/research/2026-05-06-m2-slice-e-kokoro-sweep-verdict.md`: Kokoro is same-platform deterministic but not cross-platform byte-identical; procedural remains the v0.3 default.         |
+| 3   | `runtime/manifest.ts` + `runtime/seed.ts` + `runtime/router.ts` invariant coverage | ✅     | PR #133 (manifest / seed / router, 22 invariant tests) + PR #139 (budget / retry / cli shared, 21 invariant tests). Demoted from the audit's "test:src ratio threshold" framing per the maintainer-pair review on PR #103 |
+| 4   | README "Receipts" table evidentiary-only (each row CI-gated)                       | ✅     | Initial pass via PR #134; tightened to 3 strict CI-gated rows + Engineering subsection via PR #135                                                                                                                        |
+| 5   | Supply-chain CI gating (dep-review fail-on-high; CodeQL extended)                  | ✅     | PR #132 landed config; PR #138 made `dependency-review-action` a real gate after Dependency graph was enabled in repo Settings → Security & analysis (2026-05-04)                                                         |
 
 When all five rows reach ✅ and `CHANGELOG.md` has a `v0.3.0` entry, v0.3 is cut.
 
@@ -37,26 +37,25 @@ When all five rows reach ✅ and `CHANGELOG.md` has a `v0.3.0` entry, v0.3 is cu
 
 ## Active engineering line
 
-**M2 audio port — Slice C2 + C3 + Sweep E.** Source of truth: [`codec-v2-port.md`](codec-v2-port.md) §M2. Slices A/B/C1/D + C3 parity goldens are merged. Remaining:
+**M2 audio port — release closeout.** Source of truth: [`codec-v2-port.md`](codec-v2-port.md) §M2. Slices A/B/C1/D + C2/C3 and Sweep E are complete. Remaining work is release packaging:
 
-| Slice | Issue | Status                                                                                       |
-| ----- | ----- | -------------------------------------------------------------------------------------------- |
-| C2    | #116  | Kokoro-82M ONNX backend wiring; handoff brief in issue body                                  |
-| E     | #118  | Sweep-level kill criterion verification across macOS + Linux; gates the default-backend flip |
+| Slice | Issue | Status                                                                                    |
+| ----- | ----- | ----------------------------------------------------------------------------------------- |
+| E     | #118  | Sweep verdict recorded: Kokoro stays opt-in structural-parity; procedural remains default |
 
-Slice C2 is the **single largest v0.3 blocker.** When C2 + E land, gate #2 closes.
+The remaining v0.3 work is #151 final cold-checkout verification and #149 release notes / changelog.
 
 ---
 
 ## Open backlog (not gating v0.3 but staying tracked)
 
-| Issue | Title                                        | Status                                                                                |
-| ----- | -------------------------------------------- | ------------------------------------------------------------------------------------- |
-| #91   | Research taxonomy — long-form note relabeling | Closed by PR #140 (5 surfaces banner-labeled as theory note / reference sheet / captured artifact)       |
-| #106  | README Receipts evidentiary tightening       | Closed by PR #135 (3 strict rows + Engineering subsection)                                                |
-| #107  | Supply-chain CI hardening                    | Closed by PR #138 (dep-review gate flipped real after dep-graph toggle)                                   |
-| #108  | core / cli manifest-spine invariant coverage | Closed by PR #133 (manifest / seed / router) + PR #139 (budget / retry / cli)                             |
-| #113  | ADR-0016 — untrusted-code-execution boundary | Closed by PR #136 (ADR-0016 ratified; SECURITY.md + engineering-discipline.md cite added)                 |
+| Issue | Title                                         | Status                                                                                             |
+| ----- | --------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| #91   | Research taxonomy — long-form note relabeling | Closed by PR #140 (5 surfaces banner-labeled as theory note / reference sheet / captured artifact) |
+| #106  | README Receipts evidentiary tightening        | Closed by PR #135 (3 strict rows + Engineering subsection)                                         |
+| #107  | Supply-chain CI hardening                     | Closed by PR #138 (dep-review gate flipped real after dep-graph toggle)                            |
+| #108  | core / cli manifest-spine invariant coverage  | Closed by PR #133 (manifest / seed / router) + PR #139 (budget / retry / cli)                      |
+| #113  | ADR-0016 — untrusted-code-execution boundary  | Closed by PR #136 (ADR-0016 ratified; SECURITY.md + engineering-discipline.md cite added)          |
 
 Trackers (gated on external events, not actionable until tripped):
 

--- a/docs/research/2026-05-06-m2-slice-e-kokoro-sweep-verdict.md
+++ b/docs/research/2026-05-06-m2-slice-e-kokoro-sweep-verdict.md
@@ -1,0 +1,97 @@
+# M2 Slice E Kokoro Sweep Verdict — 2026-05-06
+
+**Status:** release-facing receipt for Issue #118  
+**Inputs:** macOS local sweep, Linux GitHub Actions sweep from Issue #164 / PR #181  
+**Verdict:** Kokoro is same-platform deterministic but not cross-platform byte-identical.
+
+This receipt closes the M2 Slice E question without pretending the result is cleaner than it is.
+The Kokoro backend is useful and deterministic within each tested platform, but the same seed
+does not produce byte-identical WAV bytes across macOS arm64 and Linux x64.
+
+## Commands
+
+macOS:
+
+```sh
+pnpm sweep:audio-kokoro -- --out artifacts/tmp/kokoro-sweep-macos-current.json
+```
+
+Linux:
+
+```sh
+gh workflow run kokoro-sweep.yml -f runs=3 -f seed=7
+```
+
+Workflow run:
+
+- <https://github.com/p-to-q/wittgenstein/actions/runs/25421565027>
+
+## macOS Receipt
+
+```json
+{
+  "ok": true,
+  "platform": {
+    "os": "darwin",
+    "arch": "arm64",
+    "release": "25.5.0",
+    "node": "v22.20.0"
+  },
+  "backend": "kokoro",
+  "seed": 7,
+  "runsRequested": 3,
+  "uniqueArtifactShaCount": 1,
+  "artifactSha256": "d67ff7e5a0a3773b034db3c7347f0bc98782e3b93d4b3e48b6eca1002e18d3cc"
+}
+```
+
+## Linux Receipt
+
+```json
+{
+  "ok": true,
+  "platform": {
+    "os": "linux",
+    "arch": "x64",
+    "release": "6.17.0-1010-azure",
+    "node": "v20.19.0"
+  },
+  "backend": "kokoro",
+  "seed": 7,
+  "runsRequested": 3,
+  "uniqueArtifactShaCount": 1,
+  "artifactSha256": "9e26275d17f4891108e8408cd22a20f5d14e42b64e662e661de5c36b5bd13316"
+}
+```
+
+Both receipts report the same decoder evidence:
+
+```json
+{
+  "sampleRateHz": 24000,
+  "channels": 1,
+  "durationSec": 4.55,
+  "container": "wav",
+  "bitDepth": 32,
+  "determinismClass": "structural-parity",
+  "decoderId": "kokoro-82M:53a71ac22a70778d57162e4f92eafc62852d9e04a4460b20638d2424796e6037",
+  "decoderHash": "a13bb941e2560aaea824d1f6caf0fe3c509eb2d0c5c0b7b1f6b5c67e922bc143"
+}
+```
+
+## Decision
+
+- Kokoro same-platform determinism passes on macOS arm64 and Linux x64.
+- Kokoro cross-platform byte identity does **not** pass:
+  - macOS: `d67ff7e5a0a3773b034db3c7347f0bc98782e3b93d4b3e48b6eca1002e18d3cc`
+  - Linux: `9e26275d17f4891108e8408cd22a20f5d14e42b64e662e661de5c36b5bd13316`
+- For v0.3, keep `procedural-audio-runtime` as the default speech backend.
+- Keep Kokoro opt-in behind `WITTGENSTEIN_AUDIO_BACKEND=kokoro`.
+- Preserve Kokoro's manifest class as `determinismClass: "structural-parity"`.
+- Do not claim Piper fallback is implemented; Piper remains the ADR-0015 fallback family if the project later chooses to wire it.
+
+## Follow-Up
+
+- Issue #151 should run the final cold-checkout receipt after this verdict lands.
+- Issue #149 should write the final prerelease notes with this verdict, not the earlier "pending sweep" wording.
+- Any future attempt to flip the speech default to Kokoro needs a new receipt or a deliberate decision that structural parity is acceptable for the default backend.

--- a/docs/research/2026-05-06-v0.3-release-notes-draft.md
+++ b/docs/research/2026-05-06-v0.3-release-notes-draft.md
@@ -3,15 +3,17 @@
 **Status:** draft release surface for Issue #149. Not a tag plan, not a release
 artifact, and not a substitute for the final `CHANGELOG.md` entry.
 
-This note is the safe part of release-note work that can happen before the
-independent Docker/Linux Kokoro audit in Issue #164 returns. It keeps the
-release story ready without pretending the final M2 sweep verdict is known.
+This note began as the safe part of release-note work before the independent
+Docker/Linux Kokoro audit returned. The M2 sweep verdict is now recorded in
+`docs/research/2026-05-06-m2-slice-e-kokoro-sweep-verdict.md`: Kokoro is
+same-platform deterministic but not cross-platform byte-identical, so v0.3 keeps
+the procedural speech backend as the default and leaves Kokoro opt-in.
 
 ## Release Boundary
 
-The next prerelease should describe the v0.3 execution line after the audio
-sweep verdict is known. The release should not be tagged until these receipts
-agree:
+The next prerelease should describe the v0.3 execution line after the final
+cold-checkout receipt is complete. The release should not be tagged until these
+receipts agree:
 
 - Issue #118 — M2 audio sweep-level verification.
 - Issue #151 — final truth-surface cold-checkout rerun.
@@ -51,8 +53,8 @@ Use this as the starting point for the final `CHANGELOG.md` entry. Replace
 
 ### Changed
 
-- Kept the default audio backend procedural until the M2 sweep verdict permits
-  a backend flip.
+- Kept the default audio backend procedural after the M2 sweep showed Kokoro is
+  same-platform deterministic but not cross-platform byte-identical.
 - Updated README and status surfaces around the harness-first thesis and the
   current maturity of image, audio, sensor, SVG, and video outputs.
 - Tightened reproducibility and evidence surfaces: README receipts, sensor
@@ -78,9 +80,10 @@ Use this as the starting point for the final `CHANGELOG.md` entry. Replace
 
 ### Known limits
 
-- Final audio backend verdict: TBD pending Issue #118 and Issue #164.
-- Default backend flip: TBD pending the sweep verdict.
-- Linux/Docker Kokoro receipt: TBD pending Issue #164.
+- Kokoro remains opt-in with `determinismClass: "structural-parity"`; the v0.3
+  default speech backend remains `procedural-audio-runtime`.
+- Linux/Docker and macOS Kokoro receipts are same-platform stable but produce
+  different artifact SHA-256 values across platforms.
 - This prerelease does not add neural soundscape, neural music, GPU inference,
   voice cloning, or a new audio manifest schema.
 ```
@@ -91,6 +94,8 @@ Release notes should cite the following receipts once they are final:
 
 - `docs/research/2026-05-06-v0.3-cold-checkout-rerun.md` — macOS cold-checkout
   rehearsal on commit `df93c3ad8e6dc3c3a4898b7ea8526af77df0fc9f`.
+- `docs/research/2026-05-06-m2-slice-e-kokoro-sweep-verdict.md` — M2 Slice E
+  verdict: Kokoro structural-parity opt-in, procedural default.
 - Issue #164 — independent Linux/Docker Kokoro audit receipt.
 - Issue #118 — final M2 sweep verdict and backend decision.
 - PR #121 — audio C3 parity/golden harness.


### PR DESCRIPTION
## Summary
- records the M2 Slice E Kokoro sweep receipt from macOS + Linux
- updates audio docs and the v0.3 roadmap with the actual verdict: Kokoro is same-platform deterministic, not cross-platform byte-identical
- updates the v0.3 release-notes draft so final release wording keeps procedural as the default and Kokoro as opt-in structural-parity

## Verdict
Kokoro remains opt-in for v0.3. `procedural-audio-runtime` remains the default speech backend. Piper is not claimed as wired.

## Validation
- `pnpm exec prettier --check docs/research/2026-05-06-m2-slice-e-kokoro-sweep-verdict.md docs/exec-plans/active/v0.3-roadmap.md docs/research/2026-05-06-v0.3-release-notes-draft.md docs/codecs/audio.md`
- `git diff --check`

Refs #118, #149, #151, #164.