### PR TITLE
docs: finalize v0.3 cold-checkout receipt

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ harness/codec/manifest contract. Video targets `.mp4` once its codec slot opens.
 local 30-second sensor quickstart below is the smallest no-API-key proof; maturity levels
 are called out in `docs/implementation-status.md`.
 
-> **🧪 Project status — early-stage, doctrine-locked, M2 audio in progress.**
+> **🧪 Project status — early-stage, doctrine-locked, v0.3 release closeout.**
 > Wittgenstein is a prerelease (`v0.2.0-alpha.2`) with a working Python
 > surface, a production-shaped TypeScript harness, and a few intentionally
 > unfinished surfaces clearly flagged with ⚠️ or 🔴 in
 > [`docs/implementation-status.md`](docs/implementation-status.md). The v0.2
 > cut locks the thesis, vocabulary, and codec protocol (RFC-0001 / ADR-0008);
-> M0 and M1A have landed; M2 audio is the active implementation line against
+> M0, M1A, and the M2 audio sweep have landed; v0.3 is now in release closeout against
 > [`docs/exec-plans/active/codec-v2-port.md`](docs/exec-plans/active/codec-v2-port.md).
 > Breaking changes are still possible before a stable release. **We are
 > actively looking for early adopters and contributors** — see
@@ -101,7 +101,7 @@ The receipt set is intentionally narrow. Adding a row requires a script + a CI g
 
 ### Engineering
 
-- Workspace gates from a clean checkout: `pnpm install && pnpm typecheck && pnpm lint && pnpm test` — 10 / 10 packages green. Verified 2026-05-04 in [`docs/research/2026-05-04-cold-checkout-verification.md`](docs/research/2026-05-04-cold-checkout-verification.md).
+- Workspace gates from a clean checkout: `pnpm install --frozen-lockfile`, `pnpm typecheck`, `pnpm lint`, `pnpm test`, `pnpm test:golden`, and `pnpm smoke:cli` all pass. Verified 2026-05-06 in [`docs/research/2026-05-06-v0.3-cold-checkout-rerun.md`](docs/research/2026-05-06-v0.3-cold-checkout-rerun.md).
 - Codec independence: `pnpm lint:deps` enforces no cross-codec imports across 6 codec packages ([PR #126](https://github.com/p-to-q/wittgenstein/pull/126)).
 - Self-contained loupe HTML dashboard: ~ 117 KB, zero external CDN dependencies (run the [Quickstart](#quickstart-30-seconds-no-api-key) below, then `wc -c /tmp/ecg.html`).
 

--- a/docs/codecs/audio.md
+++ b/docs/codecs/audio.md
@@ -10,17 +10,18 @@ Audio is the second-priority modality after image. It ships three internal route
 
 Audio is a _layered_ modality, not a single decoder. Each route picks its own L3:
 
-- `speech` — `Kokoro-82M-family` local TTS render by default, with `Piper-family`
-  fallback, plus optional ambient layer.
+- `speech` — `procedural-audio-runtime` by default at v0.3, with an opt-in
+  `Kokoro-82M-family` local TTS render and a ratified but not-yet-wired
+  `Piper-family` fallback target, plus optional ambient layer.
 - `soundscape` — deterministic ambient texture render from a small operator library.
 - `music` — tiny symbolic synthesizer (chords, melody, rhythm) plus optional ambient layer.
 
 This means audio's "decoder" is per-route, not a single frozen artifact like image's
 decoder. The ADR-0005 "decoder ≠ generator" line still holds: no path samples from a
 learned distribution at inference time, and every route has an explicit reproducibility
-contract. Procedural routes are byte-stable by construction; speech is byte-stable on
-the pinned deterministic CPU backend and structural-only on GPU. There is no audio
-diffusion in the core path.
+contract. Procedural routes are byte-stable by construction; Kokoro speech is
+same-platform deterministic in the v0.3 receipts and structural-only across the tested
+macOS and Linux targets. There is no audio diffusion in the core path.
 
 At the v0.3 harness boundary there is also **no audio tokenizer**. The speech decoder
 emits a waveform directly; the codec packages waveform bytes plus manifest rows without
@@ -79,11 +80,11 @@ tested macOS and Linux targets.
 The v0.3 path picks render libraries on three constraints, in order: **license-clean,
 on-device, deterministic.**
 
-| Route      | v0.3 default                              | Why this and not X                                                                                                                                                                   |
-| ---------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| speech     | Kokoro-82M-family default; Piper fallback | ElevenLabs / cloud TTS would violate "on-device deterministic." F5 / XTTS-class paths either fail the commercial-license bar or create a less reproducible inference story for v0.3. |
-| soundscape | deterministic operator-library render     | No external sample packs (license risk); no neural soundscape model (not deterministic in the ADR-0005 sense).                                                                       |
-| music      | symbolic synth (chord → note → sample)    | MusicLM / Riffusion are generators in the ADR-0005 sense — out of scope. MIDI rendering against a frozen soundfont is in-scope and on the v0.3 upgrade path.                         |
+| Route      | v0.3 default                                             | Why this and not X                                                                                                                                                                                                                                                |
+| ---------- | -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| speech     | procedural default; Kokoro opt-in; Piper fallback target | ElevenLabs / cloud TTS would violate "on-device deterministic." Kokoro is useful but not cross-platform byte-identical in the v0.3 receipts. F5 / XTTS-class paths either fail the commercial-license bar or create a less reproducible inference story for v0.3. |
+| soundscape | deterministic operator-library render                    | No external sample packs (license risk); no neural soundscape model (not deterministic in the ADR-0005 sense).                                                                                                                                                    |
+| music      | symbolic synth (chord → note → sample)                   | MusicLM / Riffusion are generators in the ADR-0005 sense — out of scope. MIDI rendering against a frozen soundfont is in-scope and on the v0.3 upgrade path.                                                                                                      |
 
 The v0.3+ upgrade path is named in `docs/exec-plans/active/codec-v2-port.md` M5b (audio benchmark bridge): UTMOS + Whisper-WER for speech, librosa spectral metrics for soundscape, LAION-CLAP for music.
 
@@ -137,8 +138,8 @@ See `tts-launch` and `audio-music` in `benchmarks/cases.json`. Quality bridges l
 
 Audio quality at v0.3 is _structurally honest_, not _aesthetically frontier_:
 
-- Speech intelligibility from the Kokoro-82M-family default is strong for local TTS, but
-  still not ElevenLabs-grade; the Piper fallback is slightly lower.
+- Speech intelligibility from the Kokoro-82M-family opt-in path is strong for local TTS,
+  but still not ElevenLabs-grade; the Piper fallback remains ratified but not wired.
 - Soundscape texture is recognizable but not field-recording-grade.
 - Music is identifiable as music in the requested key but is not Suno / Udio quality.
 

--- a/docs/exec-plans/active/v0.3-roadmap.md
+++ b/docs/exec-plans/active/v0.3-roadmap.md
@@ -43,7 +43,9 @@ When all five rows reach ✅ and `CHANGELOG.md` has a `v0.3.0` entry, v0.3 is cu
 | ----- | ----- | ----------------------------------------------------------------------------------------- |
 | E     | #118  | Sweep verdict recorded: Kokoro stays opt-in structural-parity; procedural remains default |
 
-The remaining v0.3 work is #151 final cold-checkout verification and #149 release notes / changelog.
+The remaining v0.3 work is #149 release notes / changelog. Issue #151 has a
+final cold-checkout receipt on commit `982249c58cbbc5b732c95d2456171c0f14c41c72`
+in `docs/research/2026-05-06-v0.3-cold-checkout-rerun.md`.
 
 ---
 

--- a/docs/research/2026-05-06-v0.3-cold-checkout-rerun.md
+++ b/docs/research/2026-05-06-v0.3-cold-checkout-rerun.md
@@ -1,15 +1,16 @@
 # v0.3 Cold-checkout Rerun — 2026-05-06
 
-**Status:** pre-release rehearsal receipt for Issue #151  
-**Commit tested:** `df93c3ad8e6dc3c3a4898b7ea8526af77df0fc9f`  
-**Host:** macOS Darwin 25.5.0 arm64  
-**Node:** `v22.20.0`  
+**Status:** pre-release rehearsal receipt for Issue #151
+**Commit tested:** `982249c58cbbc5b732c95d2456171c0f14c41c72`
+**Host:** macOS Darwin 25.5.0 arm64
+**Node:** `v22.20.0`
 **pnpm:** `9.12.0`
 
-This rerun verifies the current `main` branch after the M2 Kokoro opt-in backend
-and sweep receipt tooling landed. It is a release-facing cold-checkout receipt, but
-the final v0.3 audio verdict still waits on the independent Docker/Linux audit in
-Issue #164. If #164 changes the verdict, rerun this receipt before tagging.
+This rerun verifies the current `main` branch after the M2 Slice E Kokoro sweep
+verdict landed. It is the release-facing cold-checkout receipt for Issue #151.
+The independent Docker/Linux Kokoro audit has returned and is incorporated into
+the M2 Slice E verdict receipt; v0.3 keeps procedural speech as the default and
+leaves Kokoro opt-in with `determinismClass: "structural-parity"`.
 
 ## Fresh Checkout
 
@@ -24,8 +25,8 @@ pnpm -v
 
 Result:
 
-- checkout path: `/tmp/witt-cold-151-vlII27/wittgenstein`
-- commit: `df93c3ad8e6dc3c3a4898b7ea8526af77df0fc9f`
+- checkout path: `/tmp/witt-cold-151-final-OUzZh3/wittgenstein`
+- commit: `982249c58cbbc5b732c95d2456171c0f14c41c72`
 - Node: `v22.20.0`
 - pnpm: `9.12.0`
 
@@ -37,6 +38,7 @@ pnpm typecheck
 pnpm lint
 pnpm test
 pnpm test:golden
+pnpm smoke:cli
 ```
 
 Result: all passed.
@@ -47,7 +49,7 @@ Notes:
 - Workspace typecheck passed across 13 workspace projects.
 - Workspace lint passed across 13 workspace projects.
 - Workspace tests passed.
-- Sensor golden tests passed.
+- Sensor and audio golden tests passed through `pnpm test:golden`.
 - Kokoro determinism tests remained skipped in the default test run, as intended,
   unless `WITTGENSTEIN_KOKORO_TEST=1` is set.
 
@@ -76,7 +78,7 @@ Observed doctor output:
 ## Kokoro Sweep Receipt
 
 ```sh
-pnpm sweep:audio-kokoro -- --out artifacts/tmp/kokoro-sweep-cold-checkout-macos.json
+pnpm sweep:audio-kokoro -- --out artifacts/tmp/kokoro-sweep-final-macos.json
 ```
 
 Result: passed.
@@ -134,9 +136,10 @@ The fresh checkout is healthy on macOS arm64 for the current `main` branch:
 - lint passes,
 - tests pass,
 - sensor goldens pass,
+- audio goldens pass,
 - CLI smoke passes,
 - Kokoro sweep receipt passes locally with byte-identical same-seed artifacts.
 
-This supports moving toward release-note drafting, but it does not replace the
-independent Docker/Linux audit in Issue #164. Treat the audio verdict as provisional
-until that second receipt returns.
+This supports moving to the final release-note / changelog PR. The audio verdict
+is no longer provisional: the paired macOS and Linux receipts are recorded in
+`docs/research/2026-05-06-m2-slice-e-kokoro-sweep-verdict.md`.

--- a/docs/research/2026-05-06-v0.3-release-notes-draft.md
+++ b/docs/research/2026-05-06-v0.3-release-notes-draft.md
@@ -7,13 +7,14 @@ This note began as the safe part of release-note work before the independent
 Docker/Linux Kokoro audit returned. The M2 sweep verdict is now recorded in
 `docs/research/2026-05-06-m2-slice-e-kokoro-sweep-verdict.md`: Kokoro is
 same-platform deterministic but not cross-platform byte-identical, so v0.3 keeps
-the procedural speech backend as the default and leaves Kokoro opt-in.
+the procedural speech backend as the default and leaves Kokoro opt-in. The final
+cold-checkout receipt is recorded in
+`docs/research/2026-05-06-v0.3-cold-checkout-rerun.md`.
 
 ## Release Boundary
 
-The next prerelease should describe the v0.3 execution line after the final
-cold-checkout receipt is complete. The release should not be tagged until these
-receipts agree:
+The next prerelease should describe the v0.3 execution line after the M2 sweep
+and final cold-checkout receipts. These release-facing receipts now agree:
 
 - Issue #118 — M2 audio sweep-level verification.
 - Issue #151 — final truth-surface cold-checkout rerun.
@@ -21,7 +22,7 @@ receipts agree:
 
 The current root package version is `0.2.0-alpha.2`. Do not bump
 `package.json` or add the final `CHANGELOG.md` section until the release
-version is chosen and the sweep verdict is settled.
+version is chosen.
 
 ## Draft Headline
 
@@ -84,6 +85,10 @@ Use this as the starting point for the final `CHANGELOG.md` entry. Replace
   default speech backend remains `procedural-audio-runtime`.
 - Linux/Docker and macOS Kokoro receipts are same-platform stable but produce
   different artifact SHA-256 values across platforms.
+- `costUsd` is not yet computed: both LLM adapters return `costUsd: 0`
+  regardless of provider/model/tokens. The manifest spine is honest about
+  duration, tokens, and artifact hash, but the price column is not a reliable
+  benchmark signal yet. Tracked in Issue #182.
 - This prerelease does not add neural soundscape, neural music, GPU inference,
   voice cloning, or a new audio manifest schema.
 ```
@@ -93,11 +98,12 @@ Use this as the starting point for the final `CHANGELOG.md` entry. Replace
 Release notes should cite the following receipts once they are final:
 
 - `docs/research/2026-05-06-v0.3-cold-checkout-rerun.md` — macOS cold-checkout
-  rehearsal on commit `df93c3ad8e6dc3c3a4898b7ea8526af77df0fc9f`.
+  receipt on commit `982249c58cbbc5b732c95d2456171c0f14c41c72`.
 - `docs/research/2026-05-06-m2-slice-e-kokoro-sweep-verdict.md` — M2 Slice E
   verdict: Kokoro structural-parity opt-in, procedural default.
 - Issue #164 — independent Linux/Docker Kokoro audit receipt.
 - Issue #118 — final M2 sweep verdict and backend decision.
+- Issue #182 — deferred `costUsd` pricing-table fix.
 - PR #121 — audio C3 parity/golden harness.
 - PR #163 — Kokoro opt-in test timeout fix.
 - PR #165 — Kokoro sweep receipt script.


### PR DESCRIPTION
## Summary

- updates the #151 cold-checkout receipt to the current post-#198 `main` commit (`982249c58cbbc5b732c95d2456171c0f14c41c72`)
- records that the independent Linux/Docker Kokoro audit has returned and the M2 Slice E verdict is no longer provisional
- tightens README / audio docs around the actual v0.3 state: procedural speech remains default; Kokoro is opt-in structural-parity; Piper is ratified but not wired
- updates the release-notes draft with the #182 `costUsd` known issue instead of rushing a stale pricing-table fix before the tag

## Scope

This is release-closeout documentation and receipt bookkeeping. It does not change runtime code, schema, decoder behavior, or release version numbers.

## Validation

Fresh checkout at `/tmp/witt-cold-151-final-OUzZh3/wittgenstein`, commit `982249c58cbbc5b732c95d2456171c0f14c41c72`:

- `pnpm install --frozen-lockfile`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm test:golden`
- `pnpm smoke:cli`
- `pnpm sweep:audio-kokoro -- --out artifacts/tmp/kokoro-sweep-final-macos.json`

This branch:

- `pnpm exec prettier --check README.md docs/codecs/audio.md docs/exec-plans/active/v0.3-roadmap.md docs/research/2026-05-06-v0.3-cold-checkout-rerun.md docs/research/2026-05-06-v0.3-release-notes-draft.md`
- `git diff --check`

Closes #151. Refs #149, #182.
