### PR TITLE
feat(image): add Visual Seed Code contract

### DIFF
--- a/packages/codec-image/src/codec.ts
+++ b/packages/codec-image/src/codec.ts
@@ -355,7 +355,7 @@ export class ImageCodec extends codecV2.BaseCodec<ImageRequest, ImageArtifact> {
     if (message.includes("providerLatents failed validation")) {
       return this.warnings.provider_latents_invalid;
     }
-    if (message.includes("Using placeholder scene-to-latent adapter")) {
+    if (message.includes("Using placeholder seed-expansion adapter")) {
       return this.warnings.adapter_stub;
     }
     if (message.includes("Using narrow-domain reference decoder bridge")) {

--- a/packages/codec-image/src/pipeline/adapter.ts
+++ b/packages/codec-image/src/pipeline/adapter.ts
@@ -35,7 +35,7 @@ export async function adaptSceneToLatents(
     const validated = ImageCoarseVqSchema.safeParse(parsed.coarseVq);
     if (validated.success) {
       ctx.logger.info("Using coarseVq hints; expanding to decoder-native latents.");
-      return annotateLatents(parsed, expandCoarseVqToLatents(parsed, validated.data));
+      return expandCoarseVqToLatents(parsed, validated.data);
     }
   }
 
@@ -43,7 +43,7 @@ export async function adaptSceneToLatents(
     const validated = ImageVisualSeedCodeSchema.safeParse(parsed.seedCode);
     if (validated.success) {
       ctx.logger.info("Using Visual Seed Code; expanding to decoder-native latents.");
-      return annotateLatents(parsed, expandSeedToLatents(parsed, validated.data));
+      return expandSeedToLatents(parsed, validated.data);
     }
   }
 

--- a/packages/codec-image/src/pipeline/adapter.ts
+++ b/packages/codec-image/src/pipeline/adapter.ts
@@ -1,6 +1,14 @@
 import type { RenderCtx } from "@wittgenstein/schemas";
 import { resolveMlpForScene, predictWithResolved } from "../adapters/adapter-resolve.js";
-import { ImageLatentCodesSchema, type ImageLatentCodes, type ImageSceneSpec } from "../schema.js";
+import {
+  ImageCoarseVqSchema,
+  ImageLatentCodesSchema,
+  ImageVisualSeedCodeSchema,
+  type ImageCoarseVq,
+  type ImageLatentCodes,
+  type ImageSceneSpec,
+  type ImageVisualSeedCode,
+} from "../schema.js";
 
 export type { ImageLatentCodes };
 export { ImageLatentCodesSchema };
@@ -21,6 +29,22 @@ export async function adaptSceneToLatents(
     ctx.logger.warn("providerLatents failed validation; falling back to adapter.", {
       issues: validated.error?.issues,
     });
+  }
+
+  if (parsed.coarseVq) {
+    const validated = ImageCoarseVqSchema.safeParse(parsed.coarseVq);
+    if (validated.success) {
+      ctx.logger.info("Using coarseVq hints; expanding to decoder-native latents.");
+      return annotateLatents(parsed, expandCoarseVqToLatents(parsed, validated.data));
+    }
+  }
+
+  if (parsed.seedCode) {
+    const validated = ImageVisualSeedCodeSchema.safeParse(parsed.seedCode);
+    if (validated.success) {
+      ctx.logger.info("Using Visual Seed Code; expanding to decoder-native latents.");
+      return annotateLatents(parsed, expandSeedToLatents(parsed, validated.data));
+    }
   }
 
   const resolved = await resolveMlpForScene(parsed, ctx);
@@ -52,9 +76,63 @@ function placeholderLatents(parsed: ImageSceneSpec, ctx: RenderCtx): ImageLatent
   });
 
   ctx.logger.warn(
-    "Using placeholder scene-to-latent adapter; set WITTGENSTEIN_IMAGE_ADAPTER_PREFERRED_PATH + WITTGENSTEIN_IMAGE_ADAPTER_LEGACY_PATH (or legacy aliases WITTGENSTEIN_IMAGE_ADAPTER_MLP_PATH + WITTGENSTEIN_IMAGE_ADAPTER_MLP_FALLBACK_PATH).",
+    "Using placeholder seed-expansion adapter; set WITTGENSTEIN_IMAGE_ADAPTER_PREFERRED_PATH + WITTGENSTEIN_IMAGE_ADAPTER_LEGACY_PATH (or legacy aliases WITTGENSTEIN_IMAGE_ADAPTER_MLP_PATH + WITTGENSTEIN_IMAGE_ADAPTER_MLP_FALLBACK_PATH).",
   );
   return latentCodes;
+}
+
+function expandCoarseVqToLatents(
+  parsed: ImageSceneSpec,
+  coarseVq: ImageCoarseVq,
+): ImageLatentCodes {
+  const [targetWidth, targetHeight] = parsed.decoder.latentResolution;
+  const [coarseWidth, coarseHeight] = coarseVq.tokenGrid;
+  const totalTokens = targetWidth * targetHeight;
+  const tokens = new Array<number>(totalTokens);
+
+  for (let y = 0; y < targetHeight; y += 1) {
+    const sourceY = Math.min(coarseHeight - 1, Math.floor((y * coarseHeight) / targetHeight));
+    for (let x = 0; x < targetWidth; x += 1) {
+      const sourceX = Math.min(coarseWidth - 1, Math.floor((x * coarseWidth) / targetWidth));
+      const targetIndex = y * targetWidth + x;
+      const sourceIndex = sourceY * coarseWidth + sourceX;
+      tokens[targetIndex] = coarseVq.tokens[sourceIndex] ?? 0;
+    }
+  }
+
+  return ImageLatentCodesSchema.parse({
+    schemaVersion: "witt.image.latents/v0.1",
+    family: parsed.decoder.family,
+    codebook: parsed.decoder.codebook,
+    codebookVersion: parsed.decoder.codebookVersion,
+    tokenGrid: [targetWidth, targetHeight],
+    tokens,
+  });
+}
+
+function expandSeedToLatents(
+  parsed: ImageSceneSpec,
+  seedCode: ImageVisualSeedCode,
+): ImageLatentCodes {
+  const [width, height] = parsed.decoder.latentResolution;
+  const totalTokens = width * height;
+  const codebookSize = 8192;
+  const deterministicSeed = hashSpecToSeed(parsed);
+  const tokens = new Array<number>(totalTokens);
+
+  for (let index = 0; index < totalTokens; index += 1) {
+    const base = seedCode.tokens[index % seedCode.tokens.length] ?? 0;
+    tokens[index] = (base + deterministicSeed + index * 31) % codebookSize;
+  }
+
+  return ImageLatentCodesSchema.parse({
+    schemaVersion: "witt.image.latents/v0.1",
+    family: parsed.decoder.family,
+    codebook: parsed.decoder.codebook,
+    codebookVersion: parsed.decoder.codebookVersion,
+    tokenGrid: [width, height],
+    tokens,
+  });
 }
 
 function annotateLatents(parsed: ImageSceneSpec, latents: ImageLatentCodes): ImageLatentCodes {

--- a/packages/codec-image/src/schema.ts
+++ b/packages/codec-image/src/schema.ts
@@ -8,8 +8,8 @@ export const ImageSeedCodeVersionSchema = z.literal("witt.image.seed/v0.1");
 export const ImageCoarseVqVersionSchema = z.literal("witt.image.coarse-vq/v0.1");
 export const ImageCodeModeSchema = z.enum([
   "semantic-only",
-  "one-shot-hybrid",
-  "two-pass-hybrid",
+  "one-shot-vsc",
+  "two-pass-compile",
   "provider-latents",
 ]);
 
@@ -145,9 +145,9 @@ export function imageSchemaPreamble(req: ImageRequest): string {
   const requestedSize = req.size ? `${req.size[0]}x${req.size[1]}` : "unspecified";
 
   return [
-    "Emit a JSON image-code container for the sole neural image pipeline.",
+    "Emit a JSON Visual Seed Code contract for the sole neural image pipeline.",
     "Prefer seedCode as the primary decoder-facing output.",
-    "Semantic IR is optional and is mainly for user-facing inspection or paired output with seedCode.",
+    "Use Semantic IR to organize concepts, expose the user-facing plan, and optionally condition seed expansion.",
     "Optional coarseVq hints may be included when you can provide stable partial VQ structure.",
     "Use providerLatents only when you can emit decoder-native latent tokens directly.",
     "Do not emit SVG, HTML, Canvas commands, or pixel arrays.",
@@ -171,7 +171,7 @@ function normalizeImageSceneSpec(spec: ImageSceneSpec): ImageSceneSpec {
     (spec.providerLatents
       ? "provider-latents"
       : spec.seedCode || spec.coarseVq
-        ? "one-shot-hybrid"
+        ? "one-shot-vsc"
         : "semantic-only");
 
   return {

--- a/packages/codec-image/src/schema.ts
+++ b/packages/codec-image/src/schema.ts
@@ -4,20 +4,38 @@ import { ImageRequestSchema } from "@wittgenstein/schemas";
 
 export const DecoderFamilySchema = z.enum(["llamagen", "seed", "dvae"]);
 export const ImageSceneSpecVersionSchema = z.literal("witt.image.spec/v0.1");
+export const ImageSeedCodeVersionSchema = z.literal("witt.image.seed/v0.1");
+export const ImageCoarseVqVersionSchema = z.literal("witt.image.coarse-vq/v0.1");
+export const ImageCodeModeSchema = z.enum([
+  "semantic-only",
+  "one-shot-hybrid",
+  "two-pass-hybrid",
+  "provider-latents",
+]);
 
 /** Discrete latent codes consumed by the frozen decoder bridge (also used for MiniMax / provider-included latents). */
-export const ImageLatentCodesSchema = z.object({
-  schemaVersion: z.literal("witt.image.latents/v0.1"),
-  family: DecoderFamilySchema,
-  codebook: z.string().min(1),
-  codebookVersion: z.string().min(1),
-  tokenGrid: z.tuple([z.number().int().positive(), z.number().int().positive()]),
-  tokens: z.array(z.number().int().nonnegative()),
-});
+export const ImageLatentCodesSchema = z
+  .object({
+    schemaVersion: z.literal("witt.image.latents/v0.1"),
+    family: DecoderFamilySchema,
+    codebook: z.string().min(1),
+    codebookVersion: z.string().min(1),
+    tokenGrid: z.tuple([z.number().int().positive(), z.number().int().positive()]),
+    tokens: z.array(z.number().int().nonnegative()),
+  })
+  .superRefine((value, ctx) => {
+    const [width, height] = value.tokenGrid;
+    if (value.tokens.length !== width * height) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["tokens"],
+        message: "tokens length must match tokenGrid area.",
+      });
+    }
+  });
 export type ImageLatentCodes = z.infer<typeof ImageLatentCodesSchema>;
 
-export const ImageSceneSpecSchema = z.object({
-  schemaVersion: ImageSceneSpecVersionSchema.default("witt.image.spec/v0.1"),
+const ImageSemanticLayerSchema = z.object({
   intent: z.string().default("placeholder scene"),
   subject: z.string().default("placeholder subject"),
   composition: z
@@ -39,6 +57,64 @@ export const ImageSceneSpecSchema = z.object({
       palette: z.array(z.string()).default(["black", "white"]),
     })
     .default({}),
+  constraints: z
+    .object({
+      mustHave: z.array(z.string()).default([]),
+      negative: z.array(z.string()).default([]),
+    })
+    .default({}),
+});
+
+export const ImageVisualSeedCodeSchema = z
+  .object({
+    schemaVersion: ImageSeedCodeVersionSchema.default("witt.image.seed/v0.1"),
+    family: z.string().min(1).default("vqvae"),
+    mode: z.enum(["prefix", "coarse-scale", "residual", "lexical"]).default("prefix"),
+    tokenizer: z.string().min(1).optional(),
+    length: z.number().int().positive().optional(),
+    tokens: z.array(z.number().int().nonnegative()).min(1),
+  })
+  .superRefine((value, ctx) => {
+    if (value.length !== undefined && value.length !== value.tokens.length) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["length"],
+        message: "length must match tokens length when provided.",
+      });
+    }
+  });
+export type ImageVisualSeedCode = z.infer<typeof ImageVisualSeedCodeSchema>;
+
+export const ImageCoarseVqSchema = z
+  .object({
+    schemaVersion: ImageCoarseVqVersionSchema.default("witt.image.coarse-vq/v0.1"),
+    family: DecoderFamilySchema,
+    codebook: z.string().min(1),
+    codebookVersion: z.string().min(1),
+    tokenGrid: z.tuple([z.number().int().positive(), z.number().int().positive()]),
+    tokens: z.array(z.number().int().nonnegative()).min(1),
+  })
+  .superRefine((value, ctx) => {
+    const [width, height] = value.tokenGrid;
+    if (value.tokens.length !== width * height) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["tokens"],
+        message: "tokens length must match tokenGrid area.",
+      });
+    }
+  });
+export type ImageCoarseVq = z.infer<typeof ImageCoarseVqSchema>;
+
+export const ImageSceneSpecSchema = z.object({
+  schemaVersion: ImageSceneSpecVersionSchema.default("witt.image.spec/v0.1"),
+  mode: ImageCodeModeSchema.optional(),
+  semantic: ImageSemanticLayerSchema.optional(),
+  intent: ImageSemanticLayerSchema.shape.intent,
+  subject: ImageSemanticLayerSchema.shape.subject,
+  composition: ImageSemanticLayerSchema.shape.composition,
+  lighting: ImageSemanticLayerSchema.shape.lighting,
+  style: ImageSemanticLayerSchema.shape.style,
   decoder: z
     .object({
       family: DecoderFamilySchema.default("llamagen"),
@@ -49,12 +125,7 @@ export const ImageSceneSpecSchema = z.object({
         .default([32, 32]),
     })
     .default({}),
-  constraints: z
-    .object({
-      mustHave: z.array(z.string()).default([]),
-      negative: z.array(z.string()).default([]),
-    })
-    .default({}),
+  constraints: ImageSemanticLayerSchema.shape.constraints,
   renderHints: z
     .object({
       detailLevel: z.enum(["low", "medium", "high"]).default("medium"),
@@ -62,6 +133,8 @@ export const ImageSceneSpecSchema = z.object({
       seed: z.number().int().nullable().default(null),
     })
     .default({}),
+  seedCode: ImageVisualSeedCodeSchema.optional(),
+  coarseVq: ImageCoarseVqSchema.optional(),
   /** When set (e.g. MiniMax returns VQ indices), the harness skips the learned adapter and validates these latents. */
   providerLatents: ImageLatentCodesSchema.optional(),
 });
@@ -72,12 +145,52 @@ export function imageSchemaPreamble(req: ImageRequest): string {
   const requestedSize = req.size ? `${req.size[0]}x${req.size[1]}` : "unspecified";
 
   return [
-    "Emit a JSON scene spec for the sole neural image pipeline.",
-    "Describe semantics, composition, style, and decoder hints only.",
+    "Emit a JSON image-code container for the sole neural image pipeline.",
+    "Prefer seedCode as the primary decoder-facing output.",
+    "Semantic IR is optional and is mainly for user-facing inspection or paired output with seedCode.",
+    "Optional coarseVq hints may be included when you can provide stable partial VQ structure.",
+    "Use providerLatents only when you can emit decoder-native latent tokens directly.",
     "Do not emit SVG, HTML, Canvas commands, or pixel arrays.",
     `Requested output size: ${requestedSize}.`,
     `Requested seed: ${req.seed ?? "null"}.`,
   ].join("\n");
+}
+
+function normalizeImageSceneSpec(spec: ImageSceneSpec): ImageSceneSpec {
+  const semantic = spec.semantic ?? {
+    intent: spec.intent,
+    subject: spec.subject,
+    composition: spec.composition,
+    lighting: spec.lighting,
+    style: spec.style,
+    constraints: spec.constraints,
+  };
+
+  const mode =
+    spec.mode ??
+    (spec.providerLatents
+      ? "provider-latents"
+      : spec.seedCode || spec.coarseVq
+        ? "one-shot-hybrid"
+        : "semantic-only");
+
+  return {
+    ...spec,
+    mode,
+    semantic,
+    intent: semantic.intent,
+    subject: semantic.subject,
+    composition: semantic.composition,
+    lighting: semantic.lighting,
+    style: semantic.style,
+    constraints: semantic.constraints,
+    seedCode: spec.seedCode
+      ? {
+          ...spec.seedCode,
+          length: spec.seedCode.length ?? spec.seedCode.tokens.length,
+        }
+      : undefined,
+  };
 }
 
 export function parseImageSceneSpec(raw: string): Result<ImageSceneSpec> {
@@ -100,7 +213,7 @@ export function parseImageSceneSpec(raw: string): Result<ImageSceneSpec> {
 
     return {
       ok: true,
-      value: parsed.data,
+      value: normalizeImageSceneSpec(parsed.data),
     };
   } catch (error) {
     return {

--- a/packages/codec-image/test/codec.test.ts
+++ b/packages/codec-image/test/codec.test.ts
@@ -15,7 +15,69 @@ describe("@wittgenstein/codec-image", () => {
       expect(parsed.value.schemaVersion).toBe("witt.image.spec/v0.1");
       expect(parsed.value.decoder.codebookVersion).toBe("v0");
       expect(parsed.value.constraints.negative).toEqual([]);
+      expect(parsed.value.mode).toBe("semantic-only");
     }
+  });
+
+  it("parses a hybrid image-code container and normalizes semantic + seed fields", () => {
+    const parsed = imageCodec.parse(
+      JSON.stringify({
+        mode: "one-shot-hybrid",
+        semantic: {
+          intent: "forest poster",
+          subject: "misty pine forest",
+          composition: {
+            framing: "wide",
+            camera: "eye level",
+            depthPlan: ["foreground mist", "forest", "mountains"],
+          },
+          lighting: { mood: "moody", key: "soft dawn" },
+          style: { references: ["landscape"], palette: ["green", "gray"] },
+          constraints: { mustHave: ["trees"], negative: ["people"] },
+        },
+        seedCode: {
+          family: "vqvae",
+          mode: "prefix",
+          tokens: [1, 2, 3, 4],
+        },
+      }),
+    );
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) {
+      throw new Error("hybrid parse unexpectedly failed");
+    }
+    expect(parsed.value.semantic?.subject).toBe("misty pine forest");
+    expect(parsed.value.subject).toBe("misty pine forest");
+    expect(parsed.value.seedCode?.length).toBe(4);
+    expect(parsed.value.mode).toBe("one-shot-hybrid");
+  });
+
+  it("rejects inconsistent visual code lengths", () => {
+    const badSeed = imageCodec.parse(
+      JSON.stringify({
+        seedCode: {
+          family: "vqvae",
+          mode: "prefix",
+          length: 8,
+          tokens: [1, 2, 3, 4],
+        },
+      }),
+    );
+    expect(badSeed.ok).toBe(false);
+
+    const badCoarse = imageCodec.parse(
+      JSON.stringify({
+        coarseVq: {
+          schemaVersion: "witt.image.coarse-vq/v0.1",
+          family: "llamagen",
+          codebook: "stub-codebook",
+          codebookVersion: "v0",
+          tokenGrid: [4, 4],
+          tokens: [1, 2, 3, 4],
+        },
+      }),
+    );
+    expect(badCoarse.ok).toBe(false);
   });
 
   it("renders placeholder latents into a PNG artifact", async () => {
@@ -133,5 +195,108 @@ describe("image pipeline (neural decode)", () => {
     expect(result.bytes).toBeGreaterThan(0);
     const bytes = await readFile(outPath);
     expect(Array.from(bytes.subarray(0, 8))).toEqual([137, 80, 78, 71, 13, 10, 26, 10]);
+  });
+
+  it("uses coarseVq hints before the placeholder adapter path", async () => {
+    const warnings: string[] = [];
+    const parsed = imageCodec.parse(
+      JSON.stringify({
+        intent: "test",
+        subject: "forest",
+        decoder: {
+          family: "llamagen",
+          codebook: "stub-codebook",
+          codebookVersion: "v0",
+          latentResolution: [16, 16],
+        },
+        coarseVq: {
+          schemaVersion: "witt.image.coarse-vq/v0.1",
+          family: "llamagen",
+          codebook: "stub-codebook",
+          codebookVersion: "v0",
+          tokenGrid: [4, 4],
+          tokens: Array.from({ length: 16 }, (_, index) => index),
+        },
+      }),
+    );
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) {
+      return;
+    }
+
+    const runDir = await mkdtemp(resolve(tmpdir(), "wittgenstein-codec-image-coarse-"));
+    const outPath = resolve(runDir, "out.png");
+    await renderImagePipeline(parsed.value, {
+      runId: "test-run",
+      runDir,
+      seed: null,
+      outPath,
+      logger: {
+        debug: () => {},
+        info: () => {},
+        warn: (message) => warnings.push(message),
+        error: () => {},
+      },
+    });
+
+    expect(warnings.some((message) => message.includes("placeholder seed-expansion adapter"))).toBe(
+      false,
+    );
+  });
+
+  it("uses seedCode before the placeholder adapter path", async () => {
+    const warnings: string[] = [];
+    const parsed = imageCodec.parse(
+      JSON.stringify({
+        mode: "one-shot-hybrid",
+        semantic: {
+          intent: "test",
+          subject: "coastal cliffs",
+          composition: {
+            framing: "wide",
+            camera: "neutral camera",
+            depthPlan: ["foreground", "midground", "background"],
+          },
+          lighting: { mood: "neutral", key: "soft" },
+          style: { references: [], palette: ["blue", "gray"] },
+          constraints: { mustHave: [], negative: [] },
+        },
+        decoder: {
+          family: "llamagen",
+          codebook: "stub-codebook",
+          codebookVersion: "v0",
+          latentResolution: [16, 16],
+        },
+        seedCode: {
+          schemaVersion: "witt.image.seed/v0.1",
+          family: "vqvae",
+          mode: "prefix",
+          tokens: [10, 20, 30, 40, 50, 60],
+        },
+      }),
+    );
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) {
+      return;
+    }
+
+    const runDir = await mkdtemp(resolve(tmpdir(), "wittgenstein-codec-image-seed-"));
+    const outPath = resolve(runDir, "out.png");
+    await renderImagePipeline(parsed.value, {
+      runId: "test-run",
+      runDir,
+      seed: null,
+      outPath,
+      logger: {
+        debug: () => {},
+        info: () => {},
+        warn: (message) => warnings.push(message),
+        error: () => {},
+      },
+    });
+
+    expect(warnings.some((message) => message.includes("placeholder seed-expansion adapter"))).toBe(
+      false,
+    );
   });
 });

--- a/packages/codec-image/test/codec.test.ts
+++ b/packages/codec-image/test/codec.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { imageCodec } from "../src/index.js";
+import { adaptSceneToLatents } from "../src/pipeline/adapter.js";
 import { renderImagePipeline } from "../src/pipeline/index.js";
 
 describe("@wittgenstein/codec-image", () => {
@@ -19,10 +20,10 @@ describe("@wittgenstein/codec-image", () => {
     }
   });
 
-  it("parses a hybrid image-code container and normalizes semantic + seed fields", () => {
+  it("parses a Visual Seed Code contract and normalizes semantic + seed fields", () => {
     const parsed = imageCodec.parse(
       JSON.stringify({
-        mode: "one-shot-hybrid",
+        mode: "one-shot-vsc",
         semantic: {
           intent: "forest poster",
           subject: "misty pine forest",
@@ -44,12 +45,12 @@ describe("@wittgenstein/codec-image", () => {
     );
     expect(parsed.ok).toBe(true);
     if (!parsed.ok) {
-      throw new Error("hybrid parse unexpectedly failed");
+      throw new Error("Visual Seed Code parse unexpectedly failed");
     }
     expect(parsed.value.semantic?.subject).toBe("misty pine forest");
     expect(parsed.value.subject).toBe("misty pine forest");
     expect(parsed.value.seedCode?.length).toBe(4);
-    expect(parsed.value.mode).toBe("one-shot-hybrid");
+    expect(parsed.value.mode).toBe("one-shot-vsc");
   });
 
   it("rejects inconsistent visual code lengths", () => {
@@ -244,11 +245,52 @@ describe("image pipeline (neural decode)", () => {
     );
   });
 
+  it("preserves decoder-facing coarseVq tokens during expansion", async () => {
+    const parsed = imageCodec.parse(
+      JSON.stringify({
+        subject: "forest",
+        decoder: {
+          family: "llamagen",
+          codebook: "stub-codebook",
+          codebookVersion: "v0",
+          latentResolution: [4, 4],
+        },
+        coarseVq: {
+          schemaVersion: "witt.image.coarse-vq/v0.1",
+          family: "llamagen",
+          codebook: "stub-codebook",
+          codebookVersion: "v0",
+          tokenGrid: [2, 2],
+          tokens: [700, 701, 702, 703],
+        },
+      }),
+    );
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) {
+      return;
+    }
+
+    const latents = await adaptSceneToLatents(parsed.value, {
+      runId: "coarse-preserve",
+      runDir: await mkdtemp(resolve(tmpdir(), "wittgenstein-codec-image-preserve-")),
+      seed: null,
+      outPath: "out.png",
+      logger: {
+        debug: () => {},
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+      },
+    });
+
+    expect(latents.tokens.slice(0, 4)).toEqual([700, 700, 701, 701]);
+  });
+
   it("uses seedCode before the placeholder adapter path", async () => {
     const warnings: string[] = [];
     const parsed = imageCodec.parse(
       JSON.stringify({
-        mode: "one-shot-hybrid",
+        mode: "one-shot-vsc",
         semantic: {
           intent: "test",
           subject: "coastal cliffs",


### PR DESCRIPTION
## Summary

Implements the first small #203 slice for the Visual Seed Code contract in `codec-image`.

This PR keeps the implementation narrow and follows the doctrine direction in #206:

- `Visual Seed Code` is the primary decoder-facing image output.
- `Semantic IR` is the model-side organization / user-facing inspection / optional conditioning layer, not the main image path.
- `providerLatents` remains the strongest direct decoder-native path.
- `coarseVq` is supported as an optional partial VQ bridge because it is closer to decoder-native latents than compact `seedCode`.
- semantic-only input stays as compatibility fallback / baseline.

## What changed

- Adds `ImageVisualSeedCodeSchema`, `ImageCoarseVqSchema`, and `ImageCodeModeSchema`.
- Uses VSC-first mode names: `one-shot-vsc` and `two-pass-compile`.
- Updates the image preamble to request a Visual Seed Code contract and explain Semantic IR as concept organization, user-facing plan, and optional seed-expansion conditioning.
- Normalizes VSC containers so optional `semantic` can populate legacy top-level semantic fields for compatibility.
- Tightens visual-code validation:
  - `providerLatents.tokens.length` must match `tokenGrid` area.
  - `coarseVq.tokens.length` must match `tokenGrid` area.
  - `seedCode.length`, when present, must match `seedCode.tokens.length`.
- Updates adapter priority to:
  `providerLatents > coarseVq > seedCode > semantic fallback > placeholder`.
- Preserves decoder-facing `coarseVq` / `seedCode` expansion outputs instead of silently overwriting their first tokens with scaffold annotations.
- Updates tests for VSC parsing, invalid visual-code lengths, non-placeholder `coarseVq` / `seedCode` paths, and coarse-token preservation.

## What this does not do

- Does not choose a final tokenizer family.
- Does not implement a trained SeedExpander.
- Does not add CLI / manifest / eval surfaces; that is #204 / #214 / #218.
- Does not replace the decoder family.
- Does not reopen diffusion / Path C / second raster path.

## Validation

- `pnpm --filter @wittgenstein/codec-image test`
- `pnpm --filter @wittgenstein/codec-image typecheck`
- `pnpm --filter @wittgenstein/codec-image lint`
- `pnpm exec prettier --check packages/codec-image/src/schema.ts packages/codec-image/src/pipeline/adapter.ts packages/codec-image/src/codec.ts packages/codec-image/test/codec.test.ts`
- `git diff --check`

## Related work

- Depends conceptually on #206 (doctrine correction).
- Implements #203.
- Parallel review / support tasks:
  - #208 adapter-path ordering check
  - #209 schema boundary validation hardening
  - #207 one-shot vs two-pass prompt/playbook acceptance cases
  - #204 manifest / CLI / eval support
  - #205 seed-token family comparison + eval matrix

@moapacha please review this as the first implementation slice after #206. The main review question is whether the runtime ordering and validation match the VSC-first, Semantic-supporting hierarchy without overcommitting to a tokenizer family.