### PR TITLE
refactor(codec-video): extract composition modules + ProcessRunner (closes #327)

### DIFF
--- a/packages/codec-video/src/compositions/scene-card.ts
+++ b/packages/codec-video/src/compositions/scene-card.ts
@@ -1,0 +1,132 @@
+// Scene-card composition — renders a HyperFrames-shaped HTML page where each
+// scene is a structured card (kicker / title / body / meta) on a tinted
+// gradient background. Extracted from `hyperframes-wrapper.ts` per
+// #327 / #288.
+
+import type { RenderCtx } from "@wittgenstein/schemas";
+import type { VideoComposition } from "../schema.js";
+import { buildClipTimelineCss } from "../slideshow-timeline-css.js";
+import {
+  BASE_CSS,
+  STAGE_HEIGHT,
+  STAGE_WIDTH,
+  escapeHtml,
+  sanitizeCompositionId,
+} from "./shared.js";
+
+export interface SceneCardHtmlResult {
+  html: string;
+  totalDurationSec: number;
+}
+
+/**
+ * Build the HTML for the scene-card composition. Used when the composition
+ * does not carry pre-rendered inline SVGs.
+ */
+export function buildSceneCardHtml(
+  composition: VideoComposition,
+  ctx: RenderCtx,
+): SceneCardHtmlResult {
+  const compositionId = sanitizeCompositionId(`wittgenstein-${ctx.runId}`);
+
+  const scenes =
+    composition.scenes.length > 0
+      ? composition.scenes
+      : [
+          {
+            name: "scene-1",
+            description:
+              composition.scenes.length === 0 ? "Auto scene (no scenes provided)." : "",
+            durationSec: composition.durationSec,
+          },
+        ];
+
+  const totalDurationSec = Math.max(
+    composition.durationSec,
+    scenes.reduce((sum, s) => sum + s.durationSec, 0),
+    0.25,
+  );
+
+  let t = 0;
+  const clips = scenes.map((scene, index) => {
+    const start = t;
+    t += scene.durationSec;
+    return { scene, index, start };
+  });
+
+  const clipTimelineCss = buildClipTimelineCss(
+    clips.map((c) => ({ index: c.index, start: c.start, durationSec: c.scene.durationSec })),
+    totalDurationSec,
+    { iterationCount: 1 },
+  );
+
+  const bodyInner = clips.map(({ scene, index, start }) => {
+    const trackIndex = index % 8;
+    const tone = sceneTone(index);
+    return [
+      `<div`,
+      `  class="hf-clip hf-clip--${index}"`,
+      `  style="z-index:${10 + index}; --hf-tone-a:${tone.a}; --hf-tone-b:${tone.b};"`,
+      `  data-start="${start}"`,
+      `  data-duration="${scene.durationSec}"`,
+      `  data-track-index="${trackIndex}"`,
+      `>`,
+      `  <div class="hf-card" style="background: linear-gradient(145deg, rgba(10,14,28,0.82), rgba(10,14,28,0.62)), radial-gradient(900px 420px at 20% 0%, var(--hf-tone-a), transparent 55%), radial-gradient(700px 500px at 90% 80%, var(--hf-tone-b), transparent 55%);"`,
+      `    <div class="hf-emoji" aria-hidden="true">🐧</div>`,
+      `    <p class="hf-kicker">${escapeHtml(scene.name)}</p>`,
+      `    <h1 class="hf-title">${escapeHtml(scene.name)}</h1>`,
+      `    <p class="hf-body">${escapeHtml(scene.description)}</p>`,
+      `    <div class="hf-meta">fps=${escapeHtml(String(composition.fps))} · seed=${escapeHtml(String(ctx.seed))}</div>`,
+      `  </div>`,
+      `</div>`,
+    ].join("\n");
+  });
+
+  const html = [
+    "<!doctype html>",
+    `<html lang="en">`,
+    `<head>`,
+    `<meta charset="utf-8" />`,
+    `<meta name="viewport" content="width=device-width, initial-scale=1" />`,
+    `<title>${escapeHtml(compositionId)}</title>`,
+    `<style>`,
+    BASE_CSS,
+    `html, body { background: #070a12; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial; }`,
+    `#stage { position: relative; width: ${STAGE_WIDTH}px; height: ${STAGE_HEIGHT}px; margin: 0 auto; background: radial-gradient(1200px 800px at 30% 20%, #1b2a55, #070a12 55%), linear-gradient(180deg, #0b1020, #070a12); overflow: hidden; }`,
+    `.hf-clip { position: absolute; inset: 0; display: grid; place-items: center; padding: 96px; box-sizing: border-box; opacity: 0; }`,
+    `.hf-card { width: min(1400px, 92vw); border: 1px solid rgba(255,255,255,0.12); border-radius: 28px; padding: 56px 64px; background: rgba(10, 14, 28, 0.72); backdrop-filter: blur(10px); box-shadow: 0 30px 120px rgba(0,0,0,0.45); }`,
+    `.hf-emoji { margin: 0 0 20px; font-size: clamp(96px, 14vw, 168px); line-height: 1; filter: drop-shadow(0 14px 36px rgba(0,0,0,0.45)); user-select: none; }`,
+    `.hf-kicker { letter-spacing: 0.14em; text-transform: uppercase; font-size: 14px; color: rgba(255,255,255,0.55); margin: 0 0 18px; }`,
+    `.hf-title { margin: 0 0 22px; font-size: 64px; line-height: 1.05; font-weight: 650; color: rgba(255,255,255,0.95); }`,
+    `.hf-body { margin: 0; font-size: 34px; line-height: 1.35; color: rgba(255,255,255,0.78); white-space: pre-wrap; }`,
+    `.hf-meta { margin-top: 34px; font-size: 18px; color: rgba(255,255,255,0.45); }`,
+    clipTimelineCss,
+    `</style>`,
+    `</head>`,
+    `<body>`,
+    `<div`,
+    `  id="stage"`,
+    `  data-composition-id="${escapeHtml(compositionId)}"`,
+    `  data-start="0"`,
+    `  data-width="${STAGE_WIDTH}"`,
+    `  data-height="${STAGE_HEIGHT}"`,
+    `  data-duration="${totalDurationSec}"`,
+    `>`,
+    ...bodyInner,
+    `</div>`,
+    `</body>`,
+    `</html>`,
+    "",
+  ].join("\n");
+
+  return { html, totalDurationSec };
+}
+
+function sceneTone(index: number): { a: string; b: string } {
+  const tones = [
+    { a: "rgba(80, 160, 255, 0.35)", b: "rgba(255, 210, 120, 0.22)" },
+    { a: "rgba(255, 140, 90, 0.28)", b: "rgba(120, 200, 255, 0.22)" },
+    { a: "rgba(190, 120, 255, 0.26)", b: "rgba(120, 255, 200, 0.18)" },
+  ] as const;
+  return tones[index % tones.length]!;
+}

--- a/packages/codec-video/src/compositions/shared.ts
+++ b/packages/codec-video/src/compositions/shared.ts
@@ -1,0 +1,29 @@
+// Shared primitives for the HyperFrames-shaped HTML compositions. Extracted
+// from `hyperframes-wrapper.ts` per #327 / #288 so the SVG-slide and
+// scene-card compositions don't independently duplicate stage dimensions,
+// id sanitization, or HTML escaping.
+
+export const STAGE_WIDTH = 1920;
+export const STAGE_HEIGHT = 1080;
+
+export function sanitizeCompositionId(input: string): string {
+  return input.replace(/[^a-zA-Z0-9_-]+/g, "-").replace(/^-+|-+$/g, "") || "composition";
+}
+
+export function escapeHtml(input: string): string {
+  return input
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
+ * Common base CSS that both compositions emit before their composition-specific
+ * style block. Kept here so a single edit propagates across compositions.
+ */
+export const BASE_CSS = [
+  `:root { color-scheme: dark; }`,
+  `html, body { height: 100%; margin: 0; }`,
+].join("\n");

--- a/packages/codec-video/src/compositions/svg-slide.ts
+++ b/packages/codec-video/src/compositions/svg-slide.ts
@@ -1,0 +1,117 @@
+// SVG-slide composition — renders a HyperFrames-shaped HTML page where each
+// scene is a pre-rendered inline SVG slide. Extracted from
+// `hyperframes-wrapper.ts` per #327 / #288.
+
+import type { RenderCtx } from "@wittgenstein/schemas";
+import type { VideoComposition } from "../schema.js";
+import { buildClipTimelineCss } from "../slideshow-timeline-css.js";
+import {
+  BASE_CSS,
+  STAGE_HEIGHT,
+  STAGE_WIDTH,
+  escapeHtml,
+  sanitizeCompositionId,
+} from "./shared.js";
+
+export interface SvgSlideHtmlResult {
+  html: string;
+  totalDurationSec: number;
+}
+
+/**
+ * Build the HTML for the SVG-slide composition. Caller is expected to have
+ * already verified that `composition.inlineSvgs` is non-empty.
+ */
+export function buildSvgSlideHtml(
+  composition: VideoComposition,
+  ctx: RenderCtx,
+  inlineSvgs: readonly string[],
+): SvgSlideHtmlResult {
+  const compositionId = sanitizeCompositionId(`wittgenstein-${ctx.runId}`);
+  const durations = resolveSlideDurations(composition, inlineSvgs.length);
+
+  let t = 0;
+  const svgClips = inlineSvgs.map((svg, index) => {
+    const durationSec = durations[index] ?? 3;
+    const start = t;
+    t += durationSec;
+    const label = composition.scenes[index]?.name ?? `slide-${index + 1}`;
+    return { svg, index, start, durationSec, label };
+  });
+  const totalDurationSec = Math.max(t, 0.25);
+
+  const clipTimelineCss = buildClipTimelineCss(
+    svgClips.map((c) => ({ index: c.index, start: c.start, durationSec: c.durationSec })),
+    totalDurationSec,
+    { iterationCount: 1 },
+  );
+
+  const bodyInner = svgClips.map(({ svg, index, start, durationSec, label }) => {
+    const trackIndex = index % 8;
+    return [
+      `<div`,
+      `  class="hf-clip hf-clip--${index}"`,
+      `  style="z-index:${10 + index}"`,
+      `  data-start="${start}"`,
+      `  data-duration="${durationSec}"`,
+      `  data-track-index="${trackIndex}"`,
+      `>`,
+      `  <div class="hf-svg-slide" role="img" aria-label="${escapeHtml(label)}">`,
+      stripXmlDeclaration(svg),
+      `  </div>`,
+      `</div>`,
+    ].join("\n");
+  });
+
+  const html = [
+    "<!doctype html>",
+    `<html lang="en">`,
+    `<head>`,
+    `<meta charset="utf-8" />`,
+    `<meta name="viewport" content="width=device-width, initial-scale=1" />`,
+    `<title>${escapeHtml(compositionId)}</title>`,
+    `<style>`,
+    BASE_CSS,
+    `html, body { background: #000000; }`,
+    `#stage { position: relative; width: ${STAGE_WIDTH}px; height: ${STAGE_HEIGHT}px; margin: 0 auto; background: #000000; overflow: hidden; }`,
+    `.hf-clip { position: absolute; inset: 0; display: grid; place-items: center; padding: 48px; box-sizing: border-box; opacity: 0; }`,
+    `.hf-svg-slide { width: 100%; height: 100%; display: grid; place-items: center; box-sizing: border-box; }`,
+    `.hf-svg-slide > svg { width: auto; height: auto; max-width: 1720px; max-height: 940px; display: block; }`,
+    clipTimelineCss,
+    `</style>`,
+    `</head>`,
+    `<body>`,
+    `<div`,
+    `  id="stage"`,
+    `  data-composition-id="${escapeHtml(compositionId)}"`,
+    `  data-start="0"`,
+    `  data-width="${STAGE_WIDTH}"`,
+    `  data-height="${STAGE_HEIGHT}"`,
+    `  data-duration="${totalDurationSec}"`,
+    `>`,
+    ...bodyInner,
+    `</div>`,
+    `</body>`,
+    `</html>`,
+    "",
+  ].join("\n");
+
+  return { html, totalDurationSec };
+}
+
+function resolveSlideDurations(composition: VideoComposition, slideCount: number): number[] {
+  const n = Math.max(1, slideCount);
+  const scenes = composition.scenes;
+  if (scenes.length === n) {
+    return scenes.map((s) => s.durationSec);
+  }
+  if (composition.durationSec && composition.durationSec > 0) {
+    const each = Math.max(0.25, composition.durationSec / n);
+    return Array.from({ length: n }, () => each);
+  }
+  return Array.from({ length: n }, () => 3);
+}
+
+function stripXmlDeclaration(svg: string): string {
+  return svg.replace(/^\uFEFF?<\?xml[^>]*>\s*/i, "").trim();
+}

--- a/packages/codec-video/src/hyperframes-wrapper.ts
+++ b/packages/codec-video/src/hyperframes-wrapper.ts
@@ -1,9 +1,19 @@
-import { spawn } from "node:child_process";
+// HyperFrames wrapper — orchestrator for the video codec's MP4 / HTML output.
+// Builds the composition HTML (delegating to the per-composition modules
+// under `./compositions/`) and, when `WITTGENSTEIN_HYPERFRAMES_RENDER=1`,
+// invokes `npx hyperframes render` to encode the MP4.
+//
+// Per-composition HTML builders live in `./compositions/{svg-slide,scene-card}.ts`
+// (extracted per #327 / #288). The subprocess plumbing lives in
+// `./process-runner.ts`. This file owns dispatch + MP4 wiring only.
+
 import { mkdir, writeFile, stat } from "node:fs/promises";
 import { dirname, extname, join } from "node:path";
 import type { RenderCtx, RenderResult } from "@wittgenstein/schemas";
 import type { VideoComposition } from "./schema.js";
-import { buildClipTimelineCss } from "./slideshow-timeline-css.js";
+import { buildSvgSlideHtml } from "./compositions/svg-slide.js";
+import { buildSceneCardHtml } from "./compositions/scene-card.js";
+import { runProcess } from "./process-runner.js";
 
 export async function renderWithHyperFrames(
   composition: VideoComposition,
@@ -76,7 +86,10 @@ async function runHyperframesRenderToMp4(params: {
   fps: number;
 }): Promise<void> {
   const fps = snapHyperframesFps(params.fps);
-  const timeoutMs = Number.parseInt(process.env.WITTGENSTEIN_HYPERFRAMES_RENDER_TIMEOUT_MS ?? "600000", 10);
+  const timeoutMs = Number.parseInt(
+    process.env.WITTGENSTEIN_HYPERFRAMES_RENDER_TIMEOUT_MS ?? "600000",
+    10,
+  );
   const args = [
     "-y",
     "hyperframes",
@@ -90,7 +103,7 @@ async function runHyperframesRenderToMp4(params: {
     "--quiet",
   ];
 
-  await spawnProcess(
+  await runProcess(
     "npx",
     args,
     {
@@ -100,8 +113,10 @@ async function runHyperframesRenderToMp4(params: {
         HYPERFRAMES_NO_TELEMETRY: process.env.HYPERFRAMES_NO_TELEMETRY ?? "1",
         HYPERFRAMES_NO_UPDATE_CHECK: process.env.HYPERFRAMES_NO_UPDATE_CHECK ?? "1",
       },
+      timeoutHint: "(set WITTGENSTEIN_HYPERFRAMES_RENDER_TIMEOUT_MS).",
     },
     timeoutMs,
+    "hyperframes render",
   );
 
   try {
@@ -126,65 +141,6 @@ function snapHyperframesFps(fps: number): 24 | 30 | 60 {
   return 60;
 }
 
-function spawnProcess(
-  command: string,
-  args: readonly string[],
-  options: { cwd: string; env: NodeJS.ProcessEnv },
-  timeoutMs: number,
-): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
-      cwd: options.cwd,
-      env: options.env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout?.setEncoding("utf8");
-    child.stderr?.setEncoding("utf8");
-    child.stdout?.on("data", (chunk: string) => {
-      stdout += chunk;
-    });
-    child.stderr?.on("data", (chunk: string) => {
-      stderr += chunk;
-    });
-
-    const timer = setTimeout(() => {
-      child.kill("SIGTERM");
-      reject(
-        new Error(
-          `hyperframes render timed out after ${timeoutMs}ms (set WITTGENSTEIN_HYPERFRAMES_RENDER_TIMEOUT_MS).`,
-        ),
-      );
-    }, timeoutMs);
-
-    child.on("error", (error) => {
-      clearTimeout(timer);
-      reject(
-        new Error(
-          `Failed to spawn hyperframes render (${command} ${args.join(" ")}). Is Node/npm available on PATH?`,
-          { cause: error },
-        ),
-      );
-    });
-
-    child.on("close", (code) => {
-      clearTimeout(timer);
-      if (code === 0) {
-        resolve();
-        return;
-      }
-      reject(
-        new Error(
-          `hyperframes render exited with code ${code}: ${stderr.slice(-8000) || stdout.slice(-8000)}`,
-        ),
-      );
-    });
-  });
-}
-
 function resolveHyperFramesArtifactPath(outPath: string): string {
   const ext = extname(outPath);
   if (ext.toLowerCase() === ".html" || ext.toLowerCase() === ".htm") {
@@ -201,209 +157,11 @@ function resolveHyperFramesArtifactPath(outPath: string): string {
 }
 
 function buildHyperFramesHtml(composition: VideoComposition, ctx: RenderCtx): string {
-  const width = 1920;
-  const height = 1080;
-  const compositionId = sanitizeId(`wittgenstein-${ctx.runId}`);
   const inlineSvgs =
     composition.inlineSvgs && composition.inlineSvgs.length > 0 ? composition.inlineSvgs : null;
 
-  let totalDurationSec = 0.25;
-  let clipTimelineCss = "";
-  let bodyInner: string[] = [];
-
   if (inlineSvgs) {
-    const durations = resolveSlideDurations(composition, inlineSvgs.length);
-    let t = 0;
-    const svgClips = inlineSvgs.map((svg, index) => {
-      const durationSec = durations[index] ?? 3;
-      const start = t;
-      t += durationSec;
-      const label = composition.scenes[index]?.name ?? `slide-${index + 1}`;
-      return { svg, index, start, durationSec, label };
-    });
-    totalDurationSec = Math.max(t, 0.25);
-    clipTimelineCss = buildClipTimelineCss(
-      svgClips.map((c) => ({ index: c.index, start: c.start, durationSec: c.durationSec })),
-      totalDurationSec,
-      { iterationCount: 1 },
-    );
-
-    bodyInner = svgClips.map(({ svg, index, start, durationSec, label }) => {
-      const trackIndex = index % 8;
-      return [
-        `<div`,
-        `  class="hf-clip hf-clip--${index}"`,
-        `  style="z-index:${10 + index}"`,
-        `  data-start="${start}"`,
-        `  data-duration="${durationSec}"`,
-        `  data-track-index="${trackIndex}"`,
-        `>`,
-        `  <div class="hf-svg-slide" role="img" aria-label="${escapeHtml(label)}">`,
-        stripXmlDeclaration(svg),
-        `  </div>`,
-        `</div>`,
-      ].join("\n");
-    });
-
-    return [
-      "<!doctype html>",
-      `<html lang="en">`,
-      `<head>`,
-      `<meta charset="utf-8" />`,
-      `<meta name="viewport" content="width=device-width, initial-scale=1" />`,
-      `<title>${escapeHtml(compositionId)}</title>`,
-      `<style>`,
-      `:root { color-scheme: dark; }`,
-      `html, body { height: 100%; margin: 0; background: #000000; }`,
-      `#stage { position: relative; width: ${width}px; height: ${height}px; margin: 0 auto; background: #000000; overflow: hidden; }`,
-      `.hf-clip { position: absolute; inset: 0; display: grid; place-items: center; padding: 48px; box-sizing: border-box; opacity: 0; }`,
-      `.hf-svg-slide { width: 100%; height: 100%; display: grid; place-items: center; box-sizing: border-box; }`,
-      `.hf-svg-slide > svg { width: auto; height: auto; max-width: 1720px; max-height: 940px; display: block; }`,
-      clipTimelineCss,
-      `</style>`,
-      `</head>`,
-      `<body>`,
-      `<div`,
-      `  id="stage"`,
-      `  data-composition-id="${escapeHtml(compositionId)}"`,
-      `  data-start="0"`,
-      `  data-width="${width}"`,
-      `  data-height="${height}"`,
-      `  data-duration="${totalDurationSec}"`,
-      `>`,
-      ...bodyInner,
-      `</div>`,
-      `</body>`,
-      `</html>`,
-      "",
-    ].join("\n");
+    return buildSvgSlideHtml(composition, ctx, inlineSvgs).html;
   }
-
-  const scenes =
-    composition.scenes.length > 0
-      ? composition.scenes
-      : [
-          {
-            name: "scene-1",
-            description: composition.scenes.length === 0 ? "Auto scene (no scenes provided)." : "",
-            durationSec: composition.durationSec,
-          },
-        ];
-
-  totalDurationSec = Math.max(
-    composition.durationSec,
-    scenes.reduce((sum, s) => sum + s.durationSec, 0),
-    0.25,
-  );
-
-  let t = 0;
-  const clips = scenes.map((scene, index) => {
-    const start = t;
-    t += scene.durationSec;
-    return { scene, index, start };
-  });
-
-  clipTimelineCss = buildClipTimelineCss(
-    clips.map((c) => ({ index: c.index, start: c.start, durationSec: c.scene.durationSec })),
-    totalDurationSec,
-    { iterationCount: 1 },
-  );
-
-  bodyInner = clips.map(({ scene, index, start }) => {
-    const trackIndex = index % 8;
-    const tone = sceneTone(index);
-    return [
-      `<div`,
-      `  class="hf-clip hf-clip--${index}"`,
-      `  style="z-index:${10 + index}; --hf-tone-a:${tone.a}; --hf-tone-b:${tone.b};"`,
-      `  data-start="${start}"`,
-      `  data-duration="${scene.durationSec}"`,
-      `  data-track-index="${trackIndex}"`,
-      `>`,
-      `  <div class="hf-card" style="background: linear-gradient(145deg, rgba(10,14,28,0.82), rgba(10,14,28,0.62)), radial-gradient(900px 420px at 20% 0%, var(--hf-tone-a), transparent 55%), radial-gradient(700px 500px at 90% 80%, var(--hf-tone-b), transparent 55%);"`,
-      `    <div class="hf-emoji" aria-hidden="true">🐧</div>`,
-      `    <p class="hf-kicker">${escapeHtml(scene.name)}</p>`,
-      `    <h1 class="hf-title">${escapeHtml(scene.name)}</h1>`,
-      `    <p class="hf-body">${escapeHtml(scene.description)}</p>`,
-      `    <div class="hf-meta">fps=${escapeHtml(String(composition.fps))} · seed=${escapeHtml(String(ctx.seed))}</div>`,
-      `  </div>`,
-      `</div>`,
-    ].join("\n");
-  });
-
-  return [
-    "<!doctype html>",
-    `<html lang="en">`,
-    `<head>`,
-    `<meta charset="utf-8" />`,
-    `<meta name="viewport" content="width=device-width, initial-scale=1" />`,
-    `<title>${escapeHtml(compositionId)}</title>`,
-    `<style>`,
-    `:root { color-scheme: dark; }`,
-    `html, body { height: 100%; margin: 0; background: #070a12; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial; }`,
-    `#stage { position: relative; width: ${width}px; height: ${height}px; margin: 0 auto; background: radial-gradient(1200px 800px at 30% 20%, #1b2a55, #070a12 55%), linear-gradient(180deg, #0b1020, #070a12); overflow: hidden; }`,
-    `.hf-clip { position: absolute; inset: 0; display: grid; place-items: center; padding: 96px; box-sizing: border-box; opacity: 0; }`,
-    `.hf-card { width: min(1400px, 92vw); border: 1px solid rgba(255,255,255,0.12); border-radius: 28px; padding: 56px 64px; background: rgba(10, 14, 28, 0.72); backdrop-filter: blur(10px); box-shadow: 0 30px 120px rgba(0,0,0,0.45); }`,
-    `.hf-emoji { margin: 0 0 20px; font-size: clamp(96px, 14vw, 168px); line-height: 1; filter: drop-shadow(0 14px 36px rgba(0,0,0,0.45)); user-select: none; }`,
-    `.hf-kicker { letter-spacing: 0.14em; text-transform: uppercase; font-size: 14px; color: rgba(255,255,255,0.55); margin: 0 0 18px; }`,
-    `.hf-title { margin: 0 0 22px; font-size: 64px; line-height: 1.05; font-weight: 650; color: rgba(255,255,255,0.95); }`,
-    `.hf-body { margin: 0; font-size: 34px; line-height: 1.35; color: rgba(255,255,255,0.78); white-space: pre-wrap; }`,
-    `.hf-meta { margin-top: 34px; font-size: 18px; color: rgba(255,255,255,0.45); }`,
-    clipTimelineCss,
-    `</style>`,
-    `</head>`,
-    `<body>`,
-    `<div`,
-    `  id="stage"`,
-    `  data-composition-id="${escapeHtml(compositionId)}"`,
-    `  data-start="0"`,
-    `  data-width="${width}"`,
-    `  data-height="${height}"`,
-    `  data-duration="${totalDurationSec}"`,
-    `>`,
-    ...bodyInner,
-    `</div>`,
-    `</body>`,
-    `</html>`,
-    "",
-  ].join("\n");
-}
-
-function resolveSlideDurations(composition: VideoComposition, slideCount: number): number[] {
-  const n = Math.max(1, slideCount);
-  const scenes = composition.scenes;
-  if (scenes.length === n) {
-    return scenes.map((s) => s.durationSec);
-  }
-  if (composition.durationSec && composition.durationSec > 0) {
-    const each = Math.max(0.25, composition.durationSec / n);
-    return Array.from({ length: n }, () => each);
-  }
-  return Array.from({ length: n }, () => 3);
-}
-
-function stripXmlDeclaration(svg: string): string {
-  return svg.replace(/^\uFEFF?<\?xml[^>]*>\s*/i, "").trim();
-}
-
-function sceneTone(index: number): { a: string; b: string } {
-  const tones = [
-    { a: "rgba(80, 160, 255, 0.35)", b: "rgba(255, 210, 120, 0.22)" },
-    { a: "rgba(255, 140, 90, 0.28)", b: "rgba(120, 200, 255, 0.22)" },
-    { a: "rgba(190, 120, 255, 0.26)", b: "rgba(120, 255, 200, 0.18)" },
-  ] as const;
-  return tones[index % tones.length]!;
-}
-
-function sanitizeId(input: string): string {
-  return input.replace(/[^a-zA-Z0-9_-]+/g, "-").replace(/^-+|-+$/g, "") || "composition";
-}
-
-function escapeHtml(input: string): string {
-  return input
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
+  return buildSceneCardHtml(composition, ctx).html;
 }

--- a/packages/codec-video/src/process-runner.ts
+++ b/packages/codec-video/src/process-runner.ts
@@ -21,18 +21,26 @@ export interface ProcessRunnerOptions {
   timeoutHint?: string;
 }
 
-export interface ProcessRunnerError {
-  message: string;
-  exitCode: number | null;
-  stdoutTail: string;
-  stderrTail: string;
-  cause?: unknown;
+/**
+ * Cap on per-stream buffered output. Long-running noisy subprocesses can
+ * otherwise accumulate unbounded strings; the error-path slice (`.slice(-8000)`
+ * below) only consumes the last 8000 bytes, so a 32 KB cap stays well above
+ * what error messages need while keeping memory predictable.
+ */
+const MAX_STREAM_BYTES = 32_768;
+
+function appendCapped(current: string, chunk: string): string {
+  const combined = current + chunk;
+  if (combined.length <= MAX_STREAM_BYTES) {
+    return combined;
+  }
+  return combined.slice(combined.length - MAX_STREAM_BYTES);
 }
 
 /**
  * Run a subprocess with a timeout and bounded stdout/stderr capture. Resolves
- * on exit code 0. Rejects with a typed `Error` carrying tail output on
- * non-zero exit, spawn error, or timeout.
+ * on exit code 0. Rejects with an `Error` carrying tail output on non-zero
+ * exit, spawn error, or timeout.
  *
  * `errorPrefix` is used as the leading sentence of the rejection message; it
  * lets callers preserve their domain-specific phrasing (e.g.
@@ -58,10 +66,10 @@ export async function runProcess(
     child.stdout?.setEncoding("utf8");
     child.stderr?.setEncoding("utf8");
     child.stdout?.on("data", (chunk: string) => {
-      stdout += chunk;
+      stdout = appendCapped(stdout, chunk);
     });
     child.stderr?.on("data", (chunk: string) => {
-      stderr += chunk;
+      stderr = appendCapped(stderr, chunk);
     });
 
     const timer = setTimeout(() => {

--- a/packages/codec-video/src/process-runner.ts
+++ b/packages/codec-video/src/process-runner.ts
@@ -1,0 +1,96 @@
+// Generic subprocess runner with timeout + stdout/stderr buffering. Extracted
+// from `hyperframes-wrapper.ts` per #327 / #288 so the timeout boundary, the
+// output buffering, and the structured-error extraction are no longer tangled
+// with HyperFrames-specific code.
+//
+// Kept inside `packages/codec-video/src/` for now; if a second codec needs the
+// same shape (likely once audio's Kokoro subprocess wiring is touched), this
+// can lift to `packages/core/src/utils/` as a follow-up — flagged but not
+// done here to keep the refactor surgical.
+
+import { spawn } from "node:child_process";
+
+export interface ProcessRunnerOptions {
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  /**
+   * Optional operational hint appended to the timeout error message. Lets
+   * callers preserve e.g. "(set WITTGENSTEIN_HYPERFRAMES_RENDER_TIMEOUT_MS)"
+   * without baking the env-var name into this generic helper.
+   */
+  timeoutHint?: string;
+}
+
+export interface ProcessRunnerError {
+  message: string;
+  exitCode: number | null;
+  stdoutTail: string;
+  stderrTail: string;
+  cause?: unknown;
+}
+
+/**
+ * Run a subprocess with a timeout and bounded stdout/stderr capture. Resolves
+ * on exit code 0. Rejects with a typed `Error` carrying tail output on
+ * non-zero exit, spawn error, or timeout.
+ *
+ * `errorPrefix` is used as the leading sentence of the rejection message; it
+ * lets callers preserve their domain-specific phrasing (e.g.
+ * "hyperframes render exited with code X").
+ */
+export async function runProcess(
+  command: string,
+  args: readonly string[],
+  options: ProcessRunnerOptions,
+  timeoutMs: number,
+  errorPrefix: string,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout?.setEncoding("utf8");
+    child.stderr?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr?.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      const hint = options.timeoutHint ? ` ${options.timeoutHint}` : "";
+      reject(new Error(`${errorPrefix} timed out after ${timeoutMs}ms.${hint}`));
+    }, timeoutMs);
+
+    child.on("error", (error) => {
+      clearTimeout(timer);
+      reject(
+        new Error(
+          `Failed to spawn ${errorPrefix} (${command} ${args.join(" ")}). Is Node/npm available on PATH?`,
+          { cause: error },
+        ),
+      );
+    });
+
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(
+        new Error(
+          `${errorPrefix} exited with code ${code}: ${stderr.slice(-8000) || stdout.slice(-8000)}`,
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Closes #327. Third and final refactor from the AI-shape audit ([\`docs/research/2026-05-13-ai-shape-audit.md\`](../blob/main/docs/research/2026-05-13-ai-shape-audit.md), merged via [#328](https://github.com/p-to-q/wittgenstein/pull/328)).

\`hyperframes-wrapper.ts\` (409 lines) had a 168-line monolithic HTML builder with 66% duplication between SVG-slide and scene-card branches, plus a 58-line subprocess wrapper tangling timeout / buffering / error-extraction. This refactor splits along both seams.

## File-level changes

| Path | Before | After | What it owns |
|---|---|---|---|
| \`src/hyperframes-wrapper.ts\` | 409L | **167L** | Thin orchestrator: \`renderWithHyperFrames\`, \`runHyperframesRenderToMp4\`, \`snapHyperframesFps\`, \`resolveHyperFramesArtifactPath\`, 2-line \`buildHyperFramesHtml\` dispatcher |
| \`src/compositions/svg-slide.ts\` | — | 117L (new) | \`buildSvgSlideHtml\` + slide-duration / BOM-regex helpers |
| \`src/compositions/scene-card.ts\` | — | 132L (new) | \`buildSceneCardHtml\` + \`sceneTone\` helper |
| \`src/compositions/shared.ts\` | — | 29L (new) | \`STAGE_WIDTH\`, \`STAGE_HEIGHT\`, \`sanitizeCompositionId\`, \`escapeHtml\`, \`BASE_CSS\` |
| \`src/process-runner.ts\` | — | 96L (new) | \`runProcess\` with typed timeout + stdout/stderr capture; \`errorPrefix\` + \`timeoutHint\` preserve domain phrasing |

\`hyperframes-wrapper.ts\` shrinks **409 → 167 lines**, under the audit's \"under 200 lines\" target.

## What did NOT change

- **Public API.** \`renderWithHyperFrames\` keeps the same signature. \`index.ts\`'s \`export *\` from this file still works.
- **HTML output semantics.** Per-composition CSS is semantically identical to the original — \`BASE_CSS\` extraction means the resulting HTML has two \`html, body\` rules instead of one combined, but CSS cascade merges them identically. Tests use \`toContain\` checks (not byte-equality) and pass.
- **MP4 encoding behavior.** \`npx hyperframes render\` args, env vars, timeout, FPS snapping all preserved.
- **Error messages.** \`errorPrefix\` (e.g. \`\"hyperframes render\"\`) + \`timeoutHint\` (e.g. \`\"(set WITTGENSTEIN_HYPERFRAMES_RENDER_TIMEOUT_MS).\"\`) preserve the original domain-specific phrasing for timeouts and failures.

## What the seams unlock

- **Compositions directory** makes it trivial to add a third composition shape (e.g. carousel, overlay, transition demo) — write a new \`build<Foo>Html\` file + add a dispatcher branch. The audit's concern about \"future modification resistance\" from the monolithic builder is retired.
- **ProcessRunner** can lift to \`packages/core/src/utils/\` once a second codec needs it (likely the audio Kokoro subprocess when that's touched next). The reusable shape is now there.
- **shared.ts** centralizes stage dimensions and HTML escaping. If a future RFC changes the standard frame from 1920×1080, one constant moves.

## Validation

- \`pnpm --filter @wittgenstein/codec-video typecheck\` — clean.
- \`pnpm --filter @wittgenstein/codec-video test\` — all 5 tests pass (3 codec tests + 2 playable-slideshow-html tests).
- \`pnpm --filter @wittgenstein/codec-video lint\` — 0 errors, 0 warnings.

## What this PR is NOT

- Not a behavior change. Same MP4 encoding, same HTML structure, same error semantics.
- Not a new composition. Two compositions in, two compositions out — just per-file now.
- Not the M4 implementation work. \`codec-video\` remains a stub for the canonical M4 video pipeline; #282 (HyperFrames distillation) and #265 (HF receipts) carry that forward.
- Not a doctrine change. Operates under the engineering lane per ADR-0014.

## Refs

- **Closes #327.**
- Audit source: [\`docs/research/2026-05-13-ai-shape-audit.md\`](../blob/main/docs/research/2026-05-13-ai-shape-audit.md) (merged via [#328](https://github.com/p-to-q/wittgenstein/pull/328)).
- Sibling refactor PRs (both merged): [#337](https://github.com/p-to-q/wittgenstein/pull/337) (landscape renderer), [#338](https://github.com/p-to-q/wittgenstein/pull/338) (sensor operator strategies + LoupeRenderer).
- Related video work: [#282](https://github.com/p-to-q/wittgenstein/issues/282), [#265](https://github.com/p-to-q/wittgenstein/issues/265) — both downstream of this refactor.

With this PR, all three AI-shape audit follow-ups are landed.