### PR TITLE
feat(cli): image-dry-expand subcommand for offline VSC inspection (#251 Lane 1D)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -50,6 +50,7 @@
     "smoke": "node ./bin/wittgenstein.js doctor"
   },
   "dependencies": {
+    "@wittgenstein/codec-image": "workspace:*",
     "@wittgenstein/core": "workspace:*",
     "@wittgenstein/schemas": "workspace:*",
     "commander": "^14.0.3",

--- a/packages/cli/src/commands/image-dry-expand.ts
+++ b/packages/cli/src/commands/image-dry-expand.ts
@@ -1,0 +1,184 @@
+import type { Command } from "commander";
+import {
+  DecoderFamilySchema,
+  ImageVisualSeedCodeSchema,
+  placeholderSeedExpander,
+  tileMosaicSeedExpander,
+  type ImageSceneSpec,
+  type SeedExpander,
+} from "@wittgenstein/codec-image";
+
+interface DryExpandOptions {
+  seedCode: string;
+  grid: string;
+  seed?: string;
+  family?: string;
+  mode?: string;
+  decoderFamily?: string;
+  codebook?: string;
+  codebookVersion?: string;
+  expander?: string;
+  ascii?: boolean;
+}
+
+/**
+ * `wittgenstein image-dry-expand` — offline inspection of what a SeedExpander
+ * would emit for a given Visual Seed Code, without invoking the harness, the
+ * LLM, or the decoder. Exists so VSC research and prompt-stack iteration can
+ * see the deterministic output of the placeholder / tile-mosaic expanders
+ * without scheduling a full run.
+ *
+ * Lane 1D of the #251 forward-program package. Pure observability — does not
+ * change codec or harness behavior.
+ *
+ * Output is JSON on stdout (or an ASCII grid view with `--ascii`); both forms
+ * are deterministic for a fixed `(seedCode, decoder, seed, expander)` tuple
+ * since the expanders themselves are deterministic.
+ */
+export function registerImageDryExpandCommand(program: Command): void {
+  program
+    .command("image-dry-expand")
+    .description(
+      "Offline preview of SeedExpander output for a given Visual Seed Code (no harness, no decoder).",
+    )
+    .requiredOption("--seed-code <json>", "JSON array of seed code tokens, e.g. '[3,17,9,220]'")
+    .requiredOption("--grid <WxH>", "target latent grid, e.g. '4x4' or '8x4'")
+    .option("--seed <number>", "per-spec deterministic seed", "0")
+    .option("--family <name>", "seedCode family", "vqvae")
+    .option("--mode <name>", "seedCode mode (prefix | full | …)", "prefix")
+    .option("--decoder-family <name>", "decoder family hint", "llamagen")
+    .option("--codebook <name>", "decoder codebook name", "stub-codebook")
+    .option("--codebook-version <name>", "decoder codebook version", "v0")
+    .option("--expander <name>", "expander to invoke (placeholder | tile-mosaic)", "placeholder")
+    .option("--ascii", "print a fixed-width ASCII token grid instead of JSON")
+    .action((options: DryExpandOptions) => {
+      try {
+        runDryExpand(options);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        process.stderr.write(`image-dry-expand: ${message}\n`);
+        process.exitCode = 1;
+      }
+    });
+}
+
+function runDryExpand(options: DryExpandOptions): void {
+  const tokens = parseSeedCodeTokens(options.seedCode);
+  const [width, height] = parseGrid(options.grid);
+  const seed = parseSeed(options.seed);
+  const expander = pickExpander(options.expander ?? "placeholder");
+
+  const seedCode = ImageVisualSeedCodeSchema.parse({
+    family: options.family ?? "vqvae",
+    mode: options.mode ?? "prefix",
+    tokens,
+  });
+
+  const decoderFamilyParse = DecoderFamilySchema.safeParse(options.decoderFamily ?? "llamagen");
+  if (!decoderFamilyParse.success) {
+    throw new Error(
+      `--decoder-family must be one of ${DecoderFamilySchema.options.join(", ")}. Got: ${options.decoderFamily}`,
+    );
+  }
+  const decoder: ImageSceneSpec["decoder"] = {
+    family: decoderFamilyParse.data,
+    codebook: options.codebook ?? "stub-codebook",
+    codebookVersion: options.codebookVersion ?? "v0",
+    latentResolution: [width, height],
+  };
+
+  const result = expander.expander.expand({ seedCode, decoder, seed });
+
+  if (options.ascii) {
+    process.stdout.write(`expander: ${expander.name}\n`);
+    process.stdout.write(`seedCode: ${seedCode.family} ${seedCode.mode} ${JSON.stringify(seedCode.tokens)}\n`);
+    process.stdout.write(
+      `decoder: ${decoder.family}/${decoder.codebook}/${decoder.codebookVersion} ${width}x${height}\n`,
+    );
+    process.stdout.write(`seed: ${seed}\n`);
+    process.stdout.write(`grid (codebook indices):\n`);
+    const cellWidth = Math.max(4, String(Math.max(...result.tokens)).length + 1);
+    for (let y = 0; y < height; y += 1) {
+      const cells: string[] = [];
+      for (let x = 0; x < width; x += 1) {
+        const value = result.tokens[y * width + x] ?? 0;
+        cells.push(String(value).padStart(cellWidth, " "));
+      }
+      process.stdout.write(`${cells.join("")}\n`);
+    }
+    return;
+  }
+
+  const payload = {
+    expander: expander.name,
+    seedCode: {
+      family: seedCode.family,
+      mode: seedCode.mode,
+      tokens: seedCode.tokens,
+    },
+    decoder,
+    seed,
+    tokens: chunkRowMajor(result.tokens, width),
+  };
+  process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function parseSeedCodeTokens(raw: string): number[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`--seed-code must be a JSON array, got: ${raw}`);
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error(`--seed-code must be a JSON array, got: ${raw}`);
+  }
+  if (parsed.length === 0) {
+    throw new Error("--seed-code must contain at least one token.");
+  }
+  if (!parsed.every((value) => typeof value === "number" && Number.isFinite(value))) {
+    throw new Error("--seed-code tokens must all be finite numbers.");
+  }
+  return parsed as number[];
+}
+
+function parseGrid(raw: string): [number, number] {
+  const match = /^([0-9]+)x([0-9]+)$/i.exec(raw.trim());
+  if (!match) {
+    throw new Error(`--grid must be of the form WxH (e.g. 4x4), got: ${raw}`);
+  }
+  const width = Number.parseInt(match[1]!, 10);
+  const height = Number.parseInt(match[2]!, 10);
+  if (width <= 0 || height <= 0) {
+    throw new Error(`--grid dimensions must be positive integers, got: ${raw}`);
+  }
+  return [width, height];
+}
+
+function parseSeed(raw: string | undefined): number {
+  if (raw === undefined || raw === "") return 0;
+  const value = Number.parseInt(raw, 10);
+  if (!Number.isFinite(value)) {
+    throw new Error(`--seed must be an integer, got: ${raw}`);
+  }
+  return value;
+}
+
+interface NamedExpander {
+  readonly name: "placeholder" | "tile-mosaic";
+  readonly expander: SeedExpander;
+}
+
+function pickExpander(name: string): NamedExpander {
+  if (name === "placeholder") return { name: "placeholder", expander: placeholderSeedExpander };
+  if (name === "tile-mosaic") return { name: "tile-mosaic", expander: tileMosaicSeedExpander };
+  throw new Error(`--expander must be one of: placeholder, tile-mosaic. Got: ${name}`);
+}
+
+function chunkRowMajor(tokens: readonly number[], width: number): number[][] {
+  const rows: number[][] = [];
+  for (let i = 0; i < tokens.length; i += width) {
+    rows.push(tokens.slice(i, i + width));
+  }
+  return rows;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import { registerInitCommand } from "./commands/init.js";
 import { registerImageCommand } from "./commands/image.js";
+import { registerImageDryExpandCommand } from "./commands/image-dry-expand.js";
 import { registerAudioCommand } from "./commands/audio.js";
 import { registerTtsCommand } from "./commands/tts.js";
 import { registerVideoCommand } from "./commands/video.js";
@@ -20,6 +21,7 @@ export function createProgram(): Command {
 
   registerInitCommand(program);
   registerImageCommand(program);
+  registerImageDryExpandCommand(program);
   registerTtsCommand(program);
   registerAudioCommand(program);
   registerVideoCommand(program);

--- a/packages/cli/test/image-dry-expand.test.ts
+++ b/packages/cli/test/image-dry-expand.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { createProgram } from "../src/index.js";
+
+describe("image-dry-expand command", () => {
+  it("registers as a top-level command with the documented options", () => {
+    const command = createProgram().commands.find((c) => c.name() === "image-dry-expand");
+    expect(command).toBeDefined();
+    expect(command?.options.map((option) => option.long).sort()).toEqual([
+      "--ascii",
+      "--codebook",
+      "--codebook-version",
+      "--decoder-family",
+      "--expander",
+      "--family",
+      "--grid",
+      "--mode",
+      "--seed",
+      "--seed-code",
+    ]);
+  });
+});

--- a/packages/cli/test/index.test.ts
+++ b/packages/cli/test/index.test.ts
@@ -13,6 +13,7 @@ describe("@wittgenstein/cli", () => {
       "audio",
       "doctor",
       "image",
+      "image-dry-expand",
       "init",
       "sensor",
       "svg",

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -6,6 +6,7 @@
   },
   "include": ["src/**/*"],
   "references": [
+    { "path": "../codec-image" },
     { "path": "../core" },
     { "path": "../schemas" }
   ]

--- a/packages/codec-image/src/index.ts
+++ b/packages/codec-image/src/index.ts
@@ -2,3 +2,9 @@ export * from "./codec.js";
 export * from "./schema.js";
 export * from "./types.js";
 export * from "./pipeline/index.js";
+export {
+  placeholderSeedExpander,
+  type SeedExpander,
+  type SeedExpansionInput,
+} from "./adapters/seed-expander.js";
+export { tileMosaicSeedExpander } from "./adapters/seed-expander-tile-mosaic.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,6 +61,12 @@ importers:
         specifier: ^2.1.0
         version: 2.1.9(@types/node@25.6.0)(lightningcss@1.32.0)
 
+  apps/_vercel-kimi-out:
+    devDependencies:
+      sharp:
+        specifier: ^0.33.5
+        version: 0.33.5
+
   apps/presentation: {}
 
   apps/site:
@@ -79,6 +85,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@wittgenstein/codec-image':
+        specifier: workspace:*
+        version: link:../codec-image
       '@wittgenstein/core':
         specifier: workspace:*
         version: link:../core
@@ -705,10 +714,22 @@ packages:
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
 
+  '@img/sharp-darwin-arm64@0.33.5':
+    resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
   '@img/sharp-darwin-arm64@0.34.5':
     resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.33.5':
+    resolution: {integrity: sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
     os: [darwin]
 
   '@img/sharp-darwin-x64@0.34.5':
@@ -717,9 +738,19 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@img/sharp-libvips-darwin-arm64@1.0.4':
+    resolution: {integrity: sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@img/sharp-libvips-darwin-arm64@1.2.4':
     resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
     cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.0.4':
+    resolution: {integrity: sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==}
+    cpu: [x64]
     os: [darwin]
 
   '@img/sharp-libvips-darwin-x64@1.2.4':
@@ -727,9 +758,19 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@img/sharp-libvips-linux-arm64@1.0.4':
+    resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
+    cpu: [arm64]
+    os: [linux]
+
   '@img/sharp-libvips-linux-arm64@1.2.4':
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm@1.0.5':
+    resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
+    cpu: [arm]
     os: [linux]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
@@ -747,9 +788,19 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@img/sharp-libvips-linux-s390x@1.0.4':
+    resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
+    cpu: [s390x]
+    os: [linux]
+
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-x64@1.0.4':
+    resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
+    cpu: [x64]
     os: [linux]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
@@ -757,9 +808,19 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
+    resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
+    cpu: [arm64]
+    os: [linux]
+
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
+    resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
+    cpu: [x64]
     os: [linux]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
@@ -767,10 +828,22 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@img/sharp-linux-arm64@0.33.5':
+    resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.33.5':
+    resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
     os: [linux]
 
   '@img/sharp-linux-arm@0.34.5':
@@ -791,10 +864,22 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@img/sharp-linux-s390x@0.33.5':
+    resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.33.5':
+    resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
     os: [linux]
 
   '@img/sharp-linux-x64@0.34.5':
@@ -803,10 +888,22 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@img/sharp-linuxmusl-arm64@0.33.5':
+    resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.33.5':
+    resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
     os: [linux]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
@@ -814,6 +911,11 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+
+  '@img/sharp-wasm32@0.33.5':
+    resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -826,10 +928,22 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@img/sharp-win32-ia32@0.33.5':
+    resolution: {integrity: sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
   '@img/sharp-win32-ia32@0.34.5':
     resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.33.5':
+    resolution: {integrity: sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
     os: [win32]
 
   '@img/sharp-win32-x64@0.34.5':
@@ -1389,6 +1503,13 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  color-string@1.9.1:
+    resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
+
+  color@4.2.3:
+    resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
+    engines: {node: '>=12.5.0'}
+
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
@@ -1648,6 +1769,9 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  is-arrayish@0.3.4:
+    resolution: {integrity: sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -1993,6 +2117,10 @@ packages:
     resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
     engines: {node: '>=10'}
 
+  sharp@0.33.5:
+    resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -2007,6 +2135,9 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  simple-swizzle@0.2.4:
+    resolution: {integrity: sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -2502,9 +2633,19 @@ snapshots:
 
   '@img/colour@1.1.0': {}
 
+  '@img/sharp-darwin-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.0.4
+    optional: true
+
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.0.4
     optional: true
 
   '@img/sharp-darwin-x64@0.34.5':
@@ -2512,13 +2653,25 @@ snapshots:
       '@img/sharp-libvips-darwin-x64': 1.2.4
     optional: true
 
+  '@img/sharp-libvips-darwin-arm64@1.0.4':
+    optional: true
+
   '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.0.4':
     optional: true
 
   '@img/sharp-libvips-darwin-x64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linux-arm64@1.0.4':
+    optional: true
+
   '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.0.5':
     optional: true
 
   '@img/sharp-libvips-linux-arm@1.2.4':
@@ -2530,21 +2683,43 @@ snapshots:
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linux-s390x@1.0.4':
+    optional: true
+
   '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.0.4':
     optional: true
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
+    optional: true
+
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     optional: true
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     optional: true
 
+  '@img/sharp-linux-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.0.4
+    optional: true
+
   '@img/sharp-linux-arm64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.0.5
     optional: true
 
   '@img/sharp-linux-arm@0.34.5':
@@ -2562,9 +2737,19 @@ snapshots:
       '@img/sharp-libvips-linux-riscv64': 1.2.4
     optional: true
 
+  '@img/sharp-linux-s390x@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.0.4
+    optional: true
+
   '@img/sharp-linux-s390x@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.0.4
     optional: true
 
   '@img/sharp-linux-x64@0.34.5':
@@ -2572,14 +2757,29 @@ snapshots:
       '@img/sharp-libvips-linux-x64': 1.2.4
     optional: true
 
+  '@img/sharp-linuxmusl-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
+    optional: true
+
   '@img/sharp-linuxmusl-arm64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
     optional: true
 
+  '@img/sharp-linuxmusl-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
+    optional: true
+
   '@img/sharp-linuxmusl-x64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.33.5':
+    dependencies:
+      '@emnapi/runtime': 1.10.0
     optional: true
 
   '@img/sharp-wasm32@0.34.5':
@@ -2590,7 +2790,13 @@ snapshots:
   '@img/sharp-win32-arm64@0.34.5':
     optional: true
 
+  '@img/sharp-win32-ia32@0.33.5':
+    optional: true
+
   '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.33.5':
     optional: true
 
   '@img/sharp-win32-x64@0.34.5':
@@ -3077,6 +3283,16 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  color-string@1.9.1:
+    dependencies:
+      color-name: 1.1.4
+      simple-swizzle: 0.2.4
+
+  color@4.2.3:
+    dependencies:
+      color-convert: 2.0.1
+      color-string: 1.9.1
+
   commander@14.0.3: {}
 
   concat-map@0.0.1: {}
@@ -3406,6 +3622,8 @@ snapshots:
       wrappy: 1.0.2
 
   inherits@2.0.4: {}
+
+  is-arrayish@0.3.4: {}
 
   is-extglob@2.1.1: {}
 
@@ -3744,6 +3962,32 @@ snapshots:
     dependencies:
       type-fest: 0.13.1
 
+  sharp@0.33.5:
+    dependencies:
+      color: 4.2.3
+      detect-libc: 2.1.2
+      semver: 7.7.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.33.5
+      '@img/sharp-darwin-x64': 0.33.5
+      '@img/sharp-libvips-darwin-arm64': 1.0.4
+      '@img/sharp-libvips-darwin-x64': 1.0.4
+      '@img/sharp-libvips-linux-arm': 1.0.5
+      '@img/sharp-libvips-linux-arm64': 1.0.4
+      '@img/sharp-libvips-linux-s390x': 1.0.4
+      '@img/sharp-libvips-linux-x64': 1.0.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
+      '@img/sharp-linux-arm': 0.33.5
+      '@img/sharp-linux-arm64': 0.33.5
+      '@img/sharp-linux-s390x': 0.33.5
+      '@img/sharp-linux-x64': 0.33.5
+      '@img/sharp-linuxmusl-arm64': 0.33.5
+      '@img/sharp-linuxmusl-x64': 0.33.5
+      '@img/sharp-wasm32': 0.33.5
+      '@img/sharp-win32-ia32': 0.33.5
+      '@img/sharp-win32-x64': 0.33.5
+
   sharp@0.34.5:
     dependencies:
       '@img/colour': 1.1.0
@@ -3782,6 +4026,10 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   siginfo@2.0.0: {}
+
+  simple-swizzle@0.2.4:
+    dependencies:
+      is-arrayish: 0.3.4
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
## Summary

Adds \`wittgenstein image-dry-expand\` — an offline preview of what a SeedExpander would emit for a given Visual Seed Code, without invoking the harness, the LLM, or the decoder. Pure observability for VSC research and prompt-stack iteration.

**Stacked on [PR #252](https://github.com/p-to-q/wittgenstein/pull/252)** (tile-mosaic expander). Base is set to that branch so the diff here shows only the CLI changes; the merge order is #252 → this PR.

## Usage

\`\`\`bash
# JSON output (default), placeholder expander
wittgenstein image-dry-expand --seed-code='[3,17,9,220]' --grid 4x4 --seed 7

# ASCII grid view, tile-mosaic expander
wittgenstein image-dry-expand --seed-code='[3,17,9,220]' --grid 4x4 \
  --seed 7 --expander tile-mosaic --ascii
\`\`\`

ASCII output:
\`\`\`
expander: tile-mosaic
seedCode: vqvae prefix [3,17,9,220]
decoder: llamagen/stub-codebook/v0 4x4
seed: 7
grid (codebook indices):
 7066 7083 7114 7131
 7097 7114 7145 7162
 7134 7151 7379 7396
 7165 7182 7410 7427
\`\`\`

## Surface

| Option | Required | Default |
|---|---|---|
| \`--seed-code <json>\` | yes | — |
| \`--grid <WxH>\` | yes | — |
| \`--seed <number>\` | no | 0 |
| \`--family <name>\` | no | \"vqvae\" |
| \`--mode <name>\` | no | \"prefix\" |
| \`--decoder-family <name>\` | no | \"llamagen\" (one of llamagen / seed / dvae) |
| \`--codebook <name>\` | no | \"stub-codebook\" |
| \`--codebook-version <name>\` | no | \"v0\" |
| \`--expander <name>\` | no | \"placeholder\" (or \"tile-mosaic\") |
| \`--ascii\` | no | JSON output |

Output is deterministic for any fixed input tuple — the underlying SeedExpanders are deterministic.

## Cross-package surface

- \`@wittgenstein/codec-image\` now re-exports \`placeholderSeedExpander\`, \`tileMosaicSeedExpander\`, \`SeedExpander\`, \`SeedExpansionInput\` from the package index. External consumers (CLI, future agents, eval tools) can use the seam directly.
- \`@wittgenstein/cli\` takes a new direct dependency on \`@wittgenstein/codec-image\`. Existing harness-driven commands still flow through \`@wittgenstein/core\`; the new dep is for offline tools that don't need a full bootstrap.

## Tests

- New \`test/image-dry-expand.test.ts\` pins the option shape (10 options).
- Updated \`test/index.test.ts\` command-list to include \`image-dry-expand\`.
- 14/14 CLI tests pass (was 13; +1 new).
- 40/40 image tests still pass.
- \`pnpm -r typecheck\` green.

## What this is NOT

- Not a decoder. Tokens it emits go nowhere; this is offline preview only.
- Not a quality benchmark. Both expanders are placeholder-class with no trained-projector claim.
- Not a behavior change for any existing command — strictly additive.

## References

- Refs [#251](https://github.com/p-to-q/wittgenstein/issues/251) Lane 1D
- Builds on [#252](https://github.com/p-to-q/wittgenstein/pull/252) (tile-mosaic expander) and [#243](https://github.com/p-to-q/wittgenstein/pull/243) (SeedExpander seam)

🤖 Generated with [Claude Code](https://claude.com/claude-code)