### PR TITLE
feat(image): record image-code receipts

### DIFF
--- a/packages/codec-image/src/codec.ts
+++ b/packages/codec-image/src/codec.ts
@@ -117,9 +117,9 @@ function dryRunSeedTokens(prompt: string, length = 32): number[] {
 
 function createDryRunScene(req: ImageRequest): ImageSceneSpec {
   const raw = JSON.stringify({
-    mode: "one-shot-hybrid",
+    mode: "one-shot-vsc",
     semantic: {
-      intent: "Dry-run Hybrid Image Code plan",
+      intent: "Dry-run Visual Seed Code plan",
       subject: req.prompt,
       composition: {
         framing: "centered subject",

--- a/packages/codec-image/src/codec.ts
+++ b/packages/codec-image/src/codec.ts
@@ -18,6 +18,7 @@ import { renderImagePipeline } from "./pipeline/index.js";
 import { adaptSceneToLatents } from "./pipeline/adapter.js";
 import { decodeLatentsToRaster } from "./pipeline/decoder.js";
 import { packageRasterAsPng } from "./pipeline/package.js";
+import { imageCodeReceipt } from "./image-code-receipt.js";
 import type { ImageArtifact } from "./types.js";
 
 interface ImageCodecLlmService {
@@ -109,19 +110,38 @@ function hashBytes(value: Uint8Array): string {
   return createHash("sha256").update(value).digest("hex");
 }
 
+function dryRunSeedTokens(prompt: string, length = 32): number[] {
+  const digest = createHash("sha256").update(prompt, "utf8").digest();
+  return Array.from({ length }, (_, index) => digest[index % digest.length] ?? 0);
+}
+
 function createDryRunScene(req: ImageRequest): ImageSceneSpec {
-  return ImageSceneSpecSchema.parse({
-    intent: "Photorealistic wildlife portrait suitable for print",
-    subject: req.prompt,
-    composition: {
-      framing: "tight portrait on subject",
-      camera: "telephoto compression, shallow depth of field",
-      depthPlan: ["sharp subject", "soft bokeh", "clean background"],
+  const raw = JSON.stringify({
+    mode: "one-shot-hybrid",
+    semantic: {
+      intent: "Dry-run Hybrid Image Code plan",
+      subject: req.prompt,
+      composition: {
+        framing: "centered subject",
+        camera: "neutral camera",
+        depthPlan: ["foreground", "midground", "background"],
+      },
+      lighting: { mood: "neutral", key: "soft" },
+      style: {
+        references: ["local deterministic preview"],
+        palette: ["neutral grey", "soft blue", "warm highlight"],
+      },
+      constraints: {
+        mustHave: [],
+        negative: [],
+      },
     },
-    lighting: { mood: "natural soft daylight", key: "diffused key, gentle fill" },
-    style: {
-      references: ["wildlife photography", "fine-art nature print"],
-      palette: ["neutral grey", "natural fur tones", "cool water highlights"],
+    seedCode: {
+      schemaVersion: "witt.image.seed/v0.1",
+      family: "witt-dry-run",
+      mode: "prefix",
+      length: 32,
+      tokens: dryRunSeedTokens(req.prompt, 32),
     },
     decoder: {
       family: "llamagen",
@@ -130,6 +150,11 @@ function createDryRunScene(req: ImageRequest): ImageSceneSpec {
       latentResolution: [32, 32],
     },
   });
+  const parsed = parseImageSceneSpec(raw);
+  if (!parsed.ok) {
+    throw new Error(parsed.error.message);
+  }
+  return parsed.value;
 }
 
 function asServices(services: codecV2.HarnessCtx["services"]): ImageCodecServices {
@@ -266,6 +291,7 @@ export class ImageCodec extends codecV2.BaseCodec<ImageRequest, ImageArtifact> {
       throw new Error("ImageCodec expected HybridIR after adapt().");
     }
     const payload = asPayload(ir.latent);
+    const imageCode = imageCodeReceipt(payload.scene);
     const raster = await decodeLatentsToRaster(
       payload.latents,
       this.createRenderCtx(ctx, codecV2.CodecPhase.Decode),
@@ -288,10 +314,12 @@ export class ImageCodec extends codecV2.BaseCodec<ImageRequest, ImageArtifact> {
         promptExpanded: payload.promptExpanded,
         llmOutputRaw: payload.llmOutputRaw,
         llmOutputParsed: payload.scene,
+        imageCode,
         quality: {
           structural: {
             schemaValidated: true,
             route: "raster",
+            imageCode,
             paletteCount: payload.scene.style.palette.length,
             palette: [...payload.scene.style.palette],
           },
@@ -320,6 +348,7 @@ export class ImageCodec extends codecV2.BaseCodec<ImageRequest, ImageArtifact> {
   manifestRows(art: ImageArtifact): ReadonlyArray<codecV2.ManifestRow> {
     return [
       { key: "route", value: art.metadata.route },
+      { key: "image.code", value: art.metadata.imageCode },
       { key: "quality.structural", value: art.metadata.quality.structural },
       { key: "quality.partial", value: art.metadata.quality.partial },
       { key: "metadata.warnings", value: art.metadata.warnings.length },

--- a/packages/codec-image/src/image-code-receipt.ts
+++ b/packages/codec-image/src/image-code-receipt.ts
@@ -1,0 +1,31 @@
+import type { ImageSceneSpec } from "./schema.js";
+import type { ImageCodePath, ImageCodeReceipt } from "./types.js";
+
+export function imageCodePath(scene: ImageSceneSpec): ImageCodePath {
+  if (scene.providerLatents) {
+    return "provider-latents";
+  }
+  if (scene.coarseVq) {
+    return "coarse-vq";
+  }
+  if (scene.seedCode) {
+    return "visual-seed-code";
+  }
+  return "semantic-fallback";
+}
+
+export function imageCodeReceipt(scene: ImageSceneSpec): ImageCodeReceipt {
+  return {
+    mode: scene.mode ?? "semantic-only",
+    path: imageCodePath(scene),
+    hasSemantic: scene.semantic !== undefined,
+    hasSeedCode: scene.seedCode !== undefined,
+    hasCoarseVq: scene.coarseVq !== undefined,
+    hasProviderLatents: scene.providerLatents !== undefined,
+    seedFamily: scene.seedCode?.family ?? null,
+    seedMode: scene.seedCode?.mode ?? null,
+    seedLength: scene.seedCode?.tokens.length ?? null,
+    coarseVqGrid: scene.coarseVq?.tokenGrid ?? null,
+    providerLatentGrid: scene.providerLatents?.tokenGrid ?? null,
+  };
+}

--- a/packages/codec-image/src/image-code-receipt.ts
+++ b/packages/codec-image/src/image-code-receipt.ts
@@ -1,5 +1,18 @@
 import type { ImageSceneSpec } from "./schema.js";
-import type { ImageCodePath, ImageCodeReceipt } from "./types.js";
+import type { ImageCodePath, ImageCodeReceipt, ImageSemanticSource } from "./types.js";
+
+const defaultSemantic = {
+  intent: "placeholder scene",
+  subject: "placeholder subject",
+  composition: {
+    framing: "medium shot",
+    camera: "neutral camera",
+    depthPlan: ["foreground", "midground", "background"],
+  },
+  lighting: { mood: "neutral", key: "soft" },
+  style: { references: [], palette: ["black", "white"] },
+  constraints: { mustHave: [], negative: [] },
+} as const;
 
 export function imageCodePath(scene: ImageSceneSpec): ImageCodePath {
   if (scene.providerLatents) {
@@ -14,11 +27,45 @@ export function imageCodePath(scene: ImageSceneSpec): ImageCodePath {
   return "semantic-fallback";
 }
 
+function sameList(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function hasLegacyTopLevelSemantic(scene: ImageSceneSpec): boolean {
+  return (
+    scene.intent !== defaultSemantic.intent ||
+    scene.subject !== defaultSemantic.subject ||
+    scene.composition.framing !== defaultSemantic.composition.framing ||
+    scene.composition.camera !== defaultSemantic.composition.camera ||
+    !sameList(scene.composition.depthPlan, defaultSemantic.composition.depthPlan) ||
+    scene.lighting.mood !== defaultSemantic.lighting.mood ||
+    scene.lighting.key !== defaultSemantic.lighting.key ||
+    !sameList(scene.style.references, defaultSemantic.style.references) ||
+    !sameList(scene.style.palette, defaultSemantic.style.palette) ||
+    !sameList(scene.constraints.mustHave, defaultSemantic.constraints.mustHave) ||
+    !sameList(scene.constraints.negative, defaultSemantic.constraints.negative)
+  );
+}
+
+export function imageSemanticSource(scene: ImageSceneSpec): ImageSemanticSource {
+  if (scene.semantic) {
+    return "emitted";
+  }
+  if (hasLegacyTopLevelSemantic(scene)) {
+    return "legacy-top-level";
+  }
+  return "absent";
+}
+
 export function imageCodeReceipt(scene: ImageSceneSpec): ImageCodeReceipt {
+  const semanticSource = imageSemanticSource(scene);
   return {
     mode: scene.mode ?? "semantic-only",
     path: imageCodePath(scene),
-    hasSemantic: scene.semantic !== undefined,
+    hasSemantic: semanticSource !== "absent",
+    hasEmittedSemantic: semanticSource === "emitted",
+    hasEffectiveSemantic: semanticSource !== "absent",
+    semanticSource,
     hasSeedCode: scene.seedCode !== undefined,
     hasCoarseVq: scene.coarseVq !== undefined,
     hasProviderLatents: scene.providerLatents !== undefined,

--- a/packages/codec-image/src/pipeline/index.ts
+++ b/packages/codec-image/src/pipeline/index.ts
@@ -3,6 +3,7 @@ import { expandSceneSpec } from "./expand.js";
 import { adaptSceneToLatents } from "./adapter.js";
 import { decodeLatentsToRaster } from "./decoder.js";
 import { packageRasterAsPng, toRenderResult } from "./package.js";
+import { imageCodeReceipt } from "../image-code-receipt.js";
 import type { ImageSceneSpec } from "../schema.js";
 import type { ImageArtifact } from "../types.js";
 
@@ -13,6 +14,7 @@ export async function renderImagePipeline(
   const expanded = await expandSceneSpec(parsed, ctx);
   const latentCodes = await adaptSceneToLatents(expanded, ctx);
   const raster = await decodeLatentsToRaster(latentCodes, ctx);
+  const imageCode = imageCodeReceipt(parsed);
   const artifact: ImageArtifact = {
     outPath: ctx.outPath,
     bytes: raster.pngBytes,
@@ -30,10 +32,12 @@ export async function renderImagePipeline(
       promptExpanded: null,
       llmOutputRaw: null,
       llmOutputParsed: parsed,
+      imageCode,
       quality: {
         structural: {
           schemaValidated: true,
           route: "raster",
+          imageCode,
           paletteCount: parsed.style.palette.length,
           palette: [...parsed.style.palette],
         },

--- a/packages/codec-image/src/schema.ts
+++ b/packages/codec-image/src/schema.ts
@@ -157,7 +157,7 @@ export function imageSchemaPreamble(req: ImageRequest): string {
 }
 
 function normalizeImageSceneSpec(spec: ImageSceneSpec): ImageSceneSpec {
-  const semantic = spec.semantic ?? {
+  const semanticDefaults = {
     intent: spec.intent,
     subject: spec.subject,
     composition: spec.composition,
@@ -165,6 +165,8 @@ function normalizeImageSceneSpec(spec: ImageSceneSpec): ImageSceneSpec {
     style: spec.style,
     constraints: spec.constraints,
   };
+  const semantic = spec.semantic;
+  const effectiveSemantic = semantic ?? semanticDefaults;
 
   const mode =
     spec.mode ??
@@ -178,12 +180,12 @@ function normalizeImageSceneSpec(spec: ImageSceneSpec): ImageSceneSpec {
     ...spec,
     mode,
     semantic,
-    intent: semantic.intent,
-    subject: semantic.subject,
-    composition: semantic.composition,
-    lighting: semantic.lighting,
-    style: semantic.style,
-    constraints: semantic.constraints,
+    intent: effectiveSemantic.intent,
+    subject: effectiveSemantic.subject,
+    composition: effectiveSemantic.composition,
+    lighting: effectiveSemantic.lighting,
+    style: effectiveSemantic.style,
+    constraints: effectiveSemantic.constraints,
     seedCode: spec.seedCode
       ? {
           ...spec.seedCode,

--- a/packages/codec-image/src/types.ts
+++ b/packages/codec-image/src/types.ts
@@ -7,10 +7,15 @@ export type ImageCodePath =
   | "visual-seed-code"
   | "semantic-fallback";
 
+export type ImageSemanticSource = "emitted" | "legacy-top-level" | "absent";
+
 export interface ImageCodeReceipt {
   readonly mode: NonNullable<ImageSceneSpec["mode"]>;
   readonly path: ImageCodePath;
   readonly hasSemantic: boolean;
+  readonly hasEmittedSemantic: boolean;
+  readonly hasEffectiveSemantic: boolean;
+  readonly semanticSource: ImageSemanticSource;
   readonly hasSeedCode: boolean;
   readonly hasCoarseVq: boolean;
   readonly hasProviderLatents: boolean;

--- a/packages/codec-image/src/types.ts
+++ b/packages/codec-image/src/types.ts
@@ -1,6 +1,26 @@
 import type { ImageSceneSpec } from "./schema.js";
 import type { codecV2 } from "@wittgenstein/schemas";
 
+export type ImageCodePath =
+  | "provider-latents"
+  | "coarse-vq"
+  | "visual-seed-code"
+  | "semantic-fallback";
+
+export interface ImageCodeReceipt {
+  readonly mode: NonNullable<ImageSceneSpec["mode"]>;
+  readonly path: ImageCodePath;
+  readonly hasSemantic: boolean;
+  readonly hasSeedCode: boolean;
+  readonly hasCoarseVq: boolean;
+  readonly hasProviderLatents: boolean;
+  readonly seedFamily: string | null;
+  readonly seedMode: string | null;
+  readonly seedLength: number | null;
+  readonly coarseVqGrid: readonly [number, number] | null;
+  readonly providerLatentGrid: readonly [number, number] | null;
+}
+
 export interface ImageArtifactMetadata extends codecV2.BaseArtifactMetadata {
   readonly codec: "image";
   readonly route: "raster";
@@ -12,10 +32,12 @@ export interface ImageArtifactMetadata extends codecV2.BaseArtifactMetadata {
   readonly promptExpanded: string | null;
   readonly llmOutputRaw: string | null;
   readonly llmOutputParsed: ImageSceneSpec | null;
+  readonly imageCode: ImageCodeReceipt;
   readonly quality: {
     readonly structural: {
       readonly schemaValidated: boolean;
       readonly route: "raster";
+      readonly imageCode: ImageCodeReceipt;
       readonly paletteCount: number;
       readonly palette: string[];
     };

--- a/packages/codec-image/test/codec.test.ts
+++ b/packages/codec-image/test/codec.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { imageCodec } from "../src/index.js";
+import { imageCodeReceipt } from "../src/image-code-receipt.js";
 import { adaptSceneToLatents } from "../src/pipeline/adapter.js";
 import { renderImagePipeline } from "../src/pipeline/index.js";
 
@@ -51,6 +52,46 @@ describe("@wittgenstein/codec-image", () => {
     expect(parsed.value.subject).toBe("misty pine forest");
     expect(parsed.value.seedCode?.length).toBe(4);
     expect(parsed.value.mode).toBe("one-shot-vsc");
+  });
+
+  it("distinguishes emitted semantic from legacy/effective semantic receipts", () => {
+    const emitted = imageCodec.parse(
+      JSON.stringify({
+        semantic: {
+          intent: "poster",
+          subject: "tree",
+          style: { palette: ["green"] },
+        },
+      }),
+    );
+    const legacy = imageCodec.parse(JSON.stringify({ intent: "poster", subject: "tree" }));
+    const absent = imageCodec.parse("{}");
+
+    expect(emitted.ok).toBe(true);
+    expect(legacy.ok).toBe(true);
+    expect(absent.ok).toBe(true);
+    if (!emitted.ok || !legacy.ok || !absent.ok) {
+      throw new Error("image parse unexpectedly failed");
+    }
+
+    expect(imageCodeReceipt(emitted.value)).toMatchObject({
+      hasSemantic: true,
+      hasEmittedSemantic: true,
+      hasEffectiveSemantic: true,
+      semanticSource: "emitted",
+    });
+    expect(imageCodeReceipt(legacy.value)).toMatchObject({
+      hasSemantic: true,
+      hasEmittedSemantic: false,
+      hasEffectiveSemantic: true,
+      semanticSource: "legacy-top-level",
+    });
+    expect(imageCodeReceipt(absent.value)).toMatchObject({
+      hasSemantic: false,
+      hasEmittedSemantic: false,
+      hasEffectiveSemantic: false,
+      semanticSource: "absent",
+    });
   });
 
   it("rejects inconsistent visual code lengths", () => {

--- a/packages/codec-image/test/round-trip.test.ts
+++ b/packages/codec-image/test/round-trip.test.ts
@@ -43,6 +43,9 @@ describe("image v2 round trip", () => {
       path: "visual-seed-code",
       hasSeedCode: true,
       hasSemantic: true,
+      hasEmittedSemantic: true,
+      hasEffectiveSemantic: true,
+      semanticSource: "emitted",
       seedFamily: "witt-dry-run",
       seedLength: 32,
     });

--- a/packages/codec-image/test/round-trip.test.ts
+++ b/packages/codec-image/test/round-trip.test.ts
@@ -38,8 +38,17 @@ describe("image v2 round trip", () => {
     );
     expect(art.mime).toBe("image/png");
     expect(art.metadata.route).toBe("raster");
+    expect(art.metadata.imageCode).toMatchObject({
+      mode: "one-shot-hybrid",
+      path: "visual-seed-code",
+      hasSeedCode: true,
+      hasSemantic: true,
+      seedFamily: "witt-dry-run",
+      seedLength: 32,
+    });
     expect(imageV2Codec.manifestRows(art).map((row) => row.key)).toEqual([
       "route",
+      "image.code",
       "quality.structural",
       "quality.partial",
       "metadata.warnings",
@@ -47,5 +56,8 @@ describe("image v2 round trip", () => {
       "L5.decoderHash",
       "artifact.sha256",
     ]);
+    expect(imageV2Codec.manifestRows(art).find((row) => row.key === "image.code")?.value).toEqual(
+      art.metadata.imageCode,
+    );
   });
 });

--- a/packages/codec-image/test/round-trip.test.ts
+++ b/packages/codec-image/test/round-trip.test.ts
@@ -39,7 +39,7 @@ describe("image v2 round trip", () => {
     expect(art.mime).toBe("image/png");
     expect(art.metadata.route).toBe("raster");
     expect(art.metadata.imageCode).toMatchObject({
-      mode: "one-shot-hybrid",
+      mode: "one-shot-vsc",
       path: "visual-seed-code",
       hasSeedCode: true,
       hasSemantic: true,

--- a/packages/codec-image/test/warnings-channel.test.ts
+++ b/packages/codec-image/test/warnings-channel.test.ts
@@ -19,7 +19,20 @@ describe("image v2 warnings channel", () => {
         logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
         clock: { now: () => 0, iso: () => new Date(0).toISOString() },
         sidecar: codecV2.createRunSidecar(),
-        services: { dryRun: true, telemetry: { writeText: async () => {} } },
+        services: {
+          telemetry: { writeText: async () => {} },
+          llm: {
+            provider: "test",
+            model: "test",
+            maxOutputTokens: 1024,
+            temperature: 0,
+            generate: async () => ({
+              text: "{}",
+              tokens: { input: 1, output: 1 },
+              costUsd: 0,
+            }),
+          },
+        },
         fork: () => {
           throw new Error("unused");
         },


### PR DESCRIPTION
## Summary

- adds an explicit `imageCode` receipt to image artifact metadata and the v2 manifest rows
- records which Visual Seed Code path fired: `provider-latents`, `coarse-vq`, `visual-seed-code`, or `semantic-fallback`
- aligns dry-run with the new VSC path by emitting deterministic `witt-dry-run` seed tokens instead of a semantic-first placeholder scene
- keeps semantic receipts honest by preserving `semantic` as optional instead of synthesizing it during parse normalization
- carries forward the #210 VSC terminology cleanup (`one-shot-vsc`, `two-pass-compile`) and preserves decoder-facing seed/coarse tokens during expansion

## Context

Follows #203 / #210 and addresses #214. This PR is intentionally stacked on #210, so it should remain draft until the Phase 1 Visual Seed Code contract lands.

## Scope

In scope:
- image artifact metadata shape
- image v2 manifest receipt row
- dry-run path alignment
- focused tests for receipts, token preservation, and warning-channel behavior

Out of scope:
- new decoder backend
- tokenizer-family selection
- CLI UX changes beyond metadata surfaced by the codec
- changing shared manifest schema beyond codec-authored rows

## Validation

- `pnpm --filter @wittgenstein/codec-image test`
- `pnpm --filter @wittgenstein/codec-image typecheck`
- `pnpm --filter @wittgenstein/codec-image lint`
- `pnpm exec prettier --check packages/codec-image/src/schema.ts packages/codec-image/src/pipeline/adapter.ts packages/codec-image/src/codec.ts packages/codec-image/test/codec.test.ts packages/codec-image/test/round-trip.test.ts`
- `git diff --check`