### PR TITLE
docs(site): tighten homepage copy around current modality doctrine

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,6 +1,9 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 
 reviews:
+  high_level_summary: false
+  in_progress_fortune: false
+  poem: false
   auto_review:
     drafts: false
     auto_incremental_review: true
@@ -42,3 +45,6 @@ reviews:
       instructions: |
         Prefer factual drift checks over prose polish.
         Flag claims that overstate placeholder, future, or partially-landed behavior.
+  pre_merge_checks:
+    docstrings:
+      mode: "off"

--- a/apps/site/index.html
+++ b/apps/site/index.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Wittgenstein — The modality harness for text-first models</title>
+    <title>Wittgenstein — The modality harness for text-first LLMs</title>
     <meta
       name="description"
-      content="Wittgenstein is the modality harness for text-first models — turning text-native LLMs into file-native artifact pipelines through structured IR, codecs, adapters, and frozen decoders."
+      content="Wittgenstein is the modality harness for text-first LLMs — turning planner-style language models into file-native artifact pipelines through code-bearing contracts, codecs, seed expanders, and frozen decoders."
     />
     <meta name="theme-color" content="#faf9f5" />
     <link rel="canonical" href="https://wittgenstein.wtf/" />
@@ -18,17 +18,17 @@
     <link rel="manifest" href="/site.webmanifest" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Wittgenstein" />
-    <meta property="og:title" content="Wittgenstein — The modality harness for text-first models" />
+    <meta property="og:title" content="Wittgenstein — The modality harness for text-first LLMs" />
     <meta
       property="og:description"
-      content="Text-native models, file-native outputs. Structured IR, typed codecs, adapters, frozen decoders, and traceable artifacts."
+      content="Text-first LLMs, file-native outputs. Code-bearing contracts, typed codecs, seed expanders, frozen decoders, and traceable artifacts."
     />
     <meta property="og:url" content="https://wittgenstein.wtf/" />
     <meta property="twitter:card" content="summary_large_image" />
-    <meta property="twitter:title" content="Wittgenstein — The modality harness for text-first models" />
+    <meta property="twitter:title" content="Wittgenstein — The modality harness for text-first LLMs" />
     <meta
       property="twitter:description"
-      content="Text-native models, file-native outputs. Harness engineering for PNG, WAV, JSON, HTML, and future MP4."
+      content="Text-first LLMs, file-native outputs. Harness engineering for PNG, WAV, JSON, HTML, and future MP4."
     />
   </head>
   <body>

--- a/apps/site/public/humans.txt
+++ b/apps/site/public/humans.txt
@@ -1,2 +1,2 @@
-Wittgenstein — modality harness for text-first models
+Wittgenstein — modality harness for text-first LLMs
 Site: https://wittgenstein.wtf/

--- a/apps/site/src/components/HeroAnimatedTitle.tsx
+++ b/apps/site/src/components/HeroAnimatedTitle.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 
 import { cn } from "@/lib/utils";
 
-const TITLE = "text-first LLMs, file-native outputs.";
+const TITLE = "text-first LLMs, real files out.";
 
 function readPrefersReducedMotion(): boolean {
   if (typeof window === "undefined") return false;

--- a/apps/site/src/components/HeroAnimatedTitle.tsx
+++ b/apps/site/src/components/HeroAnimatedTitle.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 
 import { cn } from "@/lib/utils";
 
-const TITLE = "text-native models, file-native outputs.";
+const TITLE = 'text-first LLMs, file-native outputs.';
 
 function readPrefersReducedMotion(): boolean {
   if (typeof window === "undefined") return false;

--- a/apps/site/src/components/HeroAnimatedTitle.tsx
+++ b/apps/site/src/components/HeroAnimatedTitle.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 
 import { cn } from "@/lib/utils";
 
-const TITLE = 'text-first LLMs, file-native outputs.';
+const TITLE = "text-first LLMs, file-native outputs.";
 
 function readPrefersReducedMotion(): boolean {
   if (typeof window === "undefined") return false;

--- a/apps/site/src/sections/AgenticSystemSection.tsx
+++ b/apps/site/src/sections/AgenticSystemSection.tsx
@@ -2,7 +2,7 @@ const toolChain = [
   {
     name: 'harness.router',
     active: true,
-    description: 'Owns retries, seeds, budgets, sandbox, telemetry, and routing while the planner stays text-native.',
+    description: 'Owns retries, seeds, budgets, sandbox, telemetry, and routing while the planner stays text-first.',
   },
   {
     name: 'codec.registry',
@@ -12,7 +12,7 @@ const toolChain = [
   {
     name: 'artifacts.replay',
     active: false,
-    description: 'Replays structured IR plus manifests from artifacts/runs/ without touching the base model weights.',
+    description: 'Replays modality contracts plus manifests from artifacts/runs/ without touching the base model weights.',
   },
 ];
 
@@ -24,7 +24,7 @@ export default function AgenticSystemSection() {
         <h2 className="text-4xl md:text-5xl font-serif mt-2 mb-4 lowercase">harness</h2>
         <p className="text-muted-foreground text-sm max-w-xl mb-10 leading-relaxed">
           The LLM plans; the harness owns routing, schema injection, validation, and traces. Modality codecs sit behind a
-          single contract so new file types can ship without pretending the backbone has become a giant native VLM.
+          shared contract surface so new file types can ship without pretending the backbone has become a giant native VLM.
         </p>
 
         <div className="card-border p-6">
@@ -37,8 +37,8 @@ export default function AgenticSystemSection() {
                   </div>
                   <div>
                     <p className="text-sm text-muted-foreground leading-relaxed">
-                      Route this request through the right codec, validate the structured IR, and show the artifact and
-                      manifest path rather than a black-box answer.
+                      Route this request through the right codec, validate the code-bearing contract, and show the artifact
+                      and manifest path rather than a black-box answer.
                     </p>
                   </div>
                 </div>

--- a/apps/site/src/sections/AgenticSystemSection.tsx
+++ b/apps/site/src/sections/AgenticSystemSection.tsx
@@ -1,6 +1,6 @@
 const toolChain = [
   {
-    name: 'harness.router',
+    name: "harness.router",
     active: true,
     description: 'Owns retries, seeds, budgets, sandbox, telemetry, and routing while the planner stays text-first.',
   },

--- a/apps/site/src/sections/AgenticSystemSection.tsx
+++ b/apps/site/src/sections/AgenticSystemSection.tsx
@@ -2,17 +2,20 @@ const toolChain = [
   {
     name: "harness.router",
     active: true,
-    description: 'Owns retries, seeds, budgets, sandbox, telemetry, and routing while the planner stays text-first.',
+    description:
+      "Owns retries, seeds, budgets, sandbox, telemetry, and routing while the planner stays text-first.",
   },
   {
-    name: 'codec.registry',
+    name: "codec.registry",
     active: false,
-    description: 'Dispatches per-modality WittgensteinCodec implementations through one shared contract.',
+    description:
+      "Dispatches per-modality WittgensteinCodec implementations through one shared contract.",
   },
   {
-    name: 'artifacts.replay',
+    name: "artifacts.replay",
     active: false,
-    description: 'Replays modality contracts plus manifests from artifacts/runs/ without touching the base model weights.',
+    description:
+      "Replays modality contracts plus manifests from artifacts/runs/ without touching the base model weights.",
   },
 ];
 
@@ -23,8 +26,9 @@ export default function AgenticSystemSection() {
         <span className="section-number">06</span>
         <h2 className="text-4xl md:text-5xl font-serif mt-2 mb-4 lowercase">harness</h2>
         <p className="text-muted-foreground text-sm max-w-xl mb-10 leading-relaxed">
-          The LLM plans; the harness owns routing, schema injection, validation, and traces. Modality codecs sit behind a
-          shared contract surface so new file types can ship without pretending the backbone has become a giant native VLM.
+          The LLM plans; the harness owns routing, schema injection, validation, and traces.
+          Modality codecs sit behind a shared contract surface so new file types can ship without
+          pretending the backbone has become a giant native VLM.
         </p>
 
         <div className="card-border p-6">
@@ -37,8 +41,9 @@ export default function AgenticSystemSection() {
                   </div>
                   <div>
                     <p className="text-sm text-muted-foreground leading-relaxed">
-                      Route this request through the right codec, validate the code-bearing contract, and show the artifact
-                      and manifest path rather than a black-box answer.
+                      Route this request through the right codec, validate the code-bearing
+                      contract, and show the artifact and manifest path rather than a black-box
+                      answer.
                     </p>
                   </div>
                 </div>
@@ -46,8 +51,9 @@ export default function AgenticSystemSection() {
 
               <div className="bg-card border border-border rounded-lg p-4">
                 <p className="text-sm text-muted-foreground leading-relaxed">
-                  Planner output is validated before any decoder or renderer runs. The harness records seed, codec id, route,
-                  and artifact hashes so work can be replayed without guessing what happened.
+                  Planner output is validated before any decoder or renderer runs. The harness
+                  records seed, codec id, route, and artifact hashes so work can be replayed without
+                  guessing what happened.
                 </p>
               </div>
             </div>
@@ -59,11 +65,13 @@ export default function AgenticSystemSection() {
                   <div
                     key={tool.name}
                     className={`p-3 rounded-lg border ${
-                      tool.active ? 'border-primary/40 bg-primary/10' : 'border-border bg-secondary'
+                      tool.active ? "border-primary/40 bg-primary/10" : "border-border bg-secondary"
                     }`}
                   >
                     <div className="flex items-center gap-2 mb-1">
-                      <div className={`w-2 h-2 rounded-full ${tool.active ? 'bg-primary' : 'bg-muted-foreground/40'}`} />
+                      <div
+                        className={`w-2 h-2 rounded-full ${tool.active ? "bg-primary" : "bg-muted-foreground/40"}`}
+                      />
                       <span className="text-xs font-mono text-muted-foreground">{tool.name}</span>
                     </div>
                     <p className="text-xs text-muted-foreground">{tool.description}</p>

--- a/apps/site/src/sections/AttributionSection.tsx
+++ b/apps/site/src/sections/AttributionSection.tsx
@@ -1,5 +1,5 @@
 const promptTokens = ['Create', 'a', 'traceable', 'PNG', 'artifact', 'from', 'text'];
-const responseTokens = ['scene', 'spec', 'JSON', 'latents', 'manifest'];
+const responseTokens = ['semantic', 'seedCode', 'decoder', 'PNG', 'manifest'];
 
 export default function AttributionSection() {
   return (
@@ -34,13 +34,13 @@ export default function AttributionSection() {
                 <path d="M12 5v14M5 12l7 7 7-7" />
               </svg>
             </div>
-            <div className="text-xs font-mono text-muted-foreground mb-4">structured IR</div>
+            <div className="text-xs font-mono text-muted-foreground mb-4">structured contract</div>
             <div className="flex flex-wrap gap-1.5">
               {responseTokens.map((token, i) => (
                 <span
                   key={i}
                   className={`px-2 py-1 text-sm rounded-md border shadow-[0_0_0_1px_hsl(var(--ring))] ${
-                    ['scene', 'spec', 'latents', 'manifest'].includes(token)
+                    ['semantic', 'seedCode', 'decoder', 'manifest'].includes(token)
                       ? 'bg-primary/15 text-foreground border-primary/35'
                       : 'bg-secondary text-secondary-foreground'
                   }`}
@@ -55,14 +55,14 @@ export default function AttributionSection() {
             <div className="text-xs font-mono text-muted-foreground mb-4">why it scales</div>
             <p className="text-sm text-muted-foreground leading-relaxed">
               Modern harnesses usually stop at tools and control flow. Wittgenstein adds a stricter seam:{' '}
-              <strong className="text-foreground font-semibold">structured IR, codec boundaries, frozen decoders,</strong>{' '}
-              and optional tiny adapters. When the trade-off is right, post-training moves to the harness bundle instead of
-              the base model. Every run leaves artifacts under{' '}
+              <strong className="text-foreground font-semibold">code-bearing contracts, codec boundaries, frozen decoders,</strong>{' '}
+              and optional tiny seed expanders. When the trade-off is right, post-training moves to the harness bundle
+              instead of the base model. Every run leaves artifacts under{' '}
               <span className="font-mono text-xs text-secondary-foreground">artifacts/runs/</span>.
             </p>
             <p className="text-sm text-muted-foreground leading-relaxed mt-4">
-              That makes the project legible to both researchers and builders: you can inspect the contract, replay the run,
-              and improve one modality without rewriting the whole system.
+              That keeps the project legible to both researchers and builders: you can inspect the contract, replay the run,
+              and improve one modality without pretending the whole stack changed shape.
             </p>
           </div>
         </div>

--- a/apps/site/src/sections/AttributionSection.tsx
+++ b/apps/site/src/sections/AttributionSection.tsx
@@ -1,5 +1,5 @@
-const promptTokens = ['Create', 'a', 'traceable', 'PNG', 'artifact', 'from', 'text'];
-const responseTokens = ['semantic', 'seedCode', 'decoder', 'PNG', 'manifest'];
+const promptTokens = ["Create", "a", "traceable", "PNG", "artifact", "from", "text"];
+const responseTokens = ["semantic", "seedCode", "decoder", "PNG", "manifest"];
 
 export default function AttributionSection() {
   return (
@@ -8,8 +8,9 @@ export default function AttributionSection() {
         <span className="section-number">01</span>
         <h2 className="text-4xl md:text-5xl font-serif mt-2 mb-4 lowercase">thesis</h2>
         <p className="text-muted-foreground text-sm max-w-xl mb-10 leading-relaxed">
-          Agent = model + harness, with modality codecs at the file boundary. The LLM remains the planner; the harness
-          owns schema injection, validation, retries, budgets, sandboxing, telemetry, and artifact traces.
+          Agent = model + harness, with modality codecs at the file boundary. The LLM remains the
+          planner; the harness owns schema injection, validation, retries, budgets, sandboxing,
+          telemetry, and artifact traces.
         </p>
 
         <div className="grid md:grid-cols-2 gap-6">
@@ -20,9 +21,9 @@ export default function AttributionSection() {
                 <span
                   key={i}
                   className={`px-2 py-1 text-sm rounded-md border shadow-[0_0_0_1px_hsl(var(--ring))] ${
-                    token === 'traceable' || token === 'PNG' || token === 'artifact'
-                      ? 'bg-primary/15 text-foreground border-primary/35'
-                      : 'bg-secondary text-secondary-foreground'
+                    token === "traceable" || token === "PNG" || token === "artifact"
+                      ? "bg-primary/15 text-foreground border-primary/35"
+                      : "bg-secondary text-secondary-foreground"
                   }`}
                 >
                   {token}
@@ -30,7 +31,14 @@ export default function AttributionSection() {
               ))}
             </div>
             <div className="flex justify-center mb-6 text-muted-foreground">
-              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <svg
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
                 <path d="M12 5v14M5 12l7 7 7-7" />
               </svg>
             </div>
@@ -40,9 +48,9 @@ export default function AttributionSection() {
                 <span
                   key={i}
                   className={`px-2 py-1 text-sm rounded-md border shadow-[0_0_0_1px_hsl(var(--ring))] ${
-                    ['semantic', 'seedCode', 'decoder', 'manifest'].includes(token)
-                      ? 'bg-primary/15 text-foreground border-primary/35'
-                      : 'bg-secondary text-secondary-foreground'
+                    ["semantic", "seedCode", "decoder", "manifest"].includes(token)
+                      ? "bg-primary/15 text-foreground border-primary/35"
+                      : "bg-secondary text-secondary-foreground"
                   }`}
                 >
                   {token}
@@ -54,15 +62,19 @@ export default function AttributionSection() {
           <div className="card-border p-6">
             <div className="text-xs font-mono text-muted-foreground mb-4">why it scales</div>
             <p className="text-sm text-muted-foreground leading-relaxed">
-              Modern harnesses usually stop at tools and control flow. Wittgenstein adds a stricter seam:{' '}
-              <strong className="text-foreground font-semibold">code-bearing contracts, codec boundaries, frozen decoders,</strong>{' '}
-              and optional tiny seed expanders. When the trade-off is right, post-training moves to the harness bundle
-              instead of the base model. Every run leaves artifacts under{' '}
+              Modern harnesses usually stop at tools and control flow. Wittgenstein adds a stricter
+              seam:{" "}
+              <strong className="text-foreground font-semibold">
+                code-bearing contracts, codec boundaries, frozen decoders,
+              </strong>{" "}
+              and optional tiny seed expanders. When the trade-off is right, post-training moves to
+              the harness bundle instead of the base model. Every run leaves artifacts under{" "}
               <span className="font-mono text-xs text-secondary-foreground">artifacts/runs/</span>.
             </p>
             <p className="text-sm text-muted-foreground leading-relaxed mt-4">
-              That keeps the project legible to both researchers and builders: you can inspect the contract, replay the run,
-              and improve one modality without pretending the whole stack changed shape.
+              That keeps the project legible to both researchers and builders: you can inspect the
+              contract, replay the run, and improve one modality without pretending the whole stack
+              changed shape.
             </p>
           </div>
         </div>

--- a/apps/site/src/sections/AttributionSection.tsx
+++ b/apps/site/src/sections/AttributionSection.tsx
@@ -8,8 +8,8 @@ export default function AttributionSection() {
         <span className="section-number">01</span>
         <h2 className="text-4xl md:text-5xl font-serif mt-2 mb-4 lowercase">thesis</h2>
         <p className="text-muted-foreground text-sm max-w-xl mb-10 leading-relaxed">
-          Agent = Model + Harness, extended with modality codecs. The LLM remains the planner; the harness owns schema
-          injection, validation, retries, budgets, sandboxing, telemetry, and artifact traces.
+          Agent = model + harness, with modality codecs at the file boundary. The LLM remains the planner; the harness
+          owns schema injection, validation, retries, budgets, sandboxing, telemetry, and artifact traces.
         </p>
 
         <div className="grid md:grid-cols-2 gap-6">

--- a/apps/site/src/sections/DiffSection.tsx
+++ b/apps/site/src/sections/DiffSection.tsx
@@ -1,28 +1,28 @@
 const layers = [
   {
-    num: 'L1',
-    title: 'Harness / runtime',
-    desc: 'Routing, retry, seed, budget, telemetry, sandbox, and replayable run invariants.',
+    num: "L1",
+    title: "Harness / runtime",
+    desc: "Routing, retry, seed, budget, telemetry, sandbox, and replayable run invariants.",
   },
   {
-    num: 'L2',
-    title: 'IR / codec',
-    desc: 'Typed schemas, modality contracts, and structured parse boundaries at every external edge.',
+    num: "L2",
+    title: "IR / codec",
+    desc: "Typed schemas, modality contracts, and structured parse boundaries at every external edge.",
   },
   {
-    num: 'L3',
-    title: 'Renderer / decoder',
-    desc: 'IR to bytes on disk; frozen decoders are in-bounds, general generators are not the default path.',
+    num: "L3",
+    title: "Renderer / decoder",
+    desc: "IR to bytes on disk; frozen decoders are in-bounds, general generators are not the default path.",
   },
   {
-    num: 'L4',
-    title: 'Optional adapter',
-    desc: 'Small learned bridges such as seed expanders or local code aligners, shipped beside codecs instead of inside the base model.',
+    num: "L4",
+    title: "Optional adapter",
+    desc: "Small learned bridges such as seed expanders or local code aligners, shipped beside codecs instead of inside the base model.",
   },
   {
-    num: 'L5',
-    title: 'Packaging',
-    desc: 'CLI, installation, shared schemas, docs, agent primers, and distribution conventions that make the stack usable.',
+    num: "L5",
+    title: "Packaging",
+    desc: "CLI, installation, shared schemas, docs, agent primers, and distribution conventions that make the stack usable.",
   },
 ];
 
@@ -33,8 +33,8 @@ export default function DiffSection() {
         <span className="section-number">02</span>
         <h2 className="text-4xl md:text-5xl font-serif mt-2 mb-4 lowercase">layers</h2>
         <p className="text-muted-foreground text-sm max-w-xl mb-10 leading-relaxed">
-          Five explicit layers map the idea to packages, responsibilities, and failure boundaries so contributors do not
-          accidentally solve the right problem in the wrong place.
+          Five explicit layers map the idea to packages, responsibilities, and failure boundaries so
+          contributors do not accidentally solve the right problem in the wrong place.
         </p>
 
         <div className="card-border p-6 space-y-3">
@@ -48,7 +48,7 @@ export default function DiffSection() {
               </span>
               <p className="text-sm text-muted-foreground leading-relaxed">
                 <strong className="text-foreground font-semibold">{row.title}</strong>
-                {' — '}
+                {" — "}
                 {row.desc}
               </p>
             </div>

--- a/apps/site/src/sections/DiffSection.tsx
+++ b/apps/site/src/sections/DiffSection.tsx
@@ -7,7 +7,7 @@ const layers = [
   {
     num: 'L2',
     title: 'IR / codec',
-    desc: 'Typed schemas, prompt contracts, and structured parse boundaries at every external edge.',
+    desc: 'Typed schemas, modality contracts, and structured parse boundaries at every external edge.',
   },
   {
     num: 'L3',
@@ -17,7 +17,7 @@ const layers = [
   {
     num: 'L4',
     title: 'Optional adapter',
-    desc: 'Small learned translators such as scene-to-latent bridges, shipped beside codecs instead of inside the base model.',
+    desc: 'Small learned bridges such as seed expanders or local code aligners, shipped beside codecs instead of inside the base model.',
   },
   {
     num: 'L5',

--- a/apps/site/src/sections/EvalsSection.tsx
+++ b/apps/site/src/sections/EvalsSection.tsx
@@ -1,48 +1,51 @@
 const modalityChecks = [
   {
-    name: 'Contract posture',
-    subtitle: 'schema & parse',
-    description: 'Structured success paths are validated up front so malformed output never silently becomes an artifact.',
+    name: "Contract posture",
+    subtitle: "schema & parse",
+    description:
+      "Structured success paths are validated up front so malformed output never silently becomes an artifact.",
     metrics: [
-      { label: 'parse guard', value: 94, tone: 'primary' as const },
-      { label: 'replay surface', value: 91, tone: 'primary' as const },
-      { label: 'manifest spine', value: 88, tone: 'primary' as const },
+      { label: "parse guard", value: 94, tone: "primary" as const },
+      { label: "replay surface", value: 91, tone: "primary" as const },
+      { label: "manifest spine", value: 88, tone: "primary" as const },
     ],
   },
   {
-    name: 'Decoder posture',
-    subtitle: 'visual seed code',
-    description: 'Frozen decoders are in-bounds for image reconstruction; the repo is not trying to smuggle in a local diffusion stack.',
+    name: "Decoder posture",
+    subtitle: "visual seed code",
+    description:
+      "Frozen decoders are in-bounds for image reconstruction; the repo is not trying to smuggle in a local diffusion stack.",
     metrics: [
-      { label: 'decoder lock', value: 100, tone: 'green' as const },
-      { label: 'seed-expander seam', value: 76, tone: 'green' as const },
-      { label: 'PNG packaging', value: 89, tone: 'green' as const },
+      { label: "decoder lock", value: 100, tone: "green" as const },
+      { label: "seed-expander seam", value: 76, tone: "green" as const },
+      { label: "PNG packaging", value: 89, tone: "green" as const },
     ],
   },
   {
-    name: 'Runnable surfaces',
-    subtitle: 'image · audio · sensor',
-    description: 'Lightweight smoke checks track the currently runnable local paths while video catches up.',
+    name: "Runnable surfaces",
+    subtitle: "image · audio · sensor",
+    description:
+      "Lightweight smoke checks track the currently runnable local paths while video catches up.",
     metrics: [
-      { label: 'image editorial', value: 85, tone: 'accent' as const },
-      { label: 'tts launch', value: 85, tone: 'accent' as const },
-      { label: 'sensor ecg', value: 85, tone: 'accent' as const },
+      { label: "image editorial", value: 85, tone: "accent" as const },
+      { label: "tts launch", value: 85, tone: "accent" as const },
+      { label: "sensor ecg", value: 85, tone: "accent" as const },
     ],
   },
 ];
 
 const runHistory = [
-  { run: 'image-editorial', ir: 94, dec: 100, vec: 85, delta: '+5 avg' },
-  { run: 'tts-launch', ir: 93, dec: 100, vec: 85, delta: '+4 avg' },
-  { run: 'audio-music', ir: 92, dec: 100, vec: 85, delta: '+3 avg' },
-  { run: 'sensor-ecg', ir: 95, dec: 100, vec: 85, delta: '+6 avg' },
-  { run: 'video-seam', ir: 90, dec: 100, vec: 62, delta: '-2 avg' },
+  { run: "image-editorial", ir: 94, dec: 100, vec: 85, delta: "+5 avg" },
+  { run: "tts-launch", ir: 93, dec: 100, vec: 85, delta: "+4 avg" },
+  { run: "audio-music", ir: 92, dec: 100, vec: 85, delta: "+3 avg" },
+  { run: "sensor-ecg", ir: 95, dec: 100, vec: 85, delta: "+6 avg" },
+  { run: "video-seam", ir: 90, dec: 100, vec: 62, delta: "-2 avg" },
 ];
 
 const barTone = {
-  primary: 'bg-primary',
-  green: 'bg-[hsl(var(--muted-green))]',
-  accent: 'bg-primary/80',
+  primary: "bg-primary",
+  green: "bg-[hsl(var(--muted-green))]",
+  accent: "bg-primary/80",
 };
 
 export default function EvalsSection() {
@@ -52,9 +55,10 @@ export default function EvalsSection() {
         <span className="section-number">05</span>
         <h2 className="text-4xl md:text-5xl font-serif mt-2 mb-4 lowercase">checks</h2>
         <p className="text-muted-foreground text-sm max-w-xl mb-10 leading-relaxed">
-          Contract-shaped checks for schemas, decoders, and runnable artifact paths. Every real run still leaves traces
-          under <span className="font-mono text-xs">artifacts/runs/</span>. The percentages below are directional product
-          surfaces, not release receipts; the ground truth still lives in manifests, tests, and docs.
+          Contract-shaped checks for schemas, decoders, and runnable artifact paths. Every real run
+          still leaves traces under <span className="font-mono text-xs">artifacts/runs/</span>. The
+          percentages below are directional product surfaces, not release receipts; the ground truth
+          still lives in manifests, tests, and docs.
         </p>
 
         <div className="grid md:grid-cols-3 gap-6 mb-10">
@@ -109,9 +113,9 @@ export default function EvalsSection() {
                       {rh.delta && (
                         <span
                           className={`px-2 py-0.5 rounded text-xs font-mono ${
-                            rh.delta.startsWith('+')
-                              ? 'bg-primary/15 text-primary'
-                              : 'bg-destructive/15 text-destructive'
+                            rh.delta.startsWith("+")
+                              ? "bg-primary/15 text-primary"
+                              : "bg-destructive/15 text-destructive"
                           }`}
                         >
                           {rh.delta}

--- a/apps/site/src/sections/EvalsSection.tsx
+++ b/apps/site/src/sections/EvalsSection.tsx
@@ -11,7 +11,7 @@ const modalityChecks = [
   },
   {
     name: 'Decoder posture',
-    subtitle: 'image path',
+    subtitle: 'visual seed code',
     description: 'Frozen decoders are in-bounds for image reconstruction; the repo is not trying to smuggle in a local diffusion stack.',
     metrics: [
       { label: 'decoder lock', value: 100, tone: 'green' as const },

--- a/apps/site/src/sections/EvalsSection.tsx
+++ b/apps/site/src/sections/EvalsSection.tsx
@@ -1,12 +1,12 @@
 const modalityChecks = [
   {
-    name: 'IR contracts',
+    name: 'Contract posture',
     subtitle: 'schema & parse',
     description: 'Structured success paths are validated up front so malformed output never silently becomes an artifact.',
     metrics: [
-      { label: 'parse coverage', value: 94, tone: 'primary' as const },
-      { label: 'replay fidelity', value: 91, tone: 'primary' as const },
-      { label: 'manifest completeness', value: 88, tone: 'primary' as const },
+      { label: 'parse guard', value: 94, tone: 'primary' as const },
+      { label: 'replay surface', value: 91, tone: 'primary' as const },
+      { label: 'manifest spine', value: 88, tone: 'primary' as const },
     ],
   },
   {
@@ -15,14 +15,14 @@ const modalityChecks = [
     description: 'Frozen decoders are in-bounds for image reconstruction; the repo is not trying to smuggle in a local diffusion stack.',
     metrics: [
       { label: 'decoder lock', value: 100, tone: 'green' as const },
-      { label: 'adapter seam tests', value: 76, tone: 'green' as const },
+      { label: 'seed-expander seam', value: 76, tone: 'green' as const },
       { label: 'PNG packaging', value: 89, tone: 'green' as const },
     ],
   },
   {
-    name: 'Launch benchmarks',
-    subtitle: 'price · latency · quality',
-    description: 'Lightweight smoke benchmarks track real file outputs for image, tts, audio, and sensor while video catches up.',
+    name: 'Runnable surfaces',
+    subtitle: 'image · audio · sensor',
+    description: 'Lightweight smoke checks track the currently runnable local paths while video catches up.',
     metrics: [
       { label: 'image editorial', value: 85, tone: 'accent' as const },
       { label: 'tts launch', value: 85, tone: 'accent' as const },
@@ -52,9 +52,9 @@ export default function EvalsSection() {
         <span className="section-number">05</span>
         <h2 className="text-4xl md:text-5xl font-serif mt-2 mb-4 lowercase">checks</h2>
         <p className="text-muted-foreground text-sm max-w-xl mb-10 leading-relaxed">
-          Contract-shaped checks for schemas, decoders, and launch-ready artifacts. Every real run still leaves traces under{' '}
-          <span className="font-mono text-xs">artifacts/runs/</span>, while the benchmark layer summarizes price, latency,
-          and quality for the current runnable paths.
+          Contract-shaped checks for schemas, decoders, and runnable artifact paths. Every real run still leaves traces
+          under <span className="font-mono text-xs">artifacts/runs/</span>. The percentages below are directional product
+          surfaces, not release receipts; the ground truth still lives in manifests, tests, and docs.
         </p>
 
         <div className="grid md:grid-cols-3 gap-6 mb-10">
@@ -86,16 +86,16 @@ export default function EvalsSection() {
         </div>
 
         <div className="card-border p-6">
-          <div className="text-xs font-mono text-muted-foreground mb-4">run history</div>
+          <div className="text-xs font-mono text-muted-foreground mb-4">mode snapshots</div>
           <div className="overflow-x-auto">
             <table className="w-full text-xs">
               <thead>
                 <tr className="text-left text-muted-foreground">
-                  <th className="pb-2 font-mono font-normal">run</th>
-                  <th className="pb-2 font-mono font-normal">IR</th>
+                  <th className="pb-2 font-mono font-normal">surface</th>
+                  <th className="pb-2 font-mono font-normal">contract</th>
                   <th className="pb-2 font-mono font-normal">decoder</th>
-                  <th className="pb-2 font-mono font-normal">launch score</th>
-                  <th className="pb-2 font-mono font-normal">delta</th>
+                  <th className="pb-2 font-mono font-normal">runnable</th>
+                  <th className="pb-2 font-mono font-normal">trend</th>
                 </tr>
               </thead>
               <tbody>

--- a/apps/site/src/sections/FactualChecksSection.tsx
+++ b/apps/site/src/sections/FactualChecksSection.tsx
@@ -1,11 +1,11 @@
 const codecs = [
   {
     label: 'Image',
-    body: 'Single raster path: scene IR, latent adapter seam, frozen decoder, and PNG packaging. This is the research path, not a fallback tier.',
+    body: 'Single raster path: Visual Seed Code-bearing contract, optional semantic layer, seed expander seam, frozen decoder, and PNG packaging. This is the research path, not a fallback tier.',
   },
   {
     label: 'Audio',
-    body: 'Typed routes for speech, soundscape, and music, with local WAV rendering, ambient layering, and one shared contract.',
+    body: 'Typed routes for speech, soundscape, and music, with local WAV rendering, ambient layering, and one shared harness contract.',
   },
   {
     label: 'Video',
@@ -30,8 +30,8 @@ export default function FactualChecksSection() {
         </p>
         <p className="text-muted-foreground text-sm max-w-2xl mb-10 leading-relaxed">
           In practice, that means each codec can move at its own speed while still fitting the same harness. Image is the
-          strictest and most research-shaped path; audio and sensor are already productive local outputs; video is waiting for
-          the fuller MP4 path to land.
+          strictest and most research-shaped path; audio and sensor already produce useful local outputs; video is waiting
+          for the fuller MP4 path to land.
         </p>
 
         <div className="grid sm:grid-cols-2 gap-4">

--- a/apps/site/src/sections/FactualChecksSection.tsx
+++ b/apps/site/src/sections/FactualChecksSection.tsx
@@ -1,19 +1,19 @@
 const codecs = [
   {
-    label: 'Image',
-    body: 'Single raster path: Visual Seed Code-bearing contract, optional semantic layer, seed expander seam, frozen decoder, and PNG packaging. This is the research path, not a fallback tier.',
+    label: "Image",
+    body: "Single raster path: Visual Seed Code-bearing contract, optional semantic layer, seed expander seam, frozen decoder, and PNG packaging. This is the research path, not a fallback tier.",
   },
   {
-    label: 'Audio',
-    body: 'Typed routes for speech, soundscape, and music, with local WAV rendering, ambient layering, and one shared harness contract.',
+    label: "Audio",
+    body: "Typed routes for speech, soundscape, and music, with local WAV rendering, ambient layering, and one shared harness contract.",
   },
   {
-    label: 'Video',
-    body: 'Composition-first IR plus a HyperFrames-shaped render seam. The structure is in place; the fuller MP4 path is still being merged.',
+    label: "Video",
+    body: "Composition-first IR plus a HyperFrames-shaped render seam. The structure is in place; the fuller MP4 path is still being merged.",
   },
   {
-    label: 'Sensor',
-    body: 'Deterministic operator specs expand into time-series outputs, then ship as JSON, CSV, and a loupe-friendly HTML view.',
+    label: "Sensor",
+    body: "Deterministic operator specs expand into time-series outputs, then ship as JSON, CSV, and a loupe-friendly HTML view.",
   },
 ];
 
@@ -24,20 +24,22 @@ export default function FactualChecksSection() {
         <span className="section-number">04</span>
         <h2 className="text-4xl md:text-5xl font-serif mt-2 mb-4 lowercase">codecs</h2>
         <p className="text-muted-foreground text-sm max-w-xl mb-10 leading-relaxed">
-          Each modality is an isolated package sharing the{' '}
-          <strong className="text-foreground font-semibold">WittgensteinCodec</strong>-shaped contract through shared
-          schemas, manifests, and runtime conventions.
+          Each modality is an isolated package sharing the{" "}
+          <strong className="text-foreground font-semibold">WittgensteinCodec</strong>-shaped
+          contract through shared schemas, manifests, and runtime conventions.
         </p>
         <p className="text-muted-foreground text-sm max-w-2xl mb-10 leading-relaxed">
-          In practice, that means each codec can move at its own speed while still fitting the same harness. Image is the
-          strictest and most research-shaped path; audio and sensor already produce useful local outputs; video is waiting
-          for the fuller MP4 path to land.
+          In practice, that means each codec can move at its own speed while still fitting the same
+          harness. Image is the strictest and most research-shaped path; audio and sensor already
+          produce useful local outputs; video is waiting for the fuller MP4 path to land.
         </p>
 
         <div className="grid sm:grid-cols-2 gap-4">
           {codecs.map((c) => (
             <div key={c.label} className="card-border p-6">
-              <p className="text-xs font-medium tracking-[0.08em] uppercase text-muted-foreground mb-2">{c.label}</p>
+              <p className="text-xs font-medium tracking-[0.08em] uppercase text-muted-foreground mb-2">
+                {c.label}
+              </p>
               <p className="text-sm text-muted-foreground leading-relaxed">{c.body}</p>
             </div>
           ))}

--- a/apps/site/src/sections/Footer.tsx
+++ b/apps/site/src/sections/Footer.tsx
@@ -14,7 +14,7 @@ export default function Footer() {
           </a>
         </div>
         <div className="text-center text-xs text-muted-foreground mb-12 text-[hsl(var(--stone))]">
-          &copy; 2026 Wittgenstein. The modality harness for text-first models. Apache-2.0.
+          &copy; 2026 Wittgenstein. The modality harness for text-first LLMs. Apache-2.0.
         </div>
         <div className="text-center">
           <span

--- a/apps/site/src/sections/HeroSection.tsx
+++ b/apps/site/src/sections/HeroSection.tsx
@@ -9,14 +9,15 @@ export default function HeroSection() {
     <section className="pt-32 pb-16 text-center px-4 relative" id="top">
       <HeroAnimatedTitle className="text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-serif mb-10 tracking-tight text-foreground leading-[1.12] max-w-5xl mx-auto animate-fade-in-up" />
       <p className="text-base text-muted-foreground max-w-2xl mx-auto mb-8 leading-relaxed">
-        A <strong className="text-foreground font-semibold">harness-first portability layer</strong> for text-native LLMs.
-        The model stays a planner; codecs, adapters, decoders, mixers, and deterministic runtimes turn structured intent
-        into real files such as <strong className="text-foreground font-semibold">PNG, WAV, HTML, JSON,</strong> and,
-        once the video branch is fully wired back in, <strong className="text-foreground font-semibold">MP4</strong>.
+        A <strong className="text-foreground font-semibold">harness-first modality layer</strong> for text-first LLMs.
+        The model stays a planner; modality contracts, codecs, seed expanders, frozen decoders, and deterministic runtimes
+        turn structured outputs into real files such as <strong className="text-foreground font-semibold">PNG, WAV, HTML, JSON,</strong>{' '}
+        and, once the video branch is fully wired back in, <strong className="text-foreground font-semibold">MP4</strong>.
       </p>
       <p className="text-sm text-muted-foreground max-w-xl mx-auto mb-8 leading-relaxed">
-        The point is not to pretend a text model is already a giant native VLM. The point is to make multimodal outputs
-        practical through contracts, local compute, and portable codec logic.
+        The point is not to pretend a text model is already a native multimodal stack. The point is to give it narrow,
+        inspectable code paths: Visual Seed Code for image, local render routes for audio and sensor, and traceable
+        artifact receipts at every step.
       </p>
       <div className="flex flex-wrap items-center justify-center gap-3">
         <a href="#s-layers" className="yellow-btn inline-flex items-center justify-center">

--- a/apps/site/src/sections/HeroSection.tsx
+++ b/apps/site/src/sections/HeroSection.tsx
@@ -1,23 +1,25 @@
-import { Github } from 'lucide-react';
+import { Github } from "lucide-react";
 
-import { HeroAnimatedTitle } from '@/components/HeroAnimatedTitle';
+import { HeroAnimatedTitle } from "@/components/HeroAnimatedTitle";
 
-const GITHUB_REPO_HREF = 'https://github.com/wittgenstein-cli/wittgenstein';
+const GITHUB_REPO_HREF = "https://github.com/wittgenstein-cli/wittgenstein";
 
 export default function HeroSection() {
   return (
     <section className="pt-32 pb-16 text-center px-4 relative" id="top">
       <HeroAnimatedTitle className="text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-serif mb-10 tracking-tight text-foreground leading-[1.12] max-w-5xl mx-auto animate-fade-in-up" />
       <p className="text-base text-muted-foreground max-w-2xl mx-auto mb-8 leading-relaxed">
-        A <strong className="text-foreground font-semibold">harness-first modality layer</strong> for text-first LLMs.
-        The model stays a planner; modality contracts, codecs, seed expanders, frozen decoders, and deterministic runtimes
-        turn structured outputs into real files such as <strong className="text-foreground font-semibold">PNG, WAV, HTML, JSON,</strong>{' '}
-        and, once the video branch is fully wired back in, <strong className="text-foreground font-semibold">MP4</strong>.
+        A <strong className="text-foreground font-semibold">harness-first modality layer</strong>{" "}
+        for text-first LLMs. The model stays a planner; modality contracts, codecs, seed expanders,
+        frozen decoders, and deterministic runtimes turn structured outputs into real files such as{" "}
+        <strong className="text-foreground font-semibold">PNG, WAV, HTML, JSON,</strong> and, once
+        the video branch is fully wired back in,{" "}
+        <strong className="text-foreground font-semibold">MP4</strong>.
       </p>
       <p className="text-sm text-muted-foreground max-w-xl mx-auto mb-8 leading-relaxed">
-        The point is not to pretend a text model is already a native multimodal stack. The point is to give it narrow,
-        inspectable code paths: Visual Seed Code for image, local render routes for audio and sensor, and traceable
-        artifact receipts at every step.
+        The point is not to pretend a text model is already a native multimodal stack. The point is
+        to give it narrow, inspectable code paths: Visual Seed Code for image, local render routes
+        for audio and sensor, and traceable artifact receipts at every step.
       </p>
       <div className="flex flex-wrap items-center justify-center gap-3">
         <a href="#s-layers" className="yellow-btn inline-flex items-center justify-center">

--- a/apps/site/src/sections/HumanReadabilitySection.tsx
+++ b/apps/site/src/sections/HumanReadabilitySection.tsx
@@ -1,6 +1,6 @@
-import { lazy, Suspense } from 'react';
+import { lazy, Suspense } from "react";
 
-const PipelineGargantua = lazy(() => import('../components/PipelineGargantua'));
+const PipelineGargantua = lazy(() => import("../components/PipelineGargantua"));
 
 export default function HumanReadabilitySection() {
   return (
@@ -10,13 +10,16 @@ export default function HumanReadabilitySection() {
     >
       <div className="max-w-5xl mx-auto">
         <span className="section-number text-[hsl(var(--warm-silver))]">03</span>
-        <h2 className="text-4xl md:text-5xl font-serif mt-2 mb-4 lowercase text-[hsl(var(--ivory))]">pipeline</h2>
+        <h2 className="text-4xl md:text-5xl font-serif mt-2 mb-4 lowercase text-[hsl(var(--ivory))]">
+          pipeline
+        </h2>
         <p className="text-[hsl(var(--warm-silver))] text-sm max-w-2xl mb-10 leading-relaxed">
-          The locked image pipeline stays narrow: Visual Seed Code-bearing contract → seed expander / adapter → frozen
-          decoder → PNG. Semantic IR still helps with model-side organization and user inspection, but it no longer owns the
-          path. Decoder ≠ generator, and every run writes a trace under{' '}
-          <span className="font-mono text-xs">artifacts/runs/</span>. Audio, sensor, and video follow the same philosophy:
-          modality-specific code first, local runtime second, file output last.
+          The locked image pipeline stays narrow: Visual Seed Code-bearing contract → seed expander
+          / adapter → frozen decoder → PNG. Semantic IR still helps with model-side organization and
+          user inspection, but it no longer owns the path. Decoder ≠ generator, and every run writes
+          a trace under <span className="font-mono text-xs">artifacts/runs/</span>. Audio, sensor,
+          and video follow the same philosophy: modality-specific code first, local runtime second,
+          file output last.
         </p>
 
         <div className="relative mb-8 rounded-xl overflow-hidden border border-[hsl(var(--dark-surface))] bg-black shadow-[0_0_0_1px_rgba(0,0,0,0.4)]">
@@ -31,7 +34,9 @@ export default function HumanReadabilitySection() {
             <PipelineGargantua className="relative w-full h-[min(22rem,50vh)] md:h-[26rem] touch-none [&_canvas]:cursor-grab [&_canvas:active]:cursor-grabbing" />
           </Suspense>
           <div className="pointer-events-none absolute left-4 top-4 z-10 text-left">
-            <p className="text-[0.65rem] font-medium uppercase tracking-[0.2em] text-white/80 drop-shadow-md">Gargantua</p>
+            <p className="text-[0.65rem] font-medium uppercase tracking-[0.2em] text-white/80 drop-shadow-md">
+              Gargantua
+            </p>
             <p className="mt-1 text-[0.6rem] uppercase tracking-[0.15em] text-white/40 drop-shadow-md">
               drag to orbit · WebGL
             </p>
@@ -44,28 +49,28 @@ export default function HumanReadabilitySection() {
             aria-hidden
           >
             <span className="text-[hsl(var(--coral))]">User prompt</span>
-            {'\n    →  schema preamble + image contract'}
-            {'\n          →  '}
+            {"\n    →  schema preamble + image contract"}
+            {"\n          →  "}
             <span className="text-[hsl(var(--coral))]">LLM</span>
-            {' (planner)'}
-            {'\n                →  '}
+            {" (planner)"}
+            {"\n                →  "}
             <span className="text-[hsl(var(--coral))]">parse</span>
-            {' (zod)'}
-            {'\n                      →  '}
+            {" (zod)"}
+            {"\n                      →  "}
             <span className="text-[hsl(var(--coral))]">inspect</span>
-            {' (semantic, optional)'}
-            {'\n                            →  '}
+            {" (semantic, optional)"}
+            {"\n                            →  "}
             <span className="text-[hsl(var(--coral))]">expand</span>
-            {' (seedCode / coarse code)'}
-            {'\n                                  →  '}
+            {" (seedCode / coarse code)"}
+            {"\n                                  →  "}
             <span className="text-[hsl(var(--coral))]">adapter</span>
-            {' (seed expander)'}
-            {'\n                                        →  '}
+            {" (seed expander)"}
+            {"\n                                        →  "}
             <span className="text-[hsl(var(--coral))]">decoder</span>
-            {' (frozen)'}
-            {'\n                                              →  '}
+            {" (frozen)"}
+            {"\n                                              →  "}
             <span className="text-[hsl(var(--coral))]">packageRasterAsPng</span>
-            {'\n                                                    →  artifact + manifest'}
+            {"\n                                                    →  artifact + manifest"}
           </pre>
         </div>
 
@@ -74,24 +79,33 @@ export default function HumanReadabilitySection() {
             coverage · scaffold depth
           </div>
           <div className="flex items-center gap-3 mb-3">
-            <span className="font-mono text-[0.7rem] text-[hsl(var(--warm-silver))] w-14 shrink-0">runtime</span>
+            <span className="font-mono text-[0.7rem] text-[hsl(var(--warm-silver))] w-14 shrink-0">
+              runtime
+            </span>
             <div className="flex-1 h-[1.35rem] rounded-md overflow-hidden border border-[hsl(var(--dark-surface))] bg-[rgba(20,20,19,0.5)]">
               <div className="h-full w-[88%] rounded-md bg-primary" />
             </div>
-            <span className="font-mono text-[0.7rem] text-[hsl(var(--warm-silver))] w-10 text-right shrink-0">88%</span>
+            <span className="font-mono text-[0.7rem] text-[hsl(var(--warm-silver))] w-10 text-right shrink-0">
+              88%
+            </span>
           </div>
           <div className="flex items-center gap-3 mb-4">
-            <span className="font-mono text-[0.7rem] text-[hsl(var(--warm-silver))] w-14 shrink-0">codecs</span>
+            <span className="font-mono text-[0.7rem] text-[hsl(var(--warm-silver))] w-14 shrink-0">
+              codecs
+            </span>
             <div className="flex-1 h-[1.35rem] rounded-md overflow-hidden border border-[hsl(var(--dark-surface))] bg-[rgba(20,20,19,0.5)]">
               <div className="h-full w-[42%] rounded-md bg-[hsl(var(--muted-green))]" />
             </div>
-            <span className="font-mono text-[0.7rem] text-[hsl(var(--warm-silver))] w-10 text-right shrink-0">42%</span>
+            <span className="font-mono text-[0.7rem] text-[hsl(var(--warm-silver))] w-10 text-right shrink-0">
+              42%
+            </span>
           </div>
           <p className="text-[0.8125rem] text-[hsl(var(--warm-silver))] leading-relaxed">
-            Illustrative only: these bars show relative scaffold depth, not benchmarked release scores. Runtime and shared
-            contracts are ahead of some finished renderers. Image already centers on Visual Seed Code plus frozen-decoder
-            wiring; sensor expands deterministic operators; audio renders local WAV artifacts; video still waits on the
-            fuller MP4 branch to be merged back into the main flow.
+            Illustrative only: these bars show relative scaffold depth, not benchmarked release
+            scores. Runtime and shared contracts are ahead of some finished renderers. Image already
+            centers on Visual Seed Code plus frozen-decoder wiring; sensor expands deterministic
+            operators; audio renders local WAV artifacts; video still waits on the fuller MP4 branch
+            to be merged back into the main flow.
           </p>
         </div>
       </div>

--- a/apps/site/src/sections/HumanReadabilitySection.tsx
+++ b/apps/site/src/sections/HumanReadabilitySection.tsx
@@ -12,9 +12,11 @@ export default function HumanReadabilitySection() {
         <span className="section-number text-[hsl(var(--warm-silver))]">03</span>
         <h2 className="text-4xl md:text-5xl font-serif mt-2 mb-4 lowercase text-[hsl(var(--ivory))]">pipeline</h2>
         <p className="text-[hsl(var(--warm-silver))] text-sm max-w-2xl mb-10 leading-relaxed">
-          The locked image pipeline stays narrow: semantic JSON → adapter → frozen decoder → PNG. Decoder ≠ generator, and
-          every run writes a trace under <span className="font-mono text-xs">artifacts/runs/</span>. Audio, sensor, and
-          video follow the same philosophy: structured intent first, local codec logic second, file output last.
+          The locked image pipeline stays narrow: Visual Seed Code-bearing contract → seed expander / adapter → frozen
+          decoder → PNG. Semantic IR still helps with model-side organization and user inspection, but it no longer owns the
+          path. Decoder ≠ generator, and every run writes a trace under{' '}
+          <span className="font-mono text-xs">artifacts/runs/</span>. Audio, sensor, and video follow the same philosophy:
+          modality-specific code first, local runtime second, file output last.
         </p>
 
         <div className="relative mb-8 rounded-xl overflow-hidden border border-[hsl(var(--dark-surface))] bg-black shadow-[0_0_0_1px_rgba(0,0,0,0.4)]">
@@ -42,7 +44,7 @@ export default function HumanReadabilitySection() {
             aria-hidden
           >
             <span className="text-[hsl(var(--coral))]">User prompt</span>
-            {'\n    →  schema preamble + JSON contract'}
+            {'\n    →  schema preamble + image contract'}
             {'\n          →  '}
             <span className="text-[hsl(var(--coral))]">LLM</span>
             {' (planner)'}
@@ -50,16 +52,20 @@ export default function HumanReadabilitySection() {
             <span className="text-[hsl(var(--coral))]">parse</span>
             {' (zod)'}
             {'\n                      →  '}
-            <span className="text-[hsl(var(--coral))]">expand</span>
-            {' →  '}
-            <span className="text-[hsl(var(--coral))]">adapter</span>
-            {' (latents)'}
+            <span className="text-[hsl(var(--coral))]">inspect</span>
+            {' (semantic, optional)'}
             {'\n                            →  '}
+            <span className="text-[hsl(var(--coral))]">expand</span>
+            {' (seedCode / coarse code)'}
+            {'\n                                  →  '}
+            <span className="text-[hsl(var(--coral))]">adapter</span>
+            {' (seed expander)'}
+            {'\n                                        →  '}
             <span className="text-[hsl(var(--coral))]">decoder</span>
             {' (frozen)'}
-            {'\n                                  →  '}
+            {'\n                                              →  '}
             <span className="text-[hsl(var(--coral))]">packageRasterAsPng</span>
-            {'\n                                        →  artifact + manifest'}
+            {'\n                                                    →  artifact + manifest'}
           </pre>
         </div>
 
@@ -82,9 +88,10 @@ export default function HumanReadabilitySection() {
             <span className="font-mono text-[0.7rem] text-[hsl(var(--warm-silver))] w-10 text-right shrink-0">42%</span>
           </div>
           <p className="text-[0.8125rem] text-[hsl(var(--warm-silver))] leading-relaxed">
-            Illustrative only: runtime and shared contracts are ahead of some finished renderers. Image already centers on
-            adapter + frozen decoder wiring; sensor expands deterministic operators; audio renders local WAV artifacts; video
-            still waits on the fuller MP4 branch to be merged back into the main flow.
+            Illustrative only: these bars show relative scaffold depth, not benchmarked release scores. Runtime and shared
+            contracts are ahead of some finished renderers. Image already centers on Visual Seed Code plus frozen-decoder
+            wiring; sensor expands deterministic operators; audio renders local WAV artifacts; video still waits on the
+            fuller MP4 branch to be merged back into the main flow.
           </p>
         </div>
       </div>

--- a/apps/site/src/sections/WeightEditingSection.tsx
+++ b/apps/site/src/sections/WeightEditingSection.tsx
@@ -1,23 +1,27 @@
 const packagingNotes = [
   {
-    name: 'CLI & install',
-    pct: 'L5',
-    description: 'Ships the command surface, install conventions, and smoke checks so contributors land in the right package quickly.',
+    name: "CLI & install",
+    pct: "L5",
+    description:
+      "Ships the command surface, install conventions, and smoke checks so contributors land in the right package quickly.",
   },
   {
-    name: 'RunManifest',
-    pct: 'IR',
-    description: 'Shared trace schema for codec id, route, adapter version, artifact hashes, and replay handles.',
+    name: "RunManifest",
+    pct: "IR",
+    description:
+      "Shared trace schema for codec id, route, adapter version, artifact hashes, and replay handles.",
   },
   {
-    name: 'docs & skills',
-    pct: 'DX',
-    description: 'Architecture docs plus per-codec READMEs keep image, audio, sensor, and video responsibilities explicit.',
+    name: "docs & skills",
+    pct: "DX",
+    description:
+      "Architecture docs plus per-codec READMEs keep image, audio, sensor, and video responsibilities explicit.",
   },
   {
-    name: 'distribution',
-    pct: 'pkg',
-    description: 'Versioned harness bundles let tiny adapters and modality-specific logic ship beside the runtime rather than inside the base model.',
+    name: "distribution",
+    pct: "pkg",
+    description:
+      "Versioned harness bundles let tiny adapters and modality-specific logic ship beside the runtime rather than inside the base model.",
   },
 ];
 
@@ -30,26 +34,30 @@ export default function WeightEditingSection() {
         <span className="section-number">07</span>
         <h2 className="text-4xl md:text-5xl font-serif mt-2 mb-4 lowercase">packaging</h2>
         <p className="text-muted-foreground text-sm max-w-xl mb-10 leading-relaxed">
-          Layer five turns the architecture into something people can actually use: CLI, install, shared schemas, docs,
-          agent primers, and distribution conventions.
+          Layer five turns the architecture into something people can actually use: CLI, install,
+          shared schemas, docs, agent primers, and distribution conventions.
         </p>
 
         <div className="card-border p-6">
           <div className="flex items-baseline justify-between mb-2">
-            <div className="text-xs font-mono text-muted-foreground">manifest depth · 16 surfaced checkpoints</div>
+            <div className="text-xs font-mono text-muted-foreground">
+              manifest depth · 16 surfaced checkpoints
+            </div>
             <div className="text-xs font-mono text-muted-foreground">target harness</div>
           </div>
           <p className="text-sm text-muted-foreground mb-6">
-            Runtime and contracts are ahead of a few renderers; packaging is where that progress becomes legible, installable,
-            and reusable.
+            Runtime and contracts are ahead of a few renderers; packaging is where that progress
+            becomes legible, installable, and reusable.
           </p>
           <p className="text-sm text-muted-foreground mb-6">
-            For a project like this, release hygiene is not an afterthought. The packaging layer is what turns a clever
-            architecture into something teammates, judges, contributors, and future users can actually pick up.
+            For a project like this, release hygiene is not an afterthought. The packaging layer is
+            what turns a clever architecture into something teammates, judges, contributors, and
+            future users can actually pick up.
           </p>
           <p className="text-sm text-muted-foreground mb-6">
-            The percentages below are directional packaging signals, not release-gating numbers. They show where the shared
-            runtime is already stable and where some modality surfaces are still catching up.
+            The percentages below are directional packaging signals, not release-gating numbers.
+            They show where the shared runtime is already stable and where some modality surfaces
+            are still catching up.
           </p>
 
           <div className="grid md:grid-cols-3 gap-8">
@@ -60,8 +68,9 @@ export default function WeightEditingSection() {
                     <div
                       className="w-8 h-8 rounded-full flex items-center justify-center border-2"
                       style={{
-                        borderColor: signal > 40 ? 'hsl(var(--primary))' : 'hsl(var(--border))',
-                        backgroundColor: i === 11 ? 'hsl(var(--primary) / 0.12)' : 'hsl(var(--card))',
+                        borderColor: signal > 40 ? "hsl(var(--primary))" : "hsl(var(--border))",
+                        backgroundColor:
+                          i === 11 ? "hsl(var(--primary) / 0.12)" : "hsl(var(--card))",
                       }}
                     >
                       <span className="text-xs font-mono text-muted-foreground">{i}</span>
@@ -86,12 +95,16 @@ export default function WeightEditingSection() {
             <div>
               <div className="text-xs font-mono text-muted-foreground mb-4">release</div>
               <div className="space-y-2">
-                {['scaffold', 'manifest', 'publish', 'tag'].map((step, idx) => (
+                {["scaffold", "manifest", "publish", "tag"].map((step, idx) => (
                   <div key={step} className="flex items-center gap-2">
                     <div
-                      className={`w-2 h-2 rounded-full ${idx < 3 ? 'bg-[hsl(var(--muted-green))]' : 'bg-muted-foreground/40'}`}
+                      className={`w-2 h-2 rounded-full ${idx < 3 ? "bg-[hsl(var(--muted-green))]" : "bg-muted-foreground/40"}`}
                     />
-                    <span className={`text-sm ${idx < 3 ? 'text-foreground' : 'text-muted-foreground'}`}>{step}</span>
+                    <span
+                      className={`text-sm ${idx < 3 ? "text-foreground" : "text-muted-foreground"}`}
+                    >
+                      {step}
+                    </span>
                   </div>
                 ))}
               </div>
@@ -128,10 +141,22 @@ export default function WeightEditingSection() {
           </div>
 
           <div className="mt-8 flex items-center justify-between pt-4 border-t border-border">
-            <div className="text-xs text-muted-foreground">Apache-2.0 · traceable artifacts · contributor-ready CLI</div>
-            <a href="#s-thesis" className="text-sm text-muted-foreground hover:text-foreground flex items-center gap-1 transition-colors">
+            <div className="text-xs text-muted-foreground">
+              Apache-2.0 · traceable artifacts · contributor-ready CLI
+            </div>
+            <a
+              href="#s-thesis"
+              className="text-sm text-muted-foreground hover:text-foreground flex items-center gap-1 transition-colors"
+            >
               read the thesis
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
                 <path d="M5 12h14M12 5l7 7-7 7" />
               </svg>
             </a>

--- a/apps/site/src/sections/WeightEditingSection.tsx
+++ b/apps/site/src/sections/WeightEditingSection.tsx
@@ -36,7 +36,7 @@ export default function WeightEditingSection() {
 
         <div className="card-border p-6">
           <div className="flex items-baseline justify-between mb-2">
-            <div className="text-xs font-mono text-muted-foreground">manifest depth · 16 checkpoints</div>
+            <div className="text-xs font-mono text-muted-foreground">manifest depth · 16 surfaced checkpoints</div>
             <div className="text-xs font-mono text-muted-foreground">target harness</div>
           </div>
           <p className="text-sm text-muted-foreground mb-6">
@@ -46,6 +46,10 @@ export default function WeightEditingSection() {
           <p className="text-sm text-muted-foreground mb-6">
             For a project like this, release hygiene is not an afterthought. The packaging layer is what turns a clever
             architecture into something teammates, judges, contributors, and future users can actually pick up.
+          </p>
+          <p className="text-sm text-muted-foreground mb-6">
+            The percentages below are directional packaging signals, not release-gating numbers. They show where the shared
+            runtime is already stable and where some modality surfaces are still catching up.
           </p>
 
           <div className="grid md:grid-cols-3 gap-8">
@@ -124,7 +128,7 @@ export default function WeightEditingSection() {
           </div>
 
           <div className="mt-8 flex items-center justify-between pt-4 border-t border-border">
-            <div className="text-xs text-muted-foreground">Apache-2.0 · traceable artifacts · publish-ready CLI</div>
+            <div className="text-xs text-muted-foreground">Apache-2.0 · traceable artifacts · contributor-ready CLI</div>
             <a href="#s-thesis" className="text-sm text-muted-foreground hover:text-foreground flex items-center gap-1 transition-colors">
               read the thesis
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">


### PR DESCRIPTION
## Summary
- retune homepage copy to match the current repo doctrine without changing layout or interaction
- replace stale image-path wording with Visual Seed Code / seed-expander language
- soften illustrative percentages and status surfaces so they do not read like hard release receipts
- align metadata, footer, and hero language around "text-first LLMs"
- sharpen the hero/title language so the homepage lands more like a product statement than an internal architecture note

## Validation
- pnpm --filter @wittgenstein/site check
- git diff --check