### PR TITLE
docs(agent-contact-text): land image-hybrid-code SKILL.md surface (closes #219)

### DIFF
--- a/packages/agent-contact-text/skills/image-hybrid-code/SKILL.md
+++ b/packages/agent-contact-text/skills/image-hybrid-code/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: image-hybrid-code
+description: Plan a Wittgenstein image render by emitting a Visual Seed Code-bearing image contract — seedCode primary, semantic IR optional, providerLatents preferred when available. Use when the user asks for an image artifact through `wittgenstein image` or its programmatic equivalents. Do not use for SVG, video, sensor, or audio.
+---
+
+# image-hybrid-code
+
+You plan Wittgenstein's image route. The repo's adapter / decoder turn the structured object you emit into a PNG. You do not emit pixels, SVG, HTML, or Canvas commands.
+
+## When to use
+
+Activate this skill when a user asks Wittgenstein to render an image — including `wittgenstein image "<prompt>"`, the programmatic `imageCodec.parse()` boundary, or any agent driver that targets the image modality.
+
+Do **not** activate for SVG (separate codec), video, sensor, or audio.
+
+## Your role
+
+You are an **image-code planner**, not an artist, not a prompt rewriter, not a decoder. You emit the container the codec parses; the codec, adapter, and frozen decoder do the rest.
+
+## Input assumptions
+
+The caller hands you:
+
+- a user prompt,
+- optional output size,
+- optional seed,
+- optional explicit `mode` hint (`"semantic-only" | "one-shot-vsc" | "two-pass-compile" | "provider-latents"`).
+
+You may not see provider-issued latents directly; only emit `providerLatents` when you can produce decoder-native VQ token indices yourself.
+
+## Output contract
+
+JSON only. Match `ImageSceneSpecSchema` in `packages/codec-image/src/schema.ts`. Default to `mode: "one-shot-vsc"` and emit:
+
+```jsonc
+{
+  "mode": "one-shot-vsc",
+  "semantic": {
+    "intent": "...",
+    "subject": "...",
+    "composition": { "framing": "...", "camera": "...", "depthPlan": ["...", "..."] },
+    "lighting": { "mood": "...", "key": "..." },
+    "style": { "references": ["..."], "palette": ["...", "..."] },
+    "constraints": { "mustHave": [], "negative": [] }
+  },
+  "seedCode": {
+    "schemaVersion": "witt.image.seed/v0.1",
+    "family": "vqvae",            // or another seed family you can speak
+    "mode": "prefix",             // or "coarse-scale" | "residual" | "lexical"
+    "tokens": [/* >=1 non-negative integers */]
+  },
+  "decoder": {
+    "family": "llamagen",         // or "seed" | "dvae"
+    "codebook": "...",
+    "codebookVersion": "v0",
+    "latentResolution": [32, 32]
+  }
+}
+```
+
+`coarseVq` and `providerLatents` are optional. If you can emit decoder-native latents, prefer `providerLatents`. If you can speak a coarse scale, add `coarseVq`. Otherwise `seedCode` alone is correct.
+
+## Path hierarchy (priority order at runtime)
+
+The codec adapter tries paths in this order and uses the first that validates:
+
+1. `providerLatents` — strongest direct-code path; codec skips the learned adapter entirely.
+2. `coarseVq` — partial VQ structure, expanded to full grid by nearest-neighbor.
+3. `seedCode` — Visual Seed Code; expanded to decoder-native latents.
+4. `semantic` (legacy / nested) — semantic-only fallback through the MLP.
+5. `placeholder` — deterministic stub when no MLP weights are present.
+
+Emit the strongest layer you can.
+
+## One-shot vs two-pass
+
+- **One-shot VSC (`mode: "one-shot-vsc"`)** — default. Emit seed + optional semantic in a single response.
+- **Two-pass compile (`mode: "two-pass-compile"`)** — high-quality lane. Pass 1 emits semantic IR; pass 2 consumes that IR and emits seedCode (and optional coarseVq). Use when you need stronger seed conditioning or when the user explicitly asks for higher fidelity.
+
+## Hard constraints
+
+- No SVG, HTML, Canvas commands, or pixel arrays in the output.
+- No second image path. Wittgenstein image has exactly one shipping path: `LLM → Visual Seed Code-bearing contract → seed expander / adapter → frozen decoder → PNG`.
+- Decoder ≠ generator. Diffusion-style generators are out of scope (ADR-0005, ADR-0007).
+- `tokens` arrays must be non-empty (`min(1)`); `seedCode.length` (when set) must equal `seedCode.tokens.length`; `coarseVq.tokenGrid` area must equal `coarseVq.tokens.length`; same for `providerLatents`.
+- `decoder.codebook` and `decoder.codebookVersion` are non-empty strings.
+
+## Validation rules at the boundary
+
+The codec runs zod validation with `superRefine` enforcement. If you emit a malformed code layer, the codec fails loudly and the manifest records the structured error — there is no silent fallback to the next layer at parse time.
+
+## Where to look for depth
+
+- `references/schema.md` — full `ImageSceneSpecSchema` + sibling layers, with annotated examples
+- `references/troubleshooting.md` — common rejection patterns and their fixes
+- `references/evals.md` — what counts as success at the receipt level
+
+Doctrine source-of-truth:
+
+- `docs/rfcs/0006-hybrid-image-code.md` — the architectural correction
+- `docs/adrs/0018-hybrid-image-code-and-visual-seed-token.md` — the ratification
+- `docs/codecs/image.md` — runtime contract
+- `docs/research/hybrid-image-code-skill-playbook.md` — design rationale for this skill surface

--- a/packages/agent-contact-text/skills/image-hybrid-code/references/evals.md
+++ b/packages/agent-contact-text/skills/image-hybrid-code/references/evals.md
@@ -1,0 +1,63 @@
+# Image evals reference
+
+What "success" looks like for an image-hybrid-code emission, at three levels.
+
+## Level 1 — Receipt-level (what the codec checks at parse time)
+
+The codec parses your output via `imageCodec.parse(text)`. Success requires:
+
+- valid JSON shape per `ImageSceneSpecSchema`
+- if `seedCode` is present: `length === tokens.length`, `tokens.length >= 1`
+- if `coarseVq` is present: `tokens.length === tokenGrid[0] * tokenGrid[1]`
+- if `providerLatents` is present: same area constraint
+- `decoder.codebook` non-empty
+- `mode` is one of the four valid enum values
+
+Receipt evidence in `manifest.json`:
+
+- `imageCode.path` ∈ `{"provider-latents", "coarse-vq", "visual-seed-code", "semantic-fallback"}` — which layer the runtime actually used
+- `imageCode.semanticSource` ∈ `{"emitted", "legacy-top-level", "absent"}` — how semantic content was provided
+- `imageCode.seedFamily` / `seedMode` / `seedLength` — when seed code fired
+- `imageCode.coarseVqGrid` / `providerLatentGrid` — when coarse / provider paths fired
+
+## Level 2 — Run-level (the artifact actually rendered)
+
+After parse, the runtime expands your code through the adapter and frozen decoder. A successful run produces:
+
+- a real PNG at `art.outPath`
+- `manifest.artifactSha256` matches the on-disk file
+- `manifest.ok === true`
+- determinism: same `seed` + same `seedCode` + same decoder = same artifact bytes (under the frozen-decoder doctrine; the v0.3 placeholder path is deterministic per-machine)
+
+Three back-to-back invocations with the same seed should produce identical `artifactSha256`.
+
+## Level 3 — Quality (proxy until M5a benchmark bridge lands)
+
+Today the receipts table claims structural integrity, not aesthetic frontier quality. Quality bridges land at M5a (Brief E):
+
+- CLIPScore — text-image alignment
+- VQAScore — fidelity to prompt
+- aesthetics scoring (post-M5a candidate)
+
+Until those land, "good seed code" is judged by:
+
+- the receipt path you wanted is the path that fired
+- the artifact bytes are stable per seed
+- the semantic layer (when emitted) reads coherent to a human reviewer
+- no warning fires for "providerLatents failed validation" or "Using placeholder seed-expansion adapter" (if you emitted a stronger layer)
+
+## Anti-patterns (you wanted to win but didn't)
+
+- Emitted `providerLatents` with bogus tokens just to "force" the strongest path — adapter rejects, falls through, manifest records `path: "semantic-fallback"`. Hopeful overclaim.
+- Emitted only `mode: "one-shot-vsc"` without an actual `seedCode` — manifest records `path: "semantic-fallback"`. Mode declares intent, not output.
+- Emitted both `seedCode` and `providerLatents` thinking it's "safer" — fine, but the runtime uses `providerLatents` and your seedCode is dropped. Choose one strongest layer per intent.
+
+## How to read your own receipt
+
+After a render:
+
+```bash
+cat artifacts/runs/<run-id>/manifest.json | jq '.imageCode'
+```
+
+This object tells you which layer fired and what shape it had. If `path !== "visual-seed-code"` when you intended VSC, your seed validation failed silently — re-emit with valid bounds.

--- a/packages/agent-contact-text/skills/image-hybrid-code/references/schema.md
+++ b/packages/agent-contact-text/skills/image-hybrid-code/references/schema.md
@@ -1,0 +1,121 @@
+# Image schema reference
+
+Full surface for `ImageSceneSpec` — the container the image codec parses. Source of truth: [`packages/codec-image/src/schema.ts`](../../../../codec-image/src/schema.ts).
+
+## Top-level shape
+
+```ts
+{
+  schemaVersion: "witt.image.spec/v0.1",          // optional, defaults
+  mode: "semantic-only" | "one-shot-vsc" | "two-pass-compile" | "provider-latents",
+  semantic: ImageSemanticLayer,                   // optional nested
+  // Legacy top-level semantic fields (compat). Prefer nested `semantic`.
+  intent: string,
+  subject: string,
+  composition: { framing, camera, depthPlan: string[] },
+  lighting: { mood, key },
+  style: { references: string[], palette: string[] },
+  constraints: { mustHave: string[], negative: string[] },
+  decoder: ImageDecoderHint,
+  renderHints: { detailLevel, aspect, seed },
+  seedCode: ImageVisualSeedCode,                  // optional
+  coarseVq: ImageCoarseVq,                        // optional
+  providerLatents: ImageLatentCodes               // optional
+}
+```
+
+## `ImageVisualSeedCode` (the primary VSC layer)
+
+```ts
+{
+  schemaVersion: "witt.image.seed/v0.1",
+  family: string,                                  // e.g. "vqvae", "titok", "flextok"
+  mode: "prefix" | "coarse-scale" | "residual" | "lexical",
+  tokenizer: string?,                              // optional vendor tag
+  length: number?,                                 // when set, must equal tokens.length
+  tokens: number[]                                 // non-empty, non-negative
+}
+```
+
+- `tokens.length` must be `>= 1` (`z.array().min(1)`).
+- `length`, when present, must match `tokens.length` exactly (superRefine).
+
+## `ImageCoarseVq` (optional partial-VQ bridge)
+
+```ts
+{
+  schemaVersion: "witt.image.coarse-vq/v0.1",
+  family: "llamagen" | "seed" | "dvae",
+  codebook: string,
+  codebookVersion: string,
+  tokenGrid: [width, height],
+  tokens: number[]                                 // length === width * height
+}
+```
+
+The runtime nearest-neighbor-upsamples this grid to `decoder.latentResolution`.
+
+## `ImageLatentCodes` (providerLatents — strongest path)
+
+```ts
+{
+  schemaVersion: "witt.image.latents/v0.1",
+  family: "llamagen" | "seed" | "dvae",
+  codebook: string,
+  codebookVersion: string,
+  tokenGrid: [width, height],
+  tokens: number[]                                 // length === width * height
+}
+```
+
+When valid, the codec skips the learned adapter entirely.
+
+## `ImageDecoderHint`
+
+```ts
+{
+  family: "llamagen" | "seed" | "dvae",
+  codebook: string,                                // non-empty
+  codebookVersion: string,                         // non-empty (defaults "v0")
+  latentResolution: [width, height]                // defaults [32, 32]
+}
+```
+
+## Annotated good example (one-shot VSC)
+
+```jsonc
+{
+  "mode": "one-shot-vsc",
+  "semantic": {
+    "intent": "Calm forest path at golden hour",
+    "subject": "forest path, ferns, distant light",
+    "composition": {
+      "framing": "wide shot",
+      "camera": "natural",
+      "depthPlan": ["foreground ferns", "midground path", "distant trees"]
+    },
+    "lighting": { "mood": "warm", "key": "low golden side light" },
+    "style": {
+      "references": ["landscape photography"],
+      "palette": ["amber", "moss", "umber"]
+    },
+    "constraints": { "mustHave": ["natural light"], "negative": ["text"] }
+  },
+  "seedCode": {
+    "schemaVersion": "witt.image.seed/v0.1",
+    "family": "vqvae",
+    "mode": "prefix",
+    "tokens": [12, 7, 41, 88, 3, 17, 9, 220, 145]
+  },
+  "decoder": {
+    "family": "llamagen",
+    "codebook": "stub-codebook",
+    "codebookVersion": "v0",
+    "latentResolution": [32, 32]
+  }
+}
+```
+
+## Compatibility note
+
+Legacy clients that emit only top-level semantic fields (no nested `semantic`, no `seedCode`, no `coarseVq`) still parse. The codec sets `mode: "semantic-only"` and routes through the MLP fallback. This is the baseline path; emit at least `seedCode` if you can.

--- a/packages/agent-contact-text/skills/image-hybrid-code/references/troubleshooting.md
+++ b/packages/agent-contact-text/skills/image-hybrid-code/references/troubleshooting.md
@@ -1,0 +1,63 @@
+# Image troubleshooting reference
+
+Common rejection patterns at the codec boundary and how to fix them.
+
+## Schema rejection — `tokens length must match tokenGrid area`
+
+You emitted `coarseVq` or `providerLatents` with `tokenGrid: [W, H]` but `tokens.length !== W * H`.
+
+**Fix.** Make the grid exactly square the array. Example: `tokenGrid: [4, 4]` requires 16 tokens.
+
+## Schema rejection — `length must match tokens length when provided`
+
+You emitted `seedCode` with both `length` and `tokens` set, but they disagree.
+
+**Fix.** Either omit `length` (the schema accepts it as derivable) or make it equal `tokens.length`.
+
+## Schema rejection — `tokens array empty`
+
+You emitted `seedCode.tokens: []` or `coarseVq.tokens: []`.
+
+**Fix.** Visual code arrays are `min(1)`. Even a single non-negative integer is valid.
+
+## Mode rejection — unknown enum value
+
+You emitted `mode: "creative"` or `seedCode.mode: "fancy"`.
+
+**Fix.** Top-level `mode` is `"semantic-only" | "one-shot-vsc" | "two-pass-compile" | "provider-latents"`. `seedCode.mode` is `"prefix" | "coarse-scale" | "residual" | "lexical"`.
+
+## Decoder hint rejection — empty codebook
+
+You emitted `decoder: { codebook: "" }` or omitted `codebook` entirely.
+
+**Fix.** `codebook` is `string.min(1)`. Use `"stub-codebook"` if no real codebook is wired.
+
+## Manifest receipt says `path: "semantic-fallback"` but you emitted `seedCode`
+
+The schema rejected your `seedCode` (validation failure → silent fall-through to MLP fallback). The codec logs a warning at this boundary.
+
+**Fix.** Re-validate locally:
+
+```ts
+import { ImageVisualSeedCodeSchema } from "@wittgenstein/codec-image/schema";
+const result = ImageVisualSeedCodeSchema.safeParse(yourSeedCode);
+if (!result.success) console.error(result.error.issues);
+```
+
+## Manifest receipt says `path: "provider-latents"` when you didn't intend it
+
+Your `providerLatents` slot was populated and validated. The codec uses the strongest layer present.
+
+**Fix.** If you wanted seed expansion specifically, omit `providerLatents` so `seedCode` becomes the active layer.
+
+## Adapter warning: `Using placeholder seed-expansion adapter`
+
+No MLP weights resolved at runtime, and your scene didn't include `seedCode` / `coarseVq` / `providerLatents`. The codec is using deterministic-stub latents.
+
+**Fix.** Either set `WITTGENSTEIN_IMAGE_ADAPTER_PREFERRED_PATH` / `WITTGENSTEIN_IMAGE_ADAPTER_LEGACY_PATH` to point at trained weights, or emit at least a `seedCode` layer.
+
+## Output contains forbidden surfaces (SVG, HTML, Canvas, raw pixels)
+
+The codec rejects these at the parse boundary because the image route is single-shipping (`hard-constraints.md`). There is no fallback to vector or canvas.
+
+**Fix.** If the user explicitly wants vector output, route through the SVG codec instead of the image codec. SVG is a separate modality, not an image escape hatch.


### PR DESCRIPTION
Closes #219.

Lands a literal repo-local Agent Skills folder for the image planner per PR #213's design verdict.

## What's new

- `packages/agent-contact-text/skills/image-hybrid-code/SKILL.md` — compact agent-loadable body (~3 KB)
- `.../references/schema.md` — full schema surface with annotated examples
- `.../references/troubleshooting.md` — rejection patterns and fixes
- `.../references/evals.md` — three success levels + anti-patterns

## Relationship

- Doctrine: RFC-0006 + ADR-0018
- Schema impl: PR #210 / #218
- Design rationale: PR #213 (`docs/research/hybrid-image-code-skill-playbook.md`)

## Out of scope

- Runtime prompt-loading wiring (deferred; skill is consumable today by agents reading SKILL.md directly)
- Final tokenizer family selection (#205)
- Full CLI UX (#204)

Per ADR-0013: `packages/agent-contact-text/skills/` not on §1 doctrine list. Docs-only PR, self-mergeable.