### PR TITLE
fix(core): throw on missing artifact instead of silent null artifactSha256 (closes #345)

### DIFF
--- a/packages/core/src/runtime/harness.ts
+++ b/packages/core/src/runtime/harness.ts
@@ -10,7 +10,7 @@ import type {
 import { codecV2 as codecV2Ns } from "@wittgenstein/schemas";
 import { loadWittgensteinConfig } from "./config.js";
 import { BudgetTracker } from "./budget.js";
-import { collectRuntimeFingerprint, hashFile } from "./manifest.js";
+import { collectRuntimeFingerprint, hashFileOrThrow } from "./manifest.js";
 import { routeRequest } from "./router.js";
 import { CodecRegistry } from "./registry.js";
 import { createRunId, resolveSeed } from "./seed.js";
@@ -313,7 +313,7 @@ export class Wittgenstein {
         const rendered = await v1Codec.render(parsed.value, renderCtx);
         result = rendered;
         manifest.artifactPath = rendered.artifactPath;
-        manifest.artifactSha256 = await hashFile(rendered.artifactPath);
+        manifest.artifactSha256 = await hashFileOrThrow(rendered.artifactPath);
         manifest.ok = true;
         manifest.durationMs = Date.now() - startedAt.getTime();
         manifest.llmTokens = rendered.metadata.llmTokens;

--- a/packages/core/src/runtime/manifest.ts
+++ b/packages/core/src/runtime/manifest.ts
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import { WittgensteinError } from "./errors.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -40,6 +41,24 @@ export async function hashFile(filePath: string): Promise<string | null> {
   } catch {
     return null;
   }
+}
+
+/**
+ * Like `hashFile` but throws an inspectable, typed error when the file can't
+ * be read. Use this when a `null` digest would silently violate the manifest's
+ * `artifactSha256` invariant — e.g. after a v1 codec render step that promised
+ * to write `artifactPath` (Issue #345, doctrine: no silent fallbacks).
+ */
+export async function hashFileOrThrow(filePath: string): Promise<string> {
+  const digest = await hashFile(filePath);
+  if (digest === null) {
+    throw new WittgensteinError(
+      "ARTIFACT_HASH_FAILED",
+      `Could not hash artifact at ${filePath}. The codec render step promised this path, but the file is missing or unreadable. The manifest cannot be honestly written with artifactSha256 = null.`,
+      { details: { artifactPath: filePath } },
+    );
+  }
+  return digest;
 }
 
 async function readGitSha(cwd: string): Promise<string | null> {

--- a/packages/core/test/manifest.test.ts
+++ b/packages/core/test/manifest.test.ts
@@ -3,7 +3,12 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { collectRuntimeFingerprint, hashFile } from "../src/runtime/manifest.js";
+import { WittgensteinError } from "../src/runtime/errors.js";
+import {
+  collectRuntimeFingerprint,
+  hashFile,
+  hashFileOrThrow,
+} from "../src/runtime/manifest.js";
 
 let tmp: string;
 
@@ -46,6 +51,31 @@ describe("hashFile", () => {
   it("returns null (not throws) for a missing file — failure must be inspectable, not silent", async () => {
     const result = await hashFile(join(tmp, "does-not-exist.txt"));
     expect(result).toBeNull();
+  });
+});
+
+describe("hashFileOrThrow (Issue #345)", () => {
+  it("returns the same digest as hashFile for an existing file", async () => {
+    const path = join(tmp, "fixture.txt");
+    const content = "deterministic content";
+    await writeFile(path, content);
+
+    const expected = createHash("sha256").update(content).digest("hex");
+    await expect(hashFileOrThrow(path)).resolves.toBe(expected);
+  });
+
+  it("throws ARTIFACT_HASH_FAILED for a missing file with the path in details", async () => {
+    const missing = join(tmp, "does-not-exist.txt");
+    let caught: unknown;
+    try {
+      await hashFileOrThrow(missing);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(WittgensteinError);
+    expect((caught as WittgensteinError).code).toBe("ARTIFACT_HASH_FAILED");
+    expect((caught as WittgensteinError).message).toContain(missing);
+    expect((caught as WittgensteinError).details).toEqual({ artifactPath: missing });
   });
 });
 

--- a/packages/core/test/manifest.test.ts
+++ b/packages/core/test/manifest.test.ts
@@ -79,6 +79,62 @@ describe("hashFileOrThrow (Issue #345)", () => {
   });
 });
 
+// Harness-level regression test for the v1 render→hash race path (Issue #345).
+// A stub v1 codec returns a `RenderResult.artifactPath` pointing at a file
+// that doesn't exist — simulating the FS race the issue describes. The
+// harness must NOT write a success manifest with `artifactSha256: null`;
+// the throw from `hashFileOrThrow` propagates to the outer catch and
+// serializes as `ARTIFACT_HASH_FAILED`.
+describe("Wittgenstein.run — v1 artifact-hash race regression (Issue #345)", () => {
+  it("sets ok=false and error.code=ARTIFACT_HASH_FAILED when render artifact is missing", async () => {
+    const { Wittgenstein } = await import("../src/runtime/harness.js");
+    const { CodecRegistry } = await import("../src/runtime/registry.js");
+    const { DEFAULT_WITTGENSTEIN_CONFIG } = await import("@wittgenstein/schemas");
+
+    const stubMissingArtifactPath = join(tmp, "stub", "missing-on-purpose.svg");
+    const stubCodec = {
+      name: "stub-svg",
+      modality: "svg" as const,
+      schemaPreamble: () => "",
+      requestSchema: { parse: (v: unknown) => v } as never,
+      outputSchema: { parse: (v: unknown) => v } as never,
+      parse: () => ({ ok: true as const, value: {} as never }),
+      render: async () => ({
+        artifactPath: stubMissingArtifactPath, // codec lies: never writes this file
+        mimeType: "image/svg+xml",
+        bytes: 0,
+        metadata: {
+          codec: "stub-svg",
+          llmTokens: { input: 0, output: 0 },
+          costUsd: 0,
+          durationMs: 0,
+          seed: null,
+        },
+      }),
+    };
+
+    const registry = new CodecRegistry();
+    registry.register(stubCodec as never);
+    const harness = new Wittgenstein(DEFAULT_WITTGENSTEIN_CONFIG, registry, null);
+
+    const outcome = await harness.run(
+      {
+        modality: "svg",
+        prompt: "hash-race regression",
+        source: "local",
+      } as never,
+      { command: "test", args: [], cwd: tmp, dryRun: true },
+    );
+
+    expect(outcome.manifest.ok).toBe(false);
+    expect(outcome.manifest.error?.code).toBe("ARTIFACT_HASH_FAILED");
+    expect(outcome.manifest.error?.message).toContain(stubMissingArtifactPath);
+    // The hash must never be silently nulled into a success manifest — the
+    // throw aborts before manifest.ok flips to true.
+    expect(outcome.manifest.artifactSha256).toBeNull();
+  });
+});
+
 describe("collectRuntimeFingerprint", () => {
   it("returns the spine shape for a directory with no git or lockfile", async () => {
     const fp = await collectRuntimeFingerprint(tmp);


### PR DESCRIPTION
Closes #345.

## Problem

The v1 manifest path at `packages/core/src/runtime/harness.ts:316` called `hashFile(rendered.artifactPath)` and assigned the result directly to `manifest.artifactSha256`. When `hashFile` returned `null` (file missing or unreadable — FS race, permissions, deletion between render and hash), the manifest was constructed with `artifactSha256: null` and `ok: true`. The `RunManifestSchema.superRefine` would have rejected this — but the validation only runs at parse time on already-persisted manifests, not in-flight inside the harness. The result was a silent invariant violation that could escape into receipts.

## Fix

- New `hashFileOrThrow(filePath)` in `packages/core/src/runtime/manifest.ts`: throws a typed `WittgensteinError` with code `ARTIFACT_HASH_FAILED`, the missing path in the message, and `{ artifactPath }` in details.
- Harness v1 path swaps `hashFile` → `hashFileOrThrow`. The outer try/catch picks up the throw, `serializeError` preserves the code, and the manifest is correctly written as `ok: false` with a structured error payload.
- `hashFile` itself is unchanged — it still returns `null` for missing files, which `collectRuntimeFingerprint` relies on for lockfile detection.

## Tests

`packages/core/test/manifest.test.ts` (added):
- `hashFileOrThrow` returns the same digest as `hashFile` for an existing file.
- `hashFileOrThrow` throws `WittgensteinError` with `code === \"ARTIFACT_HASH_FAILED\"`, the missing path in `.message`, and `{ artifactPath }` in `.details`.

All existing tests pass (64 core / 13 cli / 45 image / 18 sensor / 22 schema).

## Doctrine alignment

Matches \"no silent fallbacks\" (`docs/hard-constraints.md`, ADR-0005). When the artifact file is missing, the harness throws → the outer catch serializes → the manifest records `ok: false + error.code = ARTIFACT_HASH_FAILED`. Inspectable, not invisible.

## Non-goals (per issue)

- v2 codec path untouched — it owns its own manifest contribution via `artMeta.artifactSha256`.
- `RunManifestSchema` itself untouched — the schema was correct; the harness path now honors it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)