### PR TITLE
refactor(codec-image): extract landscape renderer from pipeline/decoder.ts (closes #325)

### DIFF
--- a/packages/codec-image/src/pipeline/decoder.ts
+++ b/packages/codec-image/src/pipeline/decoder.ts
@@ -1,24 +1,37 @@
-import { readFile, unlink } from "node:fs/promises";
-import { basename, join, resolve } from "node:path";
-import { spawn } from "node:child_process";
+// Image decoder orchestrator — builds scalar fields from latent tokens, runs
+// the placeholder/landscape pixel synthesizer, and encodes the resulting RGBA
+// buffer as PNG. The landscape-specific rendering lives in
+// `./landscape-renderer.ts` (extracted per #325 / #288); shared math helpers
+// live in `./internal-math.ts`.
+//
+// The `loadLlamagenDecoderBridge` wiring under `../decoders/llamagen.ts` is
+// what eventually replaces the placeholder path here; M1B is gated on the
+// per-candidate radar audits in #283.
+
 import { deflateSync } from "node:zlib";
 import type { RenderCtx } from "@wittgenstein/schemas";
 import type { ImageLatentCodes } from "../schema.js";
+
+import {
+  buildSceneProfile,
+  buildPalette,
+  FIELD_SALTS,
+  renderSky,
+  renderTerrain,
+  tryDecodeReferenceLandscape,
+} from "./landscape-renderer.js";
+import {
+  clamp01,
+  clampByte,
+  clampInt,
+  hash01,
+  sampleField,
+} from "./internal-math.js";
 
 export interface DecodedRaster {
   pngBytes: Uint8Array;
   width: number;
   height: number;
-}
-
-type Rgb = [number, number, number];
-type SceneMode = "coast" | "forest" | "lake" | "mountain" | "meadow";
-
-interface SceneProfile {
-  mode: SceneMode;
-  variantA: number;
-  variantB: number;
-  ruggedness: number;
 }
 
 export async function decodeLatentsToRaster(
@@ -44,10 +57,30 @@ export async function decodeLatentsToRaster(
   const rgba = new Uint8Array(pixelCount * 4);
 
   const normalizedTokens = normalizeTokens(codes.tokens);
-  const elevation = blurField(buildField(normalizedTokens, 0x1a2b3c4d), tokenWidth, tokenHeight, 2);
-  const moisture = blurField(buildField(normalizedTokens, 0x91c7e35a), tokenWidth, tokenHeight, 2);
-  const warmth = blurField(buildField(normalizedTokens, 0x4f6a9d21), tokenWidth, tokenHeight, 2);
-  const detail = blurField(buildField(normalizedTokens, 0xd15f0c77), tokenWidth, tokenHeight, 1);
+  const elevation = blurField(
+    buildField(normalizedTokens, FIELD_SALTS.elevation),
+    tokenWidth,
+    tokenHeight,
+    2,
+  );
+  const moisture = blurField(
+    buildField(normalizedTokens, FIELD_SALTS.moisture),
+    tokenWidth,
+    tokenHeight,
+    2,
+  );
+  const warmth = blurField(
+    buildField(normalizedTokens, FIELD_SALTS.warmth),
+    tokenWidth,
+    tokenHeight,
+    2,
+  );
+  const detail = blurField(
+    buildField(normalizedTokens, FIELD_SALTS.detail),
+    tokenWidth,
+    tokenHeight,
+    1,
+  );
 
   const averageElevation = averageField(elevation);
   const averageMoisture = averageField(moisture);
@@ -122,225 +155,7 @@ export async function decodeLatentsToRaster(
   };
 }
 
-function renderSky(
-  nx: number,
-  ny: number,
-  horizon: number,
-  warm: number,
-  moist: number,
-  detail: number,
-  skyTop: Rgb,
-  skyHorizon: Rgb,
-  profile: SceneProfile,
-): Rgb {
-  const t = clamp01(ny / Math.max(horizon, 0.001));
-  let color = mixColor(skyTop, skyHorizon, Math.pow(t, 0.85));
-
-  const cloudBand = smoothstep(0.12, 0.78, moist * 0.7 + detail * 0.3);
-  const cloudMask =
-    smoothstep(0.52, 0.88, sampleNoise(nx * 5.5 + detail, ny * 7.2 + warm * 2.4)) *
-    (1 - t) *
-    cloudBand *
-    0.42;
-  color = mixColor(color, [247, 244, 239], cloudMask);
-
-  const sunMask =
-    Math.exp(-Math.pow(nx - (0.18 + warm * 0.52 + profile.variantA * 0.08), 2) / 0.006) *
-    Math.exp(-Math.pow(ny - (0.11 + moist * 0.11 + profile.variantB * 0.03), 2) / 0.0025) *
-    0.35;
-  color = mixColor(color, [255, 236, 190], sunMask);
-
-  return color;
-}
-
-function renderTerrain(
-  nx: number,
-  ny: number,
-  horizon: number,
-  elevation: number,
-  moisture: number,
-  warmth: number,
-  detail: number,
-  rockBase: Rgb,
-  grassBase: Rgb,
-  waterBase: Rgb,
-  skyHorizon: Rgb,
-  elevationField: Float32Array,
-  gridWidth: number,
-  gridHeight: number,
-  profile: SceneProfile,
-): Rgb {
-  const landT = clamp01((ny - horizon) / Math.max(1 - horizon, 0.001));
-  const atmosphere = Math.pow(1 - landT, 1.5) * 0.45;
-
-  const ridgeNoise = sampleNoise(nx * 8.2 + detail * 1.5, ny * 11.3 + elevation * 1.8);
-  const vegetation = clamp01(moisture * 0.75 + (1 - landT) * 0.15 + ridgeNoise * 0.1);
-  const soilWarmth = clamp01(warmth * 0.7 + detail * 0.2);
-  const terrainBase = mixColor(rockBase, grassBase, vegetation);
-  let color = mixColor(terrainBase, [178, 134, 84], soilWarmth * 0.22);
-
-  const waterBias = profile.mode === "coast" ? 0.28 : profile.mode === "lake" ? 0.34 : 0;
-  const waterChance = clamp01((moisture - 0.52) * 1.6 + waterBias) * (1 - landT) * 1.4;
-  const waterMask =
-    smoothstep(0.16, 0.01, landT) *
-    smoothstep(0.14, 0.65, waterChance) *
-    smoothstep(0.32, 0.72, ridgeNoise);
-  color = mixColor(color, waterBase, waterMask * 0.85);
-
-  if (profile.mode === "coast") {
-    const beachMask = smoothstep(0.22, 0.58, landT) * smoothstep(0.72, 0.15, vegetation);
-    color = mixColor(color, [205, 188, 144], beachMask * 0.45);
-  }
-
-  if (profile.mode === "forest") {
-    const treeNoise = sampleNoise(nx * 18 + profile.variantA * 3, detail * 7 + nx * 4);
-    const treeMask =
-      smoothstep(0.62, 0.82, treeNoise) * smoothstep(0.2, 0.01, landT) * (1 - waterMask);
-    color = mixColor(color, [52, 79, 52], treeMask * 0.65);
-  }
-
-  if (profile.mode === "mountain") {
-    const snowMask = smoothstep(0.82, 0.96, elevation) * smoothstep(0.2, 0.02, landT);
-    color = mixColor(color, [230, 233, 236], snowMask * 0.55);
-  }
-
-  if (profile.mode === "meadow") {
-    const flowerNoise = sampleNoise(nx * 34 + profile.variantB * 5, ny * 40 + detail * 3.2);
-    const flowerMask = smoothstep(0.82, 0.94, flowerNoise) * smoothstep(0.86, 0.32, landT);
-    color = mixColor(color, [234, 198, 141], flowerMask * 0.18);
-  }
-
-  const shading = terrainShade(elevationField, gridWidth, gridHeight, nx, ny);
-  color = scaleColor(color, 0.82 + shading * 0.28);
-
-  const grain = (sampleNoise(nx * 28 + detail * 4.2, ny * 34 + warmth * 3.1) - 0.5) * 26;
-  color = [
-    clampByte(color[0] + grain),
-    clampByte(color[1] + grain * 0.7),
-    clampByte(color[2] + grain * 0.45),
-  ];
-
-  return mixColor(color, skyHorizon, atmosphere);
-}
-
-function buildSceneProfile(tokens: number[]): SceneProfile {
-  let hash = 2166136261;
-  for (let i = 0; i < tokens.length; i += 1) {
-    hash ^= (tokens[i] ?? 0) + i * 31;
-    hash = Math.imul(hash, 16777619);
-  }
-  const hashA = hash >>> 0;
-  const hashB = Math.imul(hashA ^ 0x9e3779b9, 2246822519) >>> 0;
-  const modes: SceneMode[] = ["coast", "forest", "lake", "mountain", "meadow"];
-  return {
-    mode: modes[Math.abs(tokens[0] ?? hashA) % modes.length] ?? "meadow",
-    variantA: tokens.length > 1 ? ((tokens[1] ?? 0) % 8192) / 8191 : ((hashA >>> 8) & 255) / 255,
-    variantB: tokens.length > 2 ? ((tokens[2] ?? 0) % 8192) / 8191 : ((hashB >>> 12) & 255) / 255,
-    ruggedness: 0.35 + (((hashB >>> 20) & 255) / 255) * 0.65,
-  };
-}
-
-async function tryDecodeReferenceLandscape(
-  profile: SceneProfile,
-  ctx: RenderCtx,
-): Promise<Uint8Array | null> {
-  const referencePath = selectReferenceImage(profile);
-  if (!referencePath) {
-    return null;
-  }
-
-  const outPath = join(ctx.runDir, `_reference-${profile.mode}.png`);
-  const bridgeScript = resolve(process.cwd(), "scripts/reference_image_to_png.py");
-
-  try {
-    await spawnChecked("python3", [bridgeScript, referencePath, outPath, profile.mode]);
-    const png = new Uint8Array(await readFile(outPath));
-    await unlink(outPath).catch(() => undefined);
-    ctx.logger.info(`Using reference decoder bridge asset: ${basename(referencePath)}`);
-    return png;
-  } catch (error) {
-    ctx.logger.warn(
-      "Reference decoder bridge unavailable; falling back to procedural placeholder.",
-      {
-        mode: profile.mode,
-        error,
-      },
-    );
-    return null;
-  }
-}
-
-function selectReferenceImage(profile: SceneProfile): string | null {
-  const bank: Record<SceneMode, string[]> = {
-    coast: ["9.jpg"],
-    forest: ["23.jpg"],
-    lake: ["8.jpg"],
-    mountain: ["11.jpg"],
-    meadow: ["16.jpg"],
-  };
-
-  const choices = bank[profile.mode];
-  if (!choices || choices.length === 0) {
-    return null;
-  }
-
-  const index = Math.floor(profile.variantA * choices.length) % choices.length;
-  return resolve(
-    process.cwd(),
-    "data/image_adapter/raw/images",
-    choices[index] ?? choices[0] ?? "",
-  );
-}
-
-function buildPalette(profile: SceneProfile, averageWarmth: number, averageMoisture: number) {
-  if (profile.mode === "coast") {
-    return {
-      skyTop: mixColor(
-        [49, 92, 155],
-        [116, 132, 181],
-        profile.variantA * 0.6 + averageWarmth * 0.4,
-      ),
-      skyHorizon: mixColor([236, 225, 214], [255, 210, 168], averageWarmth * 0.8 + 0.1),
-      rockBase: [142, 132, 118] as Rgb,
-      grassBase: [122, 142, 102] as Rgb,
-      waterBase: [68, 136, 176] as Rgb,
-    };
-  }
-  if (profile.mode === "forest") {
-    return {
-      skyTop: [72, 96, 150] as Rgb,
-      skyHorizon: [232, 223, 214] as Rgb,
-      rockBase: [100, 108, 102] as Rgb,
-      grassBase: mixColor([60, 92, 58], [98, 129, 80], averageMoisture * 0.8 + 0.1),
-      waterBase: [58, 112, 130] as Rgb,
-    };
-  }
-  if (profile.mode === "lake") {
-    return {
-      skyTop: [62, 98, 158] as Rgb,
-      skyHorizon: [224, 230, 240] as Rgb,
-      rockBase: [116, 122, 126] as Rgb,
-      grassBase: [104, 136, 92] as Rgb,
-      waterBase: [70, 130, 180] as Rgb,
-    };
-  }
-  if (profile.mode === "mountain") {
-    return {
-      skyTop: [74, 94, 146] as Rgb,
-      skyHorizon: [230, 220, 214] as Rgb,
-      rockBase: mixColor([108, 114, 126], [150, 130, 116], averageWarmth * 0.55),
-      grassBase: [122, 136, 106] as Rgb,
-      waterBase: [74, 116, 160] as Rgb,
-    };
-  }
-  return {
-    skyTop: [70, 100, 150] as Rgb,
-    skyHorizon: [244, 223, 194] as Rgb,
-    rockBase: [124, 120, 106] as Rgb,
-    grassBase: mixColor([96, 132, 74], [156, 164, 92], averageMoisture * 0.5 + averageWarmth * 0.3),
-    waterBase: [74, 120, 164] as Rgb,
-  };
-}
+// --- Field operations (private to the decoder orchestrator) ---
 
 function normalizeTokens(tokens: number[]): Float32Array {
   let min = Number.POSITIVE_INFINITY;
@@ -401,49 +216,6 @@ function blurField(
   return current;
 }
 
-function sampleField(
-  field: Float32Array,
-  width: number,
-  height: number,
-  nx: number,
-  ny: number,
-): number {
-  const x = clamp01(nx) * (width - 1);
-  const y = clamp01(ny) * (height - 1);
-  const x0 = Math.floor(x);
-  const y0 = Math.floor(y);
-  const x1 = Math.min(width - 1, x0 + 1);
-  const y1 = Math.min(height - 1, y0 + 1);
-  const tx = x - x0;
-  const ty = y - y0;
-
-  const c00 = field[y0 * width + x0] ?? 0;
-  const c10 = field[y0 * width + x1] ?? 0;
-  const c01 = field[y1 * width + x0] ?? 0;
-  const c11 = field[y1 * width + x1] ?? 0;
-
-  const top = lerp(c00, c10, tx);
-  const bottom = lerp(c01, c11, tx);
-  return lerp(top, bottom, ty);
-}
-
-function terrainShade(
-  field: Float32Array,
-  width: number,
-  height: number,
-  nx: number,
-  ny: number,
-): number {
-  const eps = 1 / Math.max(width, height);
-  const left = sampleField(field, width, height, nx - eps, ny);
-  const right = sampleField(field, width, height, nx + eps, ny);
-  const up = sampleField(field, width, height, nx, ny - eps);
-  const down = sampleField(field, width, height, nx, ny + eps);
-  const dx = right - left;
-  const dy = down - up;
-  return clamp01(0.55 + dx * 0.9 - dy * 0.65);
-}
-
 function averageField(field: Float32Array): number {
   let sum = 0;
   for (const value of field) {
@@ -458,59 +230,7 @@ function distanceToCenter(nx: number, ny: number): number {
   return clamp01(Math.sqrt(dx * dx + dy * dy) / 0.72);
 }
 
-function sampleNoise(x: number, y: number): number {
-  const x0 = Math.floor(x);
-  const y0 = Math.floor(y);
-  const tx = x - x0;
-  const ty = y - y0;
-
-  const n00 = hash01(x0 * 374761393 + y0 * 668265263);
-  const n10 = hash01((x0 + 1) * 374761393 + y0 * 668265263);
-  const n01 = hash01(x0 * 374761393 + (y0 + 1) * 668265263);
-  const n11 = hash01((x0 + 1) * 374761393 + (y0 + 1) * 668265263);
-
-  const sx = tx * tx * (3 - 2 * tx);
-  const sy = ty * ty * (3 - 2 * ty);
-  return lerp(lerp(n00, n10, sx), lerp(n01, n11, sx), sy);
-}
-
-function mixColor(a: Rgb, b: Rgb, t: number): Rgb {
-  return [lerp(a[0], b[0], t), lerp(a[1], b[1], t), lerp(a[2], b[2], t)];
-}
-
-function scaleColor(color: Rgb, factor: number): Rgb {
-  return [color[0] * factor, color[1] * factor, color[2] * factor];
-}
-
-function lerp(a: number, b: number, t: number): number {
-  return a + (b - a) * clamp01(t);
-}
-
-function smoothstep(edge0: number, edge1: number, x: number): number {
-  const t = clamp01((x - edge0) / Math.max(edge1 - edge0, 0.00001));
-  return t * t * (3 - 2 * t);
-}
-
-function clamp01(value: number): number {
-  return Math.max(0, Math.min(1, value));
-}
-
-function clampInt(value: number, min: number, max: number): number {
-  return Math.max(min, Math.min(max, value));
-}
-
-function clampByte(value: number): number {
-  return Math.max(0, Math.min(255, Math.round(value)));
-}
-
-function hash01(input: number): number {
-  let x = input | 0;
-  x = Math.imul(x ^ 0x7feb352d, 0x846ca68b);
-  x ^= x >>> 15;
-  x = Math.imul(x ^ 0xc2b2ae35, 0x27d4eb2d);
-  x ^= x >>> 16;
-  return (x >>> 0) / 4294967295;
-}
+// --- PNG encoding (private to the decoder orchestrator) ---
 
 function encodeRgbaAsPng(width: number, height: number, rgba: Uint8Array): Uint8Array {
   const signature = Uint8Array.from([137, 80, 78, 71, 13, 10, 26, 10]);
@@ -585,18 +305,4 @@ function crc32(data: Uint8Array): number {
     }
   }
   return (crc ^ -1) >>> 0;
-}
-
-async function spawnChecked(command: string, args: string[]): Promise<void> {
-  await new Promise<void>((resolvePromise, reject) => {
-    const child = spawn(command, args, { stdio: "ignore" });
-    child.on("error", reject);
-    child.on("exit", (code) => {
-      if (code === 0) {
-        resolvePromise();
-        return;
-      }
-      reject(new Error(`${command} exited with code ${code ?? "unknown"}`));
-    });
-  });
 }

--- a/packages/codec-image/src/pipeline/internal-math.ts
+++ b/packages/codec-image/src/pipeline/internal-math.ts
@@ -1,0 +1,89 @@
+// Internal math helpers shared between the placeholder/landscape renderer and the
+// decoder orchestrator. Deliberately small and dependency-free so both sides can
+// import without circular concerns. Not part of the public API.
+
+export type Rgb = [number, number, number];
+
+export function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+export function clampInt(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+export function clampByte(value: number): number {
+  return Math.max(0, Math.min(255, Math.round(value)));
+}
+
+export function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * clamp01(t);
+}
+
+export function smoothstep(edge0: number, edge1: number, x: number): number {
+  const t = clamp01((x - edge0) / Math.max(edge1 - edge0, 0.00001));
+  return t * t * (3 - 2 * t);
+}
+
+export function hash01(input: number): number {
+  let x = input | 0;
+  x = Math.imul(x ^ 0x7feb352d, 0x846ca68b);
+  x ^= x >>> 15;
+  x = Math.imul(x ^ 0xc2b2ae35, 0x27d4eb2d);
+  x ^= x >>> 16;
+  return (x >>> 0) / 4294967295;
+}
+
+export function sampleNoise(x: number, y: number): number {
+  const x0 = Math.floor(x);
+  const y0 = Math.floor(y);
+  const tx = x - x0;
+  const ty = y - y0;
+
+  const n00 = hash01(x0 * 374761393 + y0 * 668265263);
+  const n10 = hash01((x0 + 1) * 374761393 + y0 * 668265263);
+  const n01 = hash01(x0 * 374761393 + (y0 + 1) * 668265263);
+  const n11 = hash01((x0 + 1) * 374761393 + (y0 + 1) * 668265263);
+
+  const sx = tx * tx * (3 - 2 * tx);
+  const sy = ty * ty * (3 - 2 * ty);
+  return lerp(lerp(n00, n10, sx), lerp(n01, n11, sx), sy);
+}
+
+export function mixColor(a: Rgb, b: Rgb, t: number): Rgb {
+  return [lerp(a[0], b[0], t), lerp(a[1], b[1], t), lerp(a[2], b[2], t)];
+}
+
+export function scaleColor(color: Rgb, factor: number): Rgb {
+  return [color[0] * factor, color[1] * factor, color[2] * factor];
+}
+
+// Bilinear sampler over a 2D scalar field stored row-major. Used by both the
+// decoder orchestrator (when reading fields during the pixel loop) and the
+// landscape renderer (inside `terrainShade`). Kept here to avoid duplicating
+// the bilinear math in two places.
+export function sampleField(
+  field: Float32Array,
+  width: number,
+  height: number,
+  nx: number,
+  ny: number,
+): number {
+  const x = clamp01(nx) * (width - 1);
+  const y = clamp01(ny) * (height - 1);
+  const x0 = Math.floor(x);
+  const y0 = Math.floor(y);
+  const x1 = Math.min(width - 1, x0 + 1);
+  const y1 = Math.min(height - 1, y0 + 1);
+  const tx = x - x0;
+  const ty = y - y0;
+
+  const c00 = field[y0 * width + x0] ?? 0;
+  const c10 = field[y0 * width + x1] ?? 0;
+  const c01 = field[y1 * width + x0] ?? 0;
+  const c11 = field[y1 * width + x1] ?? 0;
+
+  const top = lerp(c00, c10, tx);
+  const bottom = lerp(c01, c11, tx);
+  return lerp(top, bottom, ty);
+}

--- a/packages/codec-image/src/pipeline/landscape-renderer.ts
+++ b/packages/codec-image/src/pipeline/landscape-renderer.ts
@@ -1,0 +1,321 @@
+// Procedural landscape renderer — the placeholder pixel synthesis that fills in
+// for a real frozen-decoder bridge until M1B wires one. Extracted from the
+// original `pipeline/decoder.ts` per #325 / #288.
+//
+// This module is intentionally self-contained for the landscape concern:
+// - five scene modes (coast / forest / lake / mountain / meadow)
+// - per-mode palette tables
+// - sky / terrain pixel shaders
+// - reference-landscape image bypass (Python bridge)
+//
+// The four FIELD_SALTS named below are the magic salts that the original
+// decoder threaded into `buildField()` — they're conceptually landscape-
+// specific (they name the four scalar fields the landscape renderer expects:
+// elevation, moisture, warmth, detail), so they live with the renderer that
+// names them rather than embedded as bare hex literals at the caller.
+
+import { readFile, unlink } from "node:fs/promises";
+import { basename, join, resolve } from "node:path";
+import { spawn } from "node:child_process";
+import type { RenderCtx } from "@wittgenstein/schemas";
+
+import {
+  clamp01,
+  clampByte,
+  hash01,
+  mixColor,
+  sampleField,
+  sampleNoise,
+  scaleColor,
+  smoothstep,
+  type Rgb,
+} from "./internal-math.js";
+
+export type SceneMode = "coast" | "forest" | "lake" | "mountain" | "meadow";
+
+export interface SceneProfile {
+  mode: SceneMode;
+  variantA: number;
+  variantB: number;
+  ruggedness: number;
+}
+
+/**
+ * Salts that drive the placeholder landscape's four scalar fields. Each salt
+ * mixes into a separate field via the decoder's `buildField()` helper; together
+ * they give the landscape renderer the deterministic-but-varied per-token
+ * inputs it needs without depending on a real decoder.
+ *
+ * These are placeholder-bridge concerns, not load-bearing decoder doctrine.
+ * They go away when a real frozen-decoder bridge wires under M1B (gated on
+ * the per-candidate audits in #283).
+ */
+export const FIELD_SALTS = {
+  elevation: 0x1a2b3c4d,
+  moisture: 0x91c7e35a,
+  warmth: 0x4f6a9d21,
+  detail: 0xd15f0c77,
+} as const;
+
+export function buildSceneProfile(tokens: number[]): SceneProfile {
+  let hash = 2166136261;
+  for (let i = 0; i < tokens.length; i += 1) {
+    hash ^= (tokens[i] ?? 0) + i * 31;
+    hash = Math.imul(hash, 16777619);
+  }
+  const hashA = hash >>> 0;
+  const hashB = Math.imul(hashA ^ 0x9e3779b9, 2246822519) >>> 0;
+  const modes: SceneMode[] = ["coast", "forest", "lake", "mountain", "meadow"];
+  return {
+    mode: modes[Math.abs(tokens[0] ?? hashA) % modes.length] ?? "meadow",
+    variantA: tokens.length > 1 ? ((tokens[1] ?? 0) % 8192) / 8191 : ((hashA >>> 8) & 255) / 255,
+    variantB: tokens.length > 2 ? ((tokens[2] ?? 0) % 8192) / 8191 : ((hashB >>> 12) & 255) / 255,
+    ruggedness: 0.35 + (((hashB >>> 20) & 255) / 255) * 0.65,
+  };
+}
+
+export function buildPalette(
+  profile: SceneProfile,
+  averageWarmth: number,
+  averageMoisture: number,
+) {
+  if (profile.mode === "coast") {
+    return {
+      skyTop: mixColor(
+        [49, 92, 155],
+        [116, 132, 181],
+        profile.variantA * 0.6 + averageWarmth * 0.4,
+      ),
+      skyHorizon: mixColor([236, 225, 214], [255, 210, 168], averageWarmth * 0.8 + 0.1),
+      rockBase: [142, 132, 118] as Rgb,
+      grassBase: [122, 142, 102] as Rgb,
+      waterBase: [68, 136, 176] as Rgb,
+    };
+  }
+  if (profile.mode === "forest") {
+    return {
+      skyTop: [72, 96, 150] as Rgb,
+      skyHorizon: [232, 223, 214] as Rgb,
+      rockBase: [100, 108, 102] as Rgb,
+      grassBase: mixColor([60, 92, 58], [98, 129, 80], averageMoisture * 0.8 + 0.1),
+      waterBase: [58, 112, 130] as Rgb,
+    };
+  }
+  if (profile.mode === "lake") {
+    return {
+      skyTop: [62, 98, 158] as Rgb,
+      skyHorizon: [224, 230, 240] as Rgb,
+      rockBase: [116, 122, 126] as Rgb,
+      grassBase: [104, 136, 92] as Rgb,
+      waterBase: [70, 130, 180] as Rgb,
+    };
+  }
+  if (profile.mode === "mountain") {
+    return {
+      skyTop: [74, 94, 146] as Rgb,
+      skyHorizon: [230, 220, 214] as Rgb,
+      rockBase: mixColor([108, 114, 126], [150, 130, 116], averageWarmth * 0.55),
+      grassBase: [122, 136, 106] as Rgb,
+      waterBase: [74, 116, 160] as Rgb,
+    };
+  }
+  return {
+    skyTop: [70, 100, 150] as Rgb,
+    skyHorizon: [244, 223, 194] as Rgb,
+    rockBase: [124, 120, 106] as Rgb,
+    grassBase: mixColor([96, 132, 74], [156, 164, 92], averageMoisture * 0.5 + averageWarmth * 0.3),
+    waterBase: [74, 120, 164] as Rgb,
+  };
+}
+
+export function renderSky(
+  nx: number,
+  ny: number,
+  horizon: number,
+  warm: number,
+  moist: number,
+  detail: number,
+  skyTop: Rgb,
+  skyHorizon: Rgb,
+  profile: SceneProfile,
+): Rgb {
+  const t = clamp01(ny / Math.max(horizon, 0.001));
+  let color = mixColor(skyTop, skyHorizon, Math.pow(t, 0.85));
+
+  const cloudBand = smoothstep(0.12, 0.78, moist * 0.7 + detail * 0.3);
+  const cloudMask =
+    smoothstep(0.52, 0.88, sampleNoise(nx * 5.5 + detail, ny * 7.2 + warm * 2.4)) *
+    (1 - t) *
+    cloudBand *
+    0.42;
+  color = mixColor(color, [247, 244, 239], cloudMask);
+
+  const sunMask =
+    Math.exp(-Math.pow(nx - (0.18 + warm * 0.52 + profile.variantA * 0.08), 2) / 0.006) *
+    Math.exp(-Math.pow(ny - (0.11 + moist * 0.11 + profile.variantB * 0.03), 2) / 0.0025) *
+    0.35;
+  color = mixColor(color, [255, 236, 190], sunMask);
+
+  return color;
+}
+
+export function renderTerrain(
+  nx: number,
+  ny: number,
+  horizon: number,
+  elevation: number,
+  moisture: number,
+  warmth: number,
+  detail: number,
+  rockBase: Rgb,
+  grassBase: Rgb,
+  waterBase: Rgb,
+  skyHorizon: Rgb,
+  elevationField: Float32Array,
+  gridWidth: number,
+  gridHeight: number,
+  profile: SceneProfile,
+): Rgb {
+  const landT = clamp01((ny - horizon) / Math.max(1 - horizon, 0.001));
+  const atmosphere = Math.pow(1 - landT, 1.5) * 0.45;
+
+  const ridgeNoise = sampleNoise(nx * 8.2 + detail * 1.5, ny * 11.3 + elevation * 1.8);
+  const vegetation = clamp01(moisture * 0.75 + (1 - landT) * 0.15 + ridgeNoise * 0.1);
+  const soilWarmth = clamp01(warmth * 0.7 + detail * 0.2);
+  const terrainBase = mixColor(rockBase, grassBase, vegetation);
+  let color = mixColor(terrainBase, [178, 134, 84], soilWarmth * 0.22);
+
+  const waterBias = profile.mode === "coast" ? 0.28 : profile.mode === "lake" ? 0.34 : 0;
+  const waterChance = clamp01((moisture - 0.52) * 1.6 + waterBias) * (1 - landT) * 1.4;
+  const waterMask =
+    smoothstep(0.16, 0.01, landT) *
+    smoothstep(0.14, 0.65, waterChance) *
+    smoothstep(0.32, 0.72, ridgeNoise);
+  color = mixColor(color, waterBase, waterMask * 0.85);
+
+  if (profile.mode === "coast") {
+    const beachMask = smoothstep(0.22, 0.58, landT) * smoothstep(0.72, 0.15, vegetation);
+    color = mixColor(color, [205, 188, 144], beachMask * 0.45);
+  }
+
+  if (profile.mode === "forest") {
+    const treeNoise = sampleNoise(nx * 18 + profile.variantA * 3, detail * 7 + nx * 4);
+    const treeMask =
+      smoothstep(0.62, 0.82, treeNoise) * smoothstep(0.2, 0.01, landT) * (1 - waterMask);
+    color = mixColor(color, [52, 79, 52], treeMask * 0.65);
+  }
+
+  if (profile.mode === "mountain") {
+    const snowMask = smoothstep(0.82, 0.96, elevation) * smoothstep(0.2, 0.02, landT);
+    color = mixColor(color, [230, 233, 236], snowMask * 0.55);
+  }
+
+  if (profile.mode === "meadow") {
+    const flowerNoise = sampleNoise(nx * 34 + profile.variantB * 5, ny * 40 + detail * 3.2);
+    const flowerMask = smoothstep(0.82, 0.94, flowerNoise) * smoothstep(0.86, 0.32, landT);
+    color = mixColor(color, [234, 198, 141], flowerMask * 0.18);
+  }
+
+  const shading = terrainShade(elevationField, gridWidth, gridHeight, nx, ny);
+  color = scaleColor(color, 0.82 + shading * 0.28);
+
+  const grain = (sampleNoise(nx * 28 + detail * 4.2, ny * 34 + warmth * 3.1) - 0.5) * 26;
+  color = [
+    clampByte(color[0] + grain),
+    clampByte(color[1] + grain * 0.7),
+    clampByte(color[2] + grain * 0.45),
+  ];
+
+  return mixColor(color, skyHorizon, atmosphere);
+}
+
+export async function tryDecodeReferenceLandscape(
+  profile: SceneProfile,
+  ctx: RenderCtx,
+): Promise<Uint8Array | null> {
+  const referencePath = selectReferenceImage(profile);
+  if (!referencePath) {
+    return null;
+  }
+
+  const outPath = join(ctx.runDir, `_reference-${profile.mode}.png`);
+  const bridgeScript = resolve(process.cwd(), "scripts/reference_image_to_png.py");
+
+  try {
+    await spawnChecked("python3", [bridgeScript, referencePath, outPath, profile.mode]);
+    const png = new Uint8Array(await readFile(outPath));
+    await unlink(outPath).catch(() => undefined);
+    ctx.logger.info(`Using reference decoder bridge asset: ${basename(referencePath)}`);
+    return png;
+  } catch (error) {
+    ctx.logger.warn(
+      "Reference decoder bridge unavailable; falling back to procedural placeholder.",
+      {
+        mode: profile.mode,
+        error,
+      },
+    );
+    return null;
+  }
+}
+
+function selectReferenceImage(profile: SceneProfile): string | null {
+  const bank: Record<SceneMode, string[]> = {
+    coast: ["9.jpg"],
+    forest: ["23.jpg"],
+    lake: ["8.jpg"],
+    mountain: ["11.jpg"],
+    meadow: ["16.jpg"],
+  };
+
+  const choices = bank[profile.mode];
+  if (!choices || choices.length === 0) {
+    return null;
+  }
+
+  const index = Math.floor(profile.variantA * choices.length) % choices.length;
+  return resolve(
+    process.cwd(),
+    "data/image_adapter/raw/images",
+    choices[index] ?? choices[0] ?? "",
+  );
+}
+
+// Terrain-specific shading sampler. Kept here because it's used only by
+// `renderTerrain`; the general field-sampling helper it builds on (`sampleField`)
+// lives in `internal-math.ts` so both the decoder orchestrator and this
+// landscape renderer can use it without duplication.
+function terrainShade(
+  field: Float32Array,
+  width: number,
+  height: number,
+  nx: number,
+  ny: number,
+): number {
+  const eps = 1 / Math.max(width, height);
+  const left = sampleField(field, width, height, nx - eps, ny);
+  const right = sampleField(field, width, height, nx + eps, ny);
+  const up = sampleField(field, width, height, nx, ny - eps);
+  const down = sampleField(field, width, height, nx, ny + eps);
+  const dx = right - left;
+  const dy = down - up;
+  return clamp01(0.55 + dx * 0.9 - dy * 0.65);
+}
+
+async function spawnChecked(command: string, args: string[]): Promise<void> {
+  await new Promise<void>((resolvePromise, reject) => {
+    const child = spawn(command, args, { stdio: "ignore" });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resolvePromise();
+        return;
+      }
+      reject(new Error(`${command} exited with code ${code ?? "unknown"}`));
+    });
+  });
+}
+
+// re-export hash01 so callers wanting deterministic noise without
+// pulling internal-math twice can grab it from here. Not load-bearing.
+export { hash01 };


### PR DESCRIPTION
## Summary

Closes #325. First refactor from the AI-shape audit ([\`docs/research/2026-05-13-ai-shape-audit.md\`](../blob/main/docs/research/2026-05-13-ai-shape-audit.md), merged via [#328](https://github.com/p-to-q/wittgenstein/pull/328)).

\`pipeline/decoder.ts\` (602 lines) was conflating four distinct concerns. This refactor splits it along the seam the audit identified as the strongest AI-shape smell — the procedural landscape renderer with 7+ magic-number constants embedded inline.

## File-level changes

| File | Before | After | What it owns |
|---|---|---|---|
| \`pipeline/decoder.ts\` | 602L | **309L** | Thin orchestrator: builds scalar fields from latent tokens, runs the landscape renderer, encodes PNG. Public API \`decodeLatentsToRaster\` preserved. |
| \`pipeline/landscape-renderer.ts\` | — | 321L (new) | Placeholder landscape rendering: \`SceneMode\` / \`SceneProfile\` types, \`FIELD_SALTS\` (magic salts hoisted to named export with doc string), \`buildSceneProfile\`, \`buildPalette\`, \`renderSky\`, \`renderTerrain\`, terrain-shade sampler, reference-landscape Python bridge. |
| \`pipeline/internal-math.ts\` | — | 89L (new) | Shared math helpers (\`clamp01\`, \`clampInt\`, \`clampByte\`, \`lerp\`, \`smoothstep\`, \`hash01\`, \`sampleNoise\`, \`mixColor\`, \`scaleColor\`, \`sampleField\`) used by both the orchestrator and the landscape renderer — no duplication. |

\`decoder.ts\` shrinks **602 → 309 lines**, well under the audit's \"under 400 lines\" target.

## What did NOT change

- **Public API.** \`decodeLatentsToRaster\` keeps the same signature including the \`onChunk\` M1B seam. Only one caller in the codebase ([\`packages/codec-image/src/codec.ts:19\`](../blob/main/packages/codec-image/src/codec.ts#L19)) and it's untouched.
- **Pixel output bytes.** The refactor moves code around but the actual per-pixel computation is character-identical. Existing tests pass byte-for-byte.
- **Magic salt values.** \`0x1a2b3c4d\` etc. are now \`FIELD_SALTS.elevation\` etc. but the values are unchanged. The hoist is naming-only.

## What the seam unlocks

The audit's reason for filing #325 was that the placeholder landscape renderer shouldn't accumulate further coupling with the eventual M1B frozen-decoder bridge wiring. With this seam in place, when [#283](https://github.com/p-to-q/wittgenstein/issues/283) per-candidate audits produce a candidate that clears all four gates, the wiring slice can replace \`decodeLatentsToRaster\`'s placeholder path with the real bridge **without having to also unentangle landscape rendering**.

## Validation

- \`pnpm --filter @wittgenstein/codec-image typecheck\` — clean.
- \`pnpm --filter @wittgenstein/codec-image test\` — all 45 tests pass.
- \`pnpm --filter @wittgenstein/codec-image lint\` — 0 errors, 0 warnings.
- \`pnpm test:golden\` — codec-audio parity + codec-sensor golden suites green (codec-image's parity is part of its main test suite which passed).

## What this PR is NOT

- Not a behavior change. Pixel output is unchanged.
- Not the M1B wiring. \`loadLlamagenDecoderBridge\` at [\`packages/codec-image/src/decoders/llamagen.ts\`](../blob/main/packages/codec-image/src/decoders/llamagen.ts) remains a \`NotImplementedError\` stub; wiring lands after #283 per-candidate audits clear all four gates ([PR #336](https://github.com/p-to-q/wittgenstein/pull/336) just landed Gates A+B for VQGAN-class).
- Not a refactor of the field operations (\`normalizeTokens\`, \`buildField\`, \`blurField\`, \`averageField\`, \`distanceToCenter\`). Those stay in \`decoder.ts\`; only the landscape-specific code moves. Audit-listed scope held.
- Not a refactor of the PNG encoding. Stays in \`decoder.ts\`.

## Refs

- **Closes #325.**
- Audit source: [\`docs/research/2026-05-13-ai-shape-audit.md\`](../blob/main/docs/research/2026-05-13-ai-shape-audit.md) (merged via [#328](https://github.com/p-to-q/wittgenstein/pull/328)).
- Sibling refactor follow-ups (not in this PR's scope): [#326](https://github.com/p-to-q/wittgenstein/issues/326) (sensor operator strategy), [#327](https://github.com/p-to-q/wittgenstein/issues/327) (HyperFrames composition + ProcessRunner).
- Related M1B unblock track: [#283](https://github.com/p-to-q/wittgenstein/issues/283) per-candidate audits, [PR #336](https://github.com/p-to-q/wittgenstein/pull/336) VQGAN-class Gates A+B (just merged), [#70](https://github.com/p-to-q/wittgenstein/issues/70) M1B umbrella.