### PR TITLE
fix(schemas): tighten manifest receipt invariants

### DIFF
--- a/packages/schemas/src/manifest.ts
+++ b/packages/schemas/src/manifest.ts
@@ -11,50 +11,95 @@ export const AudioRenderManifestSchema = z.object({
   decoderHash: z.string().optional(),
 });
 
-export const RunManifestSchema = z.object({
-  runId: z.string(),
-  gitSha: z.string().nullable(),
-  lockfileHash: z.string().nullable(),
-  nodeVersion: z.string(),
-  wittgensteinVersion: z.string(),
+const AudioRouteSchema = z.enum(["speech", "soundscape", "music"]);
 
-  command: z.string(),
-  args: z.array(z.string()),
-  seed: z.number().int().nullable(),
+export const RunManifestSchema = z
+  .object({
+    runId: z.string(),
+    gitSha: z.string().nullable(),
+    lockfileHash: z.string().nullable(),
+    nodeVersion: z.string(),
+    wittgensteinVersion: z.string(),
 
-  codec: z.string(),
-  tier: z.string().nullable().optional(),
-  route: z.string().optional(),
+    command: z.string(),
+    args: z.array(z.string()),
+    seed: z.number().int().nullable(),
 
-  llmProvider: z.string(),
-  llmModel: z.string(),
-  llmTokens: z.object({
-    input: z.number().int().nonnegative(),
-    output: z.number().int().nonnegative(),
-  }),
-  costUsd: z.number().nonnegative(),
+    codec: z.string(),
+    tier: z.string().nullable().optional(),
+    route: z.string().optional(),
 
-  promptRaw: z.string(),
-  promptExpanded: z.string().nullable(),
-  llmOutputRaw: z.string().nullable(),
-  llmOutputParsed: z.unknown().nullable(),
+    llmProvider: z.string(),
+    llmModel: z.string(),
+    llmTokens: z.object({
+      input: z.number().int().nonnegative(),
+      output: z.number().int().nonnegative(),
+    }),
+    costUsd: z.number().nonnegative(),
 
-  artifactPath: z.string().nullable(),
-  artifactSha256: z.string().nullable(),
-  audioRender: AudioRenderManifestSchema.optional(),
+    promptRaw: z.string(),
+    promptExpanded: z.string().nullable(),
+    llmOutputRaw: z.string().nullable(),
+    llmOutputParsed: z.unknown().nullable(),
 
-  startedAt: z.string(),
-  durationMs: z.number().nonnegative(),
-  ok: z.boolean(),
-  error: z
-    .object({
-      code: z.string(),
-      message: z.string(),
-      stack: z.string().optional(),
-    })
-    .nullable()
-    .optional(),
-});
+    artifactPath: z.string().nullable(),
+    artifactSha256: z.string().nullable(),
+    audioRender: AudioRenderManifestSchema.optional(),
+
+    startedAt: z.string(),
+    durationMs: z.number().nonnegative(),
+    ok: z.boolean(),
+    error: z
+      .object({
+        code: z.string(),
+        message: z.string(),
+        stack: z.string().optional(),
+      })
+      .nullable()
+      .optional(),
+  })
+  .superRefine((manifest, ctx) => {
+    if (manifest.ok) {
+      if (manifest.artifactPath === null) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["artifactPath"],
+          message: "Successful runs must record artifactPath.",
+        });
+      }
+      if (manifest.artifactSha256 === null) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["artifactSha256"],
+          message: "Successful runs must record artifactSha256.",
+        });
+      }
+      if (manifest.error !== null && manifest.error !== undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["error"],
+          message: "Successful runs must not carry an error payload.",
+        });
+      }
+    } else if (manifest.error === null || manifest.error === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["error"],
+        message: "Failed runs must record an error payload.",
+      });
+    }
+
+    if (manifest.codec === "audio" && manifest.route !== undefined) {
+      const parsedRoute = AudioRouteSchema.safeParse(manifest.route);
+      if (!parsedRoute.success) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["route"],
+          message: `Audio manifests must use one of: ${AudioRouteSchema.options.join(", ")}.`,
+        });
+      }
+    }
+  });
 
 export type AudioRenderManifest = z.infer<typeof AudioRenderManifestSchema>;
 export type RunManifest = z.infer<typeof RunManifestSchema>;

--- a/packages/schemas/test/contract.test.ts
+++ b/packages/schemas/test/contract.test.ts
@@ -68,4 +68,114 @@ describe("@wittgenstein/schemas", () => {
       }).success,
     ).toBe(true);
   });
+
+  it("requires artifact evidence on successful manifests", () => {
+    const parsed = RunManifestSchema.safeParse({
+      runId: "run-success",
+      gitSha: "abc123",
+      lockfileHash: "def456",
+      nodeVersion: process.version,
+      wittgensteinVersion: "0.0.0",
+      command: "wittgenstein audio",
+      args: ["hello"],
+      seed: 7,
+      codec: "audio",
+      route: "speech",
+      llmProvider: "anthropic",
+      llmModel: "claude-3-5-haiku-20241022",
+      llmTokens: { input: 1, output: 2 },
+      costUsd: 0,
+      promptRaw: "hello",
+      promptExpanded: "hello",
+      llmOutputRaw: "{}",
+      llmOutputParsed: {},
+      artifactPath: null,
+      artifactSha256: null,
+      audioRender: {
+        sampleRateHz: 24_000,
+        channels: 1,
+        durationSec: 1.2,
+        container: "wav",
+        bitDepth: 32,
+        determinismClass: "structural-parity",
+        decoderId: "kokoro-82m:test",
+      },
+      startedAt: new Date().toISOString(),
+      durationMs: 10,
+      ok: true,
+      error: null,
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it("requires failed manifests to carry an error payload", () => {
+    const parsed = RunManifestSchema.safeParse({
+      runId: "run-failure",
+      gitSha: "abc123",
+      lockfileHash: "def456",
+      nodeVersion: process.version,
+      wittgensteinVersion: "0.0.0",
+      command: "wittgenstein image",
+      args: ["prompt"],
+      seed: 7,
+      codec: "image",
+      llmProvider: "openai-compatible",
+      llmModel: "gpt-4.1-mini",
+      llmTokens: { input: 1, output: 2 },
+      costUsd: 0,
+      promptRaw: "prompt",
+      promptExpanded: "prompt",
+      llmOutputRaw: "{}",
+      llmOutputParsed: {},
+      artifactPath: null,
+      artifactSha256: null,
+      startedAt: new Date().toISOString(),
+      durationMs: 10,
+      ok: false,
+      error: null,
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects invalid audio routes", () => {
+    const parsed = RunManifestSchema.safeParse({
+      runId: "run-audio-route",
+      gitSha: "abc123",
+      lockfileHash: "def456",
+      nodeVersion: process.version,
+      wittgensteinVersion: "0.0.0",
+      command: "wittgenstein audio",
+      args: ["hello"],
+      seed: 7,
+      codec: "audio",
+      route: "spech",
+      llmProvider: "anthropic",
+      llmModel: "claude-3-5-haiku-20241022",
+      llmTokens: { input: 1, output: 2 },
+      costUsd: 0,
+      promptRaw: "hello",
+      promptExpanded: "hello",
+      llmOutputRaw: "{}",
+      llmOutputParsed: {},
+      artifactPath: "/tmp/out.wav",
+      artifactSha256: "sha256",
+      audioRender: {
+        sampleRateHz: 24_000,
+        channels: 1,
+        durationSec: 1.2,
+        container: "wav",
+        bitDepth: 32,
+        determinismClass: "structural-parity",
+        decoderId: "kokoro-82m:test",
+      },
+      startedAt: new Date().toISOString(),
+      durationMs: 10,
+      ok: true,
+      error: null,
+    });
+
+    expect(parsed.success).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- tighten `RunManifestSchema` so successful runs require artifact evidence and failed runs require an error payload
- reject invalid audio manifest routes at schema-parse time instead of accepting bare typos
- add focused contract tests for the new manifest invariants

## Why
- `#189` identified that the schema could accept success/failure receipts with missing spine evidence
- `#190` identified that active audio routes were still bare strings, so a typo like `spech` would silently validate
- this keeps the change small and honest: schema tightening now, broader per-modality manifest unions later if they still earn their keep

## Scope
- closes #189
- partially addresses #190 for the active audio route surface
- does not touch #182 pricing-table work
- does not reshape the manifest into a full discriminated union

## Validation
- `pnpm --filter @wittgenstein/schemas test`
- `pnpm --filter @wittgenstein/schemas typecheck`
- `pnpm --filter @wittgenstein/schemas lint`
- `pnpm typecheck`
- `pnpm exec prettier --check packages/schemas/src/manifest.ts packages/schemas/test/contract.test.ts`
- `git diff --check`
