### PR TITLE
docs(site): restore homepage title wording

### DIFF
--- a/apps/site/src/components/HeroAnimatedTitle.tsx
+++ b/apps/site/src/components/HeroAnimatedTitle.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 
 import { cn } from "@/lib/utils";
 
-const TITLE = "text-first LLMs, real files out.";
+const TITLE = "text-first LLMs, file-native outputs.";
 
 function readPrefersReducedMotion(): boolean {
   if (typeof window === "undefined") return false;


### PR DESCRIPTION
## Summary
- restore the homepage hero title to the approved wording

## Validation
- pnpm --filter @wittgenstein/site check
- git diff --check