### PR TITLE
fix(core): runtime validation in CodecRegistry.register() (closes #344)

### DIFF
--- a/packages/core/src/runtime/registry.ts
+++ b/packages/core/src/runtime/registry.ts
@@ -1,16 +1,26 @@
 import type { Modality, WittgensteinCodec, codecV2 } from "@wittgenstein/schemas";
+import { ModalitySchema } from "@wittgenstein/schemas";
 import { WittgensteinError } from "./errors.js";
 
 export type AnyCodec =
   | WittgensteinCodec<unknown, unknown>
   | codecV2.Codec<unknown, codecV2.BaseArtifact>;
 
+/**
+ * `register()` accepts a union of v1 and v2 codec shapes and stores them in a
+ * single map. The union cast is unavoidable (v1 has `parse`/`render`; v2 has
+ * `produce`/`manifestRows`), but without runtime validation an author can land
+ * a malformed codec — wrong modality string, missing `produce()` on a v2
+ * codec, etc. — and the failure surfaces only deep inside the harness at use
+ * time (Issue #344). The guard below catches the problem at registration.
+ */
 export class CodecRegistry {
   private readonly codecs = new Map<Modality, AnyCodec>();
 
   public register<Req, Parsed, Art extends codecV2.BaseArtifact>(
     codec: WittgensteinCodec<Req, Parsed> | codecV2.Codec<Req, Art>,
   ): this {
+    validateCodecShape(codec);
     this.codecs.set(codec.modality, codec as unknown as AnyCodec);
     return this;
   }
@@ -35,4 +45,68 @@ export class CodecRegistry {
   public list(): AnyCodec[] {
     return [...this.codecs.values()];
   }
+}
+
+function validateCodecShape(codec: unknown): void {
+  if (typeof codec !== "object" || codec === null) {
+    throw new WittgensteinError(
+      "INVALID_CODEC_REGISTRATION",
+      "register() requires an object — got a non-object value.",
+      { details: { receivedType: typeof codec } },
+    );
+  }
+
+  const candidate = codec as Record<string, unknown>;
+
+  if (typeof candidate.modality !== "string") {
+    throw new WittgensteinError(
+      "INVALID_CODEC_REGISTRATION",
+      "Codec is missing a string `modality` field.",
+      { details: { codec: identifyCodec(candidate) } },
+    );
+  }
+
+  const modalityCheck = ModalitySchema.safeParse(candidate.modality);
+  if (!modalityCheck.success) {
+    throw new WittgensteinError(
+      "INVALID_CODEC_REGISTRATION",
+      `Codec declares unknown modality "${candidate.modality}". Allowed: ${ModalitySchema.options.join(", ")}.`,
+      { details: { codec: identifyCodec(candidate), modality: candidate.modality } },
+    );
+  }
+
+  // Same predicate the harness uses on read (`isV2Codec`): v2 codecs have a
+  // `produce()` method. v1 codecs don't, and must instead expose `parse` +
+  // `render`. Mismatched methods signal a malformed codec.
+  const hasProduce = typeof candidate.produce === "function";
+  if (hasProduce) {
+    if (typeof candidate.manifestRows !== "function") {
+      throw new WittgensteinError(
+        "INVALID_CODEC_REGISTRATION",
+        "v2 codec (has `produce`) is missing required method `manifestRows`.",
+        { details: { codec: identifyCodec(candidate) } },
+      );
+    }
+  } else {
+    if (typeof candidate.parse !== "function") {
+      throw new WittgensteinError(
+        "INVALID_CODEC_REGISTRATION",
+        "v1 codec (no `produce`) is missing required method `parse`.",
+        { details: { codec: identifyCodec(candidate) } },
+      );
+    }
+    if (typeof candidate.render !== "function") {
+      throw new WittgensteinError(
+        "INVALID_CODEC_REGISTRATION",
+        "v1 codec (no `produce`) is missing required method `render`.",
+        { details: { codec: identifyCodec(candidate) } },
+      );
+    }
+  }
+}
+
+function identifyCodec(candidate: Record<string, unknown>): string {
+  if (typeof candidate.id === "string") return candidate.id;
+  if (typeof candidate.name === "string") return candidate.name;
+  return "<unnamed>";
 }

--- a/packages/core/test/registry.test.ts
+++ b/packages/core/test/registry.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { WittgensteinError } from "../src/runtime/errors.js";
+import { CodecRegistry } from "../src/runtime/registry.js";
+
+const validV1Codec = {
+  name: "test-svg",
+  modality: "svg" as const,
+  schemaPreamble: () => "",
+  requestSchema: z.any(),
+  outputSchema: z.any(),
+  parse: () => ({ ok: true as const, value: {} }),
+  render: async () => ({
+    artifactPath: "/tmp/x.svg",
+    mimeType: "image/svg+xml",
+    bytes: 0,
+    metadata: {
+      codec: "test-svg",
+      llmTokens: { input: 0, output: 0 },
+      costUsd: 0,
+      durationMs: 0,
+      seed: null,
+    },
+  }),
+};
+
+const validV2Codec = {
+  id: "test-image",
+  modality: "image" as const,
+  routes: [],
+  schema: { ["~standard"]: {} },
+  produce: async () => ({ outPath: "/tmp/x.png", mime: "image/png", metadata: {} }),
+  manifestRows: () => [],
+};
+
+describe("CodecRegistry.register (Issue #344)", () => {
+  it("accepts a well-formed v1 codec", () => {
+    const registry = new CodecRegistry();
+    expect(() => registry.register(validV1Codec as never)).not.toThrow();
+    expect(registry.get("svg")).toBeDefined();
+  });
+
+  it("accepts a well-formed v2 codec", () => {
+    const registry = new CodecRegistry();
+    expect(() => registry.register(validV2Codec as never)).not.toThrow();
+    expect(registry.get("image")).toBeDefined();
+  });
+
+  it("rejects a non-object value with INVALID_CODEC_REGISTRATION", () => {
+    const registry = new CodecRegistry();
+    expect(() => registry.register(null as never)).toThrow(WittgensteinError);
+    expect(() => registry.register(42 as never)).toThrow(/non-object/);
+  });
+
+  it("rejects a codec with no modality field", () => {
+    const registry = new CodecRegistry();
+    const bad = { ...validV1Codec, modality: undefined };
+    expect(() => registry.register(bad as never)).toThrow(/missing a string `modality`/);
+  });
+
+  it("rejects a codec with an unknown modality string", () => {
+    const registry = new CodecRegistry();
+    const bad = { ...validV1Codec, modality: "not-a-modality" };
+    let caught: unknown;
+    try {
+      registry.register(bad as never);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(WittgensteinError);
+    expect((caught as WittgensteinError).code).toBe("INVALID_CODEC_REGISTRATION");
+    expect((caught as WittgensteinError).message).toContain("not-a-modality");
+  });
+
+  it("rejects a v2 codec missing `manifestRows`", () => {
+    const registry = new CodecRegistry();
+    const bad = { ...validV2Codec, manifestRows: undefined };
+    expect(() => registry.register(bad as never)).toThrow(
+      /v2 codec.*missing.*manifestRows/i,
+    );
+  });
+
+  it("rejects a v1 codec missing `parse`", () => {
+    const registry = new CodecRegistry();
+    const bad = { ...validV1Codec, parse: undefined };
+    expect(() => registry.register(bad as never)).toThrow(/v1 codec.*missing.*parse/i);
+  });
+
+  it("rejects a v1 codec missing `render`", () => {
+    const registry = new CodecRegistry();
+    const bad = { ...validV1Codec, render: undefined };
+    expect(() => registry.register(bad as never)).toThrow(/v1 codec.*missing.*render/i);
+  });
+});

--- a/packages/core/test/router.test.ts
+++ b/packages/core/test/router.test.ts
@@ -10,6 +10,7 @@ function fakeCodec(modality: WittgensteinRequest["modality"]) {
     modality,
     schema: undefined as never,
     expand: () => ({}) as never,
+    parse: () => ({ ok: true as const, value: {} }) as never,
     render: () => ({}) as never,
   } as never;
 }
@@ -51,6 +52,7 @@ describe("routeRequest", () => {
       modality: "image" as const,
       schema: undefined as never,
       expand: () => ({}) as never,
+      parse: () => ({ ok: true as const, value: {} }) as never,
       render: () => {
         renderCalls += 1;
         return {} as never;


### PR DESCRIPTION
Closes #344.

## Problem

`packages/core/src/runtime/registry.ts:14` accepted a union of v1 and v2 codec shapes and stored them via `codec as unknown as AnyCodec`. The cast was necessary to unify the two protocol versions in one map, but without runtime validation a malformed codec — wrong modality string, missing `produce()` on a v2 codec, missing `parse`/`render` on a v1 codec — silently registered. The failure surfaced only deep inside the harness at use time, creating a footgun for codec authors and an architectural seam where malformation could escape into production.

## Fix

`validateCodecShape(codec)` runs before the cast in `register()`:

1. `codec.modality` must be a string and a member of the canonical `ModalitySchema` enum (image / audio / video / sensor / svg / asciipng).
2. Codec must satisfy the version contract — same predicate `isV2Codec()` uses on read:
   - has `produce` (v2): must also have `manifestRows`.
   - no `produce` (v1): must have both `parse` and `render`.
3. Any violation throws `WittgensteinError` with code `INVALID_CODEC_REGISTRATION`, identifying the codec by its `id` or `name` and naming the missing method.

## Tests

`packages/core/test/registry.test.ts` (new — 8 tests):
- accepts well-formed v1 / v2 codecs;
- rejects non-objects, missing modality field, unknown modality strings;
- rejects v2 codec missing `manifestRows`;
- rejects v1 codec missing `parse` or `render`.

`packages/core/test/router.test.ts`: stub codecs updated to satisfy the new v1 contract (added `parse`). The router test intent — routing is lookup-only, doesn't invoke methods — is preserved.

All 70 core / 13 cli / 45 image / 18 sensor / 22 schema tests green.

## Doctrine alignment

Matches \"fail at the boundary, not in production\" (no silent fallbacks, ADR-0005). Registry-level analog of [#300](https://github.com/p-to-q/wittgenstein/issues/300) (harness modality-blind invariant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)