### PR TITLE
refactor(codec-audio): tie inferIntentRoute to AudioRouteSchema enum (closes #355 Slice A)

### DIFF
--- a/packages/codec-audio/src/codec.ts
+++ b/packages/codec-audio/src/codec.ts
@@ -5,6 +5,7 @@ import { Modality, codecV2 } from "@wittgenstein/schemas";
 import {
   AudioPlanSchema,
   AudioRequestSchema,
+  AudioRouteSchema,
   audioSchemaPreamble,
   parseAudioPlan,
   type AudioPlan,
@@ -184,23 +185,35 @@ function routeFromRequest(req: AudioRequest): AudioRoute {
   return inferIntentRoute(req.prompt);
 }
 
+// Keyword patterns for intent-driven route inference. Keys MUST stay in sync
+// with `AudioRouteSchema.options` (enforced at compile time below). `speech`
+// is the implicit fallback when no other route's keywords match — adding it
+// here as a real pattern would create circular semantics (the catch-all
+// can't both match-explicitly and serve as the default).
+const ROUTE_KEYWORDS: Record<Exclude<AudioRoute, "speech">, RegExp> = {
+  music: /\b(music|soundtrack|score|melody|song|cue|theme|pulse|beat|chord|motif)\b/,
+  soundscape:
+    /\b(soundscape|ambient|ambience|rain|wind|forest|city|ocean|waves|birds|noise|texture)\b/,
+};
+
+// Compile-time guard: every non-`speech` enum member must appear in
+// `ROUTE_KEYWORDS`. If a future PR adds a route to `AudioRouteSchema`
+// without a keyword entry, this type assertion fails the build.
+const _routeKeywordKeysCheck: ReadonlySet<Exclude<AudioRoute, "speech">> = new Set(
+  AudioRouteSchema.options.filter((route): route is Exclude<AudioRoute, "speech"> => route !== "speech"),
+);
+void (_routeKeywordKeysCheck satisfies ReadonlySet<keyof typeof ROUTE_KEYWORDS>);
+
 function inferIntentRoute(prompt: string): AudioRoute {
   const normalized = prompt.toLowerCase();
-
-  if (
-    /\b(music|soundtrack|score|melody|song|cue|theme|pulse|beat|chord|motif)\b/.test(normalized)
-  ) {
-    return "music";
+  // Iterate in schema-declared order. `speech` is the fallback — skipped
+  // here, returned if no other route's keywords match.
+  for (const route of AudioRouteSchema.options) {
+    if (route === "speech") continue;
+    if (ROUTE_KEYWORDS[route].test(normalized)) {
+      return route;
+    }
   }
-
-  if (
-    /\b(soundscape|ambient|ambience|rain|wind|forest|city|ocean|waves|birds|noise|texture)\b/.test(
-      normalized,
-    )
-  ) {
-    return "soundscape";
-  }
-
   return "speech";
 }
 

--- a/packages/codec-audio/src/schema.ts
+++ b/packages/codec-audio/src/schema.ts
@@ -2,8 +2,14 @@ import { z } from "zod";
 import type { AudioRequest, Result } from "@wittgenstein/schemas";
 import { AudioRequestSchema } from "@wittgenstein/schemas";
 
+// Audio route enum surfaced separately so route inference can drive off the
+// schema (not a hardcoded list parallel to it). Adding a new audio route
+// becomes: extend AudioRouteSchema.options + add a keyword entry to
+// `ROUTE_KEYWORDS` in codec.ts (#355).
+export const AudioRouteSchema = z.enum(["speech", "soundscape", "music"]);
+
 export const AudioPlanSchema = z.object({
-  route: z.enum(["speech", "soundscape", "music"]).default("speech"),
+  route: AudioRouteSchema.default("speech"),
   script: z.string().default("Wittgenstein launches a multimodal artifact."),
   voice: z
     .object({

--- a/packages/codec-audio/test/codec.test.ts
+++ b/packages/codec-audio/test/codec.test.ts
@@ -208,4 +208,19 @@ describe("@wittgenstein/codec-audio", () => {
     expect(art.metadata.warnings).toEqual([]);
     expect(warnings).toEqual([]);
   });
+
+  // Schema-driven intent routing (#355). `inferIntentRoute` reads its
+  // keyword table off `AudioRouteSchema.options` instead of a hardcoded
+  // branch tree; these tests pin the routing contract via the codec's
+  // public route matchers.
+  it.each([
+    { prompt: "upbeat music score with motif", expected: "music" },
+    { prompt: "a calm forest soundscape with rain", expected: "soundscape" },
+    { prompt: "narrator reads a story", expected: "speech" },
+    { prompt: "", expected: "speech" }, // empty prompt falls through to speech
+  ])("infers route '$expected' for prompt: $prompt", ({ prompt, expected }) => {
+    const req = { modality: "audio" as const, prompt };
+    const matched = audioCodec.routes.find((r) => r.match(req));
+    expect(matched?.id).toBe(expected);
+  });
 });


### PR DESCRIPTION
Closes #355 (Slice A; Slice B deferred — see below).

## Problem (Slice A)

`inferIntentRoute` used a hardcoded regex tree wired to specific route literals (\`\"music\"\` / \"soundscape\" / \"speech\"). It wasn't tied to the `AudioPlan` route enum. Adding a new audio route required editing two places that could drift.

## Fix

1. **Export `AudioRouteSchema` separately** from `AudioPlanSchema` so route inference reads off the same enum the schema uses for validation.

2. **Refactor `inferIntentRoute` to be keyword-table-driven:**

   ```ts
   const ROUTE_KEYWORDS: Record<Exclude<AudioRoute, \"speech\">, RegExp> = { ... };
   for (const route of AudioRouteSchema.options) {
     if (route === \"speech\") continue;
     if (ROUTE_KEYWORDS[route].test(normalized)) return route;
   }
   return \"speech\"; // fallback
   ```

   Adding a new route now means: extend `AudioRouteSchema.options` + add a `ROUTE_KEYWORDS` entry. A **compile-time guard** (`_routeKeywordKeysCheck`) fails the build if a new enum member appears without a matching keyword entry — drift impossible.

3. **4 new parametrized tests** in `codec.test.ts` lock the routing contract via the codec's public `routes` matchers (music / soundscape / speech / empty falls through to speech).

## Verification

- `pnpm --filter @wittgenstein/codec-audio test` ✓ — **12 tests, 3 skipped** (was 8 + 4 new; parity goldens byte-identical).
- All workspace tests pass.
- `pnpm lint` clean.

## Slice B — deferred with reasoning

The issue's Slice B proposed extracting an `AudioRenderDispatcher` for the `decode()` Kokoro vs procedural branch. After reading the actual code: the two arms set 5 distinct variables (`artifactPath`, `decoderId`, `determinismClass`, `partialReason`, `slot`), then **share** the post-processing tail (bytes / wavMeta / metadata). There's no duplication; the tail is genuinely shared. Extracting a dispatcher would add indirection without removing real duplication. Leaving Slice B as documented file-forward; if a third backend lands (M2 follow-up RFCs [#348](https://github.com/p-to-q/wittgenstein/issues/348) / [#349](https://github.com/p-to-q/wittgenstein/issues/349) / [#350](https://github.com/p-to-q/wittgenstein/issues/350)), revisit.

## Note on line count

The issue's acceptance \"codec.ts shrinks (target: under 400 lines)\" was contingent on both slices. Slice A alone takes codec.ts 467 → 480 lines (the compile-time guard + explanatory comments cost more than the inferIntentRoute shrinkage saves). Net code-quality is up: the schema / keyword drift footgun is eliminated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)