### PR TITLE
fix(codec-image): warn on coarseVq / seedCode adapter fall-through (Phase A1, #208 closeout)

### DIFF
--- a/packages/codec-image/src/codec.ts
+++ b/packages/codec-image/src/codec.ts
@@ -196,6 +196,8 @@ export class ImageCodec extends codecV2.BaseCodec<ImageRequest, ImageArtifact> {
   readonly warnings = {
     palette_overflow: "image/palette-overflow",
     provider_latents_invalid: "image/provider-latents-invalid",
+    coarse_vq_invalid: "image/coarse-vq-invalid",
+    seed_code_invalid: "image/seed-code-invalid",
     adapter_stub: "image/adapter-stub",
     decoder_reference_bridge: "image/decoder-reference-bridge",
     decoder_placeholder: "image/decoder-placeholder",
@@ -383,6 +385,12 @@ export class ImageCodec extends codecV2.BaseCodec<ImageRequest, ImageArtifact> {
   private warningCodeFor(message: string): string | null {
     if (message.includes("providerLatents failed validation")) {
       return this.warnings.provider_latents_invalid;
+    }
+    if (message.includes("coarseVq failed validation")) {
+      return this.warnings.coarse_vq_invalid;
+    }
+    if (message.includes("seedCode failed validation")) {
+      return this.warnings.seed_code_invalid;
     }
     if (message.includes("Using placeholder seed-expansion adapter")) {
       return this.warnings.adapter_stub;

--- a/packages/codec-image/src/pipeline/adapter.ts
+++ b/packages/codec-image/src/pipeline/adapter.ts
@@ -37,6 +37,9 @@ export async function adaptSceneToLatents(
       ctx.logger.info("Using coarseVq hints; expanding to decoder-native latents.");
       return expandCoarseVqToLatents(parsed, validated.data);
     }
+    ctx.logger.warn("coarseVq failed validation; falling back to next adapter tier.", {
+      issues: validated.error?.issues,
+    });
   }
 
   if (parsed.seedCode) {
@@ -45,6 +48,9 @@ export async function adaptSceneToLatents(
       ctx.logger.info("Using Visual Seed Code; expanding to decoder-native latents.");
       return expandSeedToLatents(parsed, validated.data);
     }
+    ctx.logger.warn("seedCode failed validation; falling back to next adapter tier.", {
+      issues: validated.error?.issues,
+    });
   }
 
   const resolved = await resolveMlpForScene(parsed, ctx);

--- a/packages/codec-image/test/warnings-channel.test.ts
+++ b/packages/codec-image/test/warnings-channel.test.ts
@@ -42,4 +42,9 @@ describe("image v2 warnings channel", () => {
       art.metadata.warnings.some((warning) => warning.code === imageV2Codec.warnings.adapter_stub),
     ).toBe(true);
   });
+
+  it("declares image/coarse-vq-invalid + image/seed-code-invalid warning codes for adapter fall-through", () => {
+    expect(imageV2Codec.warnings.coarse_vq_invalid).toBe("image/coarse-vq-invalid");
+    expect(imageV2Codec.warnings.seed_code_invalid).toBe("image/seed-code-invalid");
+  });
 });


### PR DESCRIPTION
Closes the logger-parity gap captured in #208 audit closeout.

## What

`coarseVq` + `seedCode` adapter validation failures now `ctx.logger.warn` symmetrically with `providerLatents`. New sidecar codes `image/coarse-vq-invalid` + `image/seed-code-invalid` route these into manifest receipts.

## Why

In normal flow (codec.parse → adapter) the schema layer catches malformed VQ/seed code at parse time. The adapter's secondary safeParse is defense-in-depth. Without the warn lines, future code that bypasses the schema layer (or future mutation between parse and adapter dispatch) would lose receipt evidence. This PR makes the defensive layer honest.

## Validation

- pnpm --filter @wittgenstein/codec-image test → 22/22 (was 21/21; added 1 declaration test)
- pnpm typecheck / pnpm lint at root → green

## Per ADR-0013

`packages/codec-image/src/*` + `test/*` not on §1 doctrine list. Self-mergeable; the new warning codes follow existing `image/*` prefix convention.