### PR TITLE
docs: ratify queue label prefixes

### DIFF
--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -17,3 +17,24 @@ tracker: '^tracker[:\s]|\[tracker\]|watch[:\s]'
 research-derived: 'Brief\s+[A-Z]\b|brief-derived'
 adr-derived: 'ADR-?\d{3,4}'
 rfc-derived: 'RFC-?\d{3,4}'
+
+# Queue metadata labels ratified by ADR-0019. These are driven by explicit
+# title tokens or obvious milestone nouns, not by fuzzy prose inference.
+priority/p0: '\[p0\]|\[priority/p0\]'
+priority/p1: '\[p1\]|\[priority/p1\]'
+priority/p2: '\[p2\]|\[priority/p2\]'
+priority/p3: '\[p3\]|\[priority/p3\]'
+
+size/s: '\[size/s\]|\[small\]'
+size/m: '\[size/m\]|\[medium\]'
+size/l: '\[size/l\]|\[large\]'
+size/xl: '\[size/xl\]|\[xl\]|\[umbrella\]'
+
+stage/m1-image: '\[image\]|\[m1\]|\[m1b\]|Visual Seed Code|VSC|SeedExpander|decoder bridge'
+stage/m2-audio: '\[audio\]|\[m2\]|Kokoro|Piper|TTS'
+stage/m3-sensor: '\[sensor\]|\[m3\]|TimesFM|chaos|operator route'
+stage/m4-video: '\[video\]|\[m4\]|HyperFrames|Remotion|TEN'
+stage/release: '\[release\]|prerelease|CHANGELOG|release notes'
+stage/governance: '\[governance\]|WORKFLOW|label taxonomy|orchestration'
+stage/cross-cutting: '\[cross-cutting\]|manifest|schema|CLI|dependency|infra'
+stage/post-v0.3: '\[post-v0\.3\]|post-v0\.3|v0\.3\.x'

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -65,6 +65,10 @@ The exclusion list is load-bearing. Each excluded label has a semantic contract 
 
 An orchestrator that does not honor this list is non-conformant.
 
+Queue labels introduced by ADR-0019 (`priority/*`, `size/*`, `stage/*`) are
+triage metadata only. They may help an orchestrator rank work, but they never
+make an issue agent-eligible and they never override the exclusion list.
+
 ## 2. `polling` — how often to look
 
 `interval_ms: 60000` (1 minute). Symphony's default is 30s; ours is 60s because the repo's commit cadence already produces multiple events per minute and a faster poll buys nothing.

--- a/docs/adrs/0012-issue-pr-label-taxonomy.md
+++ b/docs/adrs/0012-issue-pr-label-taxonomy.md
@@ -4,6 +4,10 @@
 
 Accepted (ratifies `docs/labels.md` introduced via PR #71).
 
+Superseded in part by ADR-0019 for queue-management prefixes
+(`priority/*`, `size/*`, `stage/*`). The semantic label taxonomy remains in
+force.
+
 ## Context
 
 The repo had ad-hoc GitHub labels with no canonical definition. PR #71 introduced `docs/labels.md` as the single source of truth, but that PR did not have a paired ADR — the rule "doctrine lands via ADR" (ADR-0014) was not yet in place. This ADR retroactively ratifies the labels taxonomy so the audit trail is complete.

--- a/docs/adrs/0019-queue-label-prefixes.md
+++ b/docs/adrs/0019-queue-label-prefixes.md
@@ -1,0 +1,53 @@
+# 0019 Queue Label Prefixes
+
+## Status
+
+Accepted.
+
+## Context
+
+ADR-0012 deliberately kept the label taxonomy flat while the repository was
+small. That rule worked for provenance, lifecycle, type, and audience labels,
+but the queue now carries multiple parallel execution and research lines:
+Visual Seed Code image work, audio closeout, sensor research, video horizon
+tracking, release surfaces, governance work, and cross-cutting manifest / CLI /
+schema cleanup.
+
+Without explicit queue metadata, maintainers and agents have to infer three
+different things from prose:
+
+- urgency
+- effort size
+- milestone / stage ownership
+
+That inference now creates noise. We need a small, mechanical layer of queue
+labels that makes triage visible without changing the semantic contracts of the
+existing labels.
+
+## Decision
+
+Wittgenstein keeps ADR-0012's semantic labels, but adds three prefixed
+queue-label families:
+
+- `priority/*` — queue urgency, not doctrine importance.
+- `size/*` — rough expected effort, not story points.
+- `stage/*` — the milestone or cross-cutting lane that should own the issue.
+
+These labels are allowed to be prefix-based because they are operational queue
+metadata rather than type/provenance/lifecycle doctrine. They should be used in
+addition to, not instead of, labels like `enhancement`, `research-derived`,
+`tracker`, or `discussion`.
+
+Queue labels may be applied manually by maintainers and automatically by the
+issue title labeler when an issue title carries an explicit token such as
+`[p1]`, `[size/m]`, `[image]`, `[sensor]`, or `[release]`.
+
+## Consequence
+
+- `docs/labels.md` remains the canonical label reference and now documents both
+  semantic labels and queue labels.
+- The issue auto-labeler may apply queue labels from title tokens and obvious
+  milestone keywords, but it must not infer nuanced priority or size from prose.
+- Existing issues should be backfilled manually where the queue status is clear.
+- Applying a queue label does not make a tracker agent-eligible. `WORKFLOW.md`
+  exclusion labels still win.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -22,6 +22,7 @@ Architecture Decision Records capture decisions that should survive chat history
 - 0016 untrusted-code execution boundary — locks `polyglot-mini`'s subprocess+timeout+safe-globals as research-grade only; names `@wittgenstein/sandbox` (nsjail / bubblewrap / Pyodide-WASM) as the production-path entrypoint; production engagement of the painter path is a hard error until that lands
 - 0017 orchestration workflow contract — ratifies Brief K §Verdict 1; adds `WORKFLOW.md` at the repo root as the Symphony-shaped agent-dispatch contract; runtime stays unspecified at v0.3
 - 0018 visual seed code image route — ratifies the image-route correction from `scene-spec JSON as terminal image IR` toward `Visual Seed Token + optional Semantic IR + seed expansion + frozen decoder`; keeps one image path and decoder-not-generator doctrine intact while promoting `Visual Seed Token` to first-class status
+- 0019 queue label prefixes — allows `priority/*`, `size/*`, and `stage/*` queue-management labels on top of the semantic label taxonomy
 
 ## Lanes
 

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -2,7 +2,9 @@
 
 This page is the canonical definition of every label used on GitHub Issues and Pull Requests in this repository. Adding a new label without updating this page is a process bug — a future contributor cannot infer the label's intent from a one-line GitHub description alone.
 
-The taxonomy is **flat by design**. We do not use prefixes (`area:*`, `type:*`, `phase:*`) because (a) GitHub's label UI does not group by prefix, (b) prefixes consume namespace that becomes hard to refactor, and (c) the repo is small enough that ~15 well-named labels are easier to grip than 30 prefixed ones. If the label set grows past ~20, revisit and consider prefixes.
+The semantic taxonomy remains **flat by design**. Labels such as `research-derived`, `tracker`, `enhancement`, and `discussion` carry body conventions and review meaning.
+
+ADR-0019 adds a separate queue-management layer with prefixed labels: `priority/*`, `size/*`, and `stage/*`. These labels answer "when, how large, and which line?" They do not replace the semantic labels below.
 
 Per `docs/engineering-discipline.md`, a label is a contract: applying one obliges you to satisfy the body conventions listed below (e.g. `research-derived` requires citing the brief; `tracker` requires naming the gating event).
 
@@ -10,14 +12,15 @@ Per `docs/engineering-discipline.md`, a label is a contract: applying one oblige
 
 ## Categories
 
-We think of labels in four implicit categories — **provenance**, **lifecycle**, **type**, and **audience**. The categories are not encoded in the label name, but they are useful for picking which label(s) to apply.
+We think of labels in five categories — **provenance**, **lifecycle**, **type**, **audience**, and **queue metadata**. The first four categories keep flat names. Queue metadata uses prefixes by ADR-0019.
 
 - **Provenance** — where did this come from? (research brief, RFC, ADR, user)
 - **Lifecycle** — where is it in its journey? (spike, tracker, blocked, discussion)
 - **Type** — what kind of work is it? (bug, enhancement, docs, refactor)
 - **Audience** — who can pick this up? (good first issue, help wanted)
+- **Queue metadata** — urgency, size, and owning milestone / lane
 
-A typical issue carries 1–3 labels: usually one type, optionally one provenance, optionally one lifecycle. Avoid stacking more than three — they stop being grippable.
+A typical issue carries 1–3 semantic labels plus, when useful, up to three queue labels: one `priority/*`, one `size/*`, and one `stage/*`. Avoid stacking multiple labels from the same queue family unless the issue is explicitly an umbrella.
 
 ---
 
@@ -165,11 +168,81 @@ Dependabot version-bump PR.
 
 Per-ecosystem dependabot routing labels. Cosmetic; safe to ignore.
 
+### Queue metadata
+
+Queue labels are operational triage metadata. They do not change whether an issue is agent-eligible. `tracker`, `discussion`, `horizon-spike`, and `blocked` remain excluded from auto-dispatch per `WORKFLOW.md`.
+
+#### `priority/p0`
+
+Must resolve before the current release or mainline gate.
+
+#### `priority/p1`
+
+High priority after the current mainline gate. This is the normal label for the next thing maintainers should actively coordinate.
+
+#### `priority/p2`
+
+Important but not current-mainline blocking.
+
+#### `priority/p3`
+
+Parked, horizon, post-release, or only actionable when a later gate opens.
+
+#### `size/s`
+
+Small scoped change or review task. Usually one PR or one issue comment pass.
+
+#### `size/m`
+
+Medium slice with multiple files or focused research.
+
+#### `size/l`
+
+Large implementation, research, or coordination task.
+
+#### `size/xl`
+
+Very large program, umbrella, or multi-slice effort.
+
+#### `stage/m1-image`
+
+Image line: M1/M1B, Visual Seed Code, decoder, or SeedExpander work.
+
+#### `stage/m2-audio`
+
+Audio line: M2 codec v2, audio backend, or audio verification.
+
+#### `stage/m3-sensor`
+
+Sensor line: M3 or sensor research.
+
+#### `stage/m4-video`
+
+Video line: M4 or video backend research.
+
+#### `stage/release`
+
+Release, prerelease, changelog, or public release surface.
+
+#### `stage/governance`
+
+Workflow, labels, doctrine governance, or maintainer process.
+
+#### `stage/cross-cutting`
+
+Cross-cutting schema, CLI, manifest, dependency, or infra work.
+
+#### `stage/post-v0.3`
+
+Explicitly deferred until after the v0.3 release cut.
+
 ---
 
 ## How to apply labels
 
-**Issues.** When opening an issue, apply 1–3 labels: usually one type (`bug` / `enhancement` / `documentation`) plus optional provenance and lifecycle. The labelling is part of the filing — an unlabelled issue is harder to triage.
+**Issues.** When opening an issue, apply 1–3 semantic labels: usually one type (`bug` / `enhancement` / `documentation`) plus optional provenance and lifecycle. When the queue status is clear, also apply one priority, one size, and one stage label. The labelling is part of the filing — an unlabelled issue is harder to triage.
+
+For machine labelling, include explicit title tokens when useful: `[p1]`, `[size/m]`, `[image]`, `[audio]`, `[sensor]`, `[video]`, `[release]`, `[governance]`, or `[cross-cutting]`.
 
 **PRs.** When opening a PR, the labelling should match the issue(s) it closes (if any). PRs that don't close an issue still get labelled — usually one type plus one provenance.
 
@@ -187,4 +260,4 @@ Per-ecosystem dependabot routing labels. Cosmetic; safe to ignore.
 
 ---
 
-_Last updated: 2026-04-26. Next review: when the label set crosses ~20 entries (consider introducing prefixes), or when a label is renamed (always)._
+_Last updated: 2026-05-07. Next review: after the next queue-audit pass, or when a label is renamed (always)._


### PR DESCRIPTION
## Summary
- adds ADR-0019 to allow queue-management label prefixes on top of ADR-0012 semantic labels
- documents `priority/*`, `size/*`, and `stage/*` in `docs/labels.md`
- teaches the issue auto-labeler explicit title-token rules for queue labels
- clarifies in `WORKFLOW.md` that queue labels never override agent-dispatch exclusions

## Manual backfill
I also manually backfilled the current open issue queue with priority/size/stage labels so maintainers can sort the live board immediately.

## Validation
- `pnpm exec prettier --check docs/adrs/0019-queue-label-prefixes.md docs/adrs/0012-issue-pr-label-taxonomy.md docs/adrs/README.md docs/labels.md WORKFLOW.md .github/issue-labeler.yml`
- `git diff --check`

@moapacha please review this as a governance/taxonomy PR. The key question is whether these labels are narrow queue metadata rather than a replacement for the semantic labels ratified by ADR-0012.