### PR TITLE
docs(codecs/video): align with #277 distillation framing + add lineage receipt

### DIFF
--- a/docs/codecs/video.md
+++ b/docs/codecs/video.md
@@ -37,7 +37,9 @@ pnpm exec wittgenstein video "unused" --svg ./output/a.svg --svg ./output/b.svg 
 
 ## Renderer
 
-`packages/codec-video/src/hyperframes-wrapper.ts` is the integration seam for HyperFrames-shaped **HTML compositions** and optional **local MP4** encoding.
+`packages/codec-video/src/hyperframes-wrapper.ts` is the integration seam for **HyperFrames-shaped** HTML compositions and optional local MP4 encoding.
+
+> **HyperFrames-shaped, not HyperFrames-vendored.** Per PR #277 ratification + the #282 follow-up, the upstream `heygen-com/hyperframes` package is the inspiration / reference design, not a runtime dependency. The codec borrows the *spirit* (timeline + inline-SVG composition with `data-*` timing attributes; local FFmpeg + headless-Chrome render) but the implementation must be **repo-owned**: no `heygen-com/hyperframes` import as a runtime dep, no wholesale vendoring of the package into this repo, no preserving upstream modules just because they exist. The distillation work itself is tracked in #282; the verification gates (license clearance, behavioral test corpus, doctor coverage, manifest receipts) are listed there.
 
 ### HTML (default)
 
@@ -69,3 +71,18 @@ Once the MP4 branch is merged, video should align with common evaluation practic
 - motion-specific metrics such as `FVMD` when motion realism matters
 
 The package exists now so video is a first-class codec, not an afterthought, but the current main branch is still a scaffold rather than a runnable MP4 benchmark target.
+
+## Lineage receipt
+
+For agents reading this doc cold, the lineage from the v0.2 stub to today's main HEAD:
+
+| Step | Surface | Note |
+|---|---|---|
+| Codec-video stub | `packages/codec-video/` (v0.2) | 🔴 stub at v0.2 lock; codec-v2 plan §M4 explicitly defers MP4 wiring |
+| Backend research commission | #264 | Compare HyperFrames vs Remotion / Motion Canvas / Manim / Lottie / GSAP / FFmpeg-direct |
+| Backend comparison ratification | PR #277 | HyperFrames-shaped lead path **conditional on license verification + repo-owned distillation** |
+| Distillation work commission | #282 | Six slice issues named (#282A–#282F): license audit / behavioral corpus / pure-TS HTML emitter / MP4 opt-in / doctor coverage / manifest receipt block |
+| Exec plan annotation | PR #293 | Codec v2 port plan annotated to reflect that #277 / #282 activate M4 video work post-v0.2 |
+| M4 implementation | (gated on #282 slices) | Repo-owned renderer; videoRender manifest block analogous to audioRender |
+
+The distinction matters because of the doctrine line in `docs/hard-constraints.md`: the harness ships under Apache-2.0, and any external dependency we import or vendor needs license + receipt clarity before it ships in a release artifact. HyperFrames-shaped distillation lets video M4 land without taking on that gate work for an upstream package whose license + maintenance posture haven't been audited locally.


### PR DESCRIPTION
## Summary

Drift fix surfaced by the [#266 audit](https://github.com/p-to-q/wittgenstein/issues/266)'s note that *"video.md will need updating after #264 backend research."* PR #277 has merged with the explicit clarification that HyperFrames is the **shape** (inspiration / reference design), not a runtime dependency or vendored code. video.md did not yet reflect that clarification.

Same shape as the image.md drift fix in PR #273. Pure doc alignment with already-merged work.

## What changes

1. **Renderer section** — adds a clarification block: *"HyperFrames-shaped, not HyperFrames-vendored."* Borrows the spirit (timeline + inline-SVG with `data-*` timing; local FFmpeg + headless-Chrome render) but implementation must be repo-owned. No `heygen-com/hyperframes` runtime import, no wholesale vendoring, no preserving upstream modules just because they exist. Points at #282 for the distillation slice work.

2. **New Lineage receipt subsection** (sensor.md / image.md style) — table chaining: codec-video stub (v0.2) → #264 backend research → PR #277 ratification → #282 distillation slices → PR #293 exec plan annotation → eventual M4 implementation. Notes the license-and-receipt rationale (Apache-2.0 distribution gate) for repo-owned distillation rather than vendoring.

## What this PR is NOT

- Not a code change.
- Not a doctrine change.
- Not an M4 implementation start.
- Not a tokenizer / decoder pick (that's still its own gate per #283).
- Not a HyperFrames license audit (that's #282A in the planning comment on #282).

## Refs

- #277 (the merge that introduced the distillation framing)
- #282 (distillation work)
- PR #293 (exec plan annotation)
- #266 (audit that flagged this drift)
- #264 (research commission, closed by #277)

🤖 Generated with [Claude Code](https://claude.com/claude-code)