### PR TITLE
refactor(codec-image): extract SeedExpander seam (Phase A3, #70 reframed)

### DIFF
--- a/packages/codec-image/src/adapters/seed-expander.ts
+++ b/packages/codec-image/src/adapters/seed-expander.ts
@@ -1,0 +1,73 @@
+import {
+  ImageLatentCodesSchema,
+  type ImageLatentCodes,
+  type ImageSceneSpec,
+  type ImageVisualSeedCode,
+} from "../schema.js";
+
+/**
+ * SeedExpander — the seam that turns a Visual Seed Code (compact, decoder-agnostic
+ * tokens emitted by the LLM) into decoder-native ImageLatentCodes.
+ *
+ * Today the only implementation is `placeholderSeedExpander`, which deterministically
+ * fills the target latent grid by mixing seedCode tokens with a per-spec hash. This is
+ * the same logic that previously lived inline in `pipeline/adapter.ts` — extracted to
+ * its own module so future SeedExpanders (LoRA-trained projectors, frozen-model adapters
+ * per ADR-0018 §"Adapter is redefined primarily as a seed expander", #70 reframed M1B
+ * umbrella) drop in without touching adapter routing.
+ *
+ * The seam intentionally separates three concerns:
+ *   1. seed material (the model's compact code) — `seedCode`
+ *   2. decoder shape (target latent grid + codebook identity) — `decoder`
+ *   3. determinism source (per-run seed, derived by adapter.ts from the spec hash)
+ *      — `seed`
+ *
+ * adapter.ts owns the derivation; the expander is pure given its inputs.
+ */
+export interface SeedExpansionInput {
+  readonly seedCode: ImageVisualSeedCode;
+  readonly decoder: ImageSceneSpec["decoder"];
+  readonly seed: number;
+}
+
+export interface SeedExpander {
+  expand(input: SeedExpansionInput): ImageLatentCodes;
+}
+
+const PLACEHOLDER_CODEBOOK_SIZE = 8192;
+
+/**
+ * Deterministic, dependency-free SeedExpander used in v0.3 scaffolding.
+ *
+ * Behavior is preserved exactly from the prior in-line `expandSeedToLatents` helper:
+ * for each target latent slot, take `seedCode.tokens[i mod len]` and mix in the
+ * per-spec deterministic seed plus a per-position salt. Bytes are reproducible across
+ * invocations with the same `(seedCode, decoder, seed)` triple.
+ *
+ * This is a placeholder, not a trained projector. A real SeedExpander (#70 M1B
+ * reframed) would consume seed tokens and emit decoder-native VQ indices via a learned
+ * mapping. Until that lands, this expander gives the codec an end-to-end deterministic
+ * path from `seedCode` to `ImageLatentCodes` so manifests, receipts, and tests can rely
+ * on the visual-seed-code branch firing.
+ */
+export const placeholderSeedExpander: SeedExpander = {
+  expand({ seedCode, decoder, seed }) {
+    const [width, height] = decoder.latentResolution;
+    const totalTokens = width * height;
+    const tokens = new Array<number>(totalTokens);
+
+    for (let index = 0; index < totalTokens; index += 1) {
+      const base = seedCode.tokens[index % seedCode.tokens.length] ?? 0;
+      tokens[index] = (base + seed + index * 31) % PLACEHOLDER_CODEBOOK_SIZE;
+    }
+
+    return ImageLatentCodesSchema.parse({
+      schemaVersion: "witt.image.latents/v0.1",
+      family: decoder.family,
+      codebook: decoder.codebook,
+      codebookVersion: decoder.codebookVersion,
+      tokenGrid: [width, height],
+      tokens,
+    });
+  },
+};

--- a/packages/codec-image/src/pipeline/adapter.ts
+++ b/packages/codec-image/src/pipeline/adapter.ts
@@ -1,5 +1,6 @@
 import type { RenderCtx } from "@wittgenstein/schemas";
 import { resolveMlpForScene, predictWithResolved } from "../adapters/adapter-resolve.js";
+import { placeholderSeedExpander } from "../adapters/seed-expander.js";
 import {
   ImageCoarseVqSchema,
   ImageLatentCodesSchema,
@@ -7,7 +8,6 @@ import {
   type ImageCoarseVq,
   type ImageLatentCodes,
   type ImageSceneSpec,
-  type ImageVisualSeedCode,
 } from "../schema.js";
 
 export type { ImageLatentCodes };
@@ -46,7 +46,11 @@ export async function adaptSceneToLatents(
     const validated = ImageVisualSeedCodeSchema.safeParse(parsed.seedCode);
     if (validated.success) {
       ctx.logger.info("Using Visual Seed Code; expanding to decoder-native latents.");
-      return expandSeedToLatents(parsed, validated.data);
+      return placeholderSeedExpander.expand({
+        seedCode: validated.data,
+        decoder: parsed.decoder,
+        seed: hashSpecToSeed(parsed),
+      });
     }
     ctx.logger.warn("seedCode failed validation; falling back to next adapter tier.", {
       issues: validated.error?.issues,
@@ -112,31 +116,6 @@ function expandCoarseVqToLatents(
     codebook: parsed.decoder.codebook,
     codebookVersion: parsed.decoder.codebookVersion,
     tokenGrid: [targetWidth, targetHeight],
-    tokens,
-  });
-}
-
-function expandSeedToLatents(
-  parsed: ImageSceneSpec,
-  seedCode: ImageVisualSeedCode,
-): ImageLatentCodes {
-  const [width, height] = parsed.decoder.latentResolution;
-  const totalTokens = width * height;
-  const codebookSize = 8192;
-  const deterministicSeed = hashSpecToSeed(parsed);
-  const tokens = new Array<number>(totalTokens);
-
-  for (let index = 0; index < totalTokens; index += 1) {
-    const base = seedCode.tokens[index % seedCode.tokens.length] ?? 0;
-    tokens[index] = (base + deterministicSeed + index * 31) % codebookSize;
-  }
-
-  return ImageLatentCodesSchema.parse({
-    schemaVersion: "witt.image.latents/v0.1",
-    family: parsed.decoder.family,
-    codebook: parsed.decoder.codebook,
-    codebookVersion: parsed.decoder.codebookVersion,
-    tokenGrid: [width, height],
     tokens,
   });
 }

--- a/packages/codec-image/test/seed-expander.test.ts
+++ b/packages/codec-image/test/seed-expander.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { placeholderSeedExpander } from "../src/adapters/seed-expander.js";
+import { ImageVisualSeedCodeSchema, type ImageSceneSpec } from "../src/schema.js";
+
+describe("placeholderSeedExpander", () => {
+  const decoder: ImageSceneSpec["decoder"] = {
+    family: "llamagen",
+    codebook: "stub-codebook",
+    codebookVersion: "v0",
+    latentResolution: [4, 4], // 16-token target grid
+  };
+
+  const baseSeedCode = ImageVisualSeedCodeSchema.parse({
+    family: "vqvae",
+    mode: "prefix",
+    tokens: [3, 17, 9, 220],
+  });
+
+  it("returns latent codes whose tokenGrid matches decoder.latentResolution", () => {
+    const result = placeholderSeedExpander.expand({
+      seedCode: baseSeedCode,
+      decoder,
+      seed: 7,
+    });
+
+    expect(result.tokenGrid).toEqual([4, 4]);
+    expect(result.tokens.length).toBe(16);
+    expect(result.family).toBe("llamagen");
+    expect(result.codebook).toBe("stub-codebook");
+    expect(result.codebookVersion).toBe("v0");
+  });
+
+  it("is deterministic — same input triple produces identical output bytes", () => {
+    const a = placeholderSeedExpander.expand({
+      seedCode: baseSeedCode,
+      decoder,
+      seed: 7,
+    });
+    const b = placeholderSeedExpander.expand({
+      seedCode: baseSeedCode,
+      decoder,
+      seed: 7,
+    });
+    expect(a.tokens).toEqual(b.tokens);
+  });
+
+  it("varies output when the per-spec seed changes", () => {
+    const a = placeholderSeedExpander.expand({
+      seedCode: baseSeedCode,
+      decoder,
+      seed: 7,
+    });
+    const b = placeholderSeedExpander.expand({
+      seedCode: baseSeedCode,
+      decoder,
+      seed: 13,
+    });
+    expect(a.tokens).not.toEqual(b.tokens);
+  });
+
+  it("varies output when the seedCode tokens change", () => {
+    const variantSeedCode = ImageVisualSeedCodeSchema.parse({
+      family: "vqvae",
+      mode: "prefix",
+      tokens: [99, 100, 101, 102],
+    });
+    const a = placeholderSeedExpander.expand({
+      seedCode: baseSeedCode,
+      decoder,
+      seed: 7,
+    });
+    const b = placeholderSeedExpander.expand({
+      seedCode: variantSeedCode,
+      decoder,
+      seed: 7,
+    });
+    expect(a.tokens).not.toEqual(b.tokens);
+  });
+
+  it("respects target latent resolution from decoder hint", () => {
+    const wideDecoder: ImageSceneSpec["decoder"] = { ...decoder, latentResolution: [8, 4] };
+    const result = placeholderSeedExpander.expand({
+      seedCode: baseSeedCode,
+      decoder: wideDecoder,
+      seed: 7,
+    });
+    expect(result.tokenGrid).toEqual([8, 4]);
+    expect(result.tokens.length).toBe(32);
+  });
+
+  it("emits codebook indices within the placeholder codebook size (8192)", () => {
+    const result = placeholderSeedExpander.expand({
+      seedCode: baseSeedCode,
+      decoder,
+      seed: 7,
+    });
+    for (const token of result.tokens) {
+      expect(token).toBeGreaterThanOrEqual(0);
+      expect(token).toBeLessThan(8192);
+    }
+  });
+});


### PR DESCRIPTION
Extracts the placeholder seed-to-latent logic into a typed seam at `packages/codec-image/src/adapters/seed-expander.ts` per #70's post-VSC reframe. **Pure abstraction, zero behavior change (option a)** confirmed in plan.

## Design

```ts
export interface SeedExpansionInput {
  readonly seedCode: ImageVisualSeedCode;
  readonly decoder: ImageSceneSpec["decoder"];
  readonly seed: number;
}
export interface SeedExpander {
  expand(input: SeedExpansionInput): ImageLatentCodes;
}
export const placeholderSeedExpander: SeedExpander = { expand: ... };
```

Three concerns separated: seed material / decoder shape / determinism source. Future SeedExpanders implement the same interface and drop in by changing one import in `pipeline/adapter.ts`.

## Validation

- typecheck / lint / test — all green
- Tests: 32/32 (+6 new `seed-expander.test.ts` unit tests)
- Existing seedCode-path tests in `codec.test.ts` still pass — seam preserves behavior

## Per ADR-0013

`packages/codec-image/src/adapters/` not on §1 doctrine list. Self-mergeable; internal codec architecture.