### PR TITLE
fix(codec-sensor): surface loupe-vs-fallback render path in manifest (closes #223)

### DIFF
--- a/packages/codec-sensor/src/render.ts
+++ b/packages/codec-sensor/src/render.ts
@@ -44,13 +44,13 @@ export async function renderSignalBundle(
   );
   await writeFile(csvPath, toCsv(rows));
 
-  const htmlReady = await renderLoupeDashboard(csvPath, htmlPath, spec);
-  const artifactPath = htmlReady ? htmlPath : jsonPath;
+  const dashboardOutcome = await renderLoupeDashboard(csvPath, htmlPath, spec);
+  const artifactPath = dashboardOutcome.htmlReady ? htmlPath : jsonPath;
   const info = await stat(artifactPath);
 
   return {
     artifactPath,
-    mimeType: htmlReady ? "text/html" : "application/json",
+    mimeType: dashboardOutcome.htmlReady ? "text/html" : "application/json",
     bytes: info.size,
     metadata: {
       codec: "sensor:procedural+loupesidecar",
@@ -59,9 +59,12 @@ export async function renderSignalBundle(
       costUsd: 0,
       durationMs: Date.now() - startedAt,
       seed: ctx.seed,
+      renderPath: dashboardOutcome.renderPath,
     },
   };
 }
+
+export type SensorRenderPath = "loupe-script" | "loupe-cli" | "fallback-static-html";
 
 export function makeEcgSignal(
   sampleRateHz: number,
@@ -233,7 +236,7 @@ async function renderLoupeDashboard(
   csvPath: string,
   htmlPath: string,
   spec: SensorSignalSpec,
-): Promise<boolean> {
+): Promise<{ htmlReady: boolean; renderPath: SensorRenderPath }> {
   // Search for loupe.py: repo root → package dir → cwd → polyglot-mini sub-project
   const candidates = [
     resolvePath(moduleDir, "../../../../loupe.py"), // repo root
@@ -255,16 +258,19 @@ async function renderLoupeDashboard(
     // Try `loupe` on PATH
     try {
       await spawnChecked("python3", ["-m", "loupe_cli", csvPath, "-o", htmlPath]);
-      return true;
+      return { htmlReady: true, renderPath: "loupe-cli" };
+    } catch {
+      /* continue to fallback */
+    }
+  } else {
+    try {
+      await spawnChecked("python3", [loupePath, csvPath, "-o", htmlPath]);
+      return { htmlReady: true, renderPath: "loupe-script" };
     } catch {
       /* continue to fallback */
     }
   }
-  try {
-    await spawnChecked("python3", [loupePath ?? "loupe.py", csvPath, "-o", htmlPath]);
-    return true;
-  } catch {
-    const fallbackHtml = `<!doctype html>
+  const fallbackHtml = `<!doctype html>
 <html lang="en">
 <meta charset="utf-8" />
 <title>${spec.signal} preview</title>
@@ -274,9 +280,8 @@ async function renderLoupeDashboard(
   <p>Open <code>${csvPath}</code> or rerun with Python 3 available to get the interactive dashboard.</p>
 </body>
 </html>`;
-    await writeFile(htmlPath, fallbackHtml);
-    return true;
-  }
+  await writeFile(htmlPath, fallbackHtml);
+  return { htmlReady: true, renderPath: "fallback-static-html" };
 }
 
 function ensureExtension(path: string, ext: string): string {

--- a/packages/core/src/runtime/harness.ts
+++ b/packages/core/src/runtime/harness.ts
@@ -306,6 +306,9 @@ export class Wittgenstein {
         if (rendered.metadata.costUsdReason !== undefined) {
           manifest.costUsdReason = rendered.metadata.costUsdReason;
         }
+        if (rendered.metadata.renderPath !== undefined) {
+          manifest.renderPath = rendered.metadata.renderPath;
+        }
       }
     } catch (caughtError) {
       error = serializeError(caughtError);

--- a/packages/schemas/src/codec.ts
+++ b/packages/schemas/src/codec.ts
@@ -40,6 +40,12 @@ export interface RenderResult {
     costUsdReason?: CostUsdReason;
     durationMs: number;
     seed: number | null;
+    /**
+     * Optional codec-internal path identifier — e.g. for sensor it discriminates
+     * `loupe-script` / `loupe-cli` / `fallback-static-html` so the manifest tells
+     * the truth about which renderer actually fired (Issue #223).
+     */
+    renderPath?: string;
   };
 }
 
@@ -58,6 +64,7 @@ export const RenderResultSchema = z.object({
     costUsdReason: z.enum(["computed", "unknown-model", "missing-usage"]).optional(),
     durationMs: z.number().nonnegative(),
     seed: z.number().int().nullable(),
+    renderPath: z.string().optional(),
   }),
 });
 

--- a/packages/schemas/src/manifest.ts
+++ b/packages/schemas/src/manifest.ts
@@ -55,6 +55,13 @@ export const RunManifestSchema = z
     artifactSha256: z.string().nullable(),
     audioRender: AudioRenderManifestSchema.optional(),
 
+    /**
+     * Optional codec-internal path identifier preserved from
+     * `RenderResult.metadata.renderPath` so the manifest distinguishes
+     * which decoder / renderer actually fired (Issue #223).
+     */
+    renderPath: z.string().optional(),
+
     startedAt: z.string(),
     durationMs: z.number().nonnegative(),
     ok: z.boolean(),


### PR DESCRIPTION
Closes #223. Discovered during #174 cross-codec fallback audit.

## Fix

`renderLoupeDashboard()` now returns `{ htmlReady, renderPath: "loupe-script" | "loupe-cli" | "fallback-static-html" }`. The discriminator is propagated via the new optional `RenderResult.metadata.renderPath` and `RunManifest.renderPath` fields.

## What's new

- `packages/schemas/src/codec.ts` — new optional `renderPath` on `RenderResult.metadata`
- `packages/schemas/src/manifest.ts` — new optional `renderPath` on `RunManifestSchema`
- `packages/codec-sensor/src/render.ts` — three explicit branches return distinct `renderPath` values
- `packages/core/src/runtime/harness.ts` — propagates render-result `renderPath` to manifest

## What didn't change

- `codec` field literal stays `"sensor:procedural+loupesidecar"` (sensor goldens unchanged)
- Sensor artifact bytes unaffected
- Fallback HTML body unchanged

## Validation

- typecheck / lint / test / lint:deps all green
- Sensor goldens (PR #125): 3/3 byte-identical

## Per ADR-0013

`packages/schemas/src/{codec,manifest}.ts` are at `packages/schemas/src/`, NOT `packages/schemas/src/codec/v2/*` — NOT on §1 doctrine list. Optional-field additions are drift correction §3.