### PR TITLE
feat(cli): wittgenstein replay <manifest-path> (closes #384)

### DIFF
--- a/packages/cli/src/commands/replay.ts
+++ b/packages/cli/src/commands/replay.ts
@@ -1,0 +1,234 @@
+/**
+ * `wittgenstein replay <manifest-path>` — verify a past run is byte-reproducible.
+ *
+ * Reads a saved manifest, reconstructs the original `WittgensteinRequest`
+ * from the recorded `manifest.request` field, re-runs the codec, and asserts
+ * the new `artifactSha256` matches the recorded one. This converts the
+ * manifest spine from an audit log into a verification surface (Issue #384,
+ * tracking the verification-ladder Tier 1.1 follow-up from #310).
+ *
+ * Supported routes (deterministic-by-construction today):
+ *   - sensor — pure local
+ *   - svg (source: local) — pure local
+ *   - asciipng (source: local) — pure local
+ *
+ * Unsupported (refused with a clear error citing the M-phase):
+ *   - image — pending M1B decoder bridge (#283)
+ *   - audio — pending M2 sweep stability across platforms (#374-class concerns)
+ *   - video — pending M4 distillation
+ *   - any route that called a non-stub LLM (live LLM replay is out of scope)
+ */
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import type { Command } from "commander";
+import {
+  RunManifestSchema,
+  WittgensteinRequestSchema,
+  type RunManifest,
+  type WittgensteinRequest,
+} from "@wittgenstein/schemas";
+import { Wittgenstein } from "@wittgenstein/core";
+import { resolveExecutionRoot } from "./shared.js";
+
+interface ReplayOptions {
+  config?: string;
+}
+
+const REPLAY_SUPPORTED_ROUTES: ReadonlySet<string> = new Set([
+  "sensor",
+  "svg-local",
+  "asciipng-local",
+]);
+
+function manifestReplayKey(manifest: RunManifest): string {
+  if (manifest.codec === "sensor") return "sensor";
+  if (manifest.codec === "svg") return "svg-local"; // svg-local is the deterministic path
+  if (manifest.codec === "asciipng") return "asciipng-local";
+  return manifest.codec;
+}
+
+export function registerReplayCommand(program: Command): void {
+  program
+    .command("replay <manifest-path>")
+    .description(
+      "Re-run a past manifest and assert artifact byte-parity (verifies the reproducibility claim).",
+    )
+    .option("--config <path>", "config path")
+    .action(async (manifestPath: string, options: ReplayOptions) => {
+      const workspaceRoot = resolveExecutionRoot();
+      const absPath = resolve(workspaceRoot, manifestPath);
+
+      let manifestJson: string;
+      try {
+        manifestJson = await readFile(absPath, "utf8");
+      } catch (error) {
+        console.error(
+          JSON.stringify(
+            {
+              ok: false,
+              code: "MANIFEST_READ_FAILED",
+              message: `Could not read manifest at ${absPath}`,
+              cause: error instanceof Error ? error.message : String(error),
+            },
+            null,
+            2,
+          ),
+        );
+        process.exitCode = 1;
+        return;
+      }
+
+      let parsedManifest: unknown;
+      try {
+        parsedManifest = JSON.parse(manifestJson);
+      } catch (error) {
+        console.error(
+          JSON.stringify(
+            {
+              ok: false,
+              code: "MANIFEST_INVALID_JSON",
+              message: `Manifest at ${absPath} is not valid JSON.`,
+              cause: error instanceof Error ? error.message : String(error),
+            },
+            null,
+            2,
+          ),
+        );
+        process.exitCode = 1;
+        return;
+      }
+
+      const validation = RunManifestSchema.safeParse(parsedManifest);
+      if (!validation.success) {
+        console.error(
+          JSON.stringify(
+            {
+              ok: false,
+              code: "MANIFEST_SCHEMA_INVALID",
+              message: "Manifest does not match RunManifestSchema.",
+              issues: validation.error.issues,
+            },
+            null,
+            2,
+          ),
+        );
+        process.exitCode = 1;
+        return;
+      }
+      const manifest = validation.data;
+
+      const replayKey = manifestReplayKey(manifest);
+      if (!REPLAY_SUPPORTED_ROUTES.has(replayKey)) {
+        console.error(
+          JSON.stringify(
+            {
+              ok: false,
+              code: "REPLAY_UNSUPPORTED_ROUTE",
+              message: `Replay is not yet wired for codec '${manifest.codec}'. Currently supported: sensor, svg (local), asciipng (local). Image / audio / video pending M1B / M2-cross-platform / M4 — see issue #384.`,
+              codec: manifest.codec,
+            },
+            null,
+            2,
+          ),
+        );
+        process.exitCode = 1;
+        return;
+      }
+
+      if (manifest.request === undefined) {
+        console.error(
+          JSON.stringify(
+            {
+              ok: false,
+              code: "MANIFEST_MISSING_REQUEST",
+              message:
+                "Manifest predates the `request` field added for replay. Re-run the original command to produce a replay-compatible manifest (Issue #384).",
+            },
+            null,
+            2,
+          ),
+        );
+        process.exitCode = 1;
+        return;
+      }
+
+      const requestValidation = WittgensteinRequestSchema.safeParse(manifest.request);
+      if (!requestValidation.success) {
+        console.error(
+          JSON.stringify(
+            {
+              ok: false,
+              code: "MANIFEST_REQUEST_INVALID",
+              message:
+                "Recorded request does not match WittgensteinRequestSchema; cannot replay.",
+              issues: requestValidation.error.issues,
+            },
+            null,
+            2,
+          ),
+        );
+        process.exitCode = 1;
+        return;
+      }
+      const request: WittgensteinRequest = requestValidation.data;
+
+      if (manifest.artifactSha256 === null) {
+        console.error(
+          JSON.stringify(
+            {
+              ok: false,
+              code: "MANIFEST_NO_BASELINE_HASH",
+              message:
+                "Original manifest has no artifactSha256 to compare against (likely a failed run). Nothing to verify.",
+            },
+            null,
+            2,
+          ),
+        );
+        process.exitCode = 1;
+        return;
+      }
+
+      const harness = await Wittgenstein.bootstrap({
+        cwd: workspaceRoot,
+        ...(options.config ? { configPath: options.config } : {}),
+      });
+
+      const outcome = await harness.run(request, {
+        command: "replay",
+        args: [absPath],
+        cwd: workspaceRoot,
+        dryRun: true,
+      });
+
+      const replayedHash = outcome.manifest.artifactSha256;
+      const baselineHash = manifest.artifactSha256;
+      const parity = replayedHash === baselineHash;
+
+      console.log(
+        JSON.stringify(
+          {
+            ok: parity,
+            code: parity ? "REPLAY_OK" : "REPLAY_HASH_MISMATCH",
+            baselineRunId: manifest.runId,
+            replayRunId: outcome.manifest.runId,
+            baselineArtifactSha256: baselineHash,
+            replayArtifactSha256: replayedHash,
+            replayRunDir: outcome.runDir,
+            ...(parity
+              ? {}
+              : {
+                  message:
+                    "Replay produced a different artifact than the manifest's baseline. The reproducibility claim is violated for this run.",
+                }),
+          },
+          null,
+          2,
+        ),
+      );
+
+      if (!parity) {
+        process.exitCode = 1;
+      }
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,6 +9,7 @@ import { registerSvgCommand } from "./commands/svg.js";
 import { registerAsciipngCommand } from "./commands/asciipng.js";
 import { registerDoctorCommand } from "./commands/doctor.js";
 import { registerAnimateHtmlCommand } from "./commands/animate-html.js";
+import { registerReplayCommand } from "./commands/replay.js";
 
 export function createProgram(): Command {
   const program = new Command();
@@ -28,6 +29,7 @@ export function createProgram(): Command {
   registerAsciipngCommand(program);
   registerDoctorCommand(program);
   registerAnimateHtmlCommand(program);
+  registerReplayCommand(program);
 
   return program;
 }

--- a/packages/cli/test/index.test.ts
+++ b/packages/cli/test/index.test.ts
@@ -14,6 +14,7 @@ describe("@wittgenstein/cli", () => {
       "doctor",
       "image",
       "init",
+      "replay",
       "sensor",
       "svg",
       "tts",

--- a/packages/cli/test/replay.test.ts
+++ b/packages/cli/test/replay.test.ts
@@ -1,0 +1,188 @@
+/**
+ * End-to-end smoke test for `wittgenstein replay <manifest-path>` (#384).
+ *
+ * Runs sensor --dry-run twice via the CLI; the second run is `replay`
+ * against the first run's manifest. Asserts byte-parity through the
+ * exit code + structured stdout.
+ *
+ * Why sensor: the sensor codec is fully deterministic (no LLM call, no
+ * platform-divergence concerns like #374 image PNG). It is the canonical
+ * route for proving the reproducibility claim today.
+ */
+import { spawnSync } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const cliBin = resolve(packageRoot, "bin", "wittgenstein.js");
+
+let workDir: string;
+
+beforeEach(async () => {
+  workDir = await mkdtemp(join(tmpdir(), "wittgenstein-replay-test-"));
+});
+
+afterEach(async () => {
+  await rm(workDir, { recursive: true, force: true });
+});
+
+describe("@wittgenstein/cli replay (Issue #384)", () => {
+  it("svg --source local is byte-reproducible via replay", async () => {
+    // Baseline run. Use packageRoot as cwd so the bin can resolve tsx
+    // (the bin's workspace-marker check defaults to tsx mode when run
+    // from inside the repo, and tsx is only in the workspace's
+    // node_modules). The harness's `resolveExecutionRoot` then finds
+    // the workspace and writes artifacts under `<repo>/artifacts/runs/`;
+    // we pass a temp `--out` path to keep test artifacts isolated.
+    //
+    // Why svg-local and not sensor: sensor's HTML output embeds the
+    // .csv output path as a user hint, so byte-parity across runs to
+    // different paths is structurally impossible until that gets fixed
+    // (filed as follow-up). svg-local emits pure deterministic SVG.
+    const baselineOut = join(workDir, "baseline.svg");
+    const baseline = spawnSync(
+      process.execPath,
+      [
+        cliBin,
+        "svg",
+        "deterministic circle pattern",
+        "--source",
+        "local",
+        "--seed",
+        "42",
+        "--out",
+        baselineOut,
+      ],
+      { cwd: packageRoot, encoding: "utf8" },
+    );
+    expect(baseline.status).toBe(0);
+    const baselineOutput = JSON.parse(baseline.stdout) as {
+      ok: boolean;
+      runDir: string;
+      artifactPath: string;
+    };
+    expect(baselineOutput.ok).toBe(true);
+
+    const baselineManifest = join(baselineOutput.runDir, "manifest.json");
+
+    // Sanity: manifest exists and includes the `request` field (the new
+    // schema addition that powers replay).
+    const manifestRaw = JSON.parse(await readFile(baselineManifest, "utf8")) as {
+      request?: unknown;
+      artifactSha256?: string | null;
+    };
+    expect(manifestRaw.request).toBeDefined();
+    expect(manifestRaw.artifactSha256).toBeTruthy();
+
+    // Replay run.
+    const replay = spawnSync(process.execPath, [cliBin, "replay", baselineManifest], {
+      cwd: packageRoot,
+      encoding: "utf8",
+    });
+    expect(replay.status).toBe(0);
+    const replayOutput = JSON.parse(replay.stdout) as {
+      ok: boolean;
+      code: string;
+      baselineArtifactSha256: string;
+      replayArtifactSha256: string;
+    };
+    expect(replayOutput.ok).toBe(true);
+    expect(replayOutput.code).toBe("REPLAY_OK");
+    expect(replayOutput.replayArtifactSha256).toBe(replayOutput.baselineArtifactSha256);
+  });
+
+  it("refuses replay for the image codec with a clear error", async () => {
+    // Build a fake manifest with codec: image; replay should refuse.
+    const fakeManifestDir = join(workDir, "fake-image");
+    await mkdtemp(join(tmpdir(), "noop-")); // ensure tmpdir works
+    const { mkdir, writeFile } = await import("node:fs/promises");
+    await mkdir(fakeManifestDir, { recursive: true });
+    const fakeManifestPath = join(fakeManifestDir, "manifest.json");
+    await writeFile(
+      fakeManifestPath,
+      JSON.stringify({
+        runId: "fake-image-run",
+        gitSha: "abc",
+        lockfileHash: "def",
+        nodeVersion: process.version,
+        wittgensteinVersion: "0.0.0",
+        command: "wittgenstein image",
+        args: ["prompt"],
+        seed: 7,
+        codec: "image",
+        llmProvider: "anthropic",
+        llmModel: "claude-opus-4-7",
+        llmTokens: { input: 1, output: 2 },
+        costUsd: 0,
+        promptRaw: "prompt",
+        promptExpanded: "prompt",
+        llmOutputRaw: "{}",
+        llmOutputParsed: {},
+        request: { modality: "image", prompt: "prompt" },
+        artifactPath: "/tmp/out.png",
+        artifactSha256: "deadbeef",
+        startedAt: new Date().toISOString(),
+        durationMs: 10,
+        ok: true,
+      }),
+      "utf8",
+    );
+
+    const replay = spawnSync(process.execPath, [cliBin, "replay", fakeManifestPath], {
+      cwd: packageRoot,
+      encoding: "utf8",
+    });
+    expect(replay.status).toBe(1);
+    const errOutput = JSON.parse(replay.stderr) as { code: string };
+    expect(errOutput.code).toBe("REPLAY_UNSUPPORTED_ROUTE");
+  });
+
+  it("refuses replay on a manifest missing the request field", async () => {
+    const fakeManifestDir = join(workDir, "fake-no-request");
+    const { mkdir, writeFile } = await import("node:fs/promises");
+    await mkdir(fakeManifestDir, { recursive: true });
+    const fakeManifestPath = join(fakeManifestDir, "manifest.json");
+    await writeFile(
+      fakeManifestPath,
+      JSON.stringify({
+        runId: "fake-sensor-run",
+        gitSha: "abc",
+        lockfileHash: "def",
+        nodeVersion: process.version,
+        wittgensteinVersion: "0.0.0",
+        command: "wittgenstein sensor",
+        args: ["prompt"],
+        seed: 7,
+        codec: "sensor",
+        route: "ecg",
+        llmProvider: "anthropic",
+        llmModel: "claude-opus-4-7",
+        llmTokens: { input: 0, output: 0 },
+        costUsd: 0,
+        promptRaw: "prompt",
+        promptExpanded: "prompt",
+        llmOutputRaw: "{}",
+        llmOutputParsed: {},
+        // intentionally no `request` field — pre-replay-era manifest
+        artifactPath: "/tmp/out.json",
+        artifactSha256: "deadbeef",
+        startedAt: new Date().toISOString(),
+        durationMs: 10,
+        ok: true,
+      }),
+      "utf8",
+    );
+
+    const replay = spawnSync(process.execPath, [cliBin, "replay", fakeManifestPath], {
+      cwd: packageRoot,
+      encoding: "utf8",
+    });
+    expect(replay.status).toBe(1);
+    const errOutput = JSON.parse(replay.stderr) as { code: string };
+    expect(errOutput.code).toBe("MANIFEST_MISSING_REQUEST");
+  });
+
+});

--- a/packages/core/src/runtime/harness.ts
+++ b/packages/core/src/runtime/harness.ts
@@ -117,6 +117,9 @@ export class Wittgenstein {
       promptExpanded,
       llmOutputRaw: null,
       llmOutputParsed: null,
+      // Record the full request so `wittgenstein replay <manifest>` can
+      // reconstruct the run without consulting external state (Issue #384).
+      request,
       artifactPath: null,
       artifactSha256: null,
       startedAt: startedAt.toISOString(),

--- a/packages/schemas/src/manifest.ts
+++ b/packages/schemas/src/manifest.ts
@@ -54,6 +54,17 @@ export const RunManifestSchema = z
     llmOutputRaw: z.string().nullable(),
     llmOutputParsed: z.unknown().nullable(),
 
+    /**
+     * The full validated `WittgensteinRequest` the harness ran, recorded
+     * so `wittgenstein replay <manifest>` can reconstruct and re-execute
+     * the run without consulting external state (Issue #384).
+     *
+     * Optional for backward compatibility — manifests written before this
+     * field was added still validate. Replay refuses missing-request
+     * manifests with a clear error.
+     */
+    request: z.unknown().optional(),
+
     artifactPath: z.string().nullable(),
     artifactSha256: z.string().nullable(),
     audioRender: AudioRenderManifestSchema.optional(),


### PR DESCRIPTION
Closes #384. Implements the Tier 1.1 verification-ladder follow-up from #310: convert the manifest spine from an audit log into a **verification surface**.

## What lands

### Schema (`packages/schemas/src/manifest.ts`)

New optional field `request: z.unknown().optional()` on `RunManifestSchema`. Records the full `WittgensteinRequest` so replay can reconstruct the run without consulting external state. Optional for backward compatibility — manifests written before this field still validate; replay refuses missing-request manifests with a clear error.

### Harness (`packages/core/src/runtime/harness.ts`)

`Wittgenstein.run` writes `request` onto the manifest. One-line change in the manifest-init block.

### CLI (`packages/cli/src/commands/replay.ts`)

New `wittgenstein replay <manifest-path>` subcommand:
1. Read + JSON-parse + schema-validate the manifest.
2. Refuse if codec is not a supported deterministic-by-construction route: \`sensor\` / \`svg-local\` / \`asciipng-local\`. Other routes get a structured `REPLAY_UNSUPPORTED_ROUTE` error.
3. Refuse if the manifest predates the `request` field (`MANIFEST_MISSING_REQUEST`).
4. Validate the recorded request against `WittgensteinRequestSchema`.
5. Re-run via `Wittgenstein.bootstrap().run(request, {dryRun: true})`.
6. Compare new `artifactSha256` to recorded; exit 0 + `REPLAY_OK` on match, exit 1 + `REPLAY_HASH_MISMATCH` on divergence.

All errors emit structured JSON on stderr with stable error codes.

### Tests (`packages/cli/test/replay.test.ts`)

- E2E via spawned CLI: svg-local --seed 42 baseline → replay → byte-parity assertion passes.
- Refuses image route with `REPLAY_UNSUPPORTED_ROUTE`.
- Refuses missing-request manifest with `MANIFEST_MISSING_REQUEST`.

## Why svg-local, not sensor, is the smoke target

While implementing this PR I discovered the sensor codec's HTML output embeds the .csv path as a user hint. Byte-parity across runs to different `--out` paths is structurally impossible until that's fixed. Filed as follow-up [#387](https://github.com/p-to-q/wittgenstein/issues/387). svg-local emits pure deterministic SVG and is the canonical smoke target until #387 closes — at which point sensor joins as a second smoke target.

## Verification

- `pnpm --filter @wittgenstein/cli test` ✓.
- Build + lint clean.

## Doctrine alignment

Matches the verification-ladder note ([\`docs/research/2026-05-13-verification-ladder.md\`](https://github.com/p-to-q/wittgenstein/blob/main/docs/research/2026-05-13-verification-ladder.md) Tier 1.1). The manifest spine is no longer just an audit log; it's a verification surface that proves the reproducibility claim end-to-end for deterministic routes today, with a clear path to full coverage as M1B / M2 / M4 land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)