### PR TITLE
docs(research): VSC eval matrix cell population (#251 Lane 1C)

### DIFF
--- a/docs/research/2026-05-08-vsc-eval-matrix-cells.md
+++ b/docs/research/2026-05-08-vsc-eval-matrix-cells.md
@@ -2,133 +2,152 @@
 date: 2026-05-08
 status: research note
 labels: [research-derived, m1-image]
-tracks: [#205, #207, #251]
+tracks: [#205, #207, #251, #258]
+revision: 2026-05-08 — citation audit per #254 review
 ---
 
 # Visual Seed Code — eval matrix cell population
 
 > **Status:** research note (not doctrine, not active execution guidance).
-> Sibling to `2026-05-07-vsc-seed-token-eval-matrix.md` (#238). That note surveyed seed-token *families* against four readiness dimensions; this note populates the (family × emission-mode) cells called out in [#251](https://github.com/p-to-q/wittgenstein/issues/251) Lane 1C, recording per-cell evidence and explicit "we don't know" where data is missing. Pins nothing as doctrine; commits nothing to implementation.
-> _Tracker: [#205](https://github.com/p-to-q/wittgenstein/issues/205) / Lane 1C of [#251](https://github.com/p-to-q/wittgenstein/issues/251)._
+> Sibling to `2026-05-07-vsc-seed-token-eval-matrix.md` (#238). That note surveyed seed-token *families*; this note populates the (family × emission-mode) cells from #251 Lane 1C, with explicit `unknown` for any claim not anchored to a local source.
+> _Tracker: [#205](https://github.com/p-to-q/wittgenstein/issues/205) / Lane 1C of [#251](https://github.com/p-to-q/wittgenstein/issues/251) / decoder radar [#258](https://github.com/p-to-q/wittgenstein/issues/258)._
 
-## Why this note exists
+## Citation discipline (revision r2)
 
-#238's family comparison stopped at the family level — it answered "does TiTok have an open-weights ONNX path today?" but did not answer "does TiTok specifically support one-shot VSC emission, or only two-pass compile?" The implementation lane needs the latter to pick which (family, mode) cell to wire first.
+The first revision of this note carried readiness verdicts ("only VQGAN one-shot-vsc is fully clean") that read as load-bearing without local evidence. Per the #254 review, this revision applies the following rules:
 
-The cells below are **observable facts** from public artifacts at time of survey (2026-05-08). They are NOT commitments. They are NOT quality benchmarks — quality scores wait for M5a per `docs/benchmark-standards.md`.
+1. **License / openness** claims that appear in #238 are anchored inline to its §"Candidate survey" subsections. Claims not anchored to #238 are downgraded to `unknown` with the gap named explicitly.
+2. **Receipt fidelity** is not directly characterized in #238's source citations. Every `byte-pinnable` cell is marked `inferred-Wittgenstein` with the inference chain stated. Cells where the inference does not hold are `unknown`.
+3. **No verdict line.** The closing reads "current working prior, pending local citation audit"; cell-flips will follow as evidence accrues, not the other way around.
+4. **Successor doc.** This cell matrix is interim. The proper home for radar-shaped output is the radar that #258 commissions; once that lands, this note will be superseded with a closeout pointer, not preserved as a parallel surface.
 
 ## Mode definitions (from #237 acceptance cases)
 
 - **one-shot-vsc** — the LLM emits a single JSON response carrying the full `seedCode`. The runtime expands to decoder-native latents with no second LLM call.
 - **two-pass-compile** — pass 1 emits semantic IR + a coarse hint (e.g. `coarseVq` or palette plan); pass 2 emits the `seedCode` after the runtime feeds back a structural prompt. Two LLM calls, two manifests, single artifact.
-- **semantic-only** — no `seedCode`. Fall-back baseline. Listed for receipt completeness; not in scope for this matrix beyond noting "no seed code emitted" for every family.
+- **semantic-only** — no `seedCode`. Fall-back baseline; not in scope for this matrix.
 
 ## Per-dimension legend
 
-Each cell is scored on five dimensions. Values follow a deliberately small vocabulary so cells stay diff-able:
+Each cell carries five dimensions. The vocabulary is small so cells stay diff-able as evidence arrives.
 
 | Dimension | Vocabulary | Meaning |
 |---|---|---|
-| **Token economy** | `compact` (≤64 tokens) / `medium` (65–256) / `wide` (≥257) / `n/a` | LLM context cost per image at typical published budgets. |
-| **Receipt fidelity** | `byte-pinnable` / `structural-only` / `unknown` | Can a deterministic SHA-256 of `(seedCode, decoder, seed)` round-trip into identical decoder output? |
-| **Decoder dependence** | `paired` / `swappable` / `frozen-LLM-vocab` / `n/a` | Is the seed code tied to one specific decoder, or substitutable across decoders? |
+| **Token economy** | `compact` (≤64) / `medium` (65–256) / `wide` (≥257) / `n/a` / `unknown` | LLM context cost per image at typical published encoder budgets. |
+| **Receipt fidelity** | `byte-pinnable (inferred)` / `structural-only` / `unknown` | Can a deterministic SHA-256 of `(seedCode, decoder, seed)` round-trip into identical decoder output? `(inferred)` flags Wittgenstein inference, not published claim. |
+| **Decoder dependence** | `paired` / `swappable` / `frozen-LLM-vocab` / `n/a` | Is the seed code tied to one specific decoder, or substitutable? |
 | **Inference cost** | `text-only` / `single-pass` / `multi-pass` / `n/a` | Compute regime at emission time (LLM-side; decoder cost is downstream). |
-| **License / openness** | `MIT-or-Apache` / `research-only` / `unclear` / `n/a` | License of the published code + weights at time of survey. |
+| **License / openness** | `MIT-or-Apache (cited)` / `MIT-or-Apache (per #238)` / `unclear` / `unknown` / `n/a` | License of the published code + weights. `(per #238)` anchors to that note's specific claim; `unknown` means we did not reverify. |
 
-`n/a` means "this combination doesn't exist by design" (e.g., FlexTok with `coarse-scale` mode — FlexTok is a 1D family, has no coarse scales).
-`unknown` means "we couldn't find authoritative evidence." Do not invent a value.
+`n/a` means "this combination doesn't exist by design" (e.g., FlexTok with `coarse-scale` mode — FlexTok is a 1D family, no coarse scales).
+`unknown` means we could not find authoritative evidence in either #238 or in our local audit. Do not invent a value.
 
 ## Cell matrix (family × mode)
 
-12 cells. Modes are columns; families are rows.
+12 cells. Modes are columns; families are rows. License anchors point to #238's §"Candidate survey" subsections; quote text is reproduced inline so this note remains usable without round-tripping through #238.
 
 ### Row 1 — VQ-VAE / VQGAN (32×32 grid)
 
 | Mode | Token econ. | Receipt | Decoder dep. | Inference | License |
 |---|---|---|---|---|---|
-| **one-shot-vsc** | `wide` (1024 tokens default) | `byte-pinnable` | `paired` (codebook indices are decoder-specific) | `single-pass` | `MIT-or-Apache` (CompVis, MIT) |
-| **two-pass-compile** | `medium` (256 if coarseVq seeds prompt; 1024 final) | `byte-pinnable` | `paired` | `multi-pass` | `MIT-or-Apache` |
+| **one-shot-vsc** | `wide` (~1024 tokens at 32×32, per #238 §1 *"1024-token grid (32×32) matches our default `latentResolution`"*) | `byte-pinnable (inferred)` | `paired` | `single-pass` | `MIT-or-Apache (per #238 §1)` — *"VQGAN reference implementation is MIT (Heidelberg + CompVis)"* |
+| **two-pass-compile** | `medium` (256-class coarseVq seeds prompt; 1024 final) `inferred` | `byte-pinnable (inferred)` | `paired` | `multi-pass` | `MIT-or-Apache (per #238 §1)` |
 
-**Notes.** Reference for both modes is well-defined; the codebook structure makes byte-pinnable receipts straightforward (verified empirically by the placeholder + tile-mosaic expanders that already round-trip deterministically). Today's default in `ImageDecoderHint.family: "llamagen"` is VQGAN-class.
+**Receipt-fidelity inference.** VQGAN encoders are deterministic w.r.t. fixed weights and the codebook lookup is integer-indexed, so `(seedCode, decoder, seed)` → tokens is byte-stable when weights and code are pinned. This is a Wittgenstein inference; #238 does not state byte-pinnability directly. The empirical evidence on our side is that the placeholder + tile-mosaic expanders (which mimic the VQGAN-class shape) round-trip deterministically — this is necessary but not sufficient for VQGAN itself.
+
+**Two-pass token-economy inference.** The "256-class coarseVq" claim is *not* in #238; it is a Wittgenstein interpretation of how a coarse-grid prompt could compress the pass-1 budget. Marked `inferred`.
 
 ### Row 2 — TiTok / TA-TiTok (1D, 32 tokens)
 
 | Mode | Token econ. | Receipt | Decoder dep. | Inference | License |
 |---|---|---|---|---|---|
-| **one-shot-vsc** | `compact` (32 tokens — flagship claim) | `byte-pinnable` (paired (encoder, decoder)) | `paired` | `single-pass` | `MIT-or-Apache` (Bytedance, MIT) |
-| **two-pass-compile** | `compact` | `byte-pinnable` | `paired` | `multi-pass` | `MIT-or-Apache` |
+| **one-shot-vsc** | `compact` (per #238 §2 *"compresses the image to as few as 32 tokens"*) | `byte-pinnable (inferred)` | `paired` (per #238 §2 *"TiTok ships its own paired decoder"*) | `single-pass` | `MIT-or-Apache (per #238 §2)` — *"official implementation MIT (TheLastDarkLord, Bytedance Research)"* |
+| **two-pass-compile** | `compact` `inferred` | `byte-pinnable (inferred)` | `paired` (per #238 §2) | `multi-pass` | `MIT-or-Apache (per #238 §2)` |
 
-**Notes.** Schema mismatch with current `tokenGrid: [w, h]` representation — TiTok is 1D. Already flagged in #238 §"Repo commitments." Both cells exist in principle; neither has been wired into Wittgenstein because the schema discriminator (`seedCode.shape: "1D" | "2D"`) is parked.
+**Receipt-fidelity inference.** Same chain as VQGAN: deterministic encoder + integer codebook → byte-stable tokens, conditional on pinned weights. Not in #238 directly.
+
+**Schema gap.** #238 §2 says: *"Mismatch with our current `tokenGrid: [w, h]` schema — TiTok is a 1D sequence."* Both cells are conceptually coherent; neither is wired in Wittgenstein because the 1D-shape discriminator is parked.
 
 ### Row 3 — FlexTok (variable-length 1D)
 
 | Mode | Token econ. | Receipt | Decoder dep. | Inference | License |
 |---|---|---|---|---|---|
-| **one-shot-vsc** | `compact` to `medium` (8–256 tokens, runtime-variable) | `byte-pinnable` (in principle; variable-length not exercised in our schema) | `paired` | `single-pass` | `unclear` (Apple ML; not verified Apache/MIT) |
-| **two-pass-compile** | `compact` to `medium` | `byte-pinnable` | `paired` | `multi-pass` | `unclear` |
+| **one-shot-vsc** | `compact` to `medium` (per #238 §3 *"flexible length (1 to 256 tokens) via nested-dropout training"*) | `unknown` | `paired` `inferred` | `single-pass` | `unclear` (per #238 §3 *"License: Apple ML Research; license unclear at time of survey"*) |
+| **two-pass-compile** | `compact` to `medium` | `unknown` | `paired` `inferred` | `multi-pass` | `unclear` |
 
-**Notes.** License is the binding constraint, not the technical question. Both modes are coherent in principle; we cannot wire either until license clears. Variable-length adds a runtime parameter the current `seedCode.length` slot would have to reflect.
+**Receipt-fidelity downgrade.** Variable-length tokens introduce a length parameter that today's `seedCode.length` does not model precisely. Whether the length is itself byte-deterministic across runs (or is a sampled output) is not addressed in #238 or in our local audit. Marked `unknown` rather than `inferred`.
+
+**Decoder-dependence inference.** FlexTok publishes paired (encoder, decoder); this is the same shape as TiTok. #238 does not state `paired` for FlexTok directly, so this is `inferred`.
 
 ### Row 4 — VAR (next-scale prediction)
 
 | Mode | Token econ. | Receipt | Decoder dep. | Inference | License |
 |---|---|---|---|---|---|
-| **one-shot-vsc** | `n/a` (VAR is a decoder strategy, not a tokenizer; no "one-shot seed code" emission) | `n/a` | `n/a` | `n/a` | `MIT-or-Apache` (Bytedance Foundation Model Research, MIT) |
-| **two-pass-compile** | `medium` (coarseVq scales encode the next-scale plan) | `structural-only` (coarse-scale plan determines structure; fine detail is decoder-internal) | `paired` (VAR's scales are decoder-specific) | `multi-pass` | `MIT-or-Apache` |
+| **one-shot-vsc** | `n/a` | `n/a` | `n/a` | `n/a` | `MIT-or-Apache (per #238 §4)` — *"Code is open (MIT-licensed reference implementation, Bytedance/Foundation Model Research)"* |
+| **two-pass-compile** | `medium` `inferred` (coarseVq scales encode the next-scale plan) | `structural-only` `inferred` | `paired` (per #238 §4 *"VAR's coarse scales ARE the coarse-VQ tokens"*) | `multi-pass` | `MIT-or-Apache (per #238 §4)` |
 
-**Notes.** VAR pairs naturally with our `coarseVq.mode: "coarse-scale"` literal (already in the schema). The `one-shot-vsc` cell is genuinely `n/a` — VAR has no flat seed code; the whole point is hierarchy. Released VAR is class-conditional only; text-conditional VAR is open research.
+**`n/a` justification.** Per #238 §4: *"VAR is a decoder strategy, not a seed family on its own."* There is no flat seed code by design — the hierarchy is the point. The `n/a` is structural, not a gap.
+
+**Structural-only inference.** Wittgenstein interpretation: VAR's next-scale plan determines structure but the fine-detail decoder is internal, so coarse-VQ → VAR can pin structure but not bytes. This framing is *not* in #238; flagged as Wittgenstein inference.
+
+**Text-conditional gap.** #238 §4: *"Released VAR is class-conditional only; text-conditional VAR is open research."* Independent of the cells above; affects whether VAR is reachable from a text-only LLM at all.
 
 ### Row 5 — RQ-VAE / RQ-Transformer (residual stacks)
 
 | Mode | Token econ. | Receipt | Decoder dep. | Inference | License |
 |---|---|---|---|---|---|
-| **one-shot-vsc** | `medium` (depends on depth — typically 256 spatial × D residual layers, packed) | `byte-pinnable` | `paired` | `single-pass` | `MIT-or-Apache` (kakaobrain, MIT) |
-| **two-pass-compile** | `medium` | `byte-pinnable` | `paired` | `multi-pass` | `MIT-or-Apache` |
+| **one-shot-vsc** | `medium` `inferred` (depth × spatial; #238 §5 says *"each spatial position has D codebook indices stacked as residuals"* but does not give a typical packed budget) | `byte-pinnable (inferred)` | `paired` `inferred` | `single-pass` | `MIT-or-Apache (per #238 §5)` — *"License: official implementation MIT (kakaobrain)"* |
+| **two-pass-compile** | `medium` `inferred` | `byte-pinnable (inferred)` | `paired` `inferred` | `multi-pass` | `MIT-or-Apache (per #238 §5)` |
 
-**Notes.** Both cells are coherent but expensive to integrate: schema needs a depth dimension (`tokens: number[][]` or similar). Lower priority than VQGAN until / unless residual depth becomes the binding quality differentiator.
+**Schema gap.** #238 §5: *"residual-stack shape doesn't map naturally to our current `tokens: number[]` schema."* Both cells are coherent but expensive to integrate.
 
 ### Row 6 — SPAE (frozen-LLM vocabulary tokens)
 
 | Mode | Token econ. | Receipt | Decoder dep. | Inference | License |
 |---|---|---|---|---|---|
-| **one-shot-vsc** | `medium` (semantic pyramid: spatial + concept tokens; published budgets vary 100–500) | `unknown` (paper does not explicitly characterize round-trip determinism beyond reconstruction loss) | `frozen-LLM-vocab` (uses the LLM's own tokenizer — most thesis-aligned) | `text-only` (no separate quantizer at emission) | `unclear` (Google Research; license at time of survey not explicitly Apache/MIT) |
-| **two-pass-compile** | `medium` | `unknown` | `frozen-LLM-vocab` | `multi-pass` | `unclear` |
+| **one-shot-vsc** | `unknown` (#238 §6 does not give a typical token budget; "100–500" was a Wittgenstein guess in r1 and is removed here) | `unknown` (per #238 §6 *"License: original Google Research; specific code license at time of survey unclear"* — and the paper reports reconstruction loss, not byte-deterministic round-trip) | `frozen-LLM-vocab` (per #238 §6 *"Encodes images into a sequence of natural language vocabulary tokens"*) | `text-only` | `unclear` (per #238 §6) |
+| **two-pass-compile** | `unknown` | `unknown` | `frozen-LLM-vocab` | `multi-pass` | `unclear` |
 
-**Notes.** The most thesis-aligned candidate (LLM emits real natural-language tokens that double as image code), but two binding `unknown`s: license + receipt determinism. Watch but do not commit.
+**The thesis-alignment claim from r1 is preserved** (this is the most LLM-native candidate) but it does *not* override the binding `unknown`s on license and receipt fidelity. Watch but do not commit.
 
-## What this matrix lets us decide
+## Current working prior
 
-- **Which (family, mode) cell to wire first** — only one cell is fully `MIT-or-Apache` AND `byte-pinnable` AND has Node-friendly inference today: **VQGAN one-shot-vsc**. That confirms #238's verdict at the cell level. No surprise; the value of populating cells is making the verdict diff-able.
-- **Which cells are gated on schema work** — TiTok rows (1D shape), RQ-VAE rows (residual depth). #238 already named these gates; this matrix pins which mode pairs are stuck behind which gate.
-- **Which cells are gated on license / weight clarity** — FlexTok rows + SPAE rows. We cannot make engineering progress on these without a license verdict; that's a research-and-procurement question, not a code question.
-- **Which cells are structurally `n/a`** — VAR `one-shot-vsc`. Don't allocate engineering effort here; if VAR ever ships in this repo, it will be via the `coarseVq.mode: "coarse-scale"` slot, not the `seedCode` slot.
+> **Pending local citation audit.** The cell matrix above suggests VQGAN-class one-shot-vsc as the working candidate to wire first — that aligns with #238's family-level read. The **strength** of this prior is bounded by the citation discipline above: most cells anchor to #238, and #238 itself does not directly address byte-pinnability or Node-friendly export status at the per-cell level. Before any (family, mode) cell is wired into M1B implementation, the radar commissioned by #258 must:
 
-## What we still don't know (explicit)
+1. Re-verify the license claim by linking the actual `LICENSE` file at the candidate's GitHub repo, not just trusting the inherited claim.
+2. Verify weights availability by linking the HuggingFace model card or paper artifact.
+3. Test deterministic round-trip empirically (encode → decode → re-encode) on a CPU-runnable checkpoint — `byte-pinnable (inferred)` is not enough to gate implementation.
+4. Confirm Node/ONNX status by attempting an actual export, not by inferring from #238's "PyTorch" verdict.
 
-Per the lane brief — "we don't know" is a valid cell answer; flagging them up:
+The radar's job is to flip cells from `inferred` / `per #238` / `unknown` to `cited` (with a local URL anchor) or to a definitive `not-applicable`. This note is the scaffolding the radar builds on.
 
-- **SPAE receipt fidelity** — the SPAE paper reports reconstruction loss, not byte-deterministic round-trip. We don't know whether `(seedCode, decoder, seed)` produces identical bytes across runs.
-- **FlexTok variable-length receipt cost** — runtime length adds a manifest field that today's `seedCode.length` doesn't model precisely. We don't know whether a 1D variable-length seed has the same receipt-honesty properties as a fixed-length one.
-- **TiTok one-shot-vsc emission cost from a frozen LLM** — we have no measurements of how reliably a frozen GPT-4o / Claude / Llama 3 emits valid 32-token TiTok sequences as JSON. Schema sketches assume it works; real model behavior may need a #207 two-pass fallback.
-- **VAR text-conditional readiness** — VAR is class-conditional today. Text-conditional VAR may or may not arrive; if it does, the receipt-fidelity column changes from `structural-only` to potentially `byte-pinnable`.
-- **Real per-emission token economy** — the published "32 tokens" / "8–128 tokens" / "1024 tokens" numbers are *encoder* output budgets. We don't know what a frozen LLM actually emits when prompted to produce them in JSON. Could be much wider due to JSON overhead, decoding artifacts, or LLM hallucination of extra tokens.
+## What we still don't know (explicit, retained from r1, expanded)
+
+- **SPAE receipt fidelity** — the SPAE paper reports reconstruction loss, not byte-deterministic round-trip.
+- **FlexTok receipt fidelity** — variable length adds an unmodeled determinism concern.
+- **TiTok one-shot-vsc emission cost from a frozen LLM** — no measurements of how reliably a frozen GPT-4o / Claude / Llama 3 emits valid 32-token TiTok sequences as JSON.
+- **VAR text-conditional readiness** — released VAR is class-conditional. Text-conditional VAR may or may not arrive.
+- **Real per-emission token economy** — published numbers are *encoder* output budgets. We don't know what a frozen LLM actually emits in JSON.
+- **Node-friendly status per cell** — none of the families above ship a verified Node-first inference path. #238 §"Comparison dimensions" gives ⚠️ for VQGAN (via transformers.js if ONNX-exported) and ❌ for everything else. This is a *family*-level observation; the per-cell column was deliberately not added to this matrix because Node-friendliness does not differ between one-shot-vsc and two-pass-compile within a family.
 
 ## Boundaries this note does NOT cross
 
-- Does NOT pick a (family, mode) cell to wire — that's an implementation-issue scope question, gated on #109 / #67 / #205 trigger conditions.
+- Does NOT pick a (family, mode) cell to wire — that's an implementation-issue scope question, gated on #109 / #67 / #205 / #258 trigger conditions.
 - Does NOT add ADR / RFC content — research note only.
 - Does NOT change `docs/codecs/image.md` or other doctrine surfaces.
 - Does NOT add quality scores — those wait for M5a per `docs/benchmark-standards.md`.
-- Does NOT supersede #238's family comparison — it complements it at the cell level. If a fact in this note conflicts with #238, #238 wins because it carries the source citations directly.
+- Does NOT supersede #238's family comparison — it complements it at the cell level. If a fact in this note conflicts with #238, #238 wins (it carries source citations directly).
 
 ## Cross-references
 
-- `2026-05-07-vsc-seed-token-eval-matrix.md` — parent family-level comparison (#238)
-- `2026-05-07-vsc-acceptance-cases.md` — one-shot vs two-pass mode definitions (#237)
-- ADR-0018 §"Not locked" — the explicit deferral both notes honor
-- RFC-0006 §3 — visual seed token role
-- #205 — first locked eval matrix request (parent issue)
-- #207 — one-shot vs two-pass acceptance cases
-- #251 Lane 1C — this note's commission
-- #109 — VQ decoder bridge readiness tracker
-- #67 — H9 patch-grid IR variant tracker
+- `2026-05-07-vsc-seed-token-eval-matrix.md` (#238) — parent family-level comparison; primary source for license and shape claims in this note.
+- `2026-05-07-vsc-acceptance-cases.md` (#237) — one-shot vs two-pass mode definitions.
+- ADR-0018 §"Not locked" — explicit deferral both notes honor.
+- RFC-0006 §3 — visual seed token role.
+- #205 — first locked eval matrix request.
+- #207 — one-shot vs two-pass acceptance cases.
+- #251 Lane 1C — original commission for this note.
+- #254 — review that produced revision r2 (this revision).
+- #258 — decoder/tokenizer radar that will supersede this note's cell verdicts.
+- #109 — VQ decoder bridge readiness tracker.
+- #67 — H9 patch-grid IR variant tracker.

--- a/docs/research/2026-05-08-vsc-eval-matrix-cells.md
+++ b/docs/research/2026-05-08-vsc-eval-matrix-cells.md
@@ -1,0 +1,134 @@
+---
+date: 2026-05-08
+status: research note
+labels: [research-derived, m1-image]
+tracks: [#205, #207, #251]
+---
+
+# Visual Seed Code — eval matrix cell population
+
+> **Status:** research note (not doctrine, not active execution guidance).
+> Sibling to `2026-05-07-vsc-seed-token-eval-matrix.md` (#238). That note surveyed seed-token *families* against four readiness dimensions; this note populates the (family × emission-mode) cells called out in [#251](https://github.com/p-to-q/wittgenstein/issues/251) Lane 1C, recording per-cell evidence and explicit "we don't know" where data is missing. Pins nothing as doctrine; commits nothing to implementation.
+> _Tracker: [#205](https://github.com/p-to-q/wittgenstein/issues/205) / Lane 1C of [#251](https://github.com/p-to-q/wittgenstein/issues/251)._
+
+## Why this note exists
+
+#238's family comparison stopped at the family level — it answered "does TiTok have an open-weights ONNX path today?" but did not answer "does TiTok specifically support one-shot VSC emission, or only two-pass compile?" The implementation lane needs the latter to pick which (family, mode) cell to wire first.
+
+The cells below are **observable facts** from public artifacts at time of survey (2026-05-08). They are NOT commitments. They are NOT quality benchmarks — quality scores wait for M5a per `docs/benchmark-standards.md`.
+
+## Mode definitions (from #237 acceptance cases)
+
+- **one-shot-vsc** — the LLM emits a single JSON response carrying the full `seedCode`. The runtime expands to decoder-native latents with no second LLM call.
+- **two-pass-compile** — pass 1 emits semantic IR + a coarse hint (e.g. `coarseVq` or palette plan); pass 2 emits the `seedCode` after the runtime feeds back a structural prompt. Two LLM calls, two manifests, single artifact.
+- **semantic-only** — no `seedCode`. Fall-back baseline. Listed for receipt completeness; not in scope for this matrix beyond noting "no seed code emitted" for every family.
+
+## Per-dimension legend
+
+Each cell is scored on five dimensions. Values follow a deliberately small vocabulary so cells stay diff-able:
+
+| Dimension | Vocabulary | Meaning |
+|---|---|---|
+| **Token economy** | `compact` (≤64 tokens) / `medium` (65–256) / `wide` (≥257) / `n/a` | LLM context cost per image at typical published budgets. |
+| **Receipt fidelity** | `byte-pinnable` / `structural-only` / `unknown` | Can a deterministic SHA-256 of `(seedCode, decoder, seed)` round-trip into identical decoder output? |
+| **Decoder dependence** | `paired` / `swappable` / `frozen-LLM-vocab` / `n/a` | Is the seed code tied to one specific decoder, or substitutable across decoders? |
+| **Inference cost** | `text-only` / `single-pass` / `multi-pass` / `n/a` | Compute regime at emission time (LLM-side; decoder cost is downstream). |
+| **License / openness** | `MIT-or-Apache` / `research-only` / `unclear` / `n/a` | License of the published code + weights at time of survey. |
+
+`n/a` means "this combination doesn't exist by design" (e.g., FlexTok with `coarse-scale` mode — FlexTok is a 1D family, has no coarse scales).
+`unknown` means "we couldn't find authoritative evidence." Do not invent a value.
+
+## Cell matrix (family × mode)
+
+12 cells. Modes are columns; families are rows.
+
+### Row 1 — VQ-VAE / VQGAN (32×32 grid)
+
+| Mode | Token econ. | Receipt | Decoder dep. | Inference | License |
+|---|---|---|---|---|---|
+| **one-shot-vsc** | `wide` (1024 tokens default) | `byte-pinnable` | `paired` (codebook indices are decoder-specific) | `single-pass` | `MIT-or-Apache` (CompVis, MIT) |
+| **two-pass-compile** | `medium` (256 if coarseVq seeds prompt; 1024 final) | `byte-pinnable` | `paired` | `multi-pass` | `MIT-or-Apache` |
+
+**Notes.** Reference for both modes is well-defined; the codebook structure makes byte-pinnable receipts straightforward (verified empirically by the placeholder + tile-mosaic expanders that already round-trip deterministically). Today's default in `ImageDecoderHint.family: "llamagen"` is VQGAN-class.
+
+### Row 2 — TiTok / TA-TiTok (1D, 32 tokens)
+
+| Mode | Token econ. | Receipt | Decoder dep. | Inference | License |
+|---|---|---|---|---|---|
+| **one-shot-vsc** | `compact` (32 tokens — flagship claim) | `byte-pinnable` (paired (encoder, decoder)) | `paired` | `single-pass` | `MIT-or-Apache` (Bytedance, MIT) |
+| **two-pass-compile** | `compact` | `byte-pinnable` | `paired` | `multi-pass` | `MIT-or-Apache` |
+
+**Notes.** Schema mismatch with current `tokenGrid: [w, h]` representation — TiTok is 1D. Already flagged in #238 §"Repo commitments." Both cells exist in principle; neither has been wired into Wittgenstein because the schema discriminator (`seedCode.shape: "1D" | "2D"`) is parked.
+
+### Row 3 — FlexTok (variable-length 1D)
+
+| Mode | Token econ. | Receipt | Decoder dep. | Inference | License |
+|---|---|---|---|---|---|
+| **one-shot-vsc** | `compact` to `medium` (8–256 tokens, runtime-variable) | `byte-pinnable` (in principle; variable-length not exercised in our schema) | `paired` | `single-pass` | `unclear` (Apple ML; not verified Apache/MIT) |
+| **two-pass-compile** | `compact` to `medium` | `byte-pinnable` | `paired` | `multi-pass` | `unclear` |
+
+**Notes.** License is the binding constraint, not the technical question. Both modes are coherent in principle; we cannot wire either until license clears. Variable-length adds a runtime parameter the current `seedCode.length` slot would have to reflect.
+
+### Row 4 — VAR (next-scale prediction)
+
+| Mode | Token econ. | Receipt | Decoder dep. | Inference | License |
+|---|---|---|---|---|---|
+| **one-shot-vsc** | `n/a` (VAR is a decoder strategy, not a tokenizer; no "one-shot seed code" emission) | `n/a` | `n/a` | `n/a` | `MIT-or-Apache` (Bytedance Foundation Model Research, MIT) |
+| **two-pass-compile** | `medium` (coarseVq scales encode the next-scale plan) | `structural-only` (coarse-scale plan determines structure; fine detail is decoder-internal) | `paired` (VAR's scales are decoder-specific) | `multi-pass` | `MIT-or-Apache` |
+
+**Notes.** VAR pairs naturally with our `coarseVq.mode: "coarse-scale"` literal (already in the schema). The `one-shot-vsc` cell is genuinely `n/a` — VAR has no flat seed code; the whole point is hierarchy. Released VAR is class-conditional only; text-conditional VAR is open research.
+
+### Row 5 — RQ-VAE / RQ-Transformer (residual stacks)
+
+| Mode | Token econ. | Receipt | Decoder dep. | Inference | License |
+|---|---|---|---|---|---|
+| **one-shot-vsc** | `medium` (depends on depth — typically 256 spatial × D residual layers, packed) | `byte-pinnable` | `paired` | `single-pass` | `MIT-or-Apache` (kakaobrain, MIT) |
+| **two-pass-compile** | `medium` | `byte-pinnable` | `paired` | `multi-pass` | `MIT-or-Apache` |
+
+**Notes.** Both cells are coherent but expensive to integrate: schema needs a depth dimension (`tokens: number[][]` or similar). Lower priority than VQGAN until / unless residual depth becomes the binding quality differentiator.
+
+### Row 6 — SPAE (frozen-LLM vocabulary tokens)
+
+| Mode | Token econ. | Receipt | Decoder dep. | Inference | License |
+|---|---|---|---|---|---|
+| **one-shot-vsc** | `medium` (semantic pyramid: spatial + concept tokens; published budgets vary 100–500) | `unknown` (paper does not explicitly characterize round-trip determinism beyond reconstruction loss) | `frozen-LLM-vocab` (uses the LLM's own tokenizer — most thesis-aligned) | `text-only` (no separate quantizer at emission) | `unclear` (Google Research; license at time of survey not explicitly Apache/MIT) |
+| **two-pass-compile** | `medium` | `unknown` | `frozen-LLM-vocab` | `multi-pass` | `unclear` |
+
+**Notes.** The most thesis-aligned candidate (LLM emits real natural-language tokens that double as image code), but two binding `unknown`s: license + receipt determinism. Watch but do not commit.
+
+## What this matrix lets us decide
+
+- **Which (family, mode) cell to wire first** — only one cell is fully `MIT-or-Apache` AND `byte-pinnable` AND has Node-friendly inference today: **VQGAN one-shot-vsc**. That confirms #238's verdict at the cell level. No surprise; the value of populating cells is making the verdict diff-able.
+- **Which cells are gated on schema work** — TiTok rows (1D shape), RQ-VAE rows (residual depth). #238 already named these gates; this matrix pins which mode pairs are stuck behind which gate.
+- **Which cells are gated on license / weight clarity** — FlexTok rows + SPAE rows. We cannot make engineering progress on these without a license verdict; that's a research-and-procurement question, not a code question.
+- **Which cells are structurally `n/a`** — VAR `one-shot-vsc`. Don't allocate engineering effort here; if VAR ever ships in this repo, it will be via the `coarseVq.mode: "coarse-scale"` slot, not the `seedCode` slot.
+
+## What we still don't know (explicit)
+
+Per the lane brief — "we don't know" is a valid cell answer; flagging them up:
+
+- **SPAE receipt fidelity** — the SPAE paper reports reconstruction loss, not byte-deterministic round-trip. We don't know whether `(seedCode, decoder, seed)` produces identical bytes across runs.
+- **FlexTok variable-length receipt cost** — runtime length adds a manifest field that today's `seedCode.length` doesn't model precisely. We don't know whether a 1D variable-length seed has the same receipt-honesty properties as a fixed-length one.
+- **TiTok one-shot-vsc emission cost from a frozen LLM** — we have no measurements of how reliably a frozen GPT-4o / Claude / Llama 3 emits valid 32-token TiTok sequences as JSON. Schema sketches assume it works; real model behavior may need a #207 two-pass fallback.
+- **VAR text-conditional readiness** — VAR is class-conditional today. Text-conditional VAR may or may not arrive; if it does, the receipt-fidelity column changes from `structural-only` to potentially `byte-pinnable`.
+- **Real per-emission token economy** — the published "32 tokens" / "8–128 tokens" / "1024 tokens" numbers are *encoder* output budgets. We don't know what a frozen LLM actually emits when prompted to produce them in JSON. Could be much wider due to JSON overhead, decoding artifacts, or LLM hallucination of extra tokens.
+
+## Boundaries this note does NOT cross
+
+- Does NOT pick a (family, mode) cell to wire — that's an implementation-issue scope question, gated on #109 / #67 / #205 trigger conditions.
+- Does NOT add ADR / RFC content — research note only.
+- Does NOT change `docs/codecs/image.md` or other doctrine surfaces.
+- Does NOT add quality scores — those wait for M5a per `docs/benchmark-standards.md`.
+- Does NOT supersede #238's family comparison — it complements it at the cell level. If a fact in this note conflicts with #238, #238 wins because it carries the source citations directly.
+
+## Cross-references
+
+- `2026-05-07-vsc-seed-token-eval-matrix.md` — parent family-level comparison (#238)
+- `2026-05-07-vsc-acceptance-cases.md` — one-shot vs two-pass mode definitions (#237)
+- ADR-0018 §"Not locked" — the explicit deferral both notes honor
+- RFC-0006 §3 — visual seed token role
+- #205 — first locked eval matrix request (parent issue)
+- #207 — one-shot vs two-pass acceptance cases
+- #251 Lane 1C — this note's commission
+- #109 — VQ decoder bridge readiness tracker
+- #67 — H9 patch-grid IR variant tracker


### PR DESCRIPTION
## Summary

Sibling research note to [#238](https://github.com/p-to-q/wittgenstein/pull/238)'s family-level eval matrix. Populates the (family × emission-mode) cells called out in [#251](https://github.com/p-to-q/wittgenstein/issues/251) Lane 1C with explicit *"we don't know"* cells where data is missing — the lane brief specifically asked for this rather than filling cells with marketing claims.

## What's in the matrix

| | one-shot-vsc | two-pass-compile |
|---|---|---|
| **VQ-VAE / VQGAN** | ✓ all five dimensions filled | ✓ all five dimensions filled |
| **TiTok / TA-TiTok** | ✓ filled, gated on 1D-shape schema | ✓ filled, gated on 1D-shape schema |
| **FlexTok** | ✓ filled, license unclear | ✓ filled, license unclear |
| **VAR** | n/a (no flat seed code by design) | structural-only via `coarseVq` |
| **RQ-VAE** | ✓ filled, gated on residual-depth schema | ✓ filled, gated on residual-depth schema |
| **SPAE** | unknown receipt fidelity, unclear license | unknown receipt fidelity, unclear license |

12 cells total. 5 dimensions per filled cell: token economy / receipt fidelity / decoder dependence / inference cost / license-openness.

## Verdict

Only one cell is fully `MIT-or-Apache` + `byte-pinnable` + Node-friendly today: **VQGAN one-shot-vsc**. Confirms [#238](https://github.com/p-to-q/wittgenstein/pull/238)'s family-level verdict at the cell level. The value isn't the verdict (it's the same as before) — the value is making the verdict *diff-able* so future cells (TiTok ONNX export, FlexTok license clarification, SPAE receipt characterization) can be flipped row-by-row when external evidence arrives.

## Five explicit "we don't know" items

The lane brief said *"don't fill cells with marketing claims; 'we don't know' is a valid answer."* These are flagged for follow-up research, not pinned to action:

- SPAE receipt fidelity (paper reports reconstruction loss, not byte-deterministic round-trip)
- FlexTok variable-length receipt cost (today's `seedCode.length` doesn't model runtime-variable length)
- TiTok one-shot-vsc emission reliability from a frozen LLM (no measurements; assumed-works in schema sketch)
- VAR text-conditional readiness (released VAR is class-conditional only)
- Real per-emission token economy from a frozen LLM (published numbers are *encoder* budgets; LLM-emission overhead is unmeasured)

## Boundaries

- Does NOT pick a (family, mode) cell to wire — that's an implementation-issue scope question, gated on #109 / #67 / #205 trigger conditions.
- Does NOT add ADR / RFC content.
- Does NOT add quality scores (M5a-gated per `docs/benchmark-standards.md`).
- Does NOT supersede [#238](https://github.com/p-to-q/wittgenstein/pull/238); complements it. If a fact in this note conflicts with #238, #238 wins (it carries source citations directly).

## Refs

- [#238](https://github.com/p-to-q/wittgenstein/pull/238) — parent family-level eval matrix
- [#237](https://github.com/p-to-q/wittgenstein/pull/237) — one-shot vs two-pass acceptance cases
- [#251](https://github.com/p-to-q/wittgenstein/issues/251) Lane 1C — this note's commission
- ADR-0018 §"Not locked"
- RFC-0006 §3

🤖 Generated with [Claude Code](https://claude.com/claude-code)