### PR TITLE
feat(cli): expose image VSC receipt inspection

### DIFF
--- a/docs/benchmark-standards.md
+++ b/docs/benchmark-standards.md
@@ -11,11 +11,11 @@ and to give honest numbers about what the current harness can actually measure.
 
 Every benchmark result is reported in three buckets regardless of modality:
 
-| Dimension | Definition | Source |
-|---|---|---|
-| **Cost** | API spend (USD) + token counts | `manifest.costUsd`, `manifest.llmTokens` |
-| **Latency** | Wall-clock time from CLI invoke to artifact written | `manifest.durationMs` |
-| **Quality** | Modality-specific; see sections below | Depends on modality |
+| Dimension   | Definition                                          | Source                                   |
+| ----------- | --------------------------------------------------- | ---------------------------------------- |
+| **Cost**    | API spend (USD) + token counts                      | `manifest.costUsd`, `manifest.llmTokens` |
+| **Latency** | Wall-clock time from CLI invoke to artifact written | `manifest.durationMs`                    |
+| **Quality** | Modality-specific; see sections below               | Depends on modality                      |
 
 Cost and latency are always measurable from the manifest. Quality proxies vary by whether a
 real codec is running or a stub.
@@ -53,19 +53,35 @@ proxy is structural:
 
 Score range: 0.0 – 1.0. This is a smoke test, not a visual quality measure.
 
+### Visual Seed Code receipt matrix
+
+Until a real frozen decoder and trained SeedExpander ship, image evals must first report
+which decoder-facing path actually fired. The minimum receipt matrix is:
+
+| Path                | Manifest evidence                                         | What it proves today                                    |
+| ------------------- | --------------------------------------------------------- | ------------------------------------------------------- |
+| `provider-latents`  | `image.code.path`, `providerLatentGrid`                   | Direct decoder-native tokens were supplied and accepted |
+| `coarse-vq`         | `image.code.path`, `coarseVqGrid`                         | A partial VQ structure was accepted and expanded        |
+| `visual-seed-code`  | `image.code.path`, `seedFamily`, `seedMode`, `seedLength` | Compact seed code was accepted and expanded             |
+| `semantic-fallback` | `image.code.path`, `semanticSource`                       | The run fell back to semantic-only / baseline behavior  |
+
+This matrix is not a quality score. It is the first gate for comparing one-shot VSC,
+two-pass compile, semantic fallback, and direct/coarse-token experiments without hiding
+which path the runtime actually used.
+
 ### Adapter baseline (measured 2026-04)
 
 The image style MLP was trained and evaluated on real COCO captions:
 
-| Metric | Value |
-|---|---|
-| Training examples | 781 (COCO captions → extracted palette + layout stats) |
-| Training time | ~9 s on CPU |
-| Epochs | 600 |
-| Best validation BCE | 0.7698 |
-| Architecture | 3-layer MLP — 512 → 256 → 128 → 21 outputs |
-| Embedding | Hashed BoW, dim 512, double-hash + bigrams, L2-normalised |
-| Output dimensions | 5 palette RGB triplets (15 dims), noise\_scale, grain, composition one-hot (3), accent\_count |
+| Metric              | Value                                                                                       |
+| ------------------- | ------------------------------------------------------------------------------------------- |
+| Training examples   | 781 (COCO captions → extracted palette + layout stats)                                      |
+| Training time       | ~9 s on CPU                                                                                 |
+| Epochs              | 600                                                                                         |
+| Best validation BCE | 0.7698                                                                                      |
+| Architecture        | 3-layer MLP — 512 → 256 → 128 → 21 outputs                                                  |
+| Embedding           | Hashed BoW, dim 512, double-hash + bigrams, L2-normalised                                   |
+| Output dimensions   | 5 palette RGB triplets (15 dims), noise_scale, grain, composition one-hot (3), accent_count |
 
 ---
 
@@ -97,24 +113,24 @@ Score range: 0.0 – 1.0.
 
 ### Audio ambient classifier baseline (measured 2026-04)
 
-| Metric | Value |
-|---|---|
-| Training examples | 369 (41 seed phrases × 9 suffix augmentations) |
-| Training time | < 5 s on CPU |
-| Epochs | 300 |
-| Architecture | 2-layer MLP — 256 → 96 → 8 outputs (7 category logits + 1 volume sigmoid) |
-| Categories | silence · rain · wind · city · forest · electronic · white\_noise |
-| Keyword override | fires when MLP confidence < 0.75; overriding confidence set to 0.85 |
+| Metric            | Value                                                                     |
+| ----------------- | ------------------------------------------------------------------------- |
+| Training examples | 369 (41 seed phrases × 9 suffix augmentations)                            |
+| Training time     | < 5 s on CPU                                                              |
+| Epochs            | 300                                                                       |
+| Architecture      | 2-layer MLP — 256 → 96 → 8 outputs (7 category logits + 1 volume sigmoid) |
+| Categories        | silence · rain · wind · city · forest · electronic · white_noise          |
+| Keyword override  | fires when MLP confidence < 0.75; overriding confidence set to 0.85       |
 
 Spot-check predictions (all correct):
 
-| Prompt | Predicted category | Source | Confidence |
-|---|---|---|---|
-| "cozy rainy afternoon" | rain | keyword\_override | 0.85 |
-| "forest birds chirping" | forest | mlp | 0.99 |
-| "electrical hum server room" | electronic | keyword\_override | 0.85 |
-| "silent meditation empty room" | silence | mlp | 0.94 |
-| "busy city intersection" | city | mlp | 0.88 |
+| Prompt                         | Predicted category | Source           | Confidence |
+| ------------------------------ | ------------------ | ---------------- | ---------- |
+| "cozy rainy afternoon"         | rain               | keyword_override | 0.85       |
+| "forest birds chirping"        | forest             | mlp              | 0.99       |
+| "electrical hum server room"   | electronic         | keyword_override | 0.85       |
+| "silent meditation empty room" | silence            | mlp              | 0.94       |
+| "busy city intersection"       | city               | mlp              | 0.88       |
 
 ---
 
@@ -151,12 +167,12 @@ Score range: 0.0 – 1.0.
 
 ECG dry-run · 250 Hz · 10 s:
 
-| Metric | Value |
-|---|---|
-| Signal expand time | < 2 ms (pure numpy, no I/O) |
-| Sample count | 2,500 |
-| Loupe HTML size | ~117 KB (self-contained, zero external dependencies) |
-| Loupe render time | ~0.8 s (Python subprocess, one-time startup cost) |
+| Metric             | Value                                                |
+| ------------------ | ---------------------------------------------------- |
+| Signal expand time | < 2 ms (pure numpy, no I/O)                          |
+| Sample count       | 2,500                                                |
+| Loupe HTML size    | ~117 KB (self-contained, zero external dependencies) |
+| Loupe render time  | ~0.8 s (Python subprocess, one-time startup cost)    |
 
 ---
 
@@ -196,21 +212,21 @@ the full `RunManifest` in `artifacts/runs/<id>/manifest.json` can be inspected.
 
 ## Benchmark Cadence
 
-| When | Action |
-|---|---|
-| Per PR touching a codec | CI runs smoke proxy checks automatically |
-| Per release tag | Full local harness run; commit `artifacts/benchmarks/<tag>.json` |
-| Post real-codec landing | Add CLIPScore / WER / discriminative score to result schema |
-| Post human eval panel | Add MOS column to audio results |
+| When                    | Action                                                           |
+| ----------------------- | ---------------------------------------------------------------- |
+| Per PR touching a codec | CI runs smoke proxy checks automatically                         |
+| Per release tag         | Full local harness run; commit `artifacts/benchmarks/<tag>.json` |
+| Post real-codec landing | Add CLIPScore / WER / discriminative score to result schema      |
+| Post human eval panel   | Add MOS column to audio results                                  |
 
 ---
 
 ## References
 
-- Heusel, M. et al. (2017). "GANs Trained by a Two Time-Scale Update Rule." *NeurIPS 2017.* (FID)
-- Hessel, J. et al. (2021). "CLIPScore: A Reference-free Evaluation Metric for Image Captioning." *EMNLP 2021.*
+- Heusel, M. et al. (2017). "GANs Trained by a Two Time-Scale Update Rule." _NeurIPS 2017._ (FID)
+- Hessel, J. et al. (2021). "CLIPScore: A Reference-free Evaluation Metric for Image Captioning." _EMNLP 2021._
 - Lin, Z. et al. (2024). "Evaluating Text-to-Visual Generation with Image-to-Text Generation." (VQScore)
-- Saeki, T. et al. (2022). "UTMOS: UTokyo-SaruLab System for VoiceMOS Challenge 2022." *Interspeech 2022.*
-- Unterthiner, T. et al. (2019). "FVD: A new Metric for Video Generation." *ICLR 2019 Workshop.*
+- Saeki, T. et al. (2022). "UTMOS: UTokyo-SaruLab System for VoiceMOS Challenge 2022." _Interspeech 2022._
+- Unterthiner, T. et al. (2019). "FVD: A new Metric for Video Generation." _ICLR 2019 Workshop._
 - Niu, M. et al. (2024). "Video-Bench: A Comprehensive Benchmark and Toolkit for Evaluating Video-based LLMs."
 - Liao, W. et al. (2024). "A Survey on Time Series Synthesis." (discriminative/predictive score framing)

--- a/docs/codecs/image.md
+++ b/docs/codecs/image.md
@@ -53,6 +53,26 @@ Two image lanes are legal:
 One-shot VSC is the default lane to optimize first.
 Two-pass compile is the explicit high-quality lane.
 
+## CLI inspection surface
+
+The default CLI output stays compact. Image-specific inspection flags expose the already
+recorded receipt fields without changing generation behavior:
+
+```bash
+wittgenstein image "otter portrait" --dry-run --show-image-code --show-semantic --show-seed-summary
+```
+
+- `--show-image-code` prints the manifest `image.code` receipt: fired path, semantic
+  source, seed family / mode / length, and any coarse / provider latent grids.
+- `--show-semantic` prints the emitted or effective Semantic IR with its receipt source.
+  This is the human-inspection layer; it is not proof that semantic fallback was the active
+  backend path.
+- `--show-seed-summary` prints a compact execution summary for the decoder-facing layer.
+
+These flags intentionally do not add `--mode`, `--quality`, or two-pass orchestration yet.
+They expose path honesty first; generation-mode controls belong with the prompt-stack /
+eval work once the acceptance cases are settled.
+
 ## Optional `providerLatents` (MiniMax / API extensions)
 
 If the text API can return discrete VQ indices in the same object, include them under `providerLatents` using the `witt.image.latents/v0.1` shape (`family`, `codebook`, `codebookVersion`, `tokenGrid`, `tokens`). When valid, the runtime **skips** seed expansion and decodes those tokens directly.

--- a/packages/cli/src/commands/image.ts
+++ b/packages/cli/src/commands/image.ts
@@ -1,5 +1,12 @@
 import type { Command } from "commander";
+import type { RunManifest } from "@wittgenstein/schemas";
 import { runCodecCommand, parseOptionalSeed, type CommandRuntimeOptions } from "./shared.js";
+
+interface ImageCommandOptions extends CommandRuntimeOptions {
+  showImageCode?: boolean;
+  showSemantic?: boolean;
+  showSeedSummary?: boolean;
+}
 
 export function registerImageCommand(program: Command): void {
   program
@@ -9,23 +16,107 @@ export function registerImageCommand(program: Command): void {
     .option("--out <path>", "output path")
     .option("--seed <number>", "seed")
     .option("--dry-run", "skip the remote model call and exercise the manifest spine")
+    .option("--show-image-code", "print the imageCode receipt that records the fired VSC path")
+    .option("--show-semantic", "print the emitted/effective Semantic IR for inspection")
+    .option("--show-seed-summary", "print a compact seed/VQ execution summary")
     .option("--config <path>", "config path")
-    .action(
-      async (
-        prompt: string,
-        options: CommandRuntimeOptions,
-      ) => {
-        await runCodecCommand(
-          {
-            modality: "image",
-            prompt,
-            out: options.out,
-            seed: parseOptionalSeed(options.seed),
-          },
-          "wittgenstein image",
-          process.argv.slice(2),
-          options,
-        );
-      },
-    );
+    .action(async (prompt: string, options: ImageCommandOptions) => {
+      await runCodecCommand(
+        {
+          modality: "image",
+          prompt,
+          out: options.out,
+          seed: parseOptionalSeed(options.seed),
+        },
+        "wittgenstein image",
+        process.argv.slice(2),
+        options,
+        {
+          inspect: ({ manifest }) => imageInspectionPayload(manifest, options),
+        },
+      );
+    });
+}
+
+export function imageInspectionPayload(
+  manifest: RunManifest,
+  options: Pick<ImageCommandOptions, "showImageCode" | "showSemantic" | "showSeedSummary">,
+): Record<string, unknown> | undefined {
+  const payload: Record<string, unknown> = {};
+  const imageCode = readImageCodeReceipt(manifest);
+
+  if (options.showImageCode) {
+    payload.imageCode = imageCode;
+  }
+
+  if (options.showSemantic) {
+    payload.semantic = {
+      source: readStringProperty(imageCode, "semanticSource") ?? "unknown",
+      value: readSemanticLayer(manifest.llmOutputParsed),
+    };
+  }
+
+  if (options.showSeedSummary) {
+    payload.seedSummary = summarizeSeedPath(imageCode);
+  }
+
+  return Object.keys(payload).length > 0 ? payload : undefined;
+}
+
+function readImageCodeReceipt(manifest: RunManifest): Record<string, unknown> | null {
+  const value = (manifest as RunManifest & Record<string, unknown>)["image.code"];
+  return isRecord(value) ? value : null;
+}
+
+function summarizeSeedPath(imageCode: Record<string, unknown> | null): Record<string, unknown> {
+  if (!imageCode) {
+    return {
+      path: null,
+      seedFamily: null,
+      seedMode: null,
+      seedLength: null,
+      coarseVqGrid: null,
+      providerLatentGrid: null,
+    };
+  }
+
+  return {
+    path: readStringProperty(imageCode, "path"),
+    seedFamily: readStringProperty(imageCode, "seedFamily"),
+    seedMode: readStringProperty(imageCode, "seedMode"),
+    seedLength: readNumberProperty(imageCode, "seedLength"),
+    coarseVqGrid: imageCode.coarseVqGrid ?? null,
+    providerLatentGrid: imageCode.providerLatentGrid ?? null,
+  };
+}
+
+function readSemanticLayer(parsed: unknown): unknown {
+  if (!isRecord(parsed)) {
+    return null;
+  }
+
+  if (isRecord(parsed.semantic)) {
+    return parsed.semantic;
+  }
+
+  const legacyKeys = ["intent", "subject", "composition", "lighting", "style", "constraints"];
+  if (legacyKeys.some((key) => key in parsed)) {
+    return Object.fromEntries(legacyKeys.map((key) => [key, parsed[key]]));
+  }
+
+  return null;
+}
+
+function readStringProperty(value: Record<string, unknown> | null, key: string): string | null {
+  const property = value?.[key];
+  return typeof property === "string" ? property : null;
+}
+
+function readNumberProperty(value: Record<string, unknown> | null, key: string): number | null {
+  const property = value?.[key];
+  return typeof property === "number" ? property : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/packages/cli/src/commands/shared.ts
+++ b/packages/cli/src/commands/shared.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
-import type { WittgensteinRequest } from "@wittgenstein/schemas";
+import type { RunManifest, WittgensteinRequest } from "@wittgenstein/schemas";
 import { Wittgenstein } from "@wittgenstein/core";
 
 export interface CommandRuntimeOptions {
@@ -10,11 +10,22 @@ export interface CommandRuntimeOptions {
   config?: string;
 }
 
+export interface CommandInspectionContext {
+  manifest: RunManifest;
+  runDir: string;
+  error: unknown;
+}
+
+export interface CommandOutputOptions {
+  inspect?: (context: CommandInspectionContext) => Record<string, unknown> | undefined;
+}
+
 export async function runCodecCommand(
   request: WittgensteinRequest,
   command: string,
   args: string[],
   options: CommandRuntimeOptions,
+  outputOptions: CommandOutputOptions = {},
 ): Promise<void> {
   const workspaceRoot = resolveExecutionRoot();
   const harness = await Wittgenstein.bootstrap({
@@ -31,6 +42,12 @@ export async function runCodecCommand(
     ...(options.config ? { configPath: options.config } : {}),
   });
 
+  const extra = outputOptions.inspect?.({
+    manifest: outcome.manifest,
+    runDir: outcome.runDir,
+    error: outcome.error,
+  });
+
   console.log(
     JSON.stringify(
       {
@@ -39,6 +56,7 @@ export async function runCodecCommand(
         runDir: outcome.runDir,
         artifactPath: outcome.manifest.artifactPath,
         error: outcome.error,
+        ...(extra ?? {}),
       },
       null,
       2,
@@ -70,7 +88,5 @@ export function resolveExecutionRoot(): string {
     parent = dirname(current);
   }
 
-  return existsSync(resolve(current, "pnpm-workspace.yaml"))
-    ? current
-    : process.cwd();
+  return existsSync(resolve(current, "pnpm-workspace.yaml")) ? current : process.cwd();
 }

--- a/packages/cli/test/image.test.ts
+++ b/packages/cli/test/image.test.ts
@@ -1,0 +1,113 @@
+import type { RunManifest } from "@wittgenstein/schemas";
+import { describe, expect, it } from "vitest";
+import { createProgram } from "../src/index.js";
+import { imageInspectionPayload } from "../src/commands/image.js";
+
+describe("image command inspection flags", () => {
+  it("registers the image receipt inspection surface", () => {
+    const image = createProgram().commands.find((command) => command.name() === "image");
+    expect(image?.options.map((option) => option.long).sort()).toEqual([
+      "--config",
+      "--dry-run",
+      "--out",
+      "--seed",
+      "--show-image-code",
+      "--show-seed-summary",
+      "--show-semantic",
+    ]);
+  });
+
+  it("omits inspection payloads unless requested", () => {
+    expect(imageInspectionPayload(baseManifest(), {})).toBeUndefined();
+  });
+
+  it("prints image-code receipt and seed summary from manifest evidence", () => {
+    const payload = imageInspectionPayload(baseManifest(), {
+      showImageCode: true,
+      showSeedSummary: true,
+    });
+
+    expect(payload).toMatchObject({
+      imageCode: {
+        path: "visual-seed-code",
+        seedFamily: "witt-dry-run",
+        seedMode: "prefix",
+        seedLength: 32,
+      },
+      seedSummary: {
+        path: "visual-seed-code",
+        seedFamily: "witt-dry-run",
+        seedMode: "prefix",
+        seedLength: 32,
+        coarseVqGrid: null,
+        providerLatentGrid: null,
+      },
+    });
+  });
+
+  it("prints semantic source separately from backend seed execution", () => {
+    const payload = imageInspectionPayload(baseManifest(), { showSemantic: true });
+
+    expect(payload).toEqual({
+      semantic: {
+        source: "emitted",
+        value: {
+          intent: "Dry-run Visual Seed Code plan",
+          subject: "otter portrait",
+        },
+      },
+    });
+  });
+});
+
+function baseManifest(): RunManifest {
+  return {
+    runId: "r1",
+    gitSha: "abc",
+    lockfileHash: "def",
+    nodeVersion: "v20.19.0",
+    wittgensteinVersion: "0.0.0",
+    command: "wittgenstein image",
+    args: ["image", "otter portrait", "--dry-run"],
+    seed: 7,
+    codec: "image",
+    tier: null,
+    route: "raster",
+    llmProvider: "none",
+    llmModel: "dry-run",
+    llmTokens: { input: 0, output: 0 },
+    costUsd: 0,
+    costUsdReason: "computed",
+    promptRaw: "otter portrait",
+    promptExpanded: null,
+    llmOutputRaw: null,
+    llmOutputParsed: {
+      semantic: {
+        intent: "Dry-run Visual Seed Code plan",
+        subject: "otter portrait",
+      },
+    },
+    artifactPath: "/tmp/out.png",
+    artifactSha256: "sha",
+    startedAt: new Date(0).toISOString(),
+    durationMs: 0,
+    ok: true,
+    error: null,
+    "image.code": {
+      mode: "one-shot-vsc",
+      path: "visual-seed-code",
+      hasSemantic: true,
+      hasEmittedSemantic: true,
+      hasEffectiveSemantic: true,
+      semanticSource: "emitted",
+      hasSeedCode: true,
+      hasCoarseVq: false,
+      hasProviderLatents: false,
+      seedFamily: "witt-dry-run",
+      seedMode: "prefix",
+      seedLength: 32,
+      coarseVqGrid: null,
+      providerLatentGrid: null,
+    },
+  } as RunManifest;
+}


### PR DESCRIPTION
## Summary
- adds image CLI inspection flags for `image.code`, Semantic IR, and seed/VQ execution summary
- keeps generation behavior unchanged; no mode/quality/two-pass controls yet
- documents the CLI inspection surface and the receipt-level image eval matrix

## Scope
This narrows #204 after #218: manifest receipts already exist, so this PR only exposes them at the CLI/human/eval surface.

## Validation
- `pnpm --filter @wittgenstein/cli test`
- `pnpm --filter @wittgenstein/cli typecheck`
- `pnpm --filter @wittgenstein/cli lint`
- `pnpm exec prettier --check packages/cli/src/commands/shared.ts packages/cli/src/commands/image.ts packages/cli/test/image.test.ts docs/codecs/image.md docs/benchmark-standards.md`
- `git diff --check`
- `pnpm --filter @wittgenstein/cli exec wittgenstein image "otter portrait" --dry-run --show-image-code --show-semantic --show-seed-summary`

Closes #204.

@moapacha please review this as a narrow CLI/eval visibility PR: no manifest redesign, no generation-mode controls, no quality claims.