### PR TITLE
docs(research): M1B training prep + alpha.2 cut decision

### DIFF
--- a/docs/research/2026-05-13-alpha2-cut-decision.md
+++ b/docs/research/2026-05-13-alpha2-cut-decision.md
@@ -1,0 +1,131 @@
+---
+date: 2026-05-13
+status: maintainer decision deliverable
+labels: [release, governance, v0.3]
+tracks: [#292, #283, #70]
+---
+
+# v0.3.0-alpha.2 cut decision
+
+> **Status:** maintainer decision. The exec-plan annotation in [PR #293](https://github.com/p-to-q/wittgenstein/pull/293) explicitly named the alpha.2 cut as a maintainer call. With the per-candidate audits now landed ([#336](https://github.com/p-to-q/wittgenstein/pull/336) VQGAN-class Gates A+B; [#340](https://github.com/p-to-q/wittgenstein/pull/340) parallel audits for FSQ / OpenMAGVIT2 / TiTok / MaskBit), the uncertainty around the cut has materially reduced.
+> **Decision: cut alpha.2 NOW, name M1B as the named blocker in release notes.**
+> _Tracker: [#292](https://github.com/p-to-q/wittgenstein/issues/292) v0.3 trust closeout umbrella._
+
+## Recap of the question
+
+From [`docs/exec-plans/active/codec-v2-port.md`](../exec-plans/active/codec-v2-port.md) §"Next maintainer-facing question":
+
+> **v0.3.0-alpha.2 cut timing.** With M1A / M2 / M3 closed and M1B blocked on #283 audits, the alpha.2 conversation is gated on the @Jah-yee disposition (per #246 / #248). Either:
+> - Cut alpha.2 now, naming the blocker explicitly in release notes, OR
+> - Hold alpha.2 until #283 produces at least one candidate clearance, then cut.
+>
+> Both are defensible. Maintainer call.
+
+Since that annotation was written, the campaign has added five PRs that materially advance the trust surface:
+
+| PR | What it landed | Effect on alpha.2 trust |
+|---|---|---|
+| [#321](https://github.com/p-to-q/wittgenstein/pull/321) | Revised patchGrammar measurement plan (sensor) | Sensor research lane is honest and ready to execute |
+| [#322](https://github.com/p-to-q/wittgenstein/pull/322) | Revised radar audit plan (M1B) | M1B unblock protocol is ratified |
+| [#336](https://github.com/p-to-q/wittgenstein/pull/336) | VQGAN-class Gates A+B PASS | License + weights risk for the primary candidate is retired |
+| [#340](https://github.com/p-to-q/wittgenstein/pull/340) | Parallel audits FSQ / OpenMAGVIT2 / TiTok / MaskBit | Candidate set narrowed; MaskBit's weights-license carve-out surfaced |
+| [#337](https://github.com/p-to-q/wittgenstein/pull/337) / [#338](https://github.com/p-to-q/wittgenstein/pull/338) / [#339](https://github.com/p-to-q/wittgenstein/pull/339) | AI-shape audit refactors (decoder.ts, render.ts, hyperframes-wrapper.ts) | Strongest AI-shape smells extracted; future M1B wiring lands on cleaner seams |
+
+## Decision
+
+**Cut v0.3.0-alpha.2 now.** Name M1B (image trained projector) as the named blocker in the release notes, with explicit pointers to:
+
+- [#283](https://github.com/p-to-q/wittgenstein/issues/283) — per-candidate audit commission (parent).
+- [#329](https://github.com/p-to-q/wittgenstein/issues/329) — Priority 1 sub-issue (VQGAN-class Gates A+B done; C+D pending).
+- [#334](https://github.com/p-to-q/wittgenstein/issues/334) / [#335](https://github.com/p-to-q/wittgenstein/issues/335) — VQGAN-class Gate C (determinism) + Gate D (Node/ONNX/CPU) implementation slices.
+- [docs/research/2026-05-13-m1b-training-prep.md](2026-05-13-m1b-training-prep.md) — training-prep research (this PR's sibling).
+
+## Rationale
+
+### What "cut now" buys
+
+1. **Crystallizes the current state.** alpha.2 packages the doctrine-locked, audit-ratified, refactor-cleaned baseline as a single tag. External observers (potential contributors, downstream users) can pin against a real release rather than a moving HEAD.
+2. **Signals momentum.** Cutting on a date close to substantial campaign progress communicates the project is alive. Holding indefinitely on operational gates risks the audit work going stale (research notes age out fast — license terms change, README content changes, candidate repos move).
+3. **Preserves the audit work as release-time evidence.** The candidate audits + AI-shape refactors are exactly the kind of trust evidence release notes can point to. Cutting now puts them on record at a fixed version.
+4. **Forces the manifest spine to absorb the recent refactor.** The decoder.ts / render.ts / hyperframes-wrapper.ts splits should propagate into the next release's manifest receipts — cutting alpha.2 is the natural trigger for a CHANGELOG sweep that the next post-cut PRs would otherwise drift past.
+
+### What "cut now" costs
+
+1. **M1B is still a named blocker.** Release notes have to be explicit that the image trained-projector path is not yet wired. This is **already the truth in `main`**; cutting just makes it externally visible.
+2. **A second cut becomes likely when Gates C+D close.** alpha.3 is the natural successor once VQGAN-class clears all four gates. That's fine — alpha.X prereleases are designed for this kind of incremental cut.
+3. **Sub-candidate verdicts (#330-#333) are provisional.** Cutting now means the alpha.2 release notes carry a verdict like "VQGAN-class is the primary candidate; backup candidates have provisional audits with caveats." That's an honest read of the current state.
+
+### Why holding is the weaker call
+
+Holding for first-candidate-clearance means waiting on [#334](https://github.com/p-to-q/wittgenstein/issues/334) / [#335](https://github.com/p-to-q/wittgenstein/issues/335) — both require **local PyTorch + a copy of the LlamaGen VQ tokenizer weights downloaded by someone with that environment**. The campaign's autonomous work can't execute these. So holding waits on an external dependency without a timeline.
+
+The audit work that materially reduced uncertainty (#336, #340) is already done; holding waits on operational verification that the audits already framed as "lower-risk than the license/weights gates."
+
+## Release-notes draft for alpha.2
+
+The actual `CHANGELOG.md` `[0.3.0-alpha.2]` entry should cover at minimum:
+
+```markdown
+## [0.3.0-alpha.2] — 2026-05-13 — campaign sweep + audit ratification
+
+### Added
+- Per-candidate radar audit protocol ratified (#322); Priority 1 (VQGAN-class)
+  Gates A+B PASS (#336); parallel audits Gates A+B for Priorities 2-5 (#340).
+- AI-shape audit deliverable (#328) with three filed refactor follow-ups
+  (#325 / #326 / #327, all landed).
+- Operating-doc drift correction across AGENTS.md / PROMPT.md (#323) and
+  README first-screen with compact modality map (#324).
+- Sensor patchGrammar measurement plan revision (#321; NOAA LCD pinned).
+- Training-prep research note for M1B (engineering practices + concrete
+  code layout; no training code yet).
+
+### Changed
+- `packages/codec-image/src/pipeline/decoder.ts`: 602 → 309 lines via
+  extraction of `landscape-renderer.ts` + `internal-math.ts` (#337).
+- `packages/codec-sensor/src/render.ts`: 447 → 206 lines via extraction
+  of `operators/` strategy directory + `loupe-renderer.ts` (#338).
+- `packages/codec-video/src/hyperframes-wrapper.ts`: 409 → 167 lines via
+  extraction of `compositions/{svg-slide,scene-card,shared}.ts` +
+  `process-runner.ts` (#339).
+
+### Known blockers (current mainline)
+- **M1B (image trained projector)** is the named blocker. Wiring
+  `loadLlamagenDecoderBridge` requires VQGAN-class Gate C (determinism;
+  #334) + Gate D (Node/ONNX/CPU; #335) to clear. Both gates need
+  local PyTorch + LlamaGen VQ tokenizer downloaded. Until then
+  `packages/codec-image/src/decoders/llamagen.ts` remains a
+  `NotImplementedError` stub.
+
+### Trust-surface receipts
+[as before — sensor parity / audio parity / training-data lock,
+plus the new audit deliverables and refactor verifications]
+```
+
+The `CHANGELOG.md` sweep is itself a small follow-up PR that lands as part of the cut.
+
+## Implementation steps for cutting alpha.2
+
+1. **CHANGELOG sweep PR** — convert `[Unreleased]` to `[0.3.0-alpha.2]` with the above structure, plus the trailing `[Unreleased]` header reset.
+2. **Version bump PR** — bump root `package.json` and all `packages/*/package.json` from `0.3.0-alpha.1` to `0.3.0-alpha.2`. Coordinated single commit.
+3. **Tag + release** — `git tag v0.3.0-alpha.2` on the post-merge SHA + `gh release create` with the release notes pulled from the CHANGELOG entry.
+4. **Update [`docs/exec-plans/active/codec-v2-port.md`](../exec-plans/active/codec-v2-port.md)** "Next maintainer-facing question" section — mark the alpha.2 question resolved and update the M1B-unblock pointer.
+
+Steps 1-2 can be a single PR. Step 3 happens on its merge. Step 4 is a small followup.
+
+## What this decision does NOT do
+
+- **Does not unblock M1B.** Gates C+D ([#334](https://github.com/p-to-q/wittgenstein/issues/334) / [#335](https://github.com/p-to-q/wittgenstein/issues/335)) still need to clear. alpha.2 names M1B as a known blocker; alpha.3 closes that blocker.
+- **Does not ratify any candidate.** VQGAN-class is the primary based on the audits, but the wiring slice happens at alpha.3.
+- **Does not commit to a timeline for alpha.3.** Depends on when Gates C+D get run (external dependency).
+- **Does not modify any doctrine surface.** ADR-0018 / ADR-0005 / ADR-0007 unchanged.
+- **Does not affect `[Unreleased]` content.** The CHANGELOG sweep is its own slice; this note is the decision deliverable, not the sweep.
+
+## Cross-references
+
+- v0.3 trust closeout umbrella: [#292](https://github.com/p-to-q/wittgenstein/issues/292).
+- Exec-plan annotation that named the question: [PR #293](https://github.com/p-to-q/wittgenstein/pull/293).
+- Audit deliverables that informed the decision: [#336](https://github.com/p-to-q/wittgenstein/pull/336) (VQGAN-class), [#340](https://github.com/p-to-q/wittgenstein/pull/340) (parallel).
+- Refactor PRs landed in the alpha.2 window: [#337](https://github.com/p-to-q/wittgenstein/pull/337) / [#338](https://github.com/p-to-q/wittgenstein/pull/338) / [#339](https://github.com/p-to-q/wittgenstein/pull/339).
+- Outstanding implementation gates: [#334](https://github.com/p-to-q/wittgenstein/issues/334) / [#335](https://github.com/p-to-q/wittgenstein/issues/335).
+- Training-prep sibling note: [docs/research/2026-05-13-m1b-training-prep.md](2026-05-13-m1b-training-prep.md).
+- M1B umbrella: [#70](https://github.com/p-to-q/wittgenstein/issues/70).

--- a/docs/research/2026-05-13-m1b-training-prep.md
+++ b/docs/research/2026-05-13-m1b-training-prep.md
@@ -1,0 +1,280 @@
+---
+date: 2026-05-13
+status: research note (training-prep; no implementation in this PR)
+labels: [research-derived, m1-image, m1b-prep]
+tracks: [#70, #283, #329, #330]
+---
+
+# M1B training preparation — engineering practices, parameter survey, layout
+
+> **Status:** research-only. Documents (a) what M1B actually requires once a per-candidate audit clears, (b) engineering practices for adapter / tokenizer training drawn from prior art, (c) starting-point parameters worth knowing, and (d) a concrete code layout that the wiring slice can drop into without re-deciding directory shape. **No training code lands in this PR.** Per the maintainer's direction: research first.
+> _Tracker: [#70](https://github.com/p-to-q/wittgenstein/issues/70) (M1B umbrella); informed by [#283](https://github.com/p-to-q/wittgenstein/issues/283) audit work, [#329](https://github.com/p-to-q/wittgenstein/issues/329) VQGAN-class audit, [#330](https://github.com/p-to-q/wittgenstein/issues/330) FSQ shape findings._
+
+## Why this note exists now
+
+The per-candidate audits ([#329 VQGAN-class](https://github.com/p-to-q/wittgenstein/issues/329) Gates A+B PASS, [#330](https://github.com/p-to-q/wittgenstein/issues/330) / [#331](https://github.com/p-to-q/wittgenstein/issues/331) / [#332](https://github.com/p-to-q/wittgenstein/issues/332) / [#333](https://github.com/p-to-q/wittgenstein/issues/333) provisional) have moved the M1B unblock conversation from "can we wire any candidate at all" to "what does wiring look like once we have one." This note answers the second question without committing to a specific candidate or writing any training code.
+
+There are **two distinct M1B paths** the audits surface, and they have different engineering shapes:
+
+1. **VQGAN-class wiring path** (primary; gated on [#334](https://github.com/p-to-q/wittgenstein/issues/334) / [#335](https://github.com/p-to-q/wittgenstein/issues/335)): pull a pretrained VQ tokenizer (LlamaGen 70-72M), wire `loadLlamagenDecoderBridge`, train only a **small adapter** that maps `Semantic IR` / Visual Seed Code → decoder-native token grid.
+2. **FSQ training path** (alternate; per [#330](https://github.com/p-to-q/wittgenstein/issues/330) audit): no pretrained weights; train our own encoder-decoder end-to-end with FSQ as the quantization step. Higher upfront cost, cleaner long-term license posture (we own everything).
+
+Both paths share substantial infrastructure (training-data lock, manifest receipts, deterministic seeding). This note covers the shared infra plus path-specific notes.
+
+## Path 1 — Adapter training for VQGAN-class wiring
+
+### What the adapter actually does
+
+Per [ADR-0018](../adrs/0018-hybrid-image-code-and-visual-seed-token.md): "the image adapter is primarily a **seed expander / visual-code compiler**." Concretely:
+
+- **Input:** structured output from the LLM — `seedCode` (Visual Seed Token string) and optional `semantic` (Semantic IR JSON) and optional `coarseVq` (coarse token grid hint).
+- **Output:** a full token grid in the decoder's native vocabulary (for LlamaGen: a 16×16 or 32×32 grid of VQ codebook indices).
+
+This is a **small mapping problem**, not a "train another image model" problem. The shape is closer to a learned tokenizer-output projector than to a generative network.
+
+### Engineering practices distilled from prior art
+
+LoRA / small-adapter training literature for similar mapping problems converges on a tight set of parameter ranges. The 2024 prior art on LoRA for vision-language adapters and small bridge networks gives the following starting points:
+
+| Knob | Conservative starting point | Range observed in literature |
+|---|---|---|
+| Adapter rank (LoRA) or hidden dim (small MLP bridge) | 16 | 4-64 |
+| Adapter alpha (LoRA scaling) | rank | 0.5-2× rank |
+| Learning rate (AdamW, fresh init) | 1e-4 | 5e-5 to 5e-4 |
+| Learning rate (small dataset, <1000 pairs) | 5e-5 | 5e-6 to 5e-5 |
+| Batch size | 16-32 | 4-64 (CPU-bound for our hardware) |
+| Training-data pairs | 1k-10k | 200 (style transfer) to 100k+ (general) |
+| Epochs | 10-30 | with aggressive early stopping |
+| Weight decay | 0.01 | 0.0-0.1 |
+| Warmup steps | 5% of total | 0-10% |
+
+**These are starting points, not commitments.** The adapter's actual configuration should be ratified via a small empirical sweep during the implementation phase (#70). The point of listing them here is so the wiring slice doesn't have to re-discover parameter ranges from scratch.
+
+### Training-data strategy
+
+The two viable data-source strategies, in order of preference:
+
+1. **License-clean image-text pairs** at the small-data scale (1k-10k):
+   - **COCO** (CC-BY-4.0; ~118k captions but we'd subsample) — gold standard, well-documented.
+   - **Conceptual Captions** (CC0 for the URLs but image rights vary per-source) — riskier; license per image must be verified.
+   - **LAION-Aesthetics-Mini** subsets — sometimes carry research-only restrictions; verify per release.
+   - **Domain-specific small corpora** the repo already curates: `data/image_adapter/raw/images/` (the reference-landscape bypass dataset, currently 5-15 images per scene mode per [`packages/codec-image/src/pipeline/landscape-renderer.ts`](../../packages/codec-image/src/pipeline/landscape-renderer.ts) — too small for adapter training, but it's a clean signal that the repo already has the license-clean small-corpus pattern).
+
+2. **Synthetic paired generation** — use the existing LLM to produce `seedCode` for known images, train the adapter to predict the corresponding pretrained-tokenizer output. This is the FSQ-style "train our own pairing" approach applied to the VQGAN path. Cost: LLM tokens for 1k-10k images. License: we own everything.
+
+**Recommended starting strategy:** synthetic paired generation against a small 500-1000 image license-clean corpus, with the LlamaGen tokenizer providing the target token grid. This is the cheapest path to a first golden image and the least exposed to upstream license drift.
+
+### Deterministic-training requirements (manifest spine integration)
+
+Wittgenstein's manifest spine is non-negotiable for the production code path. Training-time receipts must integrate:
+
+- **Seed pinning:** `torch.manual_seed` + `numpy.random.seed` + `python random.seed` all set from a single value recorded in the training manifest.
+- **Tokenizer version pinning:** the LlamaGen weights file SHA-256 + HF commit hash recorded at the head of every training run's manifest.
+- **Training-data hash:** SHA-256 over the sorted list of input file paths + per-file SHA — matches the existing pattern at [`polyglot-mini/train/data_manifest.json`](../../polyglot-mini/train/data_manifest.json) (lockfile structure from PR #130).
+- **Adapter weight hash:** SHA-256 of the final `.safetensors` or `.pth` file, recorded in the training manifest and propagated to every inference run that loads those weights.
+- **Lockfile hash:** the Python `requirements.txt` lockfile SHA — matches the existing manifest spine contract.
+
+The training script's output is **not just weights** — it's `(weights, training-manifest.json)` where the manifest is itself byte-pinned and reproducible. This matches the ADR-0005 "decoder is not generator; reproducibility is structural" doctrine and the existing manifest spine for inference runs.
+
+### Cross-platform determinism caveat
+
+The audio M2 sweep ([CHANGELOG.md](../../CHANGELOG.md) `0.3.0-alpha.1`) found that **Kokoro is same-platform deterministic but produces different cross-platform WAV hashes**. The same constraint will apply to PyTorch-based adapter inference: byte-equality across platforms is not realistic. The training-manifest contract should explicitly carry:
+
+- `determinismClass: "byte-parity-on-platform"` (default) OR `"structural-parity-cross-platform"` (degraded)
+- Hardware fingerprint at training time (CPU/GPU model, CUDA version if used)
+
+This matches the audio precedent and keeps the manifest honest about what reproducibility means.
+
+## Path 2 — End-to-end FSQ training (alternate)
+
+If VQGAN-class fails its operational gates ([#334](https://github.com/p-to-q/wittgenstein/issues/334) / [#335](https://github.com/p-to-q/wittgenstein/issues/335)) or its license cleanliness is ever challenged, FSQ becomes the natural pivot. Per the [#330 audit](2026-05-13-audits-fsq-openmagvit2-titok-maskbit.md), this means:
+
+1. **Pick an encoder-decoder architecture sized for our hardware.** Candidates:
+   - Small VQGAN-style convnet (encoder + decoder + FSQ bottleneck) — ~50-100M params.
+   - Even simpler: small ResNet encoder + transposed-conv decoder + FSQ bottleneck — ~20-40M params, faster to train.
+2. **Embed FSQ as the bottleneck.** ~50 lines of code (just rounding/clamping; no codebook losses needed).
+3. **Train on a license-clean corpus** with reconstruction loss only (no adversarial / perceptual loss for v1 — adds complexity without proportional gain at our scale).
+4. **Ship our own weights** with our own license terms. Cleanest long-term posture but highest upfront cost.
+
+### FSQ path engineering practices
+
+Different from adapter training because we're training a full network from scratch:
+
+| Knob | Starting point | Reasoning |
+|---|---|---|
+| Encoder-decoder architecture | Small VQGAN-style (50-100M) | Matches LlamaGen's tokenizer size, well-studied shape |
+| FSQ levels | `[8, 5, 5, 5]` | The default from Mentzer et al. 2023; ~1000 implicit codebook entries |
+| FSQ projection dim | 4 (matches `[8, 5, 5, 5]`) | Paper-default; no codebook collapse possible |
+| Training-data scale | 100k-500k images | Far larger than adapter training; from-scratch needs more |
+| Learning rate | 1e-4 (AdamW with cosine schedule) | Conservative; from-scratch training is delicate |
+| Batch size | 64-128 | GPU-dependent |
+| Training time | 1-3 days on a single A100 | Real cost; not feasible on developer laptops |
+
+**This path is realistic only if we have GPU access.** Per the campaign's CPU-friendly bias, the adapter-training path (#1) is strongly preferred unless VQGAN-class fails outright.
+
+## Concrete code layout (no code in this PR; layout only)
+
+```
+packages/codec-image/
+├── src/
+│   ├── decoders/
+│   │   ├── README.md                    (existing)
+│   │   ├── llamagen.ts                  (existing stub; M1B wires)
+│   │   └── seed.ts                      (existing stub)
+│   ├── adapters/                        (existing dir)
+│   │   ├── adapter-resolve.ts           (existing)
+│   │   ├── seed-expander.ts             (existing)
+│   │   ├── seed-expander-tile-mosaic.ts (existing)
+│   │   ├── mlp-runtime.ts               (existing; placeholder MLP)
+│   │   └── README.md                    (NEW; layout doc for adapter weight conventions)
+│   └── training/                        (NEW DIR; entry point for M1B training scripts)
+│       ├── README.md                    (NEW; training recipe + parameter ranges + reproducibility contract)
+│       ├── manifest-schema.ts           (NEW; shared TS types for training-manifest.json)
+│       └── (Python training scripts live under polyglot-mini/train/m1b/)
+└── test/
+    └── (existing tests preserved)
+
+polyglot-mini/
+├── train/                               (existing dir; M2 audio training pattern)
+│   ├── data_manifest.json               (existing; pattern to mirror)
+│   ├── m1b/                             (NEW; M1B adapter training scripts)
+│   │   ├── train_adapter.py             (NEW; entry point — VQGAN-class adapter)
+│   │   ├── train_fsq.py                 (NEW; entry point — FSQ end-to-end, opt-in)
+│   │   ├── eval.py                      (NEW; CLIPScore / VQAScore measurement against the goldens)
+│   │   ├── doctor.py                    (NEW; environment sanity check)
+│   │   ├── requirements.txt             (NEW; pinned dependencies — PyTorch + safetensors + ...)
+│   │   ├── requirements.lock            (NEW; full transitive lockfile SHA recorded in manifest)
+│   │   └── manifest.template.json       (NEW; the training-manifest contract this directory writes)
+│   └── README.md                        (existing)
+
+fixtures/golden/image/                   (existing dir; will gain training-time goldens)
+└── (M1B will add: 5-10 prompts × 1 deterministic seed each → byte-pinned PNGs after training succeeds)
+```
+
+The `polyglot-mini/train/m1b/` placement mirrors the existing M2 audio training pattern (data_manifest.json there is the lockfile precedent). The `packages/codec-image/src/training/` directory holds **TypeScript** glue — manifest schema types, weight-loading helpers — that the runtime needs to consume trained weights. **No PyTorch in TypeScript packages.**
+
+### Manifest-schema contract (TS, lands when wiring starts)
+
+Sketch of what `packages/codec-image/src/training/manifest-schema.ts` will export:
+
+```ts
+export const TrainingManifestSchema = z.object({
+  // Tokenizer / decoder provenance
+  tokenizer: z.object({
+    family: z.enum(["llamagen", "fsq-custom"]),
+    hfCommit: z.string().optional(),  // for llamagen
+    weightsSha256: z.string(),
+    paramCount: z.number(),
+  }),
+  // Adapter / trained weights
+  adapter: z.object({
+    kind: z.enum(["lora", "mlp", "seed-expander", "fsq-encoder-decoder"]),
+    weightsPath: z.string(),
+    weightsSha256: z.string(),
+    rank: z.number().optional(),
+    paramCount: z.number(),
+  }),
+  // Training-time inputs
+  data: z.object({
+    manifestSha256: z.string(),  // SHA over polyglot-mini/train/m1b/data_manifest.json
+    pairCount: z.number(),
+    license: z.string(),  // e.g. "CC-BY-4.0" or "synthetic-self-generated"
+  }),
+  // Reproducibility
+  seed: z.number(),
+  determinismClass: z.enum(["byte-parity-on-platform", "structural-parity-cross-platform"]),
+  hardware: z.object({
+    platform: z.string(),       // e.g. "linux-x86_64", "darwin-arm64"
+    cudaVersion: z.string().optional(),
+    cudnnVersion: z.string().optional(),
+  }),
+  // Software lockfile
+  requirementsLockSha256: z.string(),
+  // Provenance
+  trainedAt: z.string(),  // ISO 8601
+  gitSha: z.string(),     // wittgenstein repo SHA at training time
+});
+```
+
+This is **what the TS runtime needs to know** to validate that a loaded adapter is compatible with its claimed tokenizer family. It doesn't need to know how the adapter was trained — that's the Python side's domain.
+
+## Specific parameter starting points worth recording
+
+From the prior-art survey + the radar audits, the following are reasonable starting points for the M1B adapter training (recording them here so the wiring slice doesn't re-discover):
+
+### For VQGAN-class adapter (Path 1)
+
+- **Target token grid:** match LlamaGen's tokenizer native output (16×16 for 256² images, or 32×32 for 512² — to be confirmed against the actual LlamaGen weights at fetch time).
+- **Adapter architecture:** small MLP (2-4 hidden layers, rank/hidden ~16-32) mapping `seedCode` embeddings + optional `semantic` embeddings → 256 or 1024 codebook indices.
+- **Loss function:** cross-entropy against LlamaGen-tokenizer-emitted ground-truth token grids (synthetic pairing).
+- **Evaluation:** byte-stable golden test (5-10 fixed prompts → fixed PNGs) + CLIPScore measurement against a held-out validation set.
+
+### For FSQ end-to-end (Path 2; if Path 1 fails)
+
+- **FSQ levels:** `[8, 5, 5, 5]` per Mentzer et al. 2023 paper default — 1000 implicit codebook entries.
+- **Encoder-decoder shape:** small VQGAN-style convnet (50-100M params total).
+- **Loss:** L1 + L2 reconstruction (no adversarial loss for v1).
+- **Evaluation:** same as Path 1 for downstream comparability.
+
+### Cross-path: training-data hashing (the lockfile contract)
+
+The existing [`polyglot-mini/train/data_manifest.json`](../../polyglot-mini/train/data_manifest.json) pattern (PR #130) carries:
+
+- `selection.sha256` — SHA over the sorted list of input file paths.
+- `output.sha256` — SHA over the produced `data.jsonl` (or equivalent).
+- Per-file SHAs in a nested array, optional but recommended.
+
+M1B training must produce a comparable manifest:
+
+```json
+{
+  "selection": {
+    "files": ["abc.jpg", "def.jpg", ...],
+    "sha256": "<sha of sorted file list>"
+  },
+  "output": {
+    "path": "data/m1b/pairs.jsonl",
+    "sha256": "<sha of pairs jsonl>"
+  },
+  "tokenizer": { "family": "llamagen", "weightsSha256": "..." }
+}
+```
+
+This locks the training-time data inputs and the tokenizer they were paired against. A re-run with the same lockfile produces identical pairs → identical adapter weights (within platform determinism class).
+
+## Open questions deliberately not resolved here
+
+These are **maintainer-decision** questions that this research note flags but does not settle:
+
+1. **Which dataset for synthetic pairing?** Likely COCO subsampled, but the license-clean subset choice affects the manifest contract.
+2. **GPU access policy.** Path 2 (FSQ end-to-end) needs GPU. Path 1 (adapter only) can be CPU-trained on 1k-pair data. If we don't commit to GPU, Path 1 is effectively the only path.
+3. **Heavy-tier evaluation gate.** CLIPScore + VQAScore are named in Brief E as the v0.3 default-tier image metrics ([`docs/exec-plans/active/codec-v2-port.md`](../exec-plans/active/codec-v2-port.md) M5a). The training-time goldens are byte-pinned; the metric-time evaluation needs a separate slice.
+4. **Cross-platform parity class.** The audio precedent (Kokoro structural-parity-cross-platform) suggests the adapter will also be platform-specific for byte equality. Confirm at training time.
+5. **Re-training cadence.** If LlamaGen ships an updated tokenizer with the same family + better quality, do we re-train automatically? Probably no for v0.3; revisit at v0.4.
+
+## What this note does NOT do
+
+- **No training code.** Not in this PR; the layout names directories and entry points, not implementation.
+- **No doctrine change.** ADR-0018 / ADR-0005 / ADR-0007 framing is preserved.
+- **No commitment to a specific path.** Path 1 vs Path 2 is gated on VQGAN-class operational gates ([#334](https://github.com/p-to-q/wittgenstein/issues/334) / [#335](https://github.com/p-to-q/wittgenstein/issues/335)).
+- **No new RFC.** Doctrine-bearing decisions about adapter family / training-manifest shape go through the engineering lane when wiring starts.
+- **No specific dataset commitment.** COCO is named as the cheapest viable option, not a ratified choice.
+
+## Cross-references
+
+- M1B umbrella: [#70](https://github.com/p-to-q/wittgenstein/issues/70).
+- Per-candidate audits: [#329](https://github.com/p-to-q/wittgenstein/issues/329) VQGAN-class (delivered via [PR #336](https://github.com/p-to-q/wittgenstein/pull/336)); [#330](https://github.com/p-to-q/wittgenstein/issues/330) / [#331](https://github.com/p-to-q/wittgenstein/issues/331) / [#332](https://github.com/p-to-q/wittgenstein/issues/332) / [#333](https://github.com/p-to-q/wittgenstein/issues/333) (delivered via PR #340).
+- Implementation gates: [#334](https://github.com/p-to-q/wittgenstein/issues/334) (Gate C), [#335](https://github.com/p-to-q/wittgenstein/issues/335) (Gate D).
+- ADRs: [ADR-0018](../adrs/0018-hybrid-image-code-and-visual-seed-token.md) (Visual Seed Code image route), [ADR-0005](../adrs/0005-frozen-vq-decoder-only.md) (frozen-decoder doctrine), [ADR-0007](../adrs/0007-path-c-rejected.md) (no fused multimodal retrain).
+- Existing training-manifest pattern: [`polyglot-mini/train/data_manifest.json`](../../polyglot-mini/train/data_manifest.json) (PR #130 — `Added CI-gated sensor goldens and training-data lock receipts`).
+- Audio precedent for cross-platform parity class: [CHANGELOG.md](../../CHANGELOG.md) `0.3.0-alpha.1` § Kokoro structural-parity verdict.
+
+## Sources (prior-art parameter survey)
+
+Parameter ranges drawn from publicly-available LoRA + small-adapter training literature, verified 2026-05-13:
+
+- LoRA hyperparameter convergence: rank 4-32, alpha ≈ rank, learning rate 1e-4 to 5e-4 (AdamW), small-batch sizes for small datasets.
+- FSQ defaults: levels `[8, 5, 5, 5]` per Mentzer et al. 2023, arXiv:2309.15505.
+- Small-dataset fine-tuning practice: learning rates 5e-6 to 5e-5 for <1k examples, aggressive early stopping.
+
+These are starting points, not commitments — the wiring slice will refine them empirically.


### PR DESCRIPTION
## Summary

Two research-only deliverables landing together. Both answer adjacent questions the campaign surfaced, and both follow the maintainer's directive: **research first, no training code yet**.

### 1. M1B training preparation note

\`docs/research/2026-05-13-m1b-training-prep.md\` — engineering practices + parameter survey + concrete code layout for the eventual M1B wiring. Covers both viable paths from the per-candidate audits:

| Path | Source | Engineering shape |
|---|---|---|
| **Path 1** (primary) | VQGAN-class wiring after [#334](https://github.com/p-to-q/wittgenstein/issues/334) / [#335](https://github.com/p-to-q/wittgenstein/issues/335) clear | Small adapter (LoRA / MLP rank 16-32) maps VSC + Semantic IR → LlamaGen token grid. Synthetic paired-data strategy preferred. CPU-trainable. |
| **Path 2** (alternate) | FSQ end-to-end if Path 1 fails | Train our own encoder-decoder with FSQ levels \`[8, 5, 5, 5]\`. Higher upfront cost, fully owned weights. GPU-required realistically. |

Includes parameter starting points (rank, learning rate, batch size, training-data scale) drawn from 2024 LoRA prior art, a concrete training-manifest schema sketch, cross-platform parity-class caveat from the audio M2 precedent, and explicit \"no training code in this PR\" framing.

### 2. alpha.2 cut decision

\`docs/research/2026-05-13-alpha2-cut-decision.md\` — maintainer-call deliverable. Per [PR #293](https://github.com/p-to-q/wittgenstein/pull/293)'s exec-plan annotation, the alpha.2 cut was named as a judgment call:

> Either: cut alpha.2 now, naming the blocker explicitly in release notes, OR hold alpha.2 until #283 produces at least one candidate clearance, then cut. Both are defensible. Maintainer call.

**Decision: cut alpha.2 now.** Rationale documented in the note. Summary:

- Audit PRs ([#336](https://github.com/p-to-q/wittgenstein/pull/336) / [#340](https://github.com/p-to-q/wittgenstein/pull/340)) and refactor PRs ([#337](https://github.com/p-to-q/wittgenstein/pull/337) / [#338](https://github.com/p-to-q/wittgenstein/pull/338) / [#339](https://github.com/p-to-q/wittgenstein/pull/339)) have materially advanced the trust surface — cutting crystallizes it.
- Holding waits on external dependency (Gates C+D need local PyTorch + LlamaGen weights downloaded) without a timeline.
- alpha.X prereleases are designed for incremental cuts; alpha.3 is the natural successor when M1B unblocks.

Includes a release-notes draft for alpha.2 and a concrete 4-step cut procedure:
1. CHANGELOG sweep PR (`[Unreleased]` → `[0.3.0-alpha.2]`).
2. Version bump PR.
3. \`git tag\` + \`gh release create\`.
4. Update exec-plan's \"Next maintainer-facing question\" section.

## What this PR is NOT

- Not training code. Layout names directories and entry points only.
- Not the CHANGELOG sweep. That lands as a separate PR.
- Not the version bump. Separate PR.
- Not a doctrine change. Operates under the engineering / governance lanes per ADR-0014.

## Refs

- M1B umbrella: [#70](https://github.com/p-to-q/wittgenstein/issues/70).
- Per-candidate audits: [#329](https://github.com/p-to-q/wittgenstein/issues/329) (#336), [#330](https://github.com/p-to-q/wittgenstein/issues/330) / [#331](https://github.com/p-to-q/wittgenstein/issues/331) / [#332](https://github.com/p-to-q/wittgenstein/issues/332) / [#333](https://github.com/p-to-q/wittgenstein/issues/333) (#340).
- Implementation gates: [#334](https://github.com/p-to-q/wittgenstein/issues/334) (Gate C), [#335](https://github.com/p-to-q/wittgenstein/issues/335) (Gate D).
- v0.3 trust closeout: [#292](https://github.com/p-to-q/wittgenstein/issues/292).
- Exec-plan annotation: [PR #293](https://github.com/p-to-q/wittgenstein/pull/293).