### PR TITLE
refactor(codec-sensor): extract operator strategies + LoupeRenderer (closes #326)

### DIFF
--- a/packages/codec-sensor/src/loupe-renderer.ts
+++ b/packages/codec-sensor/src/loupe-renderer.ts
@@ -1,0 +1,101 @@
+// Loupe dashboard rendering — extracted from `render.ts` per #326 / #288.
+//
+// Encapsulates the 3-level fallback chain (loupe.py search → loupe_cli on PATH
+// → static-HTML fallback) behind a single API. The renderer keeps the same
+// `SensorRenderPath` outcome string so manifests and tests stay byte-stable.
+
+import { access, writeFile } from "node:fs/promises";
+import { dirname, resolve as resolvePath } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+import type { SensorSignalSpec } from "./schema.js";
+
+export type SensorRenderPath = "loupe-script" | "loupe-cli" | "fallback-static-html";
+
+export interface LoupeRenderResult {
+  htmlReady: boolean;
+  renderPath: SensorRenderPath;
+}
+
+const moduleDir = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Default candidate locations for `loupe.py`, ordered from most-likely to
+ * least-likely. The renderer probes each in turn and falls through to the
+ * `loupe_cli` PATH lookup if none exist.
+ */
+function defaultLoupeSearchPaths(): string[] {
+  return [
+    resolvePath(moduleDir, "../../../../loupe.py"), // repo root
+    resolvePath(moduleDir, "../loupe.py"), // package root
+    resolvePath(process.cwd(), "loupe.py"), // cwd
+    resolvePath(process.cwd(), "polyglot-mini/loupe.py"), // sub-project
+  ];
+}
+
+export async function renderLoupeDashboard(
+  csvPath: string,
+  htmlPath: string,
+  spec: SensorSignalSpec,
+  searchPaths: string[] = defaultLoupeSearchPaths(),
+): Promise<LoupeRenderResult> {
+  const loupePath = await firstExistingPath(searchPaths);
+
+  if (loupePath) {
+    try {
+      await spawnChecked("python3", [loupePath, csvPath, "-o", htmlPath]);
+      return { htmlReady: true, renderPath: "loupe-script" };
+    } catch {
+      /* fall through to fallback */
+    }
+  } else {
+    try {
+      await spawnChecked("python3", ["-m", "loupe_cli", csvPath, "-o", htmlPath]);
+      return { htmlReady: true, renderPath: "loupe-cli" };
+    } catch {
+      /* fall through to fallback */
+    }
+  }
+
+  await writeFile(htmlPath, buildFallbackHtml(spec, csvPath));
+  return { htmlReady: true, renderPath: "fallback-static-html" };
+}
+
+async function firstExistingPath(candidates: string[]): Promise<string | null> {
+  for (const candidate of candidates) {
+    try {
+      await access(candidate);
+      return candidate;
+    } catch {
+      /* skip */
+    }
+  }
+  return null;
+}
+
+function buildFallbackHtml(spec: SensorSignalSpec, csvPath: string): string {
+  return `<!doctype html>
+<html lang="en">
+<meta charset="utf-8" />
+<title>${spec.signal} preview</title>
+<body style="font-family: ui-monospace, monospace; padding: 24px; background: #111; color: #f5f5f5;">
+  <h1>${spec.signal} preview</h1>
+  <p>Loupe was unavailable, so Wittgenstein wrote the raw CSV sidecar instead.</p>
+  <p>Open <code>${csvPath}</code> or rerun with Python 3 available to get the interactive dashboard.</p>
+</body>
+</html>`;
+}
+
+async function spawnChecked(command: string, args: string[]): Promise<void> {
+  await new Promise<void>((resolvePromise, reject) => {
+    const child = spawn(command, args, { stdio: "ignore" });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resolvePromise();
+        return;
+      }
+      reject(new Error(`${command} exited with code ${code ?? "unknown"}`));
+    });
+  });
+}

--- a/packages/codec-sensor/src/operators/drift.ts
+++ b/packages/codec-sensor/src/operators/drift.ts
@@ -1,0 +1,18 @@
+import type { SensorOperator } from "../schema.js";
+import type { OperatorContext } from "./index.js";
+
+/**
+ * Linear drift along the local time axis. `slopePerSec` is interpreted in
+ * local time (relative to `timeOriginFrame`); a patch-local drift starts at
+ * zero at the patch boundary.
+ */
+export function applyDrift(
+  operator: Extract<SensorOperator, { type: "drift" }>,
+  ctx: OperatorContext,
+): void {
+  const { signal, startFrame, endFrame, sampleRateHz, timeOriginFrame } = ctx;
+  for (let i = startFrame; i < endFrame; i += 1) {
+    const localTimeSec = (i - timeOriginFrame) / sampleRateHz;
+    signal[i] = (signal[i] ?? 0) + localTimeSec * operator.slopePerSec;
+  }
+}

--- a/packages/codec-sensor/src/operators/ecg-template.ts
+++ b/packages/codec-sensor/src/operators/ecg-template.ts
@@ -1,0 +1,25 @@
+import type { SensorOperator } from "../schema.js";
+import type { OperatorContext } from "./index.js";
+
+/**
+ * Deterministic ECG-shaped template (P / QRS / T components per beat) at
+ * `bpm` beats per minute, scaled by `amplitude`. Beat phase is measured in
+ * local time so a patch-local ECG starts a new beat at the patch boundary.
+ */
+export function applyEcgTemplate(
+  operator: Extract<SensorOperator, { type: "ecgTemplate" }>,
+  ctx: OperatorContext,
+): void {
+  const { signal, startFrame, endFrame, sampleRateHz, timeOriginFrame } = ctx;
+  const beatPeriod = 60 / operator.bpm;
+  for (let i = startFrame; i < endFrame; i += 1) {
+    const localTimeSec = (i - timeOriginFrame) / sampleRateHz;
+    const phase = (localTimeSec % beatPeriod) / beatPeriod;
+    const p = Math.exp(-Math.pow((phase - 0.16) * 22, 2)) * 0.08;
+    const qrs =
+      Math.exp(-Math.pow((phase - 0.34) * 55, 2)) * 0.92 -
+      Math.exp(-Math.pow((phase - 0.31) * 80, 2)) * 0.22;
+    const t = Math.exp(-Math.pow((phase - 0.58) * 15, 2)) * 0.18;
+    signal[i] = (signal[i] ?? 0) + (p + qrs + t) * operator.amplitude;
+  }
+}

--- a/packages/codec-sensor/src/operators/index.ts
+++ b/packages/codec-sensor/src/operators/index.ts
@@ -1,0 +1,79 @@
+// Sensor operator dispatch — one strategy per `SensorOperator["type"]`. Extracted
+// from `pipeline/render.ts` per #326 / #288. Each operator file owns its own
+// expansion logic; this index threads the shared `OperatorContext` and routes
+// to the right strategy.
+//
+// Behavior is intended to be byte-identical to the pre-refactor switch
+// statement — the existing sensor goldens are the regression baseline.
+
+import type { SensorOperator } from "../schema.js";
+import { applyOscillator } from "./oscillator.js";
+import { applyNoise } from "./noise.js";
+import { applyDrift } from "./drift.js";
+import { applyPulse } from "./pulse.js";
+import { applyStep } from "./step.js";
+import { applyEcgTemplate } from "./ecg-template.js";
+import { applyPatchGrammar } from "./patch-grammar.js";
+
+/**
+ * Shared arguments every operator strategy receives.
+ *
+ * - `signal` is the (already-allocated) output buffer; operators add into it.
+ * - `startFrame` / `endFrame` define the half-open frame window
+ *   `[startFrame, endFrame)` the operator should write into.
+ * - `sampleRateHz` and `rng` are shared across operators in a render.
+ * - `timeOriginFrame` defines the local zero of the operator's time axis.
+ *   At the top level it is `0` (operators see absolute time). Inside a patch
+ *   it is the patch start, so `step.atSec` / `pulse.centerSec` /
+ *   `oscillator.phaseRad` / `drift.slopePerSec` / `ecgTemplate` phase are
+ *   interpreted patch-local. See the original `expandOperator` doc comment
+ *   in `render.ts` for the contract pinned by #247.
+ */
+export interface OperatorContext {
+  signal: Float32Array;
+  startFrame: number;
+  endFrame: number;
+  sampleRateHz: number;
+  rng: () => number;
+  timeOriginFrame: number;
+}
+
+/**
+ * Dispatch a single operator to its strategy implementation.
+ *
+ * Re-exported by render.ts (and re-used recursively from patch-grammar.ts
+ * for inner operators).
+ */
+export function dispatchOperator(operator: SensorOperator, ctx: OperatorContext): void {
+  switch (operator.type) {
+    case "oscillator":
+      applyOscillator(operator, ctx);
+      return;
+    case "noise":
+      applyNoise(operator, ctx);
+      return;
+    case "drift":
+      applyDrift(operator, ctx);
+      return;
+    case "pulse":
+      applyPulse(operator, ctx);
+      return;
+    case "step":
+      applyStep(operator, ctx);
+      return;
+    case "ecgTemplate":
+      applyEcgTemplate(operator, ctx);
+      return;
+    case "patchGrammar":
+      applyPatchGrammar(operator, ctx);
+      return;
+  }
+}
+
+export { applyOscillator } from "./oscillator.js";
+export { applyNoise, whiteNoise, pinkNoise } from "./noise.js";
+export { applyDrift } from "./drift.js";
+export { applyPulse } from "./pulse.js";
+export { applyStep } from "./step.js";
+export { applyEcgTemplate } from "./ecg-template.js";
+export { applyPatchGrammar } from "./patch-grammar.js";

--- a/packages/codec-sensor/src/operators/noise.ts
+++ b/packages/codec-sensor/src/operators/noise.ts
@@ -1,0 +1,39 @@
+import type { SensorOperator } from "../schema.js";
+import type { OperatorContext } from "./index.js";
+
+/**
+ * Additive white or pink noise. Noise has no time dependence and is unaffected
+ * by `timeOriginFrame`; it consumes the shared RNG sequentially so the
+ * recursion-seam invariant (single-patch full-duration patchGrammar matches
+ * the equivalent flat operator list byte-for-byte) holds.
+ */
+export function applyNoise(
+  operator: Extract<SensorOperator, { type: "noise" }>,
+  ctx: OperatorContext,
+): void {
+  const { signal, startFrame, endFrame, rng } = ctx;
+  const span = endFrame - startFrame;
+  const noise = operator.color === "pink" ? pinkNoise(span, rng) : whiteNoise(span, rng);
+  for (let i = 0; i < span; i += 1) {
+    signal[startFrame + i] = (signal[startFrame + i] ?? 0) + (noise[i] ?? 0) * operator.amplitude;
+  }
+}
+
+export function whiteNoise(frameCount: number, rng: () => number): Float32Array {
+  const samples = new Float32Array(frameCount);
+  for (let i = 0; i < frameCount; i += 1) {
+    samples[i] = rng() * 2 - 1;
+  }
+  return samples;
+}
+
+export function pinkNoise(frameCount: number, rng: () => number): Float32Array {
+  const white = whiteNoise(frameCount, rng);
+  const pink = new Float32Array(frameCount);
+  let prev = 0;
+  for (let i = 0; i < frameCount; i += 1) {
+    prev = 0.985 * prev + 0.15 * (white[i] ?? 0);
+    pink[i] = prev;
+  }
+  return pink;
+}

--- a/packages/codec-sensor/src/operators/oscillator.ts
+++ b/packages/codec-sensor/src/operators/oscillator.ts
@@ -1,0 +1,20 @@
+import type { SensorOperator } from "../schema.js";
+import type { OperatorContext } from "./index.js";
+
+/**
+ * Additive sinusoidal oscillator. Phase reference is `timeOriginFrame` so a
+ * patch-local oscillator's `phaseRad` is interpreted at the patch boundary.
+ */
+export function applyOscillator(
+  operator: Extract<SensorOperator, { type: "oscillator" }>,
+  ctx: OperatorContext,
+): void {
+  const { signal, startFrame, endFrame, sampleRateHz, timeOriginFrame } = ctx;
+  for (let i = startFrame; i < endFrame; i += 1) {
+    const localTimeSec = (i - timeOriginFrame) / sampleRateHz;
+    signal[i] =
+      (signal[i] ?? 0) +
+      Math.sin(2 * Math.PI * operator.frequencyHz * localTimeSec + operator.phaseRad) *
+        operator.amplitude;
+  }
+}

--- a/packages/codec-sensor/src/operators/patch-grammar.ts
+++ b/packages/codec-sensor/src/operators/patch-grammar.ts
@@ -1,0 +1,83 @@
+import type { SensorOperator } from "../schema.js";
+import { dispatchOperator, type OperatorContext } from "./index.js";
+
+/**
+ * Expand a `patchGrammar` operator across `[startFrame, endFrame)`.
+ *
+ * Each patch occupies `floor(patchLengthSec * sampleRateHz)` consecutive frames,
+ * starting from `startFrame`. Patches that would extend past `endFrame` are
+ * truncated; patches whose start frame is past `endFrame` are skipped. Within
+ * each patch:
+ *   - Pre-patch signal values in the patch range are snapshotted.
+ *   - Inner operators run with `timeOriginFrame = patchStart` so all time-based
+ *     parameters (oscillator phase reference, drift origin, step.atSec,
+ *     pulse.centerSec, ecgTemplate phase) are interpreted patch-local. Noise
+ *     consumption is sequential against the parent RNG so a single-patch
+ *     full-duration `patchGrammar` stays byte-identical to the equivalent flat
+ *     operator list (the recursion-seam invariant).
+ *   - If `affineNormalize` is set, the patch's *contribution* (post-pre) is
+ *     min-max normalized to `[minOutput, maxOutput]` before being added back
+ *     onto the pre-patch values. The schema rejects `minOutput >= maxOutput`
+ *     so a degenerate range can never reach this code (#247 item 4).
+ *
+ * Nested `patchGrammar` is rejected at the schema level (#247 item 3); inner
+ * operators are typed as `SensorBaseOperator` so this function never recurses
+ * into another patchGrammar.
+ */
+export function applyPatchGrammar(
+  operator: Extract<SensorOperator, { type: "patchGrammar" }>,
+  ctx: OperatorContext,
+): void {
+  const { signal, startFrame, endFrame, sampleRateHz, rng } = ctx;
+  const patchFrames = Math.max(1, Math.floor(operator.patchLengthSec * sampleRateHz));
+  for (let patchIdx = 0; patchIdx < operator.patches.length; patchIdx += 1) {
+    const patch = operator.patches[patchIdx];
+    if (!patch) {
+      continue;
+    }
+    const patchStart = startFrame + patchIdx * patchFrames;
+    if (patchStart >= endFrame) {
+      break;
+    }
+    const patchEnd = Math.min(endFrame, patchStart + patchFrames);
+
+    const span = patchEnd - patchStart;
+    const preValues = new Float32Array(span);
+    for (let i = 0; i < span; i += 1) {
+      preValues[i] = signal[patchStart + i] ?? 0;
+    }
+
+    for (const inner of patch.operators) {
+      dispatchOperator(inner, {
+        signal,
+        startFrame: patchStart,
+        endFrame: patchEnd,
+        sampleRateHz,
+        rng,
+        timeOriginFrame: patchStart,
+      });
+    }
+
+    if (patch.affineNormalize) {
+      const contribution = new Float32Array(span);
+      let min = Infinity;
+      let max = -Infinity;
+      for (let i = 0; i < span; i += 1) {
+        const c = (signal[patchStart + i] ?? 0) - (preValues[i] ?? 0);
+        contribution[i] = c;
+        if (c < min) min = c;
+        if (c > max) max = c;
+      }
+      const range = max - min;
+      const targetMin = patch.affineNormalize.minOutput;
+      const targetMax = patch.affineNormalize.maxOutput;
+      const targetRange = targetMax - targetMin;
+      const fallbackCenter = (targetMin + targetMax) / 2;
+      for (let i = 0; i < span; i += 1) {
+        const normalized =
+          range > 0 ? ((contribution[i]! - min) / range) * targetRange + targetMin : fallbackCenter;
+        signal[patchStart + i] = (preValues[i] ?? 0) + normalized;
+      }
+    }
+  }
+}

--- a/packages/codec-sensor/src/operators/pulse.ts
+++ b/packages/codec-sensor/src/operators/pulse.ts
@@ -1,0 +1,26 @@
+import type { SensorOperator } from "../schema.js";
+import type { OperatorContext } from "./index.js";
+
+/**
+ * Half-sine pulse centered at `centerSec` (in local time) with `widthSec`
+ * span. Clipped to the operator's frame window. Patch-local pulse semantics
+ * follow `timeOriginFrame`.
+ */
+export function applyPulse(
+  operator: Extract<SensorOperator, { type: "pulse" }>,
+  ctx: OperatorContext,
+): void {
+  const { signal, startFrame, endFrame, sampleRateHz, timeOriginFrame } = ctx;
+  const start = Math.max(
+    startFrame,
+    timeOriginFrame + Math.floor((operator.centerSec - operator.widthSec / 2) * sampleRateHz),
+  );
+  const end = Math.min(
+    endFrame,
+    timeOriginFrame + Math.ceil((operator.centerSec + operator.widthSec / 2) * sampleRateHz),
+  );
+  for (let i = start; i < end; i += 1) {
+    const phase = (i - start) / Math.max(1, end - start);
+    signal[i] = (signal[i] ?? 0) + Math.sin(Math.PI * phase) * operator.amplitude;
+  }
+}

--- a/packages/codec-sensor/src/operators/step.ts
+++ b/packages/codec-sensor/src/operators/step.ts
@@ -1,0 +1,17 @@
+import type { SensorOperator } from "../schema.js";
+import type { OperatorContext } from "./index.js";
+
+/**
+ * Step (Heaviside) at `atSec` in local time. Patch-local step semantics
+ * follow `timeOriginFrame`.
+ */
+export function applyStep(
+  operator: Extract<SensorOperator, { type: "step" }>,
+  ctx: OperatorContext,
+): void {
+  const { signal, startFrame, endFrame, sampleRateHz, timeOriginFrame } = ctx;
+  const start = Math.max(startFrame, timeOriginFrame + Math.floor(operator.atSec * sampleRateHz));
+  for (let i = start; i < endFrame; i += 1) {
+    signal[i] = (signal[i] ?? 0) + operator.amplitude;
+  }
+}

--- a/packages/codec-sensor/src/render.ts
+++ b/packages/codec-sensor/src/render.ts
@@ -1,14 +1,25 @@
-import { access, mkdir, stat, writeFile } from "node:fs/promises";
-import { dirname, extname, resolve as resolvePath } from "node:path";
-import { fileURLToPath } from "node:url";
-import { spawn } from "node:child_process";
+// Sensor render orchestrator — expands a sensor signal spec into samples via
+// the operator strategy registry, writes the JSON/CSV sidecars, and runs the
+// Loupe dashboard renderer for the HTML companion.
+//
+// Operator strategies live under `./operators/` (extracted per #326 / #288).
+// The Loupe fallback chain lives in `./loupe-renderer.ts`. This file owns
+// orchestration only; the per-operator math and the dashboard plumbing are
+// no longer mixed into the same module.
+
+import { mkdir, stat, writeFile } from "node:fs/promises";
+import { dirname, extname } from "node:path";
 import type { RenderCtx, RenderResult } from "@wittgenstein/schemas";
-import type { SensorOperator, SensorSignalSpec } from "./schema.js";
+import type { SensorSignalSpec } from "./schema.js";
+import { dispatchOperator } from "./operators/index.js";
+import { renderLoupeDashboard, type SensorRenderPath } from "./loupe-renderer.js";
 
 export interface SensorSample {
   timeSec: number;
   value: number;
 }
+
+export type { SensorRenderPath };
 
 export async function renderSignalBundle(
   spec: SensorSignalSpec,
@@ -63,8 +74,6 @@ export async function renderSignalBundle(
     },
   };
 }
-
-export type SensorRenderPath = "loupe-script" | "loupe-cli" | "fallback-static-html";
 
 export function makeEcgSignal(
   sampleRateHz: number,
@@ -156,180 +165,17 @@ function expandSensorAlgorithm(
   // operator parameters inside a patch are interpreted patch-local per the
   // research note (#239) and #247 contract decision.
   for (const operator of spec.operators) {
-    expandOperator(operator, signal, 0, frameCount, sampleRateHz, rng, 0);
+    dispatchOperator(operator, {
+      signal,
+      startFrame: 0,
+      endFrame: frameCount,
+      sampleRateHz,
+      rng,
+      timeOriginFrame: 0,
+    });
   }
 
   return signal;
-}
-
-/**
- * Expand a single operator over `[startFrame, endFrame)`.
- *
- * `timeOriginFrame` defines the local zero of the operator's time axis. At top
- * level it is 0 (operators see absolute time). Inside a patch it is the patch
- * start, so `step.atSec`, `pulse.centerSec`, `oscillator.phaseRad`,
- * `drift.slopePerSec`, and `ecgTemplate` phase are all measured relative to the
- * patch boundary — the patch-local contract called out in
- * `docs/research/2026-05-07-sensor-patch-grammar.md` and pinned by #247.
- *
- * Noise has no time dependence and is unaffected by `timeOriginFrame`; it
- * continues to consume the parent RNG sequentially.
- */
-function expandOperator(
-  operator: SensorOperator,
-  signal: Float32Array,
-  startFrame: number,
-  endFrame: number,
-  sampleRateHz: number,
-  rng: () => number,
-  timeOriginFrame: number,
-): void {
-  if (operator.type === "oscillator") {
-    for (let i = startFrame; i < endFrame; i += 1) {
-      const localTimeSec = (i - timeOriginFrame) / sampleRateHz;
-      signal[i] =
-        (signal[i] ?? 0) +
-        Math.sin(2 * Math.PI * operator.frequencyHz * localTimeSec + operator.phaseRad) *
-          operator.amplitude;
-    }
-    return;
-  }
-
-  if (operator.type === "noise") {
-    const span = endFrame - startFrame;
-    const noise = operator.color === "pink" ? pinkNoise(span, rng) : whiteNoise(span, rng);
-    for (let i = 0; i < span; i += 1) {
-      signal[startFrame + i] = (signal[startFrame + i] ?? 0) + (noise[i] ?? 0) * operator.amplitude;
-    }
-    return;
-  }
-
-  if (operator.type === "drift") {
-    for (let i = startFrame; i < endFrame; i += 1) {
-      const localTimeSec = (i - timeOriginFrame) / sampleRateHz;
-      signal[i] = (signal[i] ?? 0) + localTimeSec * operator.slopePerSec;
-    }
-    return;
-  }
-
-  if (operator.type === "pulse") {
-    const start = Math.max(
-      startFrame,
-      timeOriginFrame + Math.floor((operator.centerSec - operator.widthSec / 2) * sampleRateHz),
-    );
-    const end = Math.min(
-      endFrame,
-      timeOriginFrame + Math.ceil((operator.centerSec + operator.widthSec / 2) * sampleRateHz),
-    );
-    for (let i = start; i < end; i += 1) {
-      const phase = (i - start) / Math.max(1, end - start);
-      signal[i] = (signal[i] ?? 0) + Math.sin(Math.PI * phase) * operator.amplitude;
-    }
-    return;
-  }
-
-  if (operator.type === "step") {
-    const start = Math.max(startFrame, timeOriginFrame + Math.floor(operator.atSec * sampleRateHz));
-    for (let i = start; i < endFrame; i += 1) {
-      signal[i] = (signal[i] ?? 0) + operator.amplitude;
-    }
-    return;
-  }
-
-  if (operator.type === "ecgTemplate") {
-    const beatPeriod = 60 / operator.bpm;
-    for (let i = startFrame; i < endFrame; i += 1) {
-      const localTimeSec = (i - timeOriginFrame) / sampleRateHz;
-      const phase = (localTimeSec % beatPeriod) / beatPeriod;
-      const p = Math.exp(-Math.pow((phase - 0.16) * 22, 2)) * 0.08;
-      const qrs =
-        Math.exp(-Math.pow((phase - 0.34) * 55, 2)) * 0.92 -
-        Math.exp(-Math.pow((phase - 0.31) * 80, 2)) * 0.22;
-      const t = Math.exp(-Math.pow((phase - 0.58) * 15, 2)) * 0.18;
-      signal[i] = (signal[i] ?? 0) + (p + qrs + t) * operator.amplitude;
-    }
-    return;
-  }
-
-  // operator.type === "patchGrammar"
-  expandPatchGrammar(operator, signal, startFrame, endFrame, sampleRateHz, rng);
-}
-
-/**
- * Expand a patchGrammar operator across `[startFrame, endFrame)`.
- *
- * Each patch occupies `floor(patchLengthSec * sampleRateHz)` consecutive frames,
- * starting from `startFrame`. Patches that would extend past `endFrame` are
- * truncated; patches whose start frame is past `endFrame` are skipped. Within
- * each patch:
- *   - Pre-patch signal values in the patch range are snapshotted.
- *   - Inner operators run with `timeOriginFrame = patchStart` so all time-based
- *     parameters (oscillator phase reference, drift origin, step.atSec,
- *     pulse.centerSec, ecgTemplate phase) are interpreted patch-local. Noise
- *     consumption is sequential against the parent RNG so a single-patch
- *     full-duration `patchGrammar` stays byte-identical to the equivalent flat
- *     operator list (the recursion-seam invariant).
- *   - If `affineNormalize` is set, the patch's *contribution* (post-pre) is
- *     min-max normalized to `[minOutput, maxOutput]` before being added back
- *     onto the pre-patch values. The schema rejects `minOutput >= maxOutput`
- *     so a degenerate range can never reach this code (#247 item 4).
- *
- * Nested `patchGrammar` is rejected at the schema level (#247 item 3); inner
- * operators are typed as `SensorBaseOperator` so this function never recurses
- * into another patchGrammar.
- */
-function expandPatchGrammar(
-  operator: Extract<SensorOperator, { type: "patchGrammar" }>,
-  signal: Float32Array,
-  startFrame: number,
-  endFrame: number,
-  sampleRateHz: number,
-  rng: () => number,
-): void {
-  const patchFrames = Math.max(1, Math.floor(operator.patchLengthSec * sampleRateHz));
-  for (let patchIdx = 0; patchIdx < operator.patches.length; patchIdx += 1) {
-    const patch = operator.patches[patchIdx];
-    if (!patch) {
-      continue;
-    }
-    const patchStart = startFrame + patchIdx * patchFrames;
-    if (patchStart >= endFrame) {
-      break;
-    }
-    const patchEnd = Math.min(endFrame, patchStart + patchFrames);
-
-    const span = patchEnd - patchStart;
-    const preValues = new Float32Array(span);
-    for (let i = 0; i < span; i += 1) {
-      preValues[i] = signal[patchStart + i] ?? 0;
-    }
-
-    for (const inner of patch.operators) {
-      expandOperator(inner, signal, patchStart, patchEnd, sampleRateHz, rng, patchStart);
-    }
-
-    if (patch.affineNormalize) {
-      const contribution = new Float32Array(span);
-      let min = Infinity;
-      let max = -Infinity;
-      for (let i = 0; i < span; i += 1) {
-        const c = (signal[patchStart + i] ?? 0) - (preValues[i] ?? 0);
-        contribution[i] = c;
-        if (c < min) min = c;
-        if (c > max) max = c;
-      }
-      const range = max - min;
-      const targetMin = patch.affineNormalize.minOutput;
-      const targetMax = patch.affineNormalize.maxOutput;
-      const targetRange = targetMax - targetMin;
-      const fallbackCenter = (targetMin + targetMax) / 2;
-      for (let i = 0; i < span; i += 1) {
-        const normalized =
-          range > 0 ? ((contribution[i]! - min) / range) * targetRange + targetMin : fallbackCenter;
-        signal[patchStart + i] = (preValues[i] ?? 0) + normalized;
-      }
-    }
-  }
 }
 
 function samplesToRows(samples: Float32Array, sampleRateHz: number): SensorSample[] {
@@ -341,60 +187,6 @@ function samplesToRows(samples: Float32Array, sampleRateHz: number): SensorSampl
 
 function toCsv(rows: SensorSample[]): string {
   return ["timeSec,value", ...rows.map((row) => `${row.timeSec},${row.value}`)].join("\n");
-}
-
-const moduleDir = dirname(fileURLToPath(import.meta.url));
-
-async function renderLoupeDashboard(
-  csvPath: string,
-  htmlPath: string,
-  spec: SensorSignalSpec,
-): Promise<{ htmlReady: boolean; renderPath: SensorRenderPath }> {
-  // Search for loupe.py: repo root → package dir → cwd → polyglot-mini sub-project
-  const candidates = [
-    resolvePath(moduleDir, "../../../../loupe.py"), // repo root
-    resolvePath(moduleDir, "../loupe.py"), // package root
-    resolvePath(process.cwd(), "loupe.py"), // cwd
-    resolvePath(process.cwd(), "polyglot-mini/loupe.py"), // sub-project
-  ];
-  let loupePath: string | null = null;
-  for (const c of candidates) {
-    try {
-      await access(c);
-      loupePath = c;
-      break;
-    } catch {
-      /* skip */
-    }
-  }
-  if (!loupePath) {
-    // Try `loupe` on PATH
-    try {
-      await spawnChecked("python3", ["-m", "loupe_cli", csvPath, "-o", htmlPath]);
-      return { htmlReady: true, renderPath: "loupe-cli" };
-    } catch {
-      /* continue to fallback */
-    }
-  } else {
-    try {
-      await spawnChecked("python3", [loupePath, csvPath, "-o", htmlPath]);
-      return { htmlReady: true, renderPath: "loupe-script" };
-    } catch {
-      /* continue to fallback */
-    }
-  }
-  const fallbackHtml = `<!doctype html>
-<html lang="en">
-<meta charset="utf-8" />
-<title>${spec.signal} preview</title>
-<body style="font-family: ui-monospace, monospace; padding: 24px; background: #111; color: #f5f5f5;">
-  <h1>${spec.signal} preview</h1>
-  <p>Loupe was unavailable, so Wittgenstein wrote the raw CSV sidecar instead.</p>
-  <p>Open <code>${csvPath}</code> or rerun with Python 3 available to get the interactive dashboard.</p>
-</body>
-</html>`;
-  await writeFile(htmlPath, fallbackHtml);
-  return { htmlReady: true, renderPath: "fallback-static-html" };
 }
 
 function ensureExtension(path: string, ext: string): string {
@@ -411,37 +203,4 @@ function createRng(seed: number): () => number {
     state = (state * 1103515245 + 12345) >>> 0;
     return state / 0xffffffff;
   };
-}
-
-function whiteNoise(frameCount: number, rng: () => number): Float32Array {
-  const samples = new Float32Array(frameCount);
-  for (let i = 0; i < frameCount; i += 1) {
-    samples[i] = rng() * 2 - 1;
-  }
-  return samples;
-}
-
-function pinkNoise(frameCount: number, rng: () => number): Float32Array {
-  const white = whiteNoise(frameCount, rng);
-  const pink = new Float32Array(frameCount);
-  let prev = 0;
-  for (let i = 0; i < frameCount; i += 1) {
-    prev = 0.985 * prev + 0.15 * (white[i] ?? 0);
-    pink[i] = prev;
-  }
-  return pink;
-}
-
-async function spawnChecked(command: string, args: string[]): Promise<void> {
-  await new Promise<void>((resolvePromise, reject) => {
-    const child = spawn(command, args, { stdio: "ignore" });
-    child.on("error", reject);
-    child.on("exit", (code) => {
-      if (code === 0) {
-        resolvePromise();
-        return;
-      }
-      reject(new Error(`${command} exited with code ${code ?? "unknown"}`));
-    });
-  });
 }


### PR DESCRIPTION
## Summary

Closes #326. Second refactor from the AI-shape audit ([\`docs/research/2026-05-13-ai-shape-audit.md\`](../blob/main/docs/research/2026-05-13-ai-shape-audit.md), merged via [#328](https://github.com/p-to-q/wittgenstein/pull/328)).

\`packages/codec-sensor/src/render.ts\` (447 lines) carried three canonical AI-code smells per the audit:

1. \`expandOperator()\` — 79-line switch over 7 operator types.
2. \`expandPatchGrammar()\` — recursion into \`expandOperator\` while managing \`timeOriginFrame\` offsets; patch scheduling and operator semantics tangled.
3. \`renderLoupeDashboard()\` — 3-level fallback chain with near-identical try/catch.

This refactor splits along all three seams.

## File-level changes

| Path | Before | After | What it owns |
|---|---|---|---|
| \`src/render.ts\` | 447L | **206L** | Thin orchestrator: builds samples via \`dispatchOperator\`, writes JSON/CSV, runs Loupe |
| \`src/operators/index.ts\` | — | new | Shared \`OperatorContext\` type + \`dispatchOperator(operator, ctx)\` (tight switch) |
| \`src/operators/oscillator.ts\` | — | new | \`applyOscillator\` |
| \`src/operators/noise.ts\` | — | new | \`applyNoise\` + \`whiteNoise\` + \`pinkNoise\` helpers |
| \`src/operators/drift.ts\` | — | new | \`applyDrift\` |
| \`src/operators/pulse.ts\` | — | new | \`applyPulse\` |
| \`src/operators/step.ts\` | — | new | \`applyStep\` |
| \`src/operators/ecg-template.ts\` | — | new | \`applyEcgTemplate\` |
| \`src/operators/patch-grammar.ts\` | — | new | \`applyPatchGrammar\` (uses \`dispatchOperator\` recursively for inner operators) |
| \`src/loupe-renderer.ts\` | — | new | \`renderLoupeDashboard\` with configurable search paths + \`SensorRenderPath\` type |

\`render.ts\` shrinks **447 → 206 lines**, under the audit's \"under 250 lines\" target.

## What did NOT change

- **Sample byte output.** The refactor moves code around but the actual per-frame math is character-identical. All 6 sensor goldens preserve byte-for-byte (including the patchGrammar recursion-seam fixtures).
- **Public API.** \`renderSignalBundle\`, \`makeEcgSignal\`, \`makeGyroSignal\`, \`makeTemperatureSignal\`, \`SensorSample\`, \`SensorRenderPath\` all keep the same signatures.
- **patchGrammar semantics.** The recursion-seam invariant (single-patch full-duration matches flat operator list byte-for-byte) is preserved — \`patch-grammar.ts\` passes the same arguments to \`dispatchOperator\` that the inline \`expandOperator\` received.
- **Loupe fallback paths.** The 4 candidate paths for \`loupe.py\` and the fallback static-HTML body are byte-identical (including the \`../../../../loupe.py\` repo-root depth).

## What the seams unlock

- **Operators directory** makes it trivial to add an 8th operator type — write a new \`apply<Foo>\` file, register it in \`dispatchOperator\`'s switch, done. The audit's concern about \"adding an 8th operator means extending the switch and threading more parameter wiring\" is retired.
- **patchGrammar split** decouples patch scheduling from operator semantics; if a future measurement (#284) ratifies patchGrammar to doctrine, the promotion work stays localized.
- **LoupeRenderer extraction** lets future test environments inject custom search paths without touching the renderer logic, and isolates the subprocess + fallback concern from sample-rendering math.

## Validation

- \`pnpm --filter @wittgenstein/codec-sensor typecheck\` — clean.
- \`pnpm --filter @wittgenstein/codec-sensor test\` — all 18 tests pass (12 codec tests + 6 golden tests).
- \`pnpm --filter @wittgenstein/codec-sensor lint\` — 0 errors, 0 warnings.

## What this PR is NOT

- Not a behavior change. Sample bytes unchanged; Loupe fallback paths unchanged.
- Not a new operator. The 7 operator types are exactly the same as before, just one file per type.
- Not a patchGrammar promotion. Its post-M3 \"permitted but not promoted\" status per [\`docs/codecs/sensor.md\`](../blob/main/docs/codecs/sensor.md) is unchanged; this is shape-only.
- Not a doctrine change. Operates under the engineering lane per ADR-0014.

## Refs

- **Closes #326.**
- Audit source: [\`docs/research/2026-05-13-ai-shape-audit.md\`](../blob/main/docs/research/2026-05-13-ai-shape-audit.md) (merged via [#328](https://github.com/p-to-q/wittgenstein/pull/328)).
- Sibling refactor PRs: [#337](https://github.com/p-to-q/wittgenstein/pull/337) (landscape renderer extraction, just merged), [#327](https://github.com/p-to-q/wittgenstein/issues/327) (HyperFrames composition + ProcessRunner, still queued).
- Related sensor work: [#284](https://github.com/p-to-q/wittgenstein/issues/284) patchGrammar measurement gate — unaffected by this refactor.