### PR TITLE
docs(codecs/audio): add lineage receipt referencing #274 + Slice E

### DIFF
--- a/docs/codecs/audio.md
+++ b/docs/codecs/audio.md
@@ -146,3 +146,19 @@ Audio quality at v0.3 is _structurally honest_, not _aesthetically frontier_:
 The thesis surface is preserved: the LLM plans, the codec renders, the manifest records,
 and the artifact reproduces from seed within its declared determinism class. Quality lift
 remains a v0.3 concern via M5b benchmarks and a future frozen-vocoder integration.
+
+## Lineage receipt
+
+For agents reading this doc cold, the lineage from M2 closure to today's main HEAD:
+
+| Step | Surface | Note |
+|---|---|---|
+| Codec-audio M2 port | `docs/exec-plans/active/codec-v2-port.md` §M2 | Three internal routes (speech / soundscape / music); `Codec<AudioRequest, AudioArtifact>` shape; ADR-0008 codec protocol |
+| Speech backend ratification | ADR-0015 | Kokoro-82M-family default target; Piper fallback ratified-but-not-wired |
+| Slice E receipt | `docs/research/2026-05-06-m2-slice-e-kokoro-sweep-verdict.md` | Kokoro is same-platform deterministic, **not** byte-identical across macOS arm64 vs Linux x64 → procedural-audio-runtime stays default at v0.3, Kokoro opt-in via `WITTGENSTEIN_AUDIO_BACKEND=kokoro` |
+| Route enum tightening | PR #245 | `RunManifest.route` enforces `speech` / `soundscape` / `music` per #190 partial closeout |
+| Audio code-layer research | PR #274 | Per-route distinct shapes recommended (SSML enrichment for speech, MIDI event-grid for music, sensor-style operator-graph for soundscape); RFC-routed only, NOT yet ratified |
+| Sub-RFC ordering (proposed) | per #274 §"Suggested follow-ups" | Soundscape operator-graph first, MIDI event-grid second, SSML enrichment last |
+| Implementation slices | #261 | Gated on at least one sub-RFC ratification |
+
+> **Audio routes do NOT share a single token shape.** This is the central claim of #274 and the inverse of image's Visual Seed Code framing: speech is text-shaped (script + optional prosody enrichment), music is event-grid-shaped (chords / note timings), soundscape is operator-graph-shaped (deterministic operators over time). Forcing them under one VQ-tokenizer story would re-introduce the category error the image-route correction (RFC-0006 / ADR-0018) just fixed for image. Future work should respect this asymmetry.


### PR DESCRIPTION
## Summary

Drift fix paralleling [PR #273](https://github.com/p-to-q/wittgenstein/pull/273) (image.md) and [PR #296](https://github.com/p-to-q/wittgenstein/pull/296) (video.md). Adds a "Lineage receipt" subsection at the end of `docs/codecs/audio.md` capturing the chain from M2 codec-audio port through ADR-0015 / Slice E / PR #245 / PR #274 / #261.

Surfaced by [#266 audit](https://github.com/p-to-q/wittgenstein/issues/266) — the same pattern that justified the image and video drift fixes applies to audio: research note has merged, codec doc doesn't yet reference it.

## What changes

1. **New "Lineage receipt" subsection** — sensor.md / image.md / video.md style table chaining the surfaces from M2 port to today's main HEAD.

2. **Explicit non-uniform-shape callout** — audio routes do NOT share a single token shape. This is the central claim of [PR #274](https://github.com/p-to-q/wittgenstein/pull/274) and the inverse of image's VSC framing. Speech is text-shaped, music is event-grid-shaped, soundscape is operator-graph-shaped. Future work should respect this asymmetry; forcing a single VQ-tokenizer story would re-introduce the category error the image correction (RFC-0006 / ADR-0018) just fixed.

3. **Sub-RFC ordering reproduced** from [PR #274](https://github.com/p-to-q/wittgenstein/pull/274) §"Suggested follow-ups" — soundscape operator-graph first, MIDI event-grid second, SSML enrichment last — so future agents reading audio.md cold see the plan without round-tripping through the research note.

## What this PR is NOT

- Not a code change.
- Not a doctrine modification.
- Not an RFC ratification (the three audio sub-RFCs from [#274](https://github.com/p-to-q/wittgenstein/pull/274) stay parked).
- Not a re-litigation of Kokoro / Piper / procedural backend decisions.

## Refs

- PR #274 (audio research; this lineage receipt's main reference)
- ADR-0015 (speech backend ratification)
- Slice E receipt (`docs/research/2026-05-06-m2-slice-e-kokoro-sweep-verdict.md`)
- PR #245 (route enum tightening)
- #261 (audio implementation slices, downstream)
- #266 (audit that flagged this drift pattern across codec docs)
- Parallels: PR #273 (image.md), PR #296 (video.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)