### PR TITLE
chore(ci): add CodeRabbit and reviewdog config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -14,6 +14,9 @@ reviews:
   path_filters:
     - "!artifacts/**"
     - "!fixtures/**"
+    - "!apps/site/dist/**"
+    - "!apps/wittgenstein-kimi/dist/**"
+    - "!docs/research/www.aquin.app/**"
     - "!**/pnpm-lock.yaml"
     - "!**/*.png"
     - "!**/*.wav"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+reviews:
+  auto_review:
+    drafts: false
+    auto_incremental_review: true
+    auto_pause_after_reviewed_commits: 8
+    ignore_title_keywords:
+      - "WIP"
+      - "[skip review]"
+    ignore_usernames:
+      - "dependabot[bot]"
+      - "github-actions[bot]"
+  path_filters:
+    - "!artifacts/**"
+    - "!fixtures/**"
+    - "!**/pnpm-lock.yaml"
+    - "!**/*.png"
+    - "!**/*.wav"
+    - "!**/*.m4a"
+    - "!**/*.mp4"
+    - "!**/*.csv"
+    - "!**/*.svg"
+  path_instructions:
+    - path: "packages/schemas/**"
+      instructions: |
+        Treat schema edits as contract changes.
+        Check zod boundary accuracy, manifest honesty, and whether tests/docs move
+        with the contract.
+    - path: "packages/core/**"
+      instructions: |
+        Focus on harness invariants: modality-blind routing, structured failures,
+        manifest preservation, and package-boundary cleanliness.
+    - path: "packages/codec-*/**"
+      instructions: |
+        Check that modality-specific behavior stays inside the codec package,
+        manifests remain truthful, and harness logic does not regrow in codec PRs.
+    - path: "**/*.md"
+      instructions: |
+        Prefer factual drift checks over prose polish.
+        Flag claims that overstate placeholder, future, or partially-landed behavior.

--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,6 @@
+# Keep review routing with CODEOWNERS.
+# AutoAssign is used here to make PR ownership explicit by assigning the author.
+
+addReviewers: false
+addAssignees: author
+runOnDraft: false

--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,6 +1,0 @@
-# Keep review routing with CODEOWNERS.
-# AutoAssign is used here to make PR ownership explicit by assigning the author.
-
-addReviewers: false
-addAssignees: author
-runOnDraft: false

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -12,7 +12,27 @@ jobs:
   assign:
     runs-on: ubuntu-latest
     steps:
-      - name: Auto assign PR owner
-        uses: kentaro-m/auto-assign-action@v2.0.0
+      - name: Assign counterpart maintainer
+        uses: actions/github-script@v8
         with:
-          configuration-path: .github/auto_assign.yml
+          script: |
+            const author = context.payload.pull_request.user.login;
+            const assigneesByAuthor = {
+              "Jah-yee": ["Moapacha"],
+              "Moapacha": ["Jah-yee"],
+              "moapacha": ["Jah-yee"],
+            };
+
+            const assignees = assigneesByAuthor[author] ?? [];
+            if (assignees.length === 0) {
+              core.info(`No counterpart-maintainer mapping for PR author ${author}; skipping auto-assign.`);
+              return;
+            }
+
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              assignees,
+            });
+            core.info(`Assigned ${assignees.join(", ")} to PR #${context.payload.pull_request.number}.`);

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 
 jobs:
@@ -13,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign counterpart maintainer
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const author = context.payload.pull_request.user.login;

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,18 @@
+name: Auto assign
+
+on:
+  pull_request_target:
+    types: [opened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto assign PR owner
+        uses: kentaro-m/auto-assign-action@v2.0.0
+        with:
+          configuration-path: .github/auto_assign.yml

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,0 +1,40 @@
+name: reviewdog
+
+on:
+  pull_request:
+    paths:
+      - "README.md"
+      - "CONTRIBUTING.md"
+      - "CHANGELOG.md"
+      - "PROMPT.md"
+      - "docs/THESIS.md"
+      - "docs/architecture.md"
+      - "docs/hard-constraints.md"
+      - "docs/implementation-status.md"
+      - "docs/quickstart.md"
+      - "docs/reproducibility.md"
+      - "docs/codecs/*.md"
+      - ".markdownlint-cli2.yaml"
+      - ".github/workflows/reviewdog.yml"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  markdownlint:
+    name: Markdown review comments
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Markdownlint via reviewdog
+        uses: reviewdog/action-markdownlint@3667398db9118d7e78f7a63d10e26ce454ba5f58 # v0.26.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-review
+          filter_mode: added
+          level: warning
+          fail_level: none
+          markdownlint_flags: "README.md CONTRIBUTING.md CHANGELOG.md PROMPT.md docs/THESIS.md docs/architecture.md docs/hard-constraints.md docs/implementation-status.md docs/quickstart.md docs/reproducibility.md docs/codecs/*.md"

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -3,10 +3,19 @@ name: reviewdog
 on:
   pull_request:
     paths:
+      - "package.json"
+      - ".eslintrc.cjs"
+      - ".prettierrc"
       - "README.md"
       - "CONTRIBUTING.md"
       - "CHANGELOG.md"
       - "PROMPT.md"
+      - "packages/**/*.ts"
+      - "packages/**/*.tsx"
+      - "packages/**/*.js"
+      - "apps/site/**/*.ts"
+      - "apps/site/**/*.tsx"
+      - "apps/site/**/*.js"
       - "docs/THESIS.md"
       - "docs/architecture.md"
       - "docs/hard-constraints.md"
@@ -19,6 +28,7 @@ on:
 
 permissions:
   contents: read
+  checks: write
   pull-requests: write
 
 jobs:
@@ -38,3 +48,114 @@ jobs:
           level: warning
           fail_level: none
           markdownlint_flags: "README.md CONTRIBUTING.md CHANGELOG.md PROMPT.md docs/THESIS.md docs/architecture.md docs/hard-constraints.md docs/implementation-status.md docs/quickstart.md docs/reproducibility.md docs/codecs/*.md"
+
+  eslint:
+    name: ESLint review comments
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 9.12.0
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20.19.0
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Collect changed ESLint files
+        id: changed-eslint
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          files="$(
+            git diff --name-only --diff-filter=ACMRT "${BASE_SHA}" "${HEAD_SHA}" \
+              | grep -E '^(packages|apps/site)/.*\.(ts|tsx|js)$' \
+              | tr '\n' ' ' \
+              || true
+          )"
+          if [ -z "${files}" ]; then
+            echo "has_files=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          echo "has_files=true" >> "${GITHUB_OUTPUT}"
+          echo "files=${files}" >> "${GITHUB_OUTPUT}"
+
+      - name: ESLint via reviewdog
+        if: steps.changed-eslint.outputs.has_files == 'true'
+        uses: reviewdog/action-eslint@2fee6d5014644bd9314cb0c1a588a5c8040b7372 # v1.33.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-review
+          filter_mode: added
+          level: warning
+          fail_level: none
+          eslint_flags: "${{ steps.changed-eslint.outputs.files }}"
+
+  prettier-suggestions:
+    name: Prettier suggestions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 9.12.0
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20.19.0
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Collect changed files
+        id: changed
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          files="$(
+            git diff --name-only --diff-filter=ACMRT "${BASE_SHA}" "${HEAD_SHA}" \
+              | grep -E '(^README\.md$|^CONTRIBUTING\.md$|^CHANGELOG\.md$|^PROMPT\.md$|^package\.json$|^\.eslintrc\.cjs$|^\.prettierrc$|^\.github/.*\.(md|yml|yaml)$|^docs/(THESIS\.md|architecture\.md|hard-constraints\.md|implementation-status\.md|quickstart\.md|reproducibility\.md|codecs/.*\.md)$|^packages/.*\.(ts|tsx|js|json|md)$|^apps/site/.*\.(ts|tsx|js|json|md|css)$)' \
+              || true
+          )"
+          if [ -z "${files}" ]; then
+            echo "has_files=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          {
+            echo "has_files=true"
+            echo "files<<EOF"
+            printf '%s\n' "${files}"
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Run Prettier on changed files
+        if: steps.changed.outputs.has_files == 'true'
+        run: |
+          set -euo pipefail
+          printf '%s\n' "${{ steps.changed.outputs.files }}" | xargs pnpm prettier --write
+
+      - name: Suggest formatting fixes
+        if: steps.changed.outputs.has_files == 'true'
+        uses: reviewdog/action-suggester@4746290c5f84f25f0c9b33312c8f3c43b1b15e08 # v1.21.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tool_name: prettier

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -56,6 +56,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
@@ -78,12 +80,9 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          files="$(
-            git diff --name-only --diff-filter=ACMRT "${BASE_SHA}" "${HEAD_SHA}" \
-              | grep -E '^(packages|apps/site)/.*\.(ts|tsx|js)$' \
-              | tr '\n' ' ' \
-              || true
-          )"
+          changed_files="$(mktemp)"
+          git diff --name-only --diff-filter=ACMRT "${BASE_SHA}" "${HEAD_SHA}" > "${changed_files}"
+          files="$(grep -E '^(packages|apps/site)/.*\.(ts|tsx|js)$' "${changed_files}" | tr '\n' ' ' || true)"
           if [ -z "${files}" ]; then
             echo "has_files=false" >> "${GITHUB_OUTPUT}"
             exit 0

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -29,6 +29,7 @@ on:
 permissions:
   contents: read
   checks: write
+  issues: write
   pull-requests: write
 
 jobs:
@@ -92,7 +93,7 @@ jobs:
 
       - name: ESLint via reviewdog
         if: steps.changed-eslint.outputs.has_files == 'true'
-        uses: reviewdog/action-eslint@2fee6d5014644bd9314cb0c1a588a5c8040b7372 # v1.33.2
+        uses: reviewdog/action-eslint@2fee6dd72a5419ff4113f694e2068d2a03bb35dd # v1.33.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review
@@ -155,7 +156,7 @@ jobs:
 
       - name: Suggest formatting fixes
         if: steps.changed.outputs.has_files == 'true'
-        uses: reviewdog/action-suggester@4746290c5f84f25f0c9b33312c8f3c43b1b15e08 # v1.21.0
+        uses: reviewdog/action-suggester@4747dbc9f9e37adba0943e681cc20db466642158 # v1.21.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tool_name: prettier

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,26 @@
+config:
+  default: true
+  MD004: false
+  MD013: false
+  MD024: false
+  MD028: false
+  MD029: false
+  MD031: false
+  MD032: false
+  MD034: false
+  MD033: false
+  MD040: false
+  MD041: false
+  MD060: false
+globs:
+  - "README.md"
+  - "CONTRIBUTING.md"
+  - "CHANGELOG.md"
+  - "PROMPT.md"
+  - "docs/THESIS.md"
+  - "docs/architecture.md"
+  - "docs/hard-constraints.md"
+  - "docs/implementation-status.md"
+  - "docs/quickstart.md"
+  - "docs/reproducibility.md"
+  - "docs/codecs/*.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Added a committed CodeRabbit repository configuration (`.coderabbit.yaml`) so PR
+  review behavior is versioned in-repo instead of living only in a dashboard.
+- Added a narrow Markdown `reviewdog` workflow plus `.markdownlint-cli2.yaml` so docs
+  get lightweight PR annotations without turning legacy line-length and inline-HTML
+  debt into a merge blocker.
+
 ## [0.3.0-alpha.1] — 2026-05-06 — M2 audio sweep and reproducibility gates
 
 This prerelease closes the v0.3 M2 audio line far enough to cut a release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ versioning follows [Semantic Versioning](https://semver.org/).
 
 - Added a committed CodeRabbit repository configuration (`.coderabbit.yaml`) so PR
   review behavior is versioned in-repo instead of living only in a dashboard.
-- Added AutoAssign configuration so new PRs explicitly assign ownership to the PR author
-  without duplicating CODEOWNERS-based reviewer routing.
+- Added AutoAssign configuration so new PRs assign the counterpart maintainer
+  (`Jah-yee -> Moapacha`, `Moapacha -> Jah-yee`) without duplicating
+  CODEOWNERS-based reviewer routing.
 - Added a narrow Markdown `reviewdog` workflow plus `.markdownlint-cli2.yaml` so docs
   get lightweight PR annotations without turning legacy line-length and inline-HTML
   debt into a merge blocker.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ versioning follows [Semantic Versioning](https://semver.org/).
 - Added a narrow Markdown `reviewdog` workflow plus `.markdownlint-cli2.yaml` so docs
   get lightweight PR annotations without turning legacy line-length and inline-HTML
   debt into a merge blocker.
+- Expanded `reviewdog` to cover ESLint review comments and Prettier suggestion comments
+  on changed files, keeping the checks advisory and PR-local instead of turning them into
+  hard CI gates.
 
 ## [0.3.0-alpha.1] — 2026-05-06 — M2 audio sweep and reproducibility gates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ versioning follows [Semantic Versioning](https://semver.org/).
 
 - Added a committed CodeRabbit repository configuration (`.coderabbit.yaml`) so PR
   review behavior is versioned in-repo instead of living only in a dashboard.
+- Added AutoAssign configuration so new PRs explicitly assign ownership to the PR author
+  without duplicating CODEOWNERS-based reviewer routing.
 - Added a narrow Markdown `reviewdog` workflow plus `.markdownlint-cli2.yaml` so docs
   get lightweight PR annotations without turning legacy line-length and inline-HTML
   debt into a merge blocker.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,25 @@ pnpm test
 For Python-surface changes, run the affected `python3 -m polyglot.cli ...` path end-to-end
 at least once — the Python side doesn't have CI coverage today.
 
+## Repository automation
+
+We keep repo automation deliberately small and reviewable:
+
+- **CodeRabbit** is configured in [`/.coderabbit.yaml`](.coderabbit.yaml). It is meant
+  to help with PR summarization and focused review, not replace maintainer judgment.
+  The config is biased toward contract drift, manifest honesty, and package-boundary
+  checks rather than generic prose comments.
+- **reviewdog** is wired through
+  [`.github/workflows/reviewdog.yml`](.github/workflows/reviewdog.yml) and currently
+  scopes itself to Markdown PR comments only. It uses
+  [`.markdownlint-cli2.yaml`](.markdownlint-cli2.yaml) and comments only on added
+  lines so we can tighten doc hygiene without flooding old surfaces with legacy noise.
+- Bot config changes should stay narrow. If a bot starts producing noisy or misleading
+  comments, prefer tightening scope or turning off that surface before adding more rules.
+
+Maintainer note: CodeRabbit's repository configuration is committed here, but the
+GitHub App installation and repo authorization still have to be done in GitHub.
+
 ## Experimental vs shipping code
 
 Wittgenstein explicitly mixes both. To keep users safe:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,9 +103,10 @@ We keep repo automation deliberately small and reviewable:
   The config is biased toward contract drift, manifest honesty, and package-boundary
   checks rather than generic prose comments.
 - **AutoAssign** is configured via
-  [`.github/workflows/auto-assign.yml`](.github/workflows/auto-assign.yml) and
-  [`.github/auto_assign.yml`](.github/auto_assign.yml). `CODEOWNERS` continues to handle
-  review routing; AutoAssign only makes ownership explicit by assigning the PR author.
+  [`.github/workflows/auto-assign.yml`](.github/workflows/auto-assign.yml).
+  `CODEOWNERS` continues to handle review routing; AutoAssign assigns the
+  counterpart maintainer as the PR assignee (`Jah-yee -> Moapacha`,
+  `Moapacha -> Jah-yee`) so ownership stays explicit without duplicating reviewer logic.
 - **reviewdog** is wired through
   [`.github/workflows/reviewdog.yml`](.github/workflows/reviewdog.yml) and currently
   provides three narrow PR-assist surfaces:
@@ -113,9 +114,9 @@ We keep repo automation deliberately small and reviewable:
     on contributor-facing docs
   - ESLint review comments on `packages/**` and `apps/site/**`
   - Prettier-based formatting suggestions on changed files
-  It uses [`.markdownlint-cli2.yaml`](.markdownlint-cli2.yaml) for the doc surface and
-  comments only on added lines where possible so we can tighten hygiene without flooding
-  old surfaces with legacy noise.
+    It uses [`.markdownlint-cli2.yaml`](.markdownlint-cli2.yaml) for the doc surface and
+    comments only on added lines where possible so we can tighten hygiene without flooding
+    old surfaces with legacy noise.
 - Bot config changes should stay narrow. If a bot starts producing noisy or misleading
   comments, prefer tightening scope or turning off that surface before adding more rules.
 - We are intentionally **not** enabling `textlint` yet. For this repo it needs a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,11 +104,19 @@ We keep repo automation deliberately small and reviewable:
   checks rather than generic prose comments.
 - **reviewdog** is wired through
   [`.github/workflows/reviewdog.yml`](.github/workflows/reviewdog.yml) and currently
-  scopes itself to Markdown PR comments only. It uses
-  [`.markdownlint-cli2.yaml`](.markdownlint-cli2.yaml) and comments only on added
-  lines so we can tighten doc hygiene without flooding old surfaces with legacy noise.
+  provides three narrow PR-assist surfaces:
+  - Markdown review comments via [`markdownlint`](https://github.com/DavidAnson/markdownlint)
+    on contributor-facing docs
+  - ESLint review comments on `packages/**` and `apps/site/**`
+  - Prettier-based formatting suggestions on changed files
+  It uses [`.markdownlint-cli2.yaml`](.markdownlint-cli2.yaml) for the doc surface and
+  comments only on added lines where possible so we can tighten hygiene without flooding
+  old surfaces with legacy noise.
 - Bot config changes should stay narrow. If a bot starts producing noisy or misleading
   comments, prefer tightening scope or turning off that surface before adding more rules.
+- We are intentionally **not** enabling `textlint` yet. For this repo it needs a
+  deliberate, engineering-oriented rule set first; generic prose lint would likely add
+  more noise than signal.
 
 Maintainer note: CodeRabbit's repository configuration is committed here, but the
 GitHub App installation and repo authorization still have to be done in GitHub.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,10 @@ We keep repo automation deliberately small and reviewable:
   to help with PR summarization and focused review, not replace maintainer judgment.
   The config is biased toward contract drift, manifest honesty, and package-boundary
   checks rather than generic prose comments.
+- **AutoAssign** is configured via
+  [`.github/workflows/auto-assign.yml`](.github/workflows/auto-assign.yml) and
+  [`.github/auto_assign.yml`](.github/auto_assign.yml). `CODEOWNERS` continues to handle
+  review routing; AutoAssign only makes ownership explicit by assigning the PR author.
 - **reviewdog** is wired through
   [`.github/workflows/reviewdog.yml`](.github/workflows/reviewdog.yml) and currently
   provides three narrow PR-assist surfaces:


### PR DESCRIPTION
## Summary
- add a committed `.coderabbit.yaml` for repo-level AI review policy
- add `reviewdog` PR feedback surfaces for Markdown, ESLint, and Prettier suggestions
- add counterpart-maintainer AutoAssign for the current two-maintainer setup
- document the automation surfaces in `CONTRIBUTING.md` and record them in `CHANGELOG.md`

## Why
We wanted lightweight automation that helps with small PR hygiene without reopening the whole repo's historical docs debt. This keeps CodeRabbit configuration versioned in-repo, scopes reviewdog to changed PR surfaces, and makes PR ownership explicit without replacing CODEOWNERS or maintainer review.

This is execution/tooling documentation, not new repository doctrine. The `CONTRIBUTING.md` update explains committed automation behavior and does not change the governance lane.

## Design notes
- CodeRabbit filters generated artifacts, lockfiles, media, build outputs, and captured research HTML so reviews focus on real code and truth surfaces.
- reviewdog is advisory: Markdown / ESLint comments and Prettier suggestions do not become hard CI gates.
- AutoAssign maps PR author to the other maintainer: `Jah-yee -> Moapacha`, `Moapacha -> Jah-yee`.
- `pull_request_target` automation uses pinned action refs where the workflow writes to PR state.

## Validation
- `pnpm dlx markdownlint-cli2 .`
- `pnpm format:check`
- `git diff --check`

## Notes
- CodeRabbit App installation / repo authorization is now verified: the PR received a CodeRabbit review using `.coderabbit.yaml`.
- Vercel preview deploy currently reports external authorization required; this PR does not change site code or deployment config.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled in-repo PR review automation with focused rules and path-specific review guidance.
  * Added lightweight review workflows to post markdown, lint, and formatting suggestions on changed files.
  * Added automatic PR assignment to authors for applicable events.

* **Documentation**
  * Updated contribution guide and changelog to document repository automation, review surfaces, and bot behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/p-to-q/wittgenstein/pull/314)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->