### PR TITLE
ci(vercel): only deploy site on site-affecting changes

### DIFF
--- a/apps/site/README.md
+++ b/apps/site/README.md
@@ -58,6 +58,28 @@ Supported Vercel configurations:
 
 Do not treat this migration PR as the domain cutover. The Git Source and production domain should still be switched intentionally in Vercel.
 
+### When Vercel should (and should not) deploy
+
+Rule: a Vercel deployment is only meaningful when the changed files can change the shipped website bytes. Doc-only PRs, codec/runtime changes, CI changes, etc. must not trigger a Preview build.
+
+This is enforced by [`scripts/vercel-ignore-build.sh`](../../scripts/vercel-ignore-build.sh). The script returns:
+
+- exit `1` (proceed) when any of these paths changed since the previous Vercel SHA:
+  - `apps/site/**`
+  - `vercel.json` (root)
+  - `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`
+  - `.github/workflows/site.yml`
+  - `scripts/vercel-ignore-build.sh` itself
+- exit `0` (skip) for any other diff.
+
+To enforce the rule on the live project, set in **Vercel → Project Settings → Git → Ignored Build Step → Custom command**:
+
+```
+bash scripts/vercel-ignore-build.sh
+```
+
+This must be configured in the Vercel dashboard (Vercel does not honor `ignoreCommand` for build skipping from `vercel.json` alone). The script is committed so the rule is reviewable in PRs and survives project recreation.
+
 Notes:
 
 - The app is a Vite SPA, so both Vercel configs include a rewrite to `index.html`.

--- a/scripts/vercel-ignore-build.sh
+++ b/scripts/vercel-ignore-build.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Vercel "Ignored Build Step" command for the Wittgenstein monorepo.
+#
+# Wire this up in Vercel:
+#   Project Settings → Git → Ignored Build Step → Custom command:
+#       bash scripts/vercel-ignore-build.sh
+#
+# Contract (per Vercel):
+#   exit 0 → SKIP the build (no deployment)
+#   exit 1 → PROCEED with the build
+#
+# Rule we are enforcing:
+#   The site only deploys when the changed files actually affect the site
+#   build. Doc-only changes, codec/runtime changes, CI changes, etc. must
+#   not trigger a Vercel deployment, because they cannot change the
+#   shipped website bytes.
+#
+# A change touching ANY of these paths counts as site-affecting:
+#   - apps/site/**                              (the site source itself)
+#   - vercel.json                               (root Vercel config used
+#                                                when project root is the
+#                                                repo root)
+#   - package.json, pnpm-lock.yaml,             (workspace deps that the
+#     pnpm-workspace.yaml                        site build resolves)
+#   - .github/workflows/site.yml                (site CI parity surface;
+#                                                we want a Preview deploy
+#                                                when site CI changes)
+#   - scripts/vercel-ignore-build.sh            (this file — so behavior
+#                                                changes are observable)
+#
+# Anything else → skip.
+
+set -euo pipefail
+
+# Vercel runs this command from the repo root for monorepo projects.
+# When VERCEL_GIT_PREVIOUS_SHA is unset (first deploy / unknown base),
+# we fall back to building so we never accidentally suppress a needed
+# initial deploy.
+PREV_SHA="${VERCEL_GIT_PREVIOUS_SHA:-}"
+CURR_SHA="${VERCEL_GIT_COMMIT_SHA:-HEAD}"
+
+if [ -z "$PREV_SHA" ]; then
+  echo "vercel-ignore-build: no previous SHA — proceeding with build."
+  exit 1
+fi
+
+# `git diff --name-only A B` lists files changed between two commits.
+# If git plumbing is unavailable (it should not be on Vercel), proceed.
+if ! command -v git >/dev/null 2>&1; then
+  echo "vercel-ignore-build: git not available — proceeding with build."
+  exit 1
+fi
+
+CHANGED="$(git diff --name-only "$PREV_SHA" "$CURR_SHA" 2>/dev/null || true)"
+
+if [ -z "$CHANGED" ]; then
+  echo "vercel-ignore-build: no diff vs $PREV_SHA — skipping."
+  exit 0
+fi
+
+while IFS= read -r path; do
+  case "$path" in
+    apps/site/*) MATCH=1; break ;;
+    vercel.json) MATCH=1; break ;;
+    package.json) MATCH=1; break ;;
+    pnpm-lock.yaml) MATCH=1; break ;;
+    pnpm-workspace.yaml) MATCH=1; break ;;
+    .github/workflows/site.yml) MATCH=1; break ;;
+    scripts/vercel-ignore-build.sh) MATCH=1; break ;;
+  esac
+done <<< "$CHANGED"
+
+if [ "${MATCH:-0}" = "1" ]; then
+  echo "vercel-ignore-build: site-affecting change detected — proceeding with build."
+  exit 1
+fi
+
+echo "vercel-ignore-build: no site-affecting changes — skipping."
+echo "changed files were:"
+printf '  %s\n' $CHANGED
+exit 0


### PR DESCRIPTION
## Summary

Vercel currently attempts a Preview deployment on every PR, including PRs that cannot change the shipped website (doc-only, codec, CI, etc.). For external contributors this also surfaces the \"a Team member must authorize this deployment\" prompt unnecessarily.

This PR codifies the rule that a Vercel deployment is only meaningful when the changed files can affect the site bytes, and provides the script Vercel will use to enforce it.

## Changes

- Add \`scripts/vercel-ignore-build.sh\` (executable). Returns exit \`0\` to skip and exit \`1\` to build per Vercel's Ignored Build Step contract.
- Build is allowed only when the diff (\`VERCEL_GIT_PREVIOUS_SHA\` → \`VERCEL_GIT_COMMIT_SHA\`) touches:
  - \`apps/site/**\`
  - root \`vercel.json\`
  - \`package.json\`, \`pnpm-lock.yaml\`, \`pnpm-workspace.yaml\`
  - \`.github/workflows/site.yml\`
  - \`scripts/vercel-ignore-build.sh\` itself
- Document the rule and the dashboard wiring in \`apps/site/README.md\`.

## Manual deployment step (still required)

After merge, in **Vercel → Project Settings → Git → Ignored Build Step**, set the custom command to:

\`\`\`
bash scripts/vercel-ignore-build.sh
\`\`\`

The script is committed so the rule is auditable in PRs and survives Vercel project recreation.

## Test plan

Local smoke test against recent main:

- Diff \`a98d0d3..e1ab3ad\` (touches \`apps/site/**\`, \`pnpm-lock.yaml\`) → \`exit 1\` (proceed). ✅
- Diff \`458c0f5..cc39d76\` (touches only \`docs/exec-plans/active/codec-v2-port.md\`) → \`exit 0\` (skip). ✅

After merge, doc-only / codec / CI PRs should no longer trigger Vercel deploy attempts.

Made with [Cursor](https://cursor.com)