### PR TITLE
docs(harness): classify v1-compat modality branches + bounded-count test (#300 step 1)

### DIFF
--- a/packages/core/src/runtime/harness.ts
+++ b/packages/core/src/runtime/harness.ts
@@ -197,6 +197,21 @@ export class Wittgenstein {
         manifest.ok = true;
         manifest.durationMs = Date.now() - startedAt.getTime();
       } else {
+        // ====================================================================
+        // v1 legacy codec pipeline (#300 modality-blind invariant exception)
+        // ====================================================================
+        // Every `request.modality === "..."` branch in this `else` block is
+        // v1-codec compatibility scaffolding for asciipng / svg / video — the
+        // three modalities whose codec hasn't yet ported to Codec Protocol v2.
+        // When the last v1 codec ports to v2 (#300), this entire `else` arm
+        // disappears: the harness reduces to the v2 path above, which dispatches
+        // through `codec.produce(req, ctx)` without inspecting `request.modality`.
+        //
+        // DO NOT add new modality branches here. New modalities ship as v2
+        // codecs (the `if (isV2Codec(codec))` branch above) and never touch
+        // this block. The bounded-count test in `harness-modality-references.test.ts`
+        // will trip if a new branch sneaks in.
+        // ====================================================================
         const v1Codec = codec;
         const generation =
           request.modality === "asciipng" && request.source === "minimax" && !options.dryRun
@@ -482,6 +497,10 @@ function createLlmAdapter(
   return new OpenAICompatibleLlmAdapter(llmConfig);
 }
 
+// v1-compat guard: this builder is asciipng-specific and exists only because
+// codec-asciipng hasn't ported to v2 yet. The modality check is a type narrower
+// for callers, not a real dispatch — it's a defensive assertion that retires
+// with the v1 pipeline.
 function buildAsciiPngGeneration(request: WittgensteinRequest): LlmGenerationResult {
   if (request.modality !== "asciipng") {
     throw new ValidationError("buildAsciiPngGeneration called for non-asciipng request.");
@@ -502,6 +521,10 @@ function buildAsciiPngGeneration(request: WittgensteinRequest): LlmGenerationRes
   };
 }
 
+// v1-compat: dry-run generation shapes are modality-aware because v1 codecs
+// expect modality-specific JSON shapes. v2 codecs construct their own dry-run
+// payloads via `codec.expand(req, ctx)` and never call this function. Retires
+// with the v1 pipeline (#300).
 function createDryRunGeneration(request: WittgensteinRequest): LlmGenerationResult {
   if (request.modality === "svg") {
     return {
@@ -563,6 +586,10 @@ function createDryRunGeneration(request: WittgensteinRequest): LlmGenerationResu
   };
 }
 
+// LEGITIMATE modality-aware routing (NOT v1-compat; stays even after #300).
+// The codec registry IS keyed by modality, so picking a default output file
+// extension by modality is the registry's own dispatch dimension. v2 codecs
+// can override `outPath` via the request; this just provides the convention.
 function defaultOutputPathFor(
   modality: WittgensteinRequest["modality"],
   cwd: string,

--- a/packages/core/test/harness-modality-blind.test.ts
+++ b/packages/core/test/harness-modality-blind.test.ts
@@ -5,14 +5,44 @@ import { describe, expect, it } from "vitest";
 
 const testDir = dirname(fileURLToPath(import.meta.url));
 
+async function readHarnessSource(): Promise<string> {
+  return readFile(resolve(testDir, "../src/runtime/harness.ts"), "utf8");
+}
+
 describe("harness modality blindness", () => {
   it("does not branch on request.modality === image", async () => {
-    const source = await readFile(resolve(testDir, "../src/runtime/harness.ts"), "utf8");
+    const source = await readHarnessSource();
     expect(source.includes('request.modality === "image"')).toBe(false);
   });
 
   it("does not branch on request.modality === audio", async () => {
-    const source = await readFile(resolve(testDir, "../src/runtime/harness.ts"), "utf8");
+    const source = await readHarnessSource();
     expect(source.includes('request.modality === "audio"')).toBe(false);
+  });
+
+  // Bounded count of `request.modality` references (in CODE, not comments)
+  // — #300 modality-blind invariant guard. The current 16 references are
+  // classified inline in harness.ts (separate from the modality-as-parameter
+  // references inside `defaultOutputPathFor`'s body, which use the
+  // `modality` parameter directly rather than `request.modality`):
+  //   - 2 are legitimate modality-keyed routing (outPath defaulting; v2
+  //     keeps these — the registry IS keyed by modality)
+  //   - 14 are v1-compat scaffolding (asciipng / svg / video legacy pipeline
+  //     + helper guards) that retires when the last v1 codec ports to v2
+  // If this count changes, the new reference must be classified inline in
+  // harness.ts AND the expected count updated here (or the new reference
+  // removed if it's drift).
+  it("bounds the total count of `request.modality` references in code", async () => {
+    const source = await readHarnessSource();
+    // Strip line comments and block comments so prose references inside the
+    // classifying comments don't inflate the count.
+    const stripped = source
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/\/\/.*$/gm, "");
+    const matches = stripped.match(/request\.modality/g) ?? [];
+    // 16 is the audited baseline as of 2026-05-13 cross-section health check.
+    // Reduce this number when v1 codecs retire (#300). Increase only with
+    // explicit classification in this test's comment + harness.ts inline note.
+    expect(matches.length).toBe(16);
   });
 });


### PR DESCRIPTION
## Summary

First step on [#300](https://github.com/p-to-q/wittgenstein/issues/300) (harness modality-blind invariant). Per the v0.3.0-alpha.2 cross-section architecture audit's specific recommendation:

> Document the set of \"unavoidable\" modality branches in a comment, and add a lint rule (or test) that asserts these are the only ones.

This PR does that part. **Full extraction of the v1 legacy pipeline (asciipng / svg / video) into a separate module remains tracked under #300** for a focused session — that's substantial refactor work that needs end-to-end test coverage for all 3 v1 codecs.

## What this PR contains

1. **Block-header comment** before the v1 legacy `else` branch in [\`packages/core/src/runtime/harness.ts\`](../blob/main/packages/core/src/runtime/harness.ts) explaining the v1-compat scaffolding is intentional and new modalities ship as v2 codecs.
2. **Inline comments** on \`buildAsciiPngGeneration\`, \`createDryRunGeneration\`, and \`defaultOutputPathFor\` classifying each as either v1-compat (retires with v1 pipeline) or legitimate modality-keyed routing (stays even after #300).
3. **New \`bounds the total count\` test** in \`packages/core/test/harness-modality-blind.test.ts\`:
   - Strips line + block comments first so classifying comments don't inflate the count.
   - Asserts exactly **16** references (the audited baseline as of 2026-05-13).
   - 2 legitimate (outPath defaulting) + 14 v1-compat scaffolding.
   - Test trips if a new branch sneaks in, forcing classification.

## Audit-vs-reality count reconciliation

The cross-section architecture audit (2026-05-13) had counted \"17 references\". Actual code count after stripping comments is **16**. The discrepancy is one prose reference in the original comment block that gets filtered out by the strip-comments rule.

The test comment lists the canonical breakdown so future readers can verify.

## Validation

- \`pnpm --filter @wittgenstein/core test\` — 62 tests pass (existing 61 + 1 new bounded-count test).
- \`pnpm --filter @wittgenstein/core typecheck\` — clean.
- \`pnpm --filter @wittgenstein/core lint\` — 0 errors, 0 warnings.

## What this PR is NOT

- **Not the full #300 refactor.** Extracting the v1 legacy pipeline to a separate module is a bigger slice for a focused session. This PR makes the current state explicit and bounded so future drift is impossible without intentional classification.
- Not a doctrine change. The harness invariants are unchanged; this just documents them.
- Not a new feature.

## Refs

- Parent: [#300](https://github.com/p-to-q/wittgenstein/issues/300) (harness modality-blind invariant; this is step 1).
- Cross-section audit: 2026-05-13.
- Sibling audit issues filed simultaneously: [#344](https://github.com/p-to-q/wittgenstein/issues/344) / [#345](https://github.com/p-to-q/wittgenstein/issues/345) / [#346](https://github.com/p-to-q/wittgenstein/issues/346) / [#347](https://github.com/p-to-q/wittgenstein/issues/347).