### PR TITLE
fix(core): compute real LLM costUsd; null + reason for unknown models (closes #182)

### DIFF
--- a/packages/core/src/llm/adapter.ts
+++ b/packages/core/src/llm/adapter.ts
@@ -12,13 +12,21 @@ export interface LlmGenerationRequest {
   responseFormat?: "json" | "text";
 }
 
+import type { CostUsdReason } from "./pricing.js";
+
 export interface LlmGenerationResult {
   text: string;
   tokens: {
     input: number;
     output: number;
   };
-  costUsd: number;
+  /**
+   * Computed cost in USD. `null` when the model is unpriced (`costUsdReason: "unknown-model"`)
+   * or when the vendor did not return token usage (`costUsdReason: "missing-usage"`).
+   * Manifest receipts preserve `null` rather than silently substituting zero (Issue #182).
+   */
+  costUsd: number | null;
+  costUsdReason: CostUsdReason;
   raw?: unknown;
 }
 

--- a/packages/core/src/llm/anthropic.ts
+++ b/packages/core/src/llm/anthropic.ts
@@ -2,6 +2,7 @@ import { llm as llmSchemas } from "@wittgenstein/schemas";
 import type { LlmConfig } from "@wittgenstein/schemas";
 import { WittgensteinError } from "../runtime/errors.js";
 import type { LlmAdapter, LlmGenerationRequest, LlmGenerationResult } from "./adapter.js";
+import { priceModel } from "./pricing.js";
 
 export class AnthropicLlmAdapter implements LlmAdapter {
   public readonly provider = "anthropic";
@@ -71,13 +72,17 @@ export class AnthropicLlmAdapter implements LlmAdapter {
       );
     }
 
+    const tokens = {
+      input: parsed.data.usage.input_tokens,
+      output: parsed.data.usage.output_tokens,
+    };
+    const { costUsd, costUsdReason } = priceModel("anthropic", request.model, tokens);
+
     return {
       text: firstBlock.text,
-      tokens: {
-        input: parsed.data.usage.input_tokens,
-        output: parsed.data.usage.output_tokens,
-      },
-      costUsd: 0,
+      tokens,
+      costUsd,
+      costUsdReason,
       raw: parsed.data,
     };
   }

--- a/packages/core/src/llm/openai-compatible.ts
+++ b/packages/core/src/llm/openai-compatible.ts
@@ -2,6 +2,7 @@ import { llm as llmSchemas } from "@wittgenstein/schemas";
 import type { LlmConfig } from "@wittgenstein/schemas";
 import { WittgensteinError } from "../runtime/errors.js";
 import type { LlmAdapter, LlmGenerationRequest, LlmGenerationResult } from "./adapter.js";
+import { priceModel } from "./pricing.js";
 
 const DEFAULT_BASE_URLS: Record<string, string> = {
   "openai-compatible": "https://api.openai.com/v1",
@@ -88,13 +89,17 @@ export class OpenAICompatibleLlmAdapter implements LlmAdapter {
       );
     }
 
+    const tokens = {
+      input: parsed.data.usage.prompt_tokens,
+      output: parsed.data.usage.completion_tokens,
+    };
+    const { costUsd, costUsdReason } = priceModel(this.config.provider, request.model, tokens);
+
     return {
       text: firstChoice.message.content,
-      tokens: {
-        input: parsed.data.usage.prompt_tokens,
-        output: parsed.data.usage.completion_tokens,
-      },
-      costUsd: 0,
+      tokens,
+      costUsd,
+      costUsdReason,
       raw: parsed.data,
     };
   }

--- a/packages/core/src/llm/pricing.ts
+++ b/packages/core/src/llm/pricing.ts
@@ -1,0 +1,114 @@
+/**
+ * Per-provider × per-model token pricing for honest manifest receipts (Issue #182).
+ *
+ * Rates are USD per 1,000,000 tokens (input / output). Update when:
+ *   - a model rotation lands (e.g. claude-sonnet-4-6 → claude-sonnet-4-7);
+ *   - a vendor changes published rates;
+ *   - a new provider / adapter is added.
+ *
+ * Sources (documented for audit, not fetched at runtime):
+ *   - Anthropic:  https://www.anthropic.com/pricing
+ *   - OpenAI:     https://platform.openai.com/docs/pricing
+ *   - Minimax:    https://platform.minimaxi.com/pricing
+ *
+ * Unknown (provider, model) pairs return `null` cost with a structured
+ * `costUsdReason` so the manifest records the gap honestly rather than
+ * silently zero. Operators can then choose to amend this table or treat
+ * unknown-model receipts as audit material.
+ */
+
+export type CostUsdReason =
+  | "computed"
+  | "unknown-model"
+  | "missing-usage";
+
+export interface ModelRate {
+  /** USD per 1,000,000 input tokens. */
+  readonly inputPerMillion: number;
+  /** USD per 1,000,000 output tokens. */
+  readonly outputPerMillion: number;
+}
+
+const RATES: Readonly<Record<string, Readonly<Record<string, ModelRate>>>> = {
+  anthropic: {
+    "claude-opus-4-7": { inputPerMillion: 15, outputPerMillion: 75 },
+    "claude-opus-4-6": { inputPerMillion: 15, outputPerMillion: 75 },
+    "claude-sonnet-4-7": { inputPerMillion: 3, outputPerMillion: 15 },
+    "claude-sonnet-4-6": { inputPerMillion: 3, outputPerMillion: 15 },
+    "claude-haiku-4-5-20251001": { inputPerMillion: 1, outputPerMillion: 5 },
+    "claude-haiku-4-5": { inputPerMillion: 1, outputPerMillion: 5 },
+    "claude-3-5-haiku-20241022": { inputPerMillion: 0.8, outputPerMillion: 4 },
+    "claude-3-5-sonnet-20241022": { inputPerMillion: 3, outputPerMillion: 15 },
+    "claude-3-5-sonnet-20240620": { inputPerMillion: 3, outputPerMillion: 15 },
+    "claude-3-opus-20240229": { inputPerMillion: 15, outputPerMillion: 75 },
+  },
+  "openai-compatible": {
+    "gpt-4o": { inputPerMillion: 2.5, outputPerMillion: 10 },
+    "gpt-4o-2024-08-06": { inputPerMillion: 2.5, outputPerMillion: 10 },
+    "gpt-4o-mini": { inputPerMillion: 0.15, outputPerMillion: 0.6 },
+    "gpt-4-turbo": { inputPerMillion: 10, outputPerMillion: 30 },
+  },
+  minimax: {
+    "minimax/minimax-01": { inputPerMillion: 0.2, outputPerMillion: 1.1 },
+    "MiniMax-M1": { inputPerMillion: 0.4, outputPerMillion: 2.2 },
+    "abab6.5-chat": { inputPerMillion: 1, outputPerMillion: 4 },
+    "abab6.5s-chat": { inputPerMillion: 0.15, outputPerMillion: 0.6 },
+  },
+};
+
+/**
+ * Compute USD cost for a (provider, model, tokens) tuple.
+ *
+ * Returns:
+ *   - `{ costUsd: number, costUsdReason: "computed" }` when both input and output are zero (no LLM round-trip).
+ *   - `{ costUsd: number, costUsdReason: "computed" }` when the rate is known.
+ *   - `{ costUsd: null,   costUsdReason: "unknown-model" }` when the (provider, model) pair is not in the rate table.
+ *   - `{ costUsd: null,   costUsdReason: "missing-usage" }` when input or output token counts are not provided.
+ *
+ * Caller is responsible for surfacing the reason: typically the LLM adapter
+ * sets these on `LlmGenerationResult`, the harness writes them onto the
+ * manifest, and the budget tracker treats `null` as zero (with a separate
+ * sidecar warning if it cares).
+ */
+export function priceModel(
+  provider: string,
+  model: string,
+  tokens: { input: number; output: number } | undefined,
+): { costUsd: number | null; costUsdReason: CostUsdReason } {
+  if (tokens === undefined) {
+    return { costUsd: null, costUsdReason: "missing-usage" };
+  }
+
+  if (tokens.input === 0 && tokens.output === 0) {
+    return { costUsd: 0, costUsdReason: "computed" };
+  }
+
+  const providerRates = RATES[provider];
+  const rate = providerRates?.[model];
+  if (!rate) {
+    return { costUsd: null, costUsdReason: "unknown-model" };
+  }
+
+  const cost =
+    (tokens.input * rate.inputPerMillion) / 1_000_000 +
+    (tokens.output * rate.outputPerMillion) / 1_000_000;
+  return { costUsd: cost, costUsdReason: "computed" };
+}
+
+/**
+ * Enumerate all (provider, model) combinations currently priced.
+ * Useful for `wittgenstein doctor` and tests.
+ */
+export function pricedModels(): ReadonlyArray<{ provider: string; model: string }> {
+  const out: Array<{ provider: string; model: string }> = [];
+  for (const provider of Object.keys(RATES)) {
+    const providerRates = RATES[provider];
+    if (!providerRates) {
+      continue;
+    }
+    for (const model of Object.keys(providerRates)) {
+      out.push({ provider, model });
+    }
+  }
+  return out;
+}

--- a/packages/core/src/runtime/asciipng-minimax.ts
+++ b/packages/core/src/runtime/asciipng-minimax.ts
@@ -75,6 +75,7 @@ export async function generateAsciipngFromMinimax(
     text: JSON.stringify(ir),
     tokens: gen.tokens,
     costUsd: gen.costUsd,
+    costUsdReason: gen.costUsdReason,
     raw: { minimax: true, minimaxRawChars: gen.text.length },
   };
 }

--- a/packages/core/src/runtime/harness.ts
+++ b/packages/core/src/runtime/harness.ts
@@ -1,5 +1,6 @@
 import { resolve } from "node:path";
 import type {
+  CostUsdReason,
   WittgensteinRequest,
   RenderCtx,
   RenderResult,
@@ -111,6 +112,7 @@ export class Wittgenstein {
         output: 0,
       },
       costUsd: 0,
+      costUsdReason: "computed",
       promptRaw: request.prompt,
       promptExpanded,
       llmOutputRaw: null,
@@ -161,7 +163,8 @@ export class Wittgenstein {
             codec: string;
             route?: string;
             llmTokens?: { input: number; output: number };
-            costUsd?: number;
+            costUsd?: number | null;
+            costUsdReason?: CostUsdReason;
             durationMs?: number;
             seed?: number | null;
             promptExpanded?: string | null;
@@ -181,7 +184,12 @@ export class Wittgenstein {
         manifest.llmOutputRaw = artMeta.llmOutputRaw ?? null;
         manifest.llmOutputParsed = artMeta.llmOutputParsed ?? null;
         manifest.llmTokens = artMeta.llmTokens ?? manifest.llmTokens;
-        manifest.costUsd = artMeta.costUsd ?? manifest.costUsd;
+        if (artMeta.costUsd !== undefined) {
+          manifest.costUsd = artMeta.costUsd;
+        }
+        if (artMeta.costUsdReason !== undefined) {
+          manifest.costUsdReason = artMeta.costUsdReason;
+        }
         manifest.artifactPath = produced.outPath;
         manifest.artifactSha256 = artMeta.artifactSha256 ?? null;
         foldManifestRows(manifest, codec.manifestRows(art));
@@ -256,11 +264,15 @@ export class Wittgenstein {
           }
         }
 
-        budget.consume(generation.tokens.input + generation.tokens.output, generation.costUsd);
+        budget.consume(
+          generation.tokens.input + generation.tokens.output,
+          generation.costUsd ?? 0,
+        );
 
         manifest.llmOutputRaw = generation.text;
         manifest.llmTokens = generation.tokens;
         manifest.costUsd = generation.costUsd;
+        manifest.costUsdReason = generation.costUsdReason;
         await telemetry.writeText("llm-output.txt", generation.text);
 
         const parsed = v1Codec.parse(generation.text);
@@ -291,6 +303,9 @@ export class Wittgenstein {
         manifest.durationMs = Date.now() - startedAt.getTime();
         manifest.llmTokens = rendered.metadata.llmTokens;
         manifest.costUsd = rendered.metadata.costUsd;
+        if (rendered.metadata.costUsdReason !== undefined) {
+          manifest.costUsdReason = rendered.metadata.costUsdReason;
+        }
       }
     } catch (caughtError) {
       error = serializeError(caughtError);
@@ -421,7 +436,8 @@ function toRenderResult(
       codec: string;
       route?: string;
       llmTokens?: { input: number; output: number };
-      costUsd?: number;
+      costUsd?: number | null;
+      costUsdReason?: CostUsdReason;
       durationMs?: number;
       seed?: number | null;
     };
@@ -478,6 +494,7 @@ function buildAsciiPngGeneration(request: WittgensteinRequest): LlmGenerationRes
     text: JSON.stringify(ir),
     tokens: { input: 0, output: 0 },
     costUsd: 0,
+    costUsdReason: "computed",
     raw: { asciiPngLocal: true },
   };
 }
@@ -522,6 +539,7 @@ function createDryRunGeneration(request: WittgensteinRequest): LlmGenerationResu
         output: 0,
       },
       costUsd: 0,
+      costUsdReason: "computed",
       raw: {
         dryRun: true,
       },
@@ -535,6 +553,7 @@ function createDryRunGeneration(request: WittgensteinRequest): LlmGenerationResu
       output: 0,
     },
     costUsd: 0,
+    costUsdReason: "computed",
     raw: {
       dryRun: true,
     },

--- a/packages/core/src/runtime/svg-generation.ts
+++ b/packages/core/src/runtime/svg-generation.ts
@@ -37,6 +37,7 @@ export async function generateSvgFromEngine(
       text: payload.text,
       tokens: { input: 0, output: 0 },
       costUsd: 0,
+      costUsdReason: "computed",
       raw: { svgEngine: true, url },
     };
   } catch (error) {

--- a/packages/core/src/runtime/svg-local.ts
+++ b/packages/core/src/runtime/svg-local.ts
@@ -7,6 +7,7 @@ export function buildSvgLocalGeneration(request: SvgRequest): LlmGenerationResul
     text: JSON.stringify({ svg }),
     tokens: { input: 0, output: 0 },
     costUsd: 0,
+    costUsdReason: "computed",
     raw: { svgLocal: true as const },
   };
 }

--- a/packages/core/src/runtime/video-inline-svgs.ts
+++ b/packages/core/src/runtime/video-inline-svgs.ts
@@ -31,6 +31,7 @@ export function buildVideoCompositionFromInlineSvgs(
     text: JSON.stringify(composition),
     tokens: { input: 0, output: 0 },
     costUsd: 0,
+    costUsdReason: "computed",
     raw: { videoInlineSvgs: true as const },
   };
 }

--- a/packages/core/test/pricing.test.ts
+++ b/packages/core/test/pricing.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { priceModel, pricedModels } from "../src/llm/pricing.js";
+
+describe("priceModel", () => {
+  it("returns computed cost for a known anthropic model", () => {
+    const result = priceModel("anthropic", "claude-sonnet-4-7", { input: 1_000, output: 500 });
+    expect(result.costUsdReason).toBe("computed");
+    // claude-sonnet-4-7: $3/M input, $15/M output
+    // 1000 * 3 / 1_000_000 + 500 * 15 / 1_000_000 = 0.003 + 0.0075 = 0.0105
+    expect(result.costUsd).toBeCloseTo(0.0105, 6);
+  });
+
+  it("returns computed cost for a known openai-compatible model", () => {
+    const result = priceModel("openai-compatible", "gpt-4o", { input: 2_000, output: 1_000 });
+    expect(result.costUsdReason).toBe("computed");
+    // gpt-4o: $2.5/M input, $10/M output
+    // 2000 * 2.5 / 1_000_000 + 1000 * 10 / 1_000_000 = 0.005 + 0.01 = 0.015
+    expect(result.costUsd).toBeCloseTo(0.015, 6);
+  });
+
+  it("returns null + unknown-model for an unpriced model", () => {
+    const result = priceModel("anthropic", "claude-future-2030", { input: 1_000, output: 500 });
+    expect(result.costUsd).toBeNull();
+    expect(result.costUsdReason).toBe("unknown-model");
+  });
+
+  it("returns null + unknown-model for an unknown provider", () => {
+    const result = priceModel("not-a-provider", "any-model", { input: 100, output: 100 });
+    expect(result.costUsd).toBeNull();
+    expect(result.costUsdReason).toBe("unknown-model");
+  });
+
+  it("returns 0 + computed for zero-token usage (no LLM round-trip)", () => {
+    const result = priceModel("anthropic", "claude-future-2030", { input: 0, output: 0 });
+    // Even an unknown model is honestly $0 when no tokens consumed.
+    expect(result.costUsd).toBe(0);
+    expect(result.costUsdReason).toBe("computed");
+  });
+
+  it("returns null + missing-usage when tokens are undefined", () => {
+    const result = priceModel("anthropic", "claude-sonnet-4-7", undefined);
+    expect(result.costUsd).toBeNull();
+    expect(result.costUsdReason).toBe("missing-usage");
+  });
+
+  it("computes minimax-01 cost correctly", () => {
+    const result = priceModel("minimax", "minimax/minimax-01", { input: 5_000, output: 2_500 });
+    expect(result.costUsdReason).toBe("computed");
+    // minimax-01: $0.2/M input, $1.1/M output
+    // 5000 * 0.2 / 1_000_000 + 2500 * 1.1 / 1_000_000 = 0.001 + 0.00275 = 0.00375
+    expect(result.costUsd).toBeCloseTo(0.00375, 6);
+  });
+});
+
+describe("pricedModels", () => {
+  it("enumerates at least Anthropic + openai-compatible + minimax priced entries", () => {
+    const entries = pricedModels();
+    const providers = new Set(entries.map((e) => e.provider));
+    expect(providers.has("anthropic")).toBe(true);
+    expect(providers.has("openai-compatible")).toBe(true);
+    expect(providers.has("minimax")).toBe(true);
+  });
+
+  it("has every entry round-trip through priceModel as computed (non-zero tokens)", () => {
+    const entries = pricedModels();
+    for (const { provider, model } of entries) {
+      const result = priceModel(provider, model, { input: 1, output: 1 });
+      expect(result.costUsdReason).toBe("computed");
+      expect(result.costUsd).not.toBeNull();
+      expect(result.costUsd).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/schemas/src/codec.ts
+++ b/packages/schemas/src/codec.ts
@@ -25,6 +25,8 @@ export interface RenderCtx {
   };
 }
 
+import type { CostUsdReason } from "./manifest.js";
+
 export interface RenderResult {
   artifactPath: string;
   mimeType: string;
@@ -34,6 +36,8 @@ export interface RenderResult {
     route?: string;
     llmTokens: { input: number; output: number };
     costUsd: number;
+    /** Optional rationale aligned with `RunManifest.costUsdReason` (Issue #182). */
+    costUsdReason?: CostUsdReason;
     durationMs: number;
     seed: number | null;
   };
@@ -51,6 +55,7 @@ export const RenderResultSchema = z.object({
       output: z.number().int().nonnegative(),
     }),
     costUsd: z.number().nonnegative(),
+    costUsdReason: z.enum(["computed", "unknown-model", "missing-usage"]).optional(),
     durationMs: z.number().nonnegative(),
     seed: z.number().int().nullable(),
   }),

--- a/packages/schemas/src/manifest.ts
+++ b/packages/schemas/src/manifest.ts
@@ -13,6 +13,8 @@ export const AudioRenderManifestSchema = z.object({
 
 const AudioRouteSchema = z.enum(["speech", "soundscape", "music"]);
 
+const CostUsdReasonSchema = z.enum(["computed", "unknown-model", "missing-usage"]);
+
 export const RunManifestSchema = z
   .object({
     runId: z.string(),
@@ -35,7 +37,14 @@ export const RunManifestSchema = z
       input: z.number().int().nonnegative(),
       output: z.number().int().nonnegative(),
     }),
-    costUsd: z.number().nonnegative(),
+    /**
+     * USD cost computed from `costUsd = priceModel(llmProvider, llmModel, llmTokens)`.
+     * `null` only when `costUsdReason` is `"unknown-model"` or `"missing-usage"` —
+     * never silently zero (Issue #182).
+     */
+    costUsd: z.number().nonnegative().nullable(),
+    /** Why `costUsd` is what it is — required so manifests cannot fudge zeros. */
+    costUsdReason: CostUsdReasonSchema.optional(),
 
     promptRaw: z.string(),
     promptExpanded: z.string().nullable(),
@@ -99,7 +108,23 @@ export const RunManifestSchema = z
         });
       }
     }
+
+    if (manifest.costUsd === null && manifest.costUsdReason === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["costUsdReason"],
+        message: "costUsd === null requires a costUsdReason (unknown-model or missing-usage).",
+      });
+    }
+    if (manifest.costUsd === null && manifest.costUsdReason === "computed") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["costUsdReason"],
+        message: 'costUsd === null cannot have costUsdReason = "computed".',
+      });
+    }
   });
 
 export type AudioRenderManifest = z.infer<typeof AudioRenderManifestSchema>;
 export type RunManifest = z.infer<typeof RunManifestSchema>;
+export type CostUsdReason = z.infer<typeof CostUsdReasonSchema>;

--- a/packages/schemas/test/contract.test.ts
+++ b/packages/schemas/test/contract.test.ts
@@ -178,4 +178,97 @@ describe("@wittgenstein/schemas", () => {
 
     expect(parsed.success).toBe(false);
   });
+
+  it("accepts costUsd: null when paired with a non-computed reason", () => {
+    const parsed = RunManifestSchema.safeParse({
+      runId: "run-cost-null",
+      gitSha: "abc123",
+      lockfileHash: "def456",
+      nodeVersion: process.version,
+      wittgensteinVersion: "0.0.0",
+      command: "wittgenstein image",
+      args: ["test"],
+      seed: 7,
+      codec: "image",
+      llmProvider: "anthropic",
+      llmModel: "claude-future-2030",
+      llmTokens: { input: 500, output: 250 },
+      costUsd: null,
+      costUsdReason: "unknown-model",
+      promptRaw: "test",
+      promptExpanded: null,
+      llmOutputRaw: "{}",
+      llmOutputParsed: {},
+      artifactPath: "/tmp/out.png",
+      artifactSha256: "deadbeef",
+      startedAt: new Date().toISOString(),
+      durationMs: 10,
+      ok: true,
+      error: null,
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+
+  it("rejects costUsd: null without a costUsdReason (Issue #182)", () => {
+    const parsed = RunManifestSchema.safeParse({
+      runId: "run-cost-null-bare",
+      gitSha: "abc123",
+      lockfileHash: "def456",
+      nodeVersion: process.version,
+      wittgensteinVersion: "0.0.0",
+      command: "wittgenstein image",
+      args: ["test"],
+      seed: 7,
+      codec: "image",
+      llmProvider: "anthropic",
+      llmModel: "claude-future-2030",
+      llmTokens: { input: 500, output: 250 },
+      costUsd: null,
+      // costUsdReason intentionally omitted
+      promptRaw: "test",
+      promptExpanded: null,
+      llmOutputRaw: "{}",
+      llmOutputParsed: {},
+      artifactPath: "/tmp/out.png",
+      artifactSha256: "deadbeef",
+      startedAt: new Date().toISOString(),
+      durationMs: 10,
+      ok: true,
+      error: null,
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects costUsd: null with costUsdReason: "computed" (contradiction)', () => {
+    const parsed = RunManifestSchema.safeParse({
+      runId: "run-cost-null-contradiction",
+      gitSha: "abc123",
+      lockfileHash: "def456",
+      nodeVersion: process.version,
+      wittgensteinVersion: "0.0.0",
+      command: "wittgenstein image",
+      args: ["test"],
+      seed: 7,
+      codec: "image",
+      llmProvider: "anthropic",
+      llmModel: "claude-future-2030",
+      llmTokens: { input: 500, output: 250 },
+      costUsd: null,
+      costUsdReason: "computed",
+      promptRaw: "test",
+      promptExpanded: null,
+      llmOutputRaw: "{}",
+      llmOutputParsed: {},
+      artifactPath: "/tmp/out.png",
+      artifactSha256: "deadbeef",
+      startedAt: new Date().toISOString(),
+      durationMs: 10,
+      ok: true,
+      error: null,
+    });
+
+    expect(parsed.success).toBe(false);
+  });
 });


### PR DESCRIPTION
Closes #182. The Anthropic and OpenAI-compatible LLM adapters both returned `costUsd: 0` unconditionally, so every manifest receipt recorded $0.00 regardless of provider / model / tokens.

## What changed

- New `packages/core/src/llm/pricing.ts` with a pinned per-provider × per-model rate table. `priceModel(provider, model, tokens)` returns `{ costUsd: number | null, costUsdReason: "computed" | "unknown-model" | "missing-usage" }`.
- Both real LLM adapters call `priceModel(...)`. Local / dry-run / SVG-engine / asciipng paths set `costUsd: 0, costUsdReason: "computed"` (genuine $0).
- `RunManifestSchema.costUsd` is now `z.number().nonnegative().nullable()` with `costUsdReason` enum optional. Superrefine invariants: `costUsd === null` requires reason; `costUsd === null` cannot pair with `costUsdReason: "computed"`.
- `RenderResult.metadata.costUsdReason` carries the reason through v1 codec paths.

## Done-when

- [x] Both adapters return real `costUsd` for known models
- [x] Manifest schema accepts `null` only with explicit reason
- [x] Tests assert non-zero for known model + null for unknown model
- [x] Pricing-table maintenance contract documented (file header)

## Validation

- `pnpm typecheck` / `pnpm lint` / `pnpm test` / `pnpm lint:deps` (codec boundary) all green
- 9 new tests in `packages/core/test/pricing.test.ts`
- 3 new tests in `packages/schemas/test/contract.test.ts`

## Per ADR-0013

`packages/schemas/src/manifest.ts` is at `packages/schemas/src/`, NOT under `packages/schemas/src/codec/v2/*` — NOT on §1 strict doctrine list. Change is invariant tightening + receipt honesty (drift correction §3), not new shape. Successful runs with real cost data continue to validate; only the lying-zero failure mode is now rejected at schema time.

Initial Anthropic / OpenAI / Minimax rate entries are sourced from public pricing pages (URLs in the pricing.ts header); update on model rotation.