### PR TITLE
refactor: tighten public API surface for core + codec-image (closes #365)

### DIFF
--- a/packages/codec-image/src/index.ts
+++ b/packages/codec-image/src/index.ts
@@ -1,4 +1,37 @@
-export * from "./codec.js";
-export * from "./schema.js";
-export * from "./types.js";
-export * from "./pipeline/index.js";
+/**
+ * Public consumer surface for `@wittgenstein/codec-image` (Issue #365).
+ *
+ * What ships:
+ *   - `imageCodec` (v1) / `imageV2Codec` (v2) — codec instances the harness
+ *     and external consumers register / invoke.
+ *   - Request / artifact / scene types needed to type call sites.
+ *
+ * What does NOT ship:
+ *   - `./pipeline/*` — internal renderer pipeline that changes as the M1B
+ *     decoder bridge lands. Pipeline internals are reachable from within
+ *     this package's own modules; external consumers should not depend on
+ *     them.
+ *   - Internal schemas like `DecoderFamilySchema`, `ImageLatentCodesSchema`,
+ *     etc. If a consumer needs these (e.g. for benchmark scaffolding), open
+ *     an issue — the API surface for those moves with the schema
+ *     discriminator RFC ([RFC-0007](../../../docs/rfcs/0007-image-seedcode-shape-discriminator.md)).
+ */
+export { imageCodec, imageV2Codec, ImageCodec } from "./codec.js";
+export {
+  ImageSceneSpecSchema,
+  imageSchemaPreamble,
+  parseImageSceneSpec,
+} from "./schema.js";
+export type { ImageSceneSpec } from "./schema.js";
+// `ImageRequest` + its schema live in `@wittgenstein/schemas` (the
+// modality-locked surface). Re-export from codec-image so consumers can
+// import the codec's surface from one place.
+export { ImageRequestSchema, type ImageRequest } from "@wittgenstein/schemas";
+export type {
+  ImageArtifact,
+  ImageArtifactMetadata,
+  ImageCodeReceipt,
+  ImageCodePath,
+  ImageAdapterOutcome,
+  ImageSemanticSource,
+} from "./types.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,25 +1,38 @@
-export * from "./runtime/harness.js";
-export * from "./runtime/registry.js";
-export * from "./runtime/router.js";
-export * from "./runtime/config.js";
-export * from "./runtime/retry.js";
-export * from "./runtime/budget.js";
-export * from "./runtime/manifest.js";
-export * from "./runtime/telemetry.js";
-export * from "./runtime/errors.js";
-export * from "./runtime/seed.js";
-export * from "./llm/adapter.js";
-export * from "./llm/openai-compatible.js";
-export * from "./llm/anthropic.js";
-export * from "./schema/preamble.js";
-export * from "./schema/validate.js";
-export * from "./codecs/image.js";
-export * from "./codecs/audio.js";
-export * from "./codecs/video.js";
-export * from "./codecs/sensor.js";
+/**
+ * Public consumer surface for `@wittgenstein/core` (Issue #365).
+ *
+ * What ships:
+ *   - `Wittgenstein` — the harness class consumers run requests through.
+ *   - `loadWittgensteinConfig` — the config loader CLI / consumers call.
+ *   - `codecV2` — the experimental v2 codec protocol namespace.
+ *   - Types needed to type `Wittgenstein.run`'s call site.
+ *
+ * What does NOT ship (intentionally not re-exported here):
+ *   - Runtime internals: `CodecRegistry`, `BudgetTracker`, retry / seed /
+ *     telemetry helpers. These live under `./runtime/` and are reachable via
+ *     deep imports for tests + internal wiring, but they are not the consumer
+ *     surface.
+ *   - LLM adapter implementations: `OpenAICompatibleLlmAdapter`,
+ *     `AnthropicLlmAdapter`. Consumers should configure adapters via
+ *     `loadWittgensteinConfig` and let the harness wire them.
+ *   - V1-codec helpers (`injectSchemaPreamble`, schema validators) — these
+ *     are v1-pipeline compatibility scaffolding that retires with #300.
+ *   - The `./codecs/*` registration helpers — those are harness wiring.
+ *
+ * If a consumer needs an internal, deep-import from the package's source
+ * path — but be aware those imports are unstable and not covered by semver.
+ */
+export { Wittgenstein } from "./runtime/harness.js";
+export type {
+  HarnessOutcome,
+  HarnessRunOptions,
+  WittgensteinOptions,
+} from "./runtime/harness.js";
+export { loadWittgensteinConfig } from "./runtime/config.js";
 
 /**
- * Codec protocol v2 (experimental, M0). Surfaced under a namespace to avoid
- * shadowing the v1 names exported above. See `docs/rfcs/0001-codec-protocol-v2.md`.
+ * Codec Protocol v2 (experimental, M0). Surfaced under a namespace to avoid
+ * shadowing v1 names that consumers may have grandfathered. See
+ * `docs/rfcs/0001-codec-protocol-v2.md`.
  */
 export { codecV2 } from "@wittgenstein/schemas";


### PR DESCRIPTION
Closes #365.

## Problem

Per the v0.3.0-alpha.2 cross-section architecture audit, both packages were re-exporting their internals via `export *`, exposing:

- **core**: \`CodecRegistry\`, \`BudgetTracker\`, retry/seed/telemetry helpers, LLM adapter implementations, v1 schema helpers — all surfaced on \`@wittgenstein/core\`.
- **codec-image**: \`renderImagePipeline\` + the entire \`./pipeline/index.ts\` — internal renderer that will change as M1B decoder bridges land.

This created refactoring risk: any downstream code reaching into these internals would break as v2 migration continues.

## Changes

### \`packages/core/src/index.ts\`

Narrowed from 20 `export *` lines to a curated public surface:

- \`Wittgenstein\` class + types (\`HarnessOutcome\`, \`HarnessRunOptions\`, \`WittgensteinOptions\`)
- \`loadWittgensteinConfig\` (CLI uses this)
- \`codecV2\` namespace (already curated)

The file's header doc-comment lists what intentionally does NOT ship and why. Internals stay reachable via deep imports from `packages/core/src/` for tests + harness wiring.

### \`packages/codec-image/src/index.ts\`

Narrowed to:
- \`imageCodec\` / \`imageV2Codec\` / \`ImageCodec\`
- \`ImageSceneSpecSchema\` + \`imageSchemaPreamble\` + \`parseImageSceneSpec\`
- Consumer-facing types: \`ImageRequest\`, \`ImageSceneSpec\`, \`ImageArtifact\`, \`ImageArtifactMetadata\`, \`ImageCodeReceipt\`, \`ImageCodePath\`, \`ImageAdapterOutcome\`, \`ImageSemanticSource\`
- \`ImageRequestSchema\` re-exported from \`@wittgenstein/schemas\` so codec consumers can import from one place.

Removed: \`export * from \"./pipeline/index.js\"\` (internal renderer).

## Verification (acceptance from #365)

- \`pnpm typecheck\` clean across the workspace.
- \`pnpm --filter @wittgenstein/cli test\` ✓ (13 tests).
- All packages' tests still pass byte-for-byte (62 core / 45 image / 18 sensor / 13 cli / etc.).
- A grep at workspace level confirms no public-surface consumer reaches into the removed exports.
- \`pnpm lint\` clean.

## Non-goals (per issue)

- No `unstable/` sub-path added — future structure decision.
- No deep-import path changes for tests / internal code.

## Interaction with other open PRs

If [PR #379](https://github.com/p-to-q/wittgenstein/pull/379) (ProcessRunner lift to core) merges first, this PR will need to re-export \`runProcess\` / \`ProcessRunnerOptions\` on \`packages/core/src/index.ts\` (small rebase). If this PR merges first, #379 will need the same addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)