### PR TITLE
docs: align AGENTS.md and PROMPT.md inline summaries with current ADRs (closes #311)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,7 +142,7 @@ The original Read Order is still valid as a depth path. Before that, an agent la
 2. [`docs/glossary.md`](docs/glossary.md) — locked vocabulary (the table above)
 3. [`docs/contributor-map.md`](docs/contributor-map.md) — onboarding map (humans + agents)
 4. [`docs/hard-constraints.md`](docs/hard-constraints.md) — what will not change (canonical, supersedes the bullets above)
-5. [`docs/exec-plans/active/codec-v2-port.md`](docs/exec-plans/active/codec-v2-port.md) — the live P6 plan; M0 and M1A are landed, and M2 audio is the active execution line
+5. [`docs/exec-plans/active/codec-v2-port.md`](docs/exec-plans/active/codec-v2-port.md) — the live P6 plan; M0, M1A, M2 audio, and M3 sensor are landed. M1B (image trained projector) is the current mainline blocker, gated on [#283](https://github.com/p-to-q/wittgenstein/issues/283).
 6. [`docs/inheritance-audit.md`](docs/inheritance-audit.md) — what survived / was promoted / was retired in the v0.2 lock
 7. [`docs/SYNTHESIS_v0.2.md`](docs/SYNTHESIS_v0.2.md) — branch-level merge brief
 8. [`docs/v02-final-audit.md`](docs/v02-final-audit.md) — pre-lock decision ledger

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,7 @@ The repo runs on **two separate decision lanes**. Pick the right one before you 
 | **Harness**   | L1    | Routing, retry, seed, validate, budget, record                                                       |
 | **Codec**     | L2    | Modality implementation (owns schema + render)                                                       |
 | **Spec**      | L2    | Structured artifact (`ImageSceneSpec`, `AudioPlan`, …)                                               |
-| **IR**        | L3    | Internal representation; sum type `Text \| Latent \| Hybrid`; **only `Text` is inhabited at v0.2**   |
+| **IR**        | L3    | Typed internal-representation layer; contracts may carry text, code-bearing, or hybrid sections by modality. Image's Visual Seed Code route is the current ratified example. New IR shapes require RFC/ADR routing. (ADR-0011 / ADR-0018) |
 | **Decoder**   | L3    | IR → bytes; frozen, deterministic, never generative (ADR-0005)                                       |
 | **Adapter**   | L4    | Learned bridge / seed expander (visual seed code → fuller latent tokens); optional, image only today |
 | **Packaging** | L5    | CLI · npm · manifests · install (was “Distribution” above)                                           |
@@ -152,7 +152,7 @@ Then return to the original Read Order above for engineering discipline, codec p
 ### What's currently active
 
 - **Doctrine:** locked at v0.2.0-alpha.1; M2 preflight closure cut at v0.2.0-alpha.2; governance lane introduced in ADRs 0012–0014 (see below).
-- **Code:** Codec Protocol v2 port — sequenced **M0 image → M1 image refinement → M2 audio → M3 sensor → M4 video stub → M5a/b benchmarks**. M0 and M1A are landed; M2 audio has closed its sweep gate. The next image-depth line is no longer framed as `scene-spec -> latent` alone: image now centers Visual Seed Code, with `Semantic IR` as semantic/debug/user-facing support.
+- **Code:** Codec Protocol v2 port — sequenced **M0 image → M1 image refinement → M2 audio → M3 sensor → M4 video stub → M5a/b benchmarks**. M0, M1A, M2 audio, and M3 sensor are landed (per [exec-plan annotation](docs/exec-plans/active/codec-v2-port.md), [PR #293](https://github.com/p-to-q/wittgenstein/pull/293)). **M1B (image trained projector) is the current v0.3 mainline blocker** — gated on per-candidate radar audits in [#283](https://github.com/p-to-q/wittgenstein/issues/283). M4 cleanup is partial; M5a/b deferred until M1B lands. The image-depth line centers Visual Seed Code (per ADR-0018), with `Semantic IR` as semantic/debug/user-facing support.
 - **Out of scope until M5b:** new modalities, diffusion samplers, trained model weights, website rewrite, RFC-0003 renaming.
 
 ### Two decision lanes (v0.2.0-alpha.2 governance addition)

--- a/PROMPT.md
+++ b/PROMPT.md
@@ -24,7 +24,7 @@ surface (`polyglot-mini/`), with a manifest-spine reproducibility contract.
 1. [`docs/THESIS.md`](docs/THESIS.md) — the smallest locked statement (≤1 page)
 2. [`docs/glossary.md`](docs/glossary.md) — locked vocabulary; do not invent alternatives
 3. [`docs/hard-constraints.md`](docs/hard-constraints.md) — what will not change
-4. [`docs/exec-plans/active/codec-v2-port.md`](docs/exec-plans/active/codec-v2-port.md) — the live P6 workstream (M0 → M5b); M0 and M1A are landed, and M2 audio is the active execution line
+4. [`docs/exec-plans/active/codec-v2-port.md`](docs/exec-plans/active/codec-v2-port.md) — the live P6 workstream (M0 → M5b); M0, M1A, M2 audio, and M3 sensor are landed. M1B (image trained projector) is the current mainline blocker, gated on [#283](https://github.com/p-to-q/wittgenstein/issues/283) (per-candidate radar audits).
 
 That's enough to start. Pull deeper docs **only when the task forces you to**.
 
@@ -35,7 +35,7 @@ That's enough to start. Pull deeper docs **only when the task forces you to**.
 | **Harness**   | L1    | Routing, retry, seed, validate, budget, record                                    |
 | **Codec**     | L2    | Modality implementation (owns schema + render)                                    |
 | **Spec**      | L2    | Structured artifact (`ImageSceneSpec`, `AudioPlan`, …)                            |
-| **IR**        | L3    | Internal representation; sum type `Text \| Latent \| Hybrid`; only `Text` at v0.2 |
+| **IR**        | L3    | Typed internal-representation layer; contracts may carry text, code-bearing, or hybrid sections by modality. Image's Visual Seed Code route is the current ratified example. (ADR-0011 / ADR-0018) |
 | **Decoder**   | L3    | IR → bytes; **frozen, deterministic, never generative** (ADR-0005)                |
 | **Adapter**   | L4    | Learned bridge (Spec → latent); optional, image only today                        |
 | **Packaging** | L5    | CLI · npm · manifests · install                                                   |


### PR DESCRIPTION
## Summary

Closes #311. Inline status-surface and wording alignment across the four operating docs the issue audits. No doctrine change.

The PR follows #311's expected workflow: audit, classify (status surface vs doctrine), and apply a small inline correction where the docs are out of step with already-ratified ADRs. Anything doctrine-bearing was not touched.

## Drift audit (per #311's expected output)

| Surface | Up to date | Inline correction | Doctrine routing | Notes |
|---|---|---|---|---|
| `AGENTS.md` | mostly | **L112** IR row in glossary; **L155** M-phase status block | no | Matches the README correction shape #312 already landed (parallel glossary tables; same factual alignment with ADR-0018) |
| `WORKFLOW.md` | yes | none | no | Label semantics current (per ADR-0012); orchestration contract current (per ADR-0017); runtime intentionally unspecified at v0.3 |
| `README.md` | yes | none | no | Post-#312, the README first-screen architecture block already reflects current doctrine |
| `CHANGELOG.md` | yes | none | no | `[Unreleased]` + `[0.3.0-alpha.1]` structure is acting as release receipt, not doctrine surface |
| `PROMPT.md` | mostly | **L27** M-phase status; **L38** IR row in glossary | no | Parallel surface to AGENTS.md — same factual updates |

## What this PR changes

Two pairs of edits, both inline corrections:

### 1. IR row in glossary tables (AGENTS.md L112, PROMPT.md L38)

The prior wording asserted that the IR sum type \"only `Text` is inhabited at v0.2,\" which read narrower than what ADR-0018 / RFC-0006 ratified for the image route. The README's #312 correction softened this surface to \"typed internal-representation layer; contracts may carry text, code-bearing, or hybrid sections by modality.\" This PR applies the matching wording to AGENTS.md and PROMPT.md so the three glossary surfaces agree.

References **both** ADR-0011 (naming v2 lock — still authoritative for the underlying type) and ADR-0018 (VSC image route ratification — the practical reading). ADR-0011's \"only `Text` ships at v0.2\" framing remains correct **in the ADR itself**; this PR updates the operating-doc inline summaries only, per ADR-0014's governance lane rule.

### 2. M-phase status block (AGENTS.md L155, PROMPT.md L27)

Both said \"M0 and M1A are landed; M2 audio has closed its sweep gate\" / \"M2 audio is the active execution line.\" Per the exec-plan annotation in [PR #293](https://github.com/p-to-q/wittgenstein/pull/293), the actual state is:

- M0, M1A, M2 audio, M3 sensor → **landed**
- M1B (image trained projector) → **current v0.3 mainline blocker**, gated on per-candidate radar audits in [#283](https://github.com/p-to-q/wittgenstein/issues/283)
- M4 cleanup → partial
- M5a/b → deferred until M1B lands

Updated both surfaces to reflect this with links to the canonical sources.

## What this PR does NOT do

- Does **not** modify any ADR / RFC / exec-plan. Engineering-lane work is upstream of this PR.
- Does **not** touch ADR-0013 / ADR-0014 governance routing. This PR follows that routing — it's an inline summary update, not new doctrine.
- Does **not** edit WORKFLOW.md (no drift found).
- Does **not** add a CHANGELOG entry. The `[Unreleased]` section is acting as a release-receipt surface; this kind of inline doc-tightening lands there naturally via the next release sweep.
- Does **not** rewrite the README first-screen (separate issue [#256](https://github.com/p-to-q/wittgenstein/issues/256), distinct scope).

## Validation

- \`git diff --stat\` → 2 files changed, 4 insertions, 4 deletions.
- \`rg -n 'only.*Text.*inhabited|sum type.*Text.*Latent.*Hybrid' README.md AGENTS.md PROMPT.md WORKFLOW.md CHANGELOG.md\` returns no matches after this PR (was 3 matches before, 2 of which this PR addresses; README hit was already removed by #312).
- \`git diff --check\` clean.

## Refs

- Closes **#311**.
- Parallels **#312** (the README fix shape this PR mirrors).
- Cross-links **#293** (exec-plan annotation source for the status updates).
- Cross-links **#283** (M1B unblock gate; named in the updated status blocks).
- Anchored to **ADR-0018** + **ADR-0011** (existing doctrine, not modified).

## Continuation

- The README first-screen rewrite (#256) is the natural next slice in Cluster A; it can now build on a consistent glossary surface across all three primer docs.
- If a future ADR amends ADR-0011's IR sum-type framing in light of ADR-0018, the inline summaries here become the natural follow-up surface to re-tighten. That ADR work is **not** in scope for this PR.