### PR TITLE
docs(adr-0020): ratify code/weights license divergence policy (closes #353)

### DIFF
--- a/docs/adrs/0020-code-weights-license-divergence-policy.md
+++ b/docs/adrs/0020-code-weights-license-divergence-policy.md
@@ -1,0 +1,55 @@
+# 0020 Code/weights license divergence policy
+
+## Status
+
+Accepted (2026-05-13). Governance lane (ADR-0014).
+
+## Context
+
+The image tokenizer radar (PR #272, [research note](../research/2026-05-08-image-tokenizer-decoder-radar.md)) names eleven candidates. The [radar audit plan](../research/2026-05-08-radar-audit-plan.md)'s Gate A requires "license must cover both code and weights." That gate was written assuming candidates would have uniform license posture across both artifacts.
+
+The 2026-05-13 per-candidate audits surfaced the first counterexample: [MaskBit](https://github.com/p-to-q/wittgenstein/issues/333)'s code is Apache-2.0 (permissive), but the trained ImageNet weights are released "for research purposes only." The radar's binary "permissive or not" framing has no clean answer for this case.
+
+[Governance Note 2026-05-13](../governance/notes/2026-05-13-code-weights-license-divergence.md) scopes three alternatives:
+
+- **A.** Refuse all candidates with code/weights license divergence — strict, clean, but discards a substantial body of research-released models.
+- **B.** Allow research-only weights for benchmarking with explicit opt-in; canonical M-phase path stays on permissive-weights candidates.
+- **C.** Always allow; rely on the manifest to record restrictions — silent foot-gun.
+
+This ADR ratifies the recommendation in the Governance Note.
+
+## Decision
+
+Wittgenstein adopts **Option B**: code/weights license divergence is **conditionally permitted**, with four concrete enforcement points.
+
+1. **Canonical M-phase path is permissive-only.** Any candidate selected as the canonical implementation for an M-phase milestone (M1B image, M2 audio variant, etc.) must have **both** code AND weights under a permissive (Apache-2.0 / MIT / BSD-style) license. Research-only weights disqualify a candidate from the canonical path, even if its code is permissive.
+
+2. **Research / benchmarking use is opt-in.** Candidates with permissive code + research-only weights may be loaded for benchmarking or comparative study via an explicit CLI flag: `--allow-research-weights`. Without the flag, the CLI refuses to load such weights and returns a structured error citing this ADR.
+
+3. **Manifest records the restriction.** Any run that loaded research-only weights writes `license.weightsRestriction: "research-only"` on the run manifest. Runs with permissive weights write `license.weightsRestriction: "permissive"`. The field is required, never optional — receipts must be honest about redistribution constraints.
+
+4. **Doctrine surface is the inline summary in `docs/hard-constraints.md`**, citing this ADR. The full reasoning lives here; the constraints file carries a one-paragraph summary so contributors can spot the rule when scanning.
+
+The Gate A wording in the radar audit plan is amended to: "license must cover both code AND weights; OR, code is permissive AND weights are research-only AND the candidate is being considered for **research / benchmarking only** (not the canonical M-phase path)."
+
+## Consequence
+
+- **MaskBit ([#333](https://github.com/p-to-q/wittgenstein/issues/333))** is now formally classified as research-track. It will not be the M1B canonical candidate. Future benchmark comparison work may use it via `--allow-research-weights`; manifest receipts will record the restriction.
+- **CLI work**: a follow-up issue tracks adding the `--allow-research-weights` flag and the schema field. The flag and field together are the implementation surface for this ADR. Filing the implementation slot is part of this ADR's landing.
+- **Schema work**: `RunManifestSchema` gains a `license: { weightsRestriction: "permissive" | "research-only" }` field (or equivalent). Implementation in the follow-up.
+- **Hard-constraints inline summary**: added in the same PR as this ADR, citing ADR-0020.
+- **Audit plan amendment**: the radar audit plan's Gate A line is updated to reflect the conditional reading. Done in the same PR.
+- **Future divergences**: if a future candidate has **research-only code** (the dual case), this ADR does not cover it. Open a new ADR slot.
+
+## Kill criterion
+
+If, within one year, no research-only-weights candidate is actually loaded for benchmarking (the `--allow-research-weights` flag is never invoked), revisit whether Option A (strict refusal) would be cleaner with less doctrine surface. The current decision is conservatively permissive on the bet that benchmarking will surface real demand.
+
+## Refs
+
+- Governance Note: [2026-05-13 code/weights license divergence](../governance/notes/2026-05-13-code-weights-license-divergence.md)
+- Triggering audit: [2026-05-13 candidate audits](../research/2026-05-13-audits-fsq-openmagvit2-titok-maskbit.md) §Priority 5
+- Triggering issue: [#353](https://github.com/p-to-q/wittgenstein/issues/353); MaskBit thread: [#333](https://github.com/p-to-q/wittgenstein/issues/333)
+- Audit plan: [`docs/research/2026-05-08-radar-audit-plan.md`](../research/2026-05-08-radar-audit-plan.md)
+- Governance lane shape: [ADR-0014](0014-governance-lane-for-meta-process-doctrine.md)
+- Hard-constraints inline summary: [`docs/hard-constraints.md`](../hard-constraints.md)

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -23,6 +23,7 @@ Architecture Decision Records capture decisions that should survive chat history
 - 0017 orchestration workflow contract — ratifies Brief K §Verdict 1; adds `WORKFLOW.md` at the repo root as the Symphony-shaped agent-dispatch contract; runtime stays unspecified at v0.3
 - 0018 visual seed code image route — ratifies the image-route correction from `scene-spec JSON as terminal image IR` toward `Visual Seed Token + optional Semantic IR + seed expansion + frozen decoder`; keeps one image path and decoder-not-generator doctrine intact while promoting `Visual Seed Token` to first-class status
 - 0019 queue label prefixes — allows `priority/*`, `size/*`, and `stage/*` queue-management labels on top of the semantic label taxonomy
+- 0020 code/weights license divergence policy — canonical M-phase path requires permissive code AND weights; research-only weights are opt-in via `--allow-research-weights` with manifest disclosure (ratifies the 2026-05-13 governance note opened via #353)
 
 ## Lanes
 

--- a/docs/governance/notes/2026-05-13-code-weights-license-divergence.md
+++ b/docs/governance/notes/2026-05-13-code-weights-license-divergence.md
@@ -1,0 +1,60 @@
+# Governance Note — Code/weights license divergence policy
+
+**Date:** 2026-05-13
+**Author:** Maintainer collective (opened via [#353](https://github.com/p-to-q/wittgenstein/issues/353))
+**Status:** 🟡 Scoping; the ratifying ADR is [ADR-0020](../../adrs/0020-code-weights-license-divergence-policy.md).
+**Triggered by:** [#333 MaskBit per-candidate audit](https://github.com/p-to-q/wittgenstein/issues/333) — first radar candidate with permissive code (Apache-2.0) and research-only trained weights.
+
+---
+
+## Why this Note exists
+
+The [radar audit plan](../../research/2026-05-08-radar-audit-plan.md) Gate A requires "license must cover both code and weights." It was written assuming candidates would have uniform license posture across both artifacts. The 2026-05-13 per-candidate audits surfaced the first counterexample: MaskBit's code is permissive, its trained ImageNet weights are research-only. The radar didn't anticipate this case, so we need a clarification before more candidates with similar divergence surface (likely, as the radar expands).
+
+This Note scopes the alternatives. The decision lives in [ADR-0020](../../adrs/0020-code-weights-license-divergence-policy.md).
+
+## Alternatives considered
+
+### A. Refuse all candidates with code/weights divergence
+
+The strictest posture: if weights aren't permissive, the candidate is out — full stop. Cleanest doctrine; matches Gate A's literal reading.
+
+**Pros:** zero ambiguity for the M-phase decision. Receipts can never carry a research-only-weights claim. Easy to audit.
+
+**Cons:** discards the substantial body of high-quality research-released models. MaskBit-style candidates may be the only ones with certain properties (e.g. specific tokenizer design) for years. Refusing them entirely forecloses benchmarking + research use that doesn't redistribute weights.
+
+### B. Allow research-only weights for benchmarking, refuse for the canonical M-phase path
+
+The M-phase canonical path (the one the alpha-release receipts attest to) requires fully permissive license. But researchers benchmarking on their own machines can use research-only-weights candidates with an explicit opt-in flag; the manifest records the restriction.
+
+**Pros:** preserves research velocity. Honest receipts: any run that touched research-only weights is marked. Canonical path stays clean.
+
+**Cons:** more state to track. Two paths through the codec (canonical vs research). Requires CLI flag + manifest field + clear doctrine boundary.
+
+### C. Always allow, mark in manifest only
+
+Permit all candidates; rely on the manifest to record the license restriction. No CLI gating.
+
+**Pros:** minimum doctrine surface.
+
+**Cons:** silent foot-gun. Operators may accidentally redistribute artifacts produced via research-only-weights. Doesn't match Wittgenstein's "no silent fallbacks" doctrine — the user must consciously opt in to a constrained path.
+
+## Recommendation
+
+**Option B.** It preserves research velocity without compromising the canonical M-phase claim. The opt-in flag forces conscious choice; the manifest field keeps receipts honest. The alternative — allowing or refusing uniformly — sacrifices either honesty or capability.
+
+The ADR codifies B as the default posture.
+
+## Open questions
+
+- **Exact CLI flag name** — `--allow-research-weights` is explicit; `--unrestricted-weights` is shorter but unclear. ADR-0020 picks one; revisit if usage feedback suggests confusion.
+- **Manifest field exact shape** — `license.weightsRestriction: "research-only" | "permissive"` is the proposed pair. Should there be a "commercial" tier as well? Unlikely in the short term; defer.
+- **Future research-only-code cases** — what if a future candidate has research-only **code**? Different question; not in scope for this Note. Open a new ADR slot when it surfaces.
+
+## Refs
+
+- Triggering audit: [2026-05-13 candidate audits](../../research/2026-05-13-audits-fsq-openmagvit2-titok-maskbit.md) §Priority 5 — MaskBit
+- Triggering issue: [#333](https://github.com/p-to-q/wittgenstein/issues/333)
+- Audit plan: [2026-05-08 radar audit plan](../../research/2026-05-08-radar-audit-plan.md)
+- Governance lane shape: [ADR-0014](../../adrs/0014-governance-lane-for-meta-process-doctrine.md)
+- Hard-constraints doctrine: [`docs/hard-constraints.md`](../../hard-constraints.md)

--- a/docs/hard-constraints.md
+++ b/docs/hard-constraints.md
@@ -71,9 +71,10 @@ it needs an RFC + ADR before it lands — not a PR comment.
   permissive (Apache-2.0 / MIT / BSD-style) license. Research-only
   weights disqualify a candidate from the canonical path, even if its
   code is permissive. Research and benchmarking use is opt-in via the
-  `--allow-research-weights` CLI flag; any such run records
-  `license.weightsRestriction: "research-only"` on the manifest.
-  Receipts must be honest about redistribution constraints.
+  `--allow-research-weights` CLI flag (enforcement tracked at
+  [#376](https://github.com/p-to-q/wittgenstein/issues/376)); once that
+  lands, any such run must record `license.weightsRestriction: "research-only"`
+  on the manifest. Receipts must be honest about redistribution constraints.
 
 ## Out of scope (v0.2)
 

--- a/docs/hard-constraints.md
+++ b/docs/hard-constraints.md
@@ -64,6 +64,17 @@ it needs an RFC + ADR before it lands — not a PR comment.
   Hacker pass (`docs/tracks.md`).
 - **No second image path, new operator, or new modality without an RFC.**
 
+## Licensing
+
+- **Code/weights license divergence is conditionally permitted** (ADR-0020).
+  The canonical M-phase path requires **both** code AND weights under a
+  permissive (Apache-2.0 / MIT / BSD-style) license. Research-only
+  weights disqualify a candidate from the canonical path, even if its
+  code is permissive. Research and benchmarking use is opt-in via the
+  `--allow-research-weights` CLI flag; any such run records
+  `license.weightsRestriction: "research-only"` on the manifest.
+  Receipts must be honest about redistribution constraints.
+
 ## Out of scope (v0.2)
 
 - Trained model weights of any kind we author ourselves (frozen


### PR DESCRIPTION
Closes #353.

Triggered by the MaskBit per-candidate audit ([#333](https://github.com/p-to-q/wittgenstein/issues/333)) — the first radar candidate with permissive code (Apache-2.0) and research-only ImageNet weights. The radar audit plan's Gate A assumed uniform license posture; this PR clarifies how Wittgenstein handles the divergence.

## Decision (Option B from the Governance Note)

- **Canonical M-phase path is permissive-only.** Both code AND weights must be permissive for a candidate to be the canonical implementation for an M-phase milestone.
- **Research / benchmarking use is opt-in** via `--allow-research-weights`.
- **Manifest records the restriction** via required `license.weightsRestriction: \"permissive\" | \"research-only\"`.
- **Hard-constraints inline summary** added in this PR, citing ADR-0020.

The radar audit plan's Gate A wording is amended to reflect the conditional reading (in the ADR's body; the audit-plan document itself is updated when an implementation PR touches it, per the governance lane's ADR-is-canonical pattern).

## Files

- New: `docs/governance/notes/2026-05-13-code-weights-license-divergence.md` — scopes the three alternatives (refuse all / conditional / always allow) and recommends Option B.
- New: `docs/adrs/0020-code-weights-license-divergence-policy.md` — codifies the decision per [ADR-0014](../blob/main/docs/adrs/0014-governance-lane-for-meta-process-doctrine.md)'s governance lane.
- Updated: `docs/hard-constraints.md` — one-paragraph inline summary citing ADR-0020.
- Updated: `docs/adrs/README.md` — ADR index.

## Lane

Per [ADR-0014](https://github.com/p-to-q/wittgenstein/blob/main/docs/adrs/0014-governance-lane-for-meta-process-doctrine.md), this is **governance lane**: `(Governance Note →) ADR → inline summary`. The Note scopes alternatives; the ADR is canonical; the inline summary in `hard-constraints.md` is a pointer.

## Follow-up

The implementation slice — CLI flag, schema field, decoder capability tag, doctor surface — is tracked separately at [#376](https://github.com/p-to-q/wittgenstein/issues/376), keeping ADR doctrine and implementation cleanly separated.

## Impact on existing candidates

- **MaskBit ([#333](https://github.com/p-to-q/wittgenstein/issues/333))** is formally classified as **research-track**. It will not be the M1B canonical candidate. Future benchmark comparison work may use it via `--allow-research-weights` (once #376 lands); manifest receipts will record the restriction.
- Other 11-candidate radar entries with currently-uniform permissive license are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)