### PR TITLE
release: prepare v0.3.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,47 @@ versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.3.0-alpha.1] — 2026-05-06 — M2 audio sweep and reproducibility gates
+
+This prerelease closes the v0.3 M2 audio line far enough to cut a release
+surface: audio has codec-v2 routing, codec-authored manifest evidence,
+same-seed parity receipts, an opt-in Kokoro speech backend, and a recorded
+sweep verdict. It also tightens the repo's release-facing evidence story:
+goldens, cold-checkout receipts, LLM-boundary validation, and CI/supply-chain
+gates now back the public claims.
+
+The key audio verdict is intentionally conservative. Kokoro-82M is useful and
+same-platform deterministic, but macOS and Linux produce different same-seed
+WAV artifact hashes. Therefore `procedural-audio-runtime` remains the v0.3
+default speech backend, while Kokoro stays opt-in via
+`WITTGENSTEIN_AUDIO_BACKEND=kokoro` and records
+`determinismClass: "structural-parity"`.
+
+### Added
+
+- Added the Kokoro-82M family as an opt-in speech decoder backend for the audio
+  codec, gated behind `WITTGENSTEIN_AUDIO_BACKEND=kokoro`.
+- Added same-seed audio parity/golden tests for speech, soundscape, and music
+  routes.
+- Added `pnpm sweep:audio-kokoro`, a release-facing receipt script that runs
+  three same-seed Kokoro speech renders and records artifact hashes plus
+  manifest evidence.
+- Added release-facing cold-checkout receipts for the v0.3 truth surface.
+- Added CI-gated sensor goldens and training-data lock receipts so the README
+  receipts table points at checkable artifacts rather than narrative claims.
+- Added benchmark-tool skeletons and generalized `pnpm test:golden` across codec
+  packages.
+- Added doctrine guardrail coverage for manifest and modality schemas.
+
 ### Changed
 
+- Kept the default audio backend procedural after the M2 sweep showed Kokoro is
+  same-platform deterministic but not cross-platform byte-identical.
+- Updated README and status surfaces around the harness-first thesis and the
+  current maturity of image, audio, sensor, SVG, and video outputs.
+- Tightened reproducibility and evidence surfaces: README receipts, sensor
+  goldens, audio sweep receipts, and cold-checkout verification now point to
+  concrete commands or artifacts.
 - Isolated `apps/wittgenstein-kimi` from the root `pnpm` workspace (Issue #112).
   The Kimi-flavored agent demo (~7,400 LOC of React / Radix / Vite) now carries
   its own `pnpm-lock.yaml` under `apps/wittgenstein-kimi/`, so its 70+ transitive
@@ -17,6 +56,18 @@ versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Fixed the Kokoro opt-in test timeout so local decoder initialization can
+  complete before Vitest aborts.
+- Fixed the Kokoro integrity-mismatch path so SHA-256 mismatches surface with a
+  typed `INTEGRITY_MISMATCH` code.
+- Fixed LLM response handling so provider responses are zod-validated at the
+  boundary instead of being trusted through TypeScript casts.
+- Fixed the polyglot-mini TTS status surface so Linux no longer advertises a
+  fictional `edge-tts` fallback.
+- Fixed the Kokoro sweep workflow summary so it includes nested manifest
+  evidence, not only artifact SHA-256 values.
+- Fixed release-gate drift by recording the current v0.3 gate state in an
+  explicit roadmap index.
 - Aligned top-level onboarding/status docs with the `v0.2.0-alpha.2` pre-M2
   state instead of the older M0/M1A wording.
 - Added a top-level research program map that closes the pre-M2 engineering-borrow
@@ -31,6 +82,29 @@ versioning follows [Semantic Versioning](https://semver.org/).
     using Tailwind v4's `@tailwindcss/postcss` plugin.
   - `apps/wittgenstein-kimi` stays on its Tailwind v3 / Vite 7-compatible
     stack instead of half-migrating to Tailwind v4 / Vite 8.
+
+### Verification
+
+- `pnpm install --frozen-lockfile`
+- `pnpm typecheck`
+- `pnpm lint`
+- `pnpm test`
+- `pnpm test:golden`
+- `pnpm smoke:cli`
+- `pnpm sweep:audio-kokoro -- --out artifacts/tmp/kokoro-sweep-final-macos.json`
+
+### Known limits
+
+- Kokoro remains opt-in with `determinismClass: "structural-parity"`; the v0.3
+  default speech backend remains `procedural-audio-runtime`.
+- Linux/Docker and macOS Kokoro receipts are same-platform stable but produce
+  different artifact SHA-256 values across platforms.
+- `costUsd` is not yet computed: both LLM adapters return `costUsd: 0`
+  regardless of provider/model/tokens. The manifest spine is honest about
+  duration, tokens, and artifact hash, but the price column is not a reliable
+  benchmark signal yet. Tracked in Issue #182.
+- This prerelease does not add neural soundscape, neural music, GPU inference,
+  voice cloning, Piper wiring, or a new audio manifest schema.
 
 ## [0.2.0-alpha.2] — 2026-04-29 — M2 preflight closure
 
@@ -387,7 +461,8 @@ video renderer remain intentionally incomplete.
 - Every run writes a manifest under `artifacts/runs/<id>/`
 - Shared contracts live in `@wittgenstein/schemas`; codec packages depend on schemas, not each other
 
-[Unreleased]: https://github.com/p-to-q/wittgenstein/compare/v0.2.0-alpha.2...HEAD
+[Unreleased]: https://github.com/p-to-q/wittgenstein/compare/v0.3.0-alpha.1...HEAD
+[0.3.0-alpha.1]: https://github.com/p-to-q/wittgenstein/compare/v0.2.0-alpha.2...v0.3.0-alpha.1
 [0.2.0-alpha.2]: https://github.com/p-to-q/wittgenstein/compare/v0.2.0-alpha.1...v0.2.0-alpha.2
 [0.2.0-alpha.1]: https://github.com/p-to-q/wittgenstein/compare/v0.1.0-alpha.2...v0.2.0-alpha.1
 [0.1.0-alpha.2]: https://github.com/p-to-q/wittgenstein/compare/v0.1.0-alpha.1...v0.1.0-alpha.2

--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ harness/codec/manifest contract. Video targets `.mp4` once its codec slot opens.
 local 30-second sensor quickstart below is the smallest no-API-key proof; maturity levels
 are called out in `docs/implementation-status.md`.
 
-> **🧪 Project status — early-stage, doctrine-locked, v0.3 release closeout.**
-> Wittgenstein is a prerelease (`v0.2.0-alpha.2`) with a working Python
+> **🧪 Project status — early-stage, doctrine-locked, v0.3 prerelease.**
+> Wittgenstein is a prerelease (`v0.3.0-alpha.1`) with a working Python
 > surface, a production-shaped TypeScript harness, and a few intentionally
 > unfinished surfaces clearly flagged with ⚠️ or 🔴 in
 > [`docs/implementation-status.md`](docs/implementation-status.md). The v0.2
 > cut locks the thesis, vocabulary, and codec protocol (RFC-0001 / ADR-0008);
-> M0, M1A, and the M2 audio sweep have landed; v0.3 is now in release closeout against
+> M0, M1A, and the M2 audio sweep have landed; v0.3 is packaged against
 > [`docs/exec-plans/active/codec-v2-port.md`](docs/exec-plans/active/codec-v2-port.md).
 > Breaking changes are still possible before a stable release. **We are
 > actively looking for early adopters and contributors** — see

--- a/docs/exec-plans/active/v0.3-roadmap.md
+++ b/docs/exec-plans/active/v0.3-roadmap.md
@@ -31,7 +31,8 @@ Five concrete checks, lifted from the audit's "from doctrinal claim to checkable
 | 4   | README "Receipts" table evidentiary-only (each row CI-gated)                       | ✅     | Initial pass via PR #134; tightened to 3 strict CI-gated rows + Engineering subsection via PR #135                                                                                                                        |
 | 5   | Supply-chain CI gating (dep-review fail-on-high; CodeQL extended)                  | ✅     | PR #132 landed config; PR #138 made `dependency-review-action` a real gate after Dependency graph was enabled in repo Settings → Security & analysis (2026-05-04)                                                         |
 
-When all five rows reach ✅ and `CHANGELOG.md` has a `v0.3.0` entry, v0.3 is cut.
+When all five rows reach ✅ and `CHANGELOG.md` has a `0.3.0-alpha.1` entry, the
+v0.3 prerelease can be tagged.
 
 ---
 
@@ -43,9 +44,10 @@ When all five rows reach ✅ and `CHANGELOG.md` has a `v0.3.0` entry, v0.3 is cu
 | ----- | ----- | ----------------------------------------------------------------------------------------- |
 | E     | #118  | Sweep verdict recorded: Kokoro stays opt-in structural-parity; procedural remains default |
 
-The remaining v0.3 work is #149 release notes / changelog. Issue #151 has a
-final cold-checkout receipt on commit `982249c58cbbc5b732c95d2456171c0f14c41c72`
-in `docs/research/2026-05-06-v0.3-cold-checkout-rerun.md`.
+Issue #149 is the final release-packaging PR: it adds the `0.3.0-alpha.1`
+changelog entry, bumps the root package version, and cites the final
+cold-checkout receipt on commit `982249c58cbbc5b732c95d2456171c0f14c41c72` in
+`docs/research/2026-05-06-v0.3-cold-checkout-rerun.md`.
 
 ---
 

--- a/docs/research/2026-05-06-v0.3-release-notes-draft.md
+++ b/docs/research/2026-05-06-v0.3-release-notes-draft.md
@@ -1,7 +1,8 @@
 # v0.3 Release Notes Draft — 2026-05-06
 
-**Status:** draft release surface for Issue #149. Not a tag plan, not a release
-artifact, and not a substitute for the final `CHANGELOG.md` entry.
+**Status:** release-closeout surface for Issue #149. This note preserves the
+reasoning behind the `0.3.0-alpha.1` changelog entry; the tag should still be
+created only after the release PR merges.
 
 This note began as the safe part of release-note work before the independent
 Docker/Linux Kokoro audit returned. The M2 sweep verdict is now recorded in
@@ -20,24 +21,22 @@ and final cold-checkout receipts. These release-facing receipts now agree:
 - Issue #151 — final truth-surface cold-checkout rerun.
 - Issue #164 — independent Docker/Linux Kokoro sweep audit.
 
-The current root package version is `0.2.0-alpha.2`. Do not bump
-`package.json` or add the final `CHANGELOG.md` section until the release
-version is chosen.
+The release PR chooses `0.3.0-alpha.1` as the prerelease version and bumps the
+root `package.json` to match the future tag.
 
 ## Draft Headline
 
 v0.3 moves Wittgenstein from a codec-v2 image proof into a broader
 reproducibility-oriented harness: audio gains an opt-in frozen-decoder path,
-golden/parity receipts are CI-gated, and the repo's workflow now distinguishes
-execution, governance, fallback, and research-first lanes.
+golden/parity receipts are CI-gated, and release-facing truth surfaces now cite
+the receipts that back them.
 
 ## Candidate CHANGELOG Section
 
-Use this as the starting point for the final `CHANGELOG.md` entry. Replace
-`TBD` fields only after Issues #118, #151, and #164 close.
+This is the source draft used for the final `CHANGELOG.md` entry.
 
 ```md
-## [0.3.0-alpha.1] — TBD — v0.3 audio sweep and reproducibility gates
+## [0.3.0-alpha.1] — 2026-05-06 — M2 audio sweep and reproducibility gates
 
 ### Added
 
@@ -49,8 +48,11 @@ Use this as the starting point for the final `CHANGELOG.md` entry. Replace
   same-seed Kokoro speech renders and records artifact hashes plus manifest
   evidence.
 - Added release-facing cold-checkout receipts for the v0.3 truth surface.
-- Added workflow/governance guidance for orchestration, explicit fallback
-  discipline, and research-first development.
+- Added CI-gated sensor goldens and training-data lock receipts so the README
+  receipts table points at checkable artifacts rather than narrative claims.
+- Added benchmark-tool skeletons and generalized `pnpm test:golden` across codec
+  packages.
+- Added doctrine guardrail coverage for manifest and modality schemas.
 
 ### Changed
 
@@ -66,6 +68,14 @@ Use this as the starting point for the final `CHANGELOG.md` entry. Replace
 
 - Fixed the Kokoro opt-in test timeout so local decoder initialization can
   complete before Vitest aborts.
+- Fixed the Kokoro integrity-mismatch path so SHA-256 mismatches surface with a
+  typed `INTEGRITY_MISMATCH` code.
+- Fixed LLM response handling so provider responses are zod-validated at the
+  boundary instead of being trusted through TypeScript casts.
+- Fixed the polyglot-mini TTS status surface so Linux no longer advertises a
+  fictional `edge-tts` fallback.
+- Fixed the Kokoro sweep workflow summary so it includes nested manifest
+  evidence, not only artifact SHA-256 values.
 - Fixed release-gate drift by recording the current v0.3 gate state in an
   explicit roadmap index.
 
@@ -108,16 +118,18 @@ Release notes should cite the following receipts once they are final:
 - PR #163 — Kokoro opt-in test timeout fix.
 - PR #165 — Kokoro sweep receipt script.
 - PR #166 — cold-checkout rerun receipt.
+- PR #199 — final post-verdict cold-checkout receipt.
 
 ## Release PR Checklist
 
 When the final release PR is opened:
 
-- choose the prerelease version,
+- choose the prerelease version: `0.3.0-alpha.1`,
 - bump the root `package.json` version to match the future tag,
 - add the matching `CHANGELOG.md` section,
-- replace every `TBD` with a concrete verdict or remove the line,
 - cite #118, #151, and #164 in the PR body,
 - run the release-facing validation commands from the candidate section,
+- capture whether `WORKFLOW.md` was consulted during release closeout for the
+  future ADR-0017 sprint-end audit,
 - do not publish a tag until the merged `CHANGELOG.md` section and package
   version match the intended tag.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wittgenstein-monorepo",
   "private": true,
-  "version": "0.2.0-alpha.2",
+  "version": "0.3.0-alpha.1",
   "description": "Wittgenstein — harness-first multimodal runtime: text LLMs, typed codecs, traceable artifacts.",
   "license": "Apache-2.0",
   "engines": {

--- a/packages/cli/test/shared.test.ts
+++ b/packages/cli/test/shared.test.ts
@@ -1,3 +1,5 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { parseOptionalSeed, resolveExecutionRoot } from "../src/commands/shared.js";
 
@@ -37,7 +39,7 @@ describe("resolveExecutionRoot", () => {
     // invoked via `pnpm --filter`. The function should walk up to the
     // monorepo root, where pnpm-workspace.yaml lives.
     const root = resolveExecutionRoot();
-    expect(root.endsWith("/wittgenstein") || root.endsWith("\\wittgenstein")).toBe(true);
+    expect(existsSync(resolve(root, "pnpm-workspace.yaml"))).toBe(true);
   });
 
   it("returns an absolute path", () => {


### PR DESCRIPTION
## Summary

- bumps the root package version from `0.2.0-alpha.2` to `0.3.0-alpha.1`
- adds the final `0.3.0-alpha.1` CHANGELOG entry for the M2 audio sweep and reproducibility gates
- updates README / v0.3 roadmap / release-note draft so the release surface agrees on the current truth:
  - #118 is closed: Kokoro is same-platform deterministic but not cross-platform byte-identical
  - `procedural-audio-runtime` remains the v0.3 default speech backend
  - Kokoro stays opt-in via `WITTGENSTEIN_AUDIO_BACKEND=kokoro` with `determinismClass: "structural-parity"`
  - #151 and #164 receipts are final release evidence
  - #182 is a Known Issue, deferred to v0.3.x / v0.3 pricing-table work
- fixes the CLI root-resolution test to assert the actual contract (`pnpm-workspace.yaml` exists at the resolved root) instead of assuming the checkout directory is lowercase `wittgenstein`

## Scope Guard

PR #162 is still pending re-review, so this release PR deliberately does **not** claim that explicit fallback discipline or research-first workflow governance has landed in this release. Those can enter a future release note only after #162 merges.

## Release Receipts

- #118 — M2 sweep-level verdict recorded
- #151 — final cold-checkout rerun closed by #199
- #164 — independent Linux/Docker Kokoro sweep receipt incorporated into the M2 verdict
- #182 — `costUsd` pricing-table bug acknowledged as a Known Issue, not rushed into this prerelease

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter @wittgenstein/cli test`
- `pnpm test`
- `pnpm test:golden`
- `pnpm smoke:cli`
- `pnpm sweep:audio-kokoro -- --out artifacts/tmp/kokoro-sweep-v0.3.0-alpha.1-macos.json`
- `pnpm exec prettier --check package.json README.md CHANGELOG.md docs/research/2026-05-06-v0.3-release-notes-draft.md docs/exec-plans/active/v0.3-roadmap.md packages/cli/test/shared.test.ts`
- `git diff --check`

## WORKFLOW.md Capture For #150

For the ADR-0017 sprint-end audit: I did not use `WORKFLOW.md` as the primary execution guide for this release PR. I used the existing issue sequencing and the release-note checklist in `docs/research/2026-05-06-v0.3-release-notes-draft.md`. This is a useful signal for #150: the workflow contract may still be more dispatch-oriented than release-closeout-oriented.

Closes #149.
