### PR TITLE
feat(schemas): close image/sensor/video route enums in RunManifest (#190)

### DIFF
--- a/packages/schemas/src/manifest.ts
+++ b/packages/schemas/src/manifest.ts
@@ -12,6 +12,9 @@ export const AudioRenderManifestSchema = z.object({
 });
 
 const AudioRouteSchema = z.enum(["speech", "soundscape", "music"]);
+const ImageRouteSchema = z.enum(["raster"]);
+const SensorRouteSchema = z.enum(["ecg", "temperature", "gyro"]);
+const VideoRouteSchema = z.enum(["hyperframes-mp4", "hyperframes-html"]);
 
 const CostUsdReasonSchema = z.enum(["computed", "unknown-model", "missing-usage"]);
 
@@ -112,6 +115,39 @@ export const RunManifestSchema = z
           code: z.ZodIssueCode.custom,
           path: ["route"],
           message: `Audio manifests must use one of: ${AudioRouteSchema.options.join(", ")}.`,
+        });
+      }
+    }
+
+    if (manifest.codec === "image" && manifest.route !== undefined) {
+      const parsedRoute = ImageRouteSchema.safeParse(manifest.route);
+      if (!parsedRoute.success) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["route"],
+          message: `Image manifests must use one of: ${ImageRouteSchema.options.join(", ")}.`,
+        });
+      }
+    }
+
+    if (manifest.codec === "sensor" && manifest.route !== undefined) {
+      const parsedRoute = SensorRouteSchema.safeParse(manifest.route);
+      if (!parsedRoute.success) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["route"],
+          message: `Sensor manifests must use one of: ${SensorRouteSchema.options.join(", ")}.`,
+        });
+      }
+    }
+
+    if (manifest.codec === "video" && manifest.route !== undefined) {
+      const parsedRoute = VideoRouteSchema.safeParse(manifest.route);
+      if (!parsedRoute.success) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["route"],
+          message: `Video manifests must use one of: ${VideoRouteSchema.options.join(", ")}.`,
         });
       }
     }

--- a/packages/schemas/test/contract.test.ts
+++ b/packages/schemas/test/contract.test.ts
@@ -179,6 +179,194 @@ describe("@wittgenstein/schemas", () => {
     expect(parsed.success).toBe(false);
   });
 
+  it("rejects invalid image routes (Issue #190)", () => {
+    const parsed = RunManifestSchema.safeParse({
+      runId: "run-image-route",
+      gitSha: "abc123",
+      lockfileHash: "def456",
+      nodeVersion: process.version,
+      wittgensteinVersion: "0.0.0",
+      command: "wittgenstein image",
+      args: ["hello"],
+      seed: 7,
+      codec: "image",
+      route: "rastr",
+      llmProvider: "anthropic",
+      llmModel: "claude-opus-4-7",
+      llmTokens: { input: 10, output: 20 },
+      costUsd: 0,
+      promptRaw: "hello",
+      promptExpanded: "hello",
+      llmOutputRaw: "{}",
+      llmOutputParsed: {},
+      artifactPath: "/tmp/out.png",
+      artifactSha256: "sha256",
+      startedAt: new Date().toISOString(),
+      durationMs: 10,
+      ok: true,
+      error: null,
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it("accepts the canonical image route literal (Issue #190)", () => {
+    const parsed = RunManifestSchema.safeParse({
+      runId: "run-image-route-ok",
+      gitSha: "abc123",
+      lockfileHash: "def456",
+      nodeVersion: process.version,
+      wittgensteinVersion: "0.0.0",
+      command: "wittgenstein image",
+      args: ["hello"],
+      seed: 7,
+      codec: "image",
+      route: "raster",
+      llmProvider: "anthropic",
+      llmModel: "claude-opus-4-7",
+      llmTokens: { input: 10, output: 20 },
+      costUsd: 0,
+      promptRaw: "hello",
+      promptExpanded: "hello",
+      llmOutputRaw: "{}",
+      llmOutputParsed: {},
+      artifactPath: "/tmp/out.png",
+      artifactSha256: "sha256",
+      startedAt: new Date().toISOString(),
+      durationMs: 10,
+      ok: true,
+      error: null,
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+
+  it("rejects invalid sensor routes (Issue #190)", () => {
+    const parsed = RunManifestSchema.safeParse({
+      runId: "run-sensor-route",
+      gitSha: "abc123",
+      lockfileHash: "def456",
+      nodeVersion: process.version,
+      wittgensteinVersion: "0.0.0",
+      command: "wittgenstein sensor",
+      args: ["hello"],
+      seed: 7,
+      codec: "sensor",
+      route: "ekg",
+      llmProvider: "anthropic",
+      llmModel: "claude-opus-4-7",
+      llmTokens: { input: 10, output: 20 },
+      costUsd: 0,
+      promptRaw: "hello",
+      promptExpanded: "hello",
+      llmOutputRaw: "{}",
+      llmOutputParsed: {},
+      artifactPath: "/tmp/out.json",
+      artifactSha256: "sha256",
+      startedAt: new Date().toISOString(),
+      durationMs: 10,
+      ok: true,
+      error: null,
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it("accepts canonical sensor route literals (Issue #190)", () => {
+    for (const route of ["ecg", "temperature", "gyro"]) {
+      const parsed = RunManifestSchema.safeParse({
+        runId: `run-sensor-route-${route}`,
+        gitSha: "abc123",
+        lockfileHash: "def456",
+        nodeVersion: process.version,
+        wittgensteinVersion: "0.0.0",
+        command: "wittgenstein sensor",
+        args: ["hello"],
+        seed: 7,
+        codec: "sensor",
+        route,
+        llmProvider: "anthropic",
+        llmModel: "claude-opus-4-7",
+        llmTokens: { input: 10, output: 20 },
+        costUsd: 0,
+        promptRaw: "hello",
+        promptExpanded: "hello",
+        llmOutputRaw: "{}",
+        llmOutputParsed: {},
+        artifactPath: "/tmp/out.json",
+        artifactSha256: "sha256",
+        startedAt: new Date().toISOString(),
+        durationMs: 10,
+        ok: true,
+        error: null,
+      });
+      expect(parsed.success).toBe(true);
+    }
+  });
+
+  it("rejects invalid video routes (Issue #190)", () => {
+    const parsed = RunManifestSchema.safeParse({
+      runId: "run-video-route",
+      gitSha: "abc123",
+      lockfileHash: "def456",
+      nodeVersion: process.version,
+      wittgensteinVersion: "0.0.0",
+      command: "wittgenstein video",
+      args: ["hello"],
+      seed: 7,
+      codec: "video",
+      route: "hyperframes-mov",
+      llmProvider: "anthropic",
+      llmModel: "claude-opus-4-7",
+      llmTokens: { input: 10, output: 20 },
+      costUsd: 0,
+      promptRaw: "hello",
+      promptExpanded: "hello",
+      llmOutputRaw: "{}",
+      llmOutputParsed: {},
+      artifactPath: "/tmp/out.mp4",
+      artifactSha256: "sha256",
+      startedAt: new Date().toISOString(),
+      durationMs: 10,
+      ok: true,
+      error: null,
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it("accepts canonical video route literals (Issue #190)", () => {
+    for (const route of ["hyperframes-mp4", "hyperframes-html"]) {
+      const parsed = RunManifestSchema.safeParse({
+        runId: `run-video-route-${route}`,
+        gitSha: "abc123",
+        lockfileHash: "def456",
+        nodeVersion: process.version,
+        wittgensteinVersion: "0.0.0",
+        command: "wittgenstein video",
+        args: ["hello"],
+        seed: 7,
+        codec: "video",
+        route,
+        llmProvider: "anthropic",
+        llmModel: "claude-opus-4-7",
+        llmTokens: { input: 10, output: 20 },
+        costUsd: 0,
+        promptRaw: "hello",
+        promptExpanded: "hello",
+        llmOutputRaw: "{}",
+        llmOutputParsed: {},
+        artifactPath: "/tmp/out.mp4",
+        artifactSha256: "sha256",
+        startedAt: new Date().toISOString(),
+        durationMs: 10,
+        ok: true,
+        error: null,
+      });
+      expect(parsed.success).toBe(true);
+    }
+  });
+
   it("accepts costUsd: null when paired with a non-computed reason", () => {
     const parsed = RunManifestSchema.safeParse({
       runId: "run-cost-null",


### PR DESCRIPTION
## Summary

Extends the audio route-enum precedent from #201 to image/sensor/video. svg and asciipng do not emit a route to manifest and remain unchanged.

| Codec    | Route enum                                      |
| -------- | ----------------------------------------------- |
| audio    | speech / soundscape / music _(was #201)_       |
| image    | raster                                          |
| sensor   | ecg / temperature / gyro                       |
| video    | hyperframes-mp4 / hyperframes-html             |

Each new branch in \`RunManifestSchema.superRefine\` mirrors the audio branch verbatim: the check fires only when \`codec === <modality>\` and \`route !== undefined\`, so codecs that don't emit a route stay unaffected.

## Why this scope and not the horizon shape

Issue #190 also names the broader cleanup — codec-keyed \`RunManifest\` discriminated union, per-modality typed \`tier\`, central registry — which @Jah-yee called out in the comment:

> That broader cleanup still needs to earn its complexity against the rest of the benchmark/tooling line.

I agree. This PR closes the **active** silent-typo footgun for the codecs we ship (so a manifest writer that emits \`route: \"raster1\"\` or \`route: \"ekg\"\` now fails parse), without forcing the broader refactor before benchmark aggregation actually consumes routes by enum.

## Test plan

- [x] \`pnpm --filter @wittgenstein/schemas typecheck\` — green
- [x] \`pnpm --filter @wittgenstein/schemas lint\` — green
- [x] \`pnpm --filter @wittgenstein/schemas test\` — 20/20 (was 14; +6 new positive/negative cases)
- [x] \`pnpm -r typecheck\` across all packages — green
- [x] \`pnpm -r test\` across all packages — green (existing manifest writers in core / codecs already use the canonical route literals; no codec change required)

Closes the active part of #190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)