### PR TITLE
chore(lint): document why no-misused-promises is disabled

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -29,6 +29,11 @@ module.exports = {
       { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
     ],
     "@typescript-eslint/consistent-type-imports": "warn",
+    // Disabled because we lean on TypeScript strict mode + vitest coverage to
+    // catch misused-promise patterns. The rule produces too many false positives
+    // on intentional async callback shapes (vitest beforeEach, promise-returning
+    // event handlers) to be useful as a hard gate. Re-enable selectively via
+    // inline `eslint-disable-next-line` if a specific path is high-risk.
     "@typescript-eslint/no-misused-promises": "off",
     "@typescript-eslint/naming-convention": [
       "warn",


### PR DESCRIPTION
## Summary

Inline comment fix from the v0.3.0-alpha.2 cross-section config audit (LOW finding #5). The \`@typescript-eslint/no-misused-promises\` rule was disabled in \`.eslintrc.cjs\` without explanation; the audit flagged it as worth documenting in place.

Comment added explains:
- The rule is disabled because TypeScript strict mode + vitest coverage already catch the real cases.
- False positives on intentional async-callback shapes (vitest beforeEach, promise-returning event handlers) make it noisy as a hard gate.
- Re-enable selectively via inline \`eslint-disable-next-line\` if a specific path is high-risk.

## Validation

- \`pnpm lint\` — clean across all 8 packages (no behavior change).

## Not in this PR

- Other config-audit findings (golden test drift #347, registry validation #344, hashFile null #345, fork() implementation #346) are filed as their own issues. This PR addresses only the LOW-severity inline-comment item.
- TypeScript \`skipLibCheck: true\` trade-off — NOT documented in \`tsconfig.base.json\` because that file should remain comment-free JSON. The audit issue is the documentation surface.

## Refs

- Cross-section audit run: 2026-05-13.
- Audit findings: #344 / #345 / #346 / #347.