### PR TITLE
feat(codec-image): tileMosaicSeedExpander as second SeedExpander impl (#251 Lane 1A)

### DIFF
--- a/packages/codec-image/src/adapters/seed-expander-tile-mosaic.ts
+++ b/packages/codec-image/src/adapters/seed-expander-tile-mosaic.ts
@@ -1,0 +1,84 @@
+import {
+  ImageLatentCodesSchema,
+  type ImageLatentCodes,
+  type ImageSceneSpec,
+  type ImageVisualSeedCode,
+} from "../schema.js";
+import type { SeedExpander } from "./seed-expander.js";
+
+const PLACEHOLDER_CODEBOOK_SIZE = 8192;
+
+/**
+ * Pick a near-square `coarseW × coarseH` layout for `seedCode.tokens` so the
+ * seed acts as a 2D mosaic of tile bases rather than a 1D ring. Width
+ * dominates by one when the count is not a perfect square so a 4-token
+ * seedCode lays out as 2×2, a 32-token seedCode as 6×6 (with two unused
+ * cells, harmless because we wrap modulo `tokens.length`), etc.
+ */
+function pickCoarseLayout(tokenCount: number): { coarseW: number; coarseH: number } {
+  const root = Math.max(1, Math.round(Math.sqrt(tokenCount)));
+  const coarseW = root;
+  const coarseH = Math.max(1, Math.ceil(tokenCount / coarseW));
+  return { coarseW, coarseH };
+}
+
+/**
+ * Deterministic, dependency-free SeedExpander that demonstrates the
+ * `SeedExpander` seam (#243) is an ABI rather than a refactor. Distinct
+ * algorithm from `placeholderSeedExpander`:
+ *
+ *   - placeholder: linear `seedCode.tokens[i mod len]` plus a positional
+ *     salt — treats the target grid as 1D.
+ *   - tile-mosaic: lays the seed tokens out as a near-square coarse grid,
+ *     then for each target cell looks up the *enclosing tile's* base token
+ *     and adds a per-target-position salt. Adjacent target cells inside the
+ *     same tile share the same base, so the output has 2D block structure
+ *     visible as token-value plateaus that differ per region.
+ *
+ * Like the placeholder, this is **not a trained projector** — it makes no
+ * decoder-quality claim. It exists so future SeedExpanders (LoRA-trained
+ * projector under #70 reframed M1B; frozen-projector candidates per
+ * ADR-0018 §"Adapter is redefined primarily as a seed expander") have a
+ * working ABI peer to compare against, and so codec consumers can verify
+ * via `WITTGENSTEIN_IMAGE_SEED_EXPANDER` (when selection ships, #251 Lane
+ * 1A follow-up) that the seam actually swaps.
+ *
+ * Determinism contract is identical to the placeholder: same
+ * `(seedCode, decoder, seed)` triple → byte-identical `ImageLatentCodes`.
+ */
+export const tileMosaicSeedExpander: SeedExpander = {
+  expand({ seedCode, decoder, seed }: {
+    seedCode: ImageVisualSeedCode;
+    decoder: ImageSceneSpec["decoder"];
+    seed: number;
+  }): ImageLatentCodes {
+    const [width, height] = decoder.latentResolution;
+    const totalTokens = width * height;
+    const tokens = new Array<number>(totalTokens);
+    const { coarseW, coarseH } = pickCoarseLayout(seedCode.tokens.length);
+
+    for (let y = 0; y < height; y += 1) {
+      // Map target row to coarse-grid row.
+      const yc = Math.min(coarseH - 1, Math.floor((y * coarseH) / Math.max(1, height)));
+      for (let x = 0; x < width; x += 1) {
+        const xc = Math.min(coarseW - 1, Math.floor((x * coarseW) / Math.max(1, width)));
+        // Wrap modulo tokens.length so non-square layouts (e.g. 6×6 over 32
+        // tokens) still resolve to a valid base.
+        const tileIndex = (yc * coarseW + xc) % seedCode.tokens.length;
+        const base = seedCode.tokens[tileIndex] ?? 0;
+        const localSalt = x * 17 + y * 31 + seed * 1009;
+        const targetIndex = y * width + x;
+        tokens[targetIndex] = (base + localSalt) % PLACEHOLDER_CODEBOOK_SIZE;
+      }
+    }
+
+    return ImageLatentCodesSchema.parse({
+      schemaVersion: "witt.image.latents/v0.1",
+      family: decoder.family,
+      codebook: decoder.codebook,
+      codebookVersion: decoder.codebookVersion,
+      tokenGrid: [width, height],
+      tokens,
+    });
+  },
+};

--- a/packages/codec-image/test/seed-expander-tile-mosaic.test.ts
+++ b/packages/codec-image/test/seed-expander-tile-mosaic.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import { placeholderSeedExpander } from "../src/adapters/seed-expander.js";
+import { tileMosaicSeedExpander } from "../src/adapters/seed-expander-tile-mosaic.js";
+import { ImageVisualSeedCodeSchema, type ImageSceneSpec } from "../src/schema.js";
+
+describe("tileMosaicSeedExpander", () => {
+  const decoder: ImageSceneSpec["decoder"] = {
+    family: "llamagen",
+    codebook: "stub-codebook",
+    codebookVersion: "v0",
+    latentResolution: [4, 4],
+  };
+
+  const baseSeedCode = ImageVisualSeedCodeSchema.parse({
+    family: "vqvae",
+    mode: "prefix",
+    tokens: [3, 17, 9, 220],
+  });
+
+  it("returns latent codes whose tokenGrid matches decoder.latentResolution", () => {
+    const result = tileMosaicSeedExpander.expand({
+      seedCode: baseSeedCode,
+      decoder,
+      seed: 7,
+    });
+
+    expect(result.tokenGrid).toEqual([4, 4]);
+    expect(result.tokens.length).toBe(16);
+    expect(result.family).toBe("llamagen");
+    expect(result.codebook).toBe("stub-codebook");
+    expect(result.codebookVersion).toBe("v0");
+  });
+
+  it("is deterministic — same input triple produces identical output bytes", () => {
+    const a = tileMosaicSeedExpander.expand({
+      seedCode: baseSeedCode,
+      decoder,
+      seed: 7,
+    });
+    const b = tileMosaicSeedExpander.expand({
+      seedCode: baseSeedCode,
+      decoder,
+      seed: 7,
+    });
+    expect(a.tokens).toEqual(b.tokens);
+  });
+
+  it("varies output when the per-spec seed changes", () => {
+    const a = tileMosaicSeedExpander.expand({
+      seedCode: baseSeedCode,
+      decoder,
+      seed: 7,
+    });
+    const b = tileMosaicSeedExpander.expand({
+      seedCode: baseSeedCode,
+      decoder,
+      seed: 13,
+    });
+    expect(a.tokens).not.toEqual(b.tokens);
+  });
+
+  it("varies output when the seedCode tokens change", () => {
+    const variantSeedCode = ImageVisualSeedCodeSchema.parse({
+      family: "vqvae",
+      mode: "prefix",
+      tokens: [99, 100, 101, 102],
+    });
+    const a = tileMosaicSeedExpander.expand({
+      seedCode: baseSeedCode,
+      decoder,
+      seed: 7,
+    });
+    const b = tileMosaicSeedExpander.expand({
+      seedCode: variantSeedCode,
+      decoder,
+      seed: 7,
+    });
+    expect(a.tokens).not.toEqual(b.tokens);
+  });
+
+  it("respects target latent resolution from decoder hint", () => {
+    const wideDecoder: ImageSceneSpec["decoder"] = { ...decoder, latentResolution: [8, 4] };
+    const result = tileMosaicSeedExpander.expand({
+      seedCode: baseSeedCode,
+      decoder: wideDecoder,
+      seed: 7,
+    });
+    expect(result.tokenGrid).toEqual([8, 4]);
+    expect(result.tokens.length).toBe(32);
+  });
+
+  it("emits codebook indices within the placeholder codebook size (8192)", () => {
+    const result = tileMosaicSeedExpander.expand({
+      seedCode: baseSeedCode,
+      decoder,
+      seed: 7,
+    });
+    for (const token of result.tokens) {
+      expect(token).toBeGreaterThanOrEqual(0);
+      expect(token).toBeLessThan(8192);
+    }
+  });
+
+  // The whole point of having a second expander is to prove the seam swaps.
+  // If both expanders produced byte-identical output for a non-trivial input
+  // they would be the same algorithm, the seam would be cosmetic, and #243
+  // would only be a refactor — not the ABI it claims to be. This test pins
+  // that they are genuinely distinct.
+  it("produces output distinct from placeholderSeedExpander for the same input", () => {
+    const placeholder = placeholderSeedExpander.expand({
+      seedCode: baseSeedCode,
+      decoder,
+      seed: 7,
+    });
+    const tileMosaic = tileMosaicSeedExpander.expand({
+      seedCode: baseSeedCode,
+      decoder,
+      seed: 7,
+    });
+    expect(tileMosaic.tokens).not.toEqual(placeholder.tokens);
+    // Both must still hit the same grid + codebook surface — the seam
+    // doesn't let an expander redefine the decoder shape.
+    expect(tileMosaic.tokenGrid).toEqual(placeholder.tokenGrid);
+    expect(tileMosaic.family).toBe(placeholder.family);
+    expect(tileMosaic.codebook).toBe(placeholder.codebook);
+    expect(tileMosaic.codebookVersion).toBe(placeholder.codebookVersion);
+  });
+
+  // Adjacent target cells that fall inside the same coarse seed tile should
+  // share the same `base` token; the per-position salt is the *only* thing
+  // that differs between them. This is the structural claim of the
+  // tile-mosaic algorithm — without it the expander would just be the
+  // placeholder under another name.
+  it("adjacent cells inside the same tile differ only by the per-position salt", () => {
+    const seedFour = ImageVisualSeedCodeSchema.parse({
+      family: "vqvae",
+      mode: "prefix",
+      tokens: [10, 20, 30, 40], // 2×2 coarse grid
+    });
+    const decoder8x8: ImageSceneSpec["decoder"] = { ...decoder, latentResolution: [8, 8] };
+    const result = tileMosaicSeedExpander.expand({
+      seedCode: seedFour,
+      decoder: decoder8x8,
+      seed: 0,
+    });
+    // The top-left 4×4 quadrant maps to coarse tile (0,0) → base = 10.
+    // Cell (0,0): base + (0*17 + 0*31 + 0*1009) = 10
+    // Cell (1,0): base + (1*17 + 0*31 + 0*1009) = 27
+    // Cell (0,1): base + (0*17 + 1*31 + 0*1009) = 41
+    expect(result.tokens[0]).toBe(10);
+    expect(result.tokens[1]).toBe(27);
+    expect(result.tokens[8]).toBe(41); // y=1, x=0 → index 8 in row-major 8-wide grid
+
+    // The top-right 4×4 quadrant maps to coarse tile (1,0) → base = 20.
+    // Cell (4,0): base + (4*17 + 0*31 + 0*1009) = 88
+    expect(result.tokens[4]).toBe(88);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a second deterministic `SeedExpander` to `packages/codec-image/src/adapters/seed-expander-tile-mosaic.ts`. Pairs with the placeholder from #243.

The seam claim in #243 was *"future SeedExpanders drop in by changing one import"*. Until today there was only one implementation, so the seam was structurally extracted but not behaviorally exercised. This PR adds a second genuinely distinct algorithm reaching the same `(grid, codebook)` surface, and pins the swap with a regression test.

## Algorithm distinction

| Expander | Treatment of grid | Per-cell behavior |
|---|---|---|
| `placeholderSeedExpander` | 1D | `tokens[i mod len]` + positional salt — no 2D awareness |
| `tileMosaicSeedExpander` | 2D | seed tokens laid out as near-square coarse mosaic; each target cell looks up its enclosing tile's base, then adds a per-position salt — adjacent cells inside the same tile share base, neighboring tiles use different seed tokens |

Both are **deterministic** with identical input → output triple semantics. Both are **placeholder-class** (no trained-projector claim). The structural difference is what makes the seam a real ABI rather than a refactor.

## Out of scope

- **Selection wiring.** This PR does not modify `pipeline/adapter.ts`. The default expander remains `placeholderSeedExpander` and no env var consumes `WITTGENSTEIN_IMAGE_SEED_EXPANDER` yet. Selection is a follow-up slice per the explicit guidance in [#251](https://github.com/p-to-q/wittgenstein/issues/251) Lane 1A: *"Selection: defer. Probably an env var consumed in pipeline/adapter.ts, defaulting to 'placeholder'. But selection is a separate slice — start with just the second impl."*
- **Trained projector.** Still the M1B umbrella under #70, still research-led, still requires a frozen-decoder pick + dataset before code.

## Tests

8 cases in `seed-expander-tile-mosaic.test.ts`:
- 6 mirroring the placeholder's existing tests (shape preservation, determinism, per-spec seed variation, seedCode token variation, decoder resolution respect, codebook bound)
- 1 **distinct-from-placeholder** (the seam-is-an-ABI claim — fails if the two algorithms degenerate to the same output)
- 1 **structural claim** (adjacent cells inside the same tile differ only by the per-position salt — the tile-mosaic algorithm contract; fails if the implementation drifts away from the documented behavior)

40/40 image tests pass (was 32; +8 new). No existing tests modified.

## Verification

- [x] `pnpm --filter @wittgenstein/codec-image typecheck` — green
- [x] `pnpm --filter @wittgenstein/codec-image lint` — green
- [x] `pnpm --filter @wittgenstein/codec-image test` — 40/40
- [x] `pnpm -r typecheck` — green across all packages

## References

- Refs [#251](https://github.com/p-to-q/wittgenstein/issues/251) Lane 1A
- Refs [#70](https://github.com/p-to-q/wittgenstein/issues/70) (M1B umbrella, future trained projector)
- Refs [#243](https://github.com/p-to-q/wittgenstein/pull/243) (SeedExpander seam extraction)
- ADR-0018 §"Adapter is redefined primarily as a seed expander"

🤖 Generated with [Claude Code](https://claude.com/claude-code)