### PR TITLE
docs: align image research notes with VSC route

### DIFF
--- a/docs/research/frozen-llm-multimodality.md
+++ b/docs/research/frozen-llm-multimodality.md
@@ -28,15 +28,15 @@ The core insight is that large pretrained models already contain cross-modal gro
 
 ## Applied to Wittgenstein
 
-The image adapter in Wittgenstein is 781 COCO captions trained in approximately nine seconds. It maps text embeddings (from the scene spec fields) to VQ codebook logits that the frozen decoder expects. The audio ambient classifier is 369 examples trained in under five seconds. Neither component learns image or audio semantics from scratch. The LLM backbone already encodes the semantic content. The adapters learn only the interface geometry.
+The early image adapter in Wittgenstein used 781 COCO captions and trained in approximately nine seconds. That historical receipt mapped text embeddings from scene-spec fields to VQ codebook logits. After the Visual Seed Code correction, the forward-looking adapter role is narrower and cleaner: expand decoder-facing seed code / VQ hints into fuller decoder-native token grids, with Semantic IR available as optional conditioning and inspection. The audio ambient classifier is 369 examples trained in under five seconds. Neither component learns image or audio semantics from scratch. The LLM backbone already encodes much of the semantic content. The adapters learn only the interface geometry.
 
 This has three immediate practical consequences.
 
 **Codec swaps.** The decoder can be replaced — swap a LlamaGen decoder for a SEED tokenizer, or a VQGAN for a TiTok decoder — without touching the LLM or retraining the adapter beyond a short re-calibration on the new codebook. The LLM's semantic representation does not change.
 
-**Provider swaps.** The LLM can be replaced — swap Kimi for Claude, or GPT-4o for a local Llama 3 instance — without retraining the adapters. The scene JSON schema is the stable interface contract.
+**Provider swaps.** The LLM can be replaced — swap Kimi for Claude, or GPT-4o for a local Llama 3 instance — without retraining the adapters. The Visual Seed Code-bearing image contract is the stable interface, with Semantic IR as inspectable support rather than the whole image route.
 
-**Independent debugging.** If the output image is wrong, the failure can be localized: is the scene spec malformed (LLM problem)? Are the VQ indices plausible (adapter problem)? Is the reconstruction faithful (decoder problem)? Each component is inspectable in isolation.
+**Independent debugging.** If the output image is wrong, the failure can be localized: is the Visual Seed Code contract malformed (LLM / prompt-stack problem)? Are the expanded VQ indices plausible (adapter problem)? Is the reconstruction faithful (decoder problem)? Each component is inspectable in isolation.
 
 ## The Locality Principle
 
@@ -48,7 +48,7 @@ A frozen pipeline with a deterministic decoder produces identical output for ide
 
 ## References
 
-- Radford, A. et al. (2021). "Learning Transferable Visual Models From Natural Language Supervision." *ICML 2021* (CLIP).
-- Liu, H. et al. (2023). "Visual Instruction Tuning." *NeurIPS 2023* (LLaVA).
-- Li, J. et al. (2023). "BLIP-2: Bootstrapping Language-Image Pre-training with Frozen Image Encoders and Large Language Models." *ICML 2023*.
-- Jia, C. et al. (2021). "Scaling Up Visual and Vision-Language Representation Learning With Noisy Text Supervision." *ICML 2021* (ALIGN).
+- Radford, A. et al. (2021). "Learning Transferable Visual Models From Natural Language Supervision." _ICML 2021_ (CLIP).
+- Liu, H. et al. (2023). "Visual Instruction Tuning." _NeurIPS 2023_ (LLaVA).
+- Li, J. et al. (2023). "BLIP-2: Bootstrapping Language-Image Pre-training with Frozen Image Encoders and Large Language Models." _ICML 2023_.
+- Jia, C. et al. (2021). "Scaling Up Visual and Vision-Language Representation Learning With Noisy Text Supervision." _ICML 2021_ (ALIGN).

--- a/docs/research/vq-tokens-as-interface.md
+++ b/docs/research/vq-tokens-as-interface.md
@@ -63,12 +63,12 @@ VQ (vector quantization) maps a continuous latent to the nearest entry in a lear
 of K discrete vectors. The result is an index in {0, …, K−1}. This is directly analogous to
 BPE tokenization:
 
-| Text tokenization | Image VQ tokenization |
-|---|---|
-| Character sequence → BPE token indices | Image patches → codebook indices |
-| Vocabulary size: ~50,000 tokens | Codebook size: 1,024–16,384 codes |
-| Sequence: ~256–2048 tokens per prompt | Sequence: 256–1024 tokens per image |
-| Autoregressive prediction: next token | Autoregressive prediction: next code |
+| Text tokenization                      | Image VQ tokenization                |
+| -------------------------------------- | ------------------------------------ |
+| Character sequence → BPE token indices | Image patches → codebook indices     |
+| Vocabulary size: ~50,000 tokens        | Codebook size: 1,024–16,384 codes    |
+| Sequence: ~256–2048 tokens per prompt  | Sequence: 256–1024 tokens per image  |
+| Autoregressive prediction: next token  | Autoregressive prediction: next code |
 
 The key property is that an autoregressive language model can be trained or prompted to
 predict the next VQ code in a sequence using the same objective it uses for text. DALL-E 1
@@ -89,7 +89,7 @@ distribution over codebook indices for each position in the token grid.
 
 The adapter does not learn image generation. The frozen decoder already knows how to
 reconstruct an image from a code sequence — that knowledge is baked into its weights. The
-adapter only needs to learn the *projection* between the LLM's semantic representation and
+adapter only needs to learn the _projection_ between the LLM's semantic representation and
 the decoder's code vocabulary. Because both spaces are semantically structured (text embeddings
 carry semantic content; VQ codes are trained to encode image semantics), the projection is a
 low-dimensional problem. This is why a small MLP suffices.
@@ -142,8 +142,9 @@ The VQ token interface is chosen because:
 5. the decoder can be frozen and swapped without touching the LLM
 6. the sequence length is trending toward 32–256 tokens (TiTok direction)
 
-The scene spec sits upstream of the VQ tokens. The LLM is never asked to predict raw VQ
-indices directly — it emits semantic structure that the adapter translates. The two-stage
-design (scene spec → adapter → VQ tokens → frozen decoder) separates concerns cleanly:
-the LLM does semantic planning, the adapter does vocabulary alignment, the decoder does
-reconstruction.
+The image contract now sits upstream of the VQ tokens. It may carry Semantic IR for
+model-side organization and inspection, but Visual Seed Code / VQ hints are the primary
+decoder-facing research layer. The staged design (Visual Seed Code-bearing contract →
+seed expander / adapter → VQ tokens → frozen decoder) separates concerns cleanly: the LLM
+does structured planning and initial visual coding, the adapter does vocabulary / grid
+alignment, and the decoder does reconstruction.

--- a/docs/technical-details-script.md
+++ b/docs/technical-details-script.md
@@ -319,8 +319,8 @@ This gives us shared control flow with per-modality specialization and makes tes
 
 ### Modality status (2 min)
 
-"Image has the strongest shape today: the sole neural path is fixed as scene-spec to adapter to frozen decoder to PNG.
-Audio, video, and sensor have typed schemas and dispatch seams, but renderer bodies are still intentionally stubs."
+"Image has the strongest shape today: the sole neural path is now framed as Visual Seed Code-bearing contract to seed expander / adapter to frozen decoder to PNG.
+Semantic IR remains useful for model-side organization and user inspection, but it is not the terminal image research object. Audio, video, and sensor have typed schemas and dispatch seams, with maturity called out per modality."
 
 ### Product/UX assets (1 min)
 


### PR DESCRIPTION
## Summary
- updates the technical-details script to describe the image path as Visual Seed Code-bearing rather than scene-spec-terminal
- updates VQ-token and frozen-LLM research notes so they preserve historical adapter receipts while naming the forward VSC / SeedExpander role
- keeps RFC/ADR historical context untouched

## Why
After #233/#234/#237/#238 landed, these public/research notes were the remaining surfaces that still sounded like the old scene-spec-only image story.

## Validation
- `pnpm exec prettier --check docs/technical-details-script.md docs/research/vq-tokens-as-interface.md docs/research/frozen-llm-multimodality.md`
- `git diff --check`

@moapacha this is a narrow drift cleanup after your closeout pass; please check that it does not rewrite historical RFC/ADR context or overstate current decoder quality.