### PR TITLE
fix(cli): use @wittgenstein/codec-video public entry, not src/ path (closes #364)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -50,6 +50,7 @@
     "smoke": "node ./bin/wittgenstein.js doctor"
   },
   "dependencies": {
+    "@wittgenstein/codec-video": "workspace:*",
     "@wittgenstein/core": "workspace:*",
     "@wittgenstein/schemas": "workspace:*",
     "commander": "^14.0.3",

--- a/packages/cli/src/commands/animate-html.ts
+++ b/packages/cli/src/commands/animate-html.ts
@@ -1,7 +1,7 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import type { Command } from "commander";
-import { buildPlayableSlideshowHtml } from "../../../codec-video/src/playable-slideshow-html.js";
+import { buildPlayableSlideshowHtml } from "@wittgenstein/codec-video";
 import { resolveExecutionRoot } from "./shared.js";
 
 function collectSvgPath(value: string, previous: string[] | undefined): string[] {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -266,6 +266,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@wittgenstein/codec-video':
+        specifier: workspace:*
+        version: link:../codec-video
       '@wittgenstein/core':
         specifier: workspace:*
         version: link:../core


### PR DESCRIPTION
Closes #364.

## Problem

`packages/cli/src/commands/animate-html.ts:4` imported `buildPlayableSlideshowHtml` via `../../../codec-video/src/playable-slideshow-html.js` — reaching three directory levels up into another package's \`src/\` path, bypassing the public entry. The function is exported from `packages/codec-video/src/index.ts`, so the cross-package \`src\` reach was needlessly fragile and broke encapsulation.

## Fix

- Import from `@wittgenstein/codec-video` (the package entry).
- Add `@wittgenstein/codec-video: workspace:*` to `packages/cli/package.json` dependencies. The package was being resolved implicitly via the relative src path before; making it an explicit dep matches reality.

## Verification (per issue acceptance)

- `pnpm --filter @wittgenstein/cli typecheck` ✓
- `pnpm --filter @wittgenstein/cli lint` ✓
- `pnpm --filter @wittgenstein/cli test` ✓ (13 tests)
- `pnpm --filter @wittgenstein/cli build` ✓
- `wittgenstein animate-html --help` prints the expected usage block ✓

## Doctrine alignment

Public-entry imports preserve refactoring freedom — `codec-video` can rename / split internal modules without breaking the CLI. Matches the audit-driven pattern of cleaning up cross-package src reach.

## Non-goals (per issue)

- No other CLI commands touched.
- No lint rule added to ban cross-package src imports — separate slice if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)