### PR TITLE
fix(core): thread parentRunId through HarnessCtx.fork() (closes #346)

### DIFF
--- a/packages/core/src/runtime/harness.ts
+++ b/packages/core/src/runtime/harness.ts
@@ -378,6 +378,7 @@ function isV2Codec(
 
 function createHarnessCtx(options: {
   runId: string;
+  parentRunId?: string | null;
   runDir: string;
   seed: number | null;
   outPath: string;
@@ -391,7 +392,7 @@ function createHarnessCtx(options: {
 }): codecV2.HarnessCtx {
   const ctx: codecV2.HarnessCtx = {
     runId: options.runId,
-    parentRunId: null,
+    parentRunId: options.parentRunId ?? null,
     runDir: options.runDir,
     seed: options.seed,
     outPath: options.outPath,
@@ -419,6 +420,10 @@ function createHarnessCtx(options: {
       createHarnessCtx({
         ...options,
         runId: childRunId,
+        // Derive parentRunId from the forking ctx so multi-stage codecs
+        // can trace sub-run lineage on receipts (Issue #346; contract
+        // pinned by `packages/schemas/test/codec-v2.test.ts`).
+        parentRunId: options.runId,
         runDir: overrides?.runDir ?? options.runDir,
         seed: overrides?.seed ?? options.seed,
         outPath: overrides?.outPath ?? options.outPath,


### PR DESCRIPTION
Closes #346.

## Problem

\`HarnessCtx.fork()\` was implemented in the harness (\`packages/core/src/runtime/harness.ts:418\`), but it always emitted the child ctx with \`parentRunId: null\` — losing the lineage that the schema contract (and the existing test in \`packages/schemas/test/codec-v2.test.ts:170-175\`) requires:

```ts
it(\"HarnessCtx.fork derives parentRunId\", () => {
  const ctx = makeCtx();
  const child = ctx.fork(\"run-2\");
  expect(child.runId).toBe(\"run-2\");
  expect(child.parentRunId).toBe(\"run-1\");
});
```

The schema test uses a local helper that satisfies the contract; the harness implementation didn't. Multi-stage codecs that call \`ctx.fork()\` would have no way to thread sub-run provenance back to the parent on receipts.

## Decision (revisits issue's Option A vs B)

The issue offered Option A (implement) or Option B (remove the method). I took **Option A** — implement correctly — because:

1. The implementation already exists (since 2026-04-26, predating the audit by ~3 weeks); the audit's claim \"does not create a forking instance\" was based on the wrong line range (#346 cites lines 364-399; the `fork:` assignment is at line 418).
2. The schema contract is already pinned by the test, so this isn't a speculative design — the shape is fixed and the harness just needs to honor it.
3. The fix is 6 lines — well under the issue's estimate of \"~30 line change\".

## Fix

- Add \`parentRunId?: string | null\` to \`createHarnessCtx\`'s options.
- Initialize from \`options.parentRunId ?? null\` (preserves the root call's null default).
- \`fork()\` now passes \`options.runId\` as the child's \`parentRunId\`.

## Verification

- All 62 core + 20 schema tests green.
- Build, lint clean.
- No behavior change for any code that doesn't call \`fork()\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)