### PR TITLE
fix(codec-sensor): HTML fallback embeds csv basename, not absolute path (closes #387)

### DIFF
--- a/packages/codec-sensor/src/loupe-renderer.ts
+++ b/packages/codec-sensor/src/loupe-renderer.ts
@@ -5,7 +5,7 @@
 // `SensorRenderPath` outcome string so manifests and tests stay byte-stable.
 
 import { access, writeFile } from "node:fs/promises";
-import { dirname, resolve as resolvePath } from "node:path";
+import { basename, dirname, resolve as resolvePath } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawn } from "node:child_process";
 import type { SensorSignalSpec } from "./schema.js";
@@ -74,6 +74,14 @@ async function firstExistingPath(candidates: string[]): Promise<string | null> {
 }
 
 function buildFallbackHtml(spec: SensorSignalSpec, csvPath: string): string {
+  // Embed only the CSV file's basename, not its absolute path. Absolute
+  // paths bake the run's output directory into the artifact bytes, which
+  // breaks the "same IR + same seed → same bytes" reproducibility doctrine
+  // (manifest replay across runs to different outPaths would diverge by
+  // path bytes alone). The basename + the colocated layout (csv sits next
+  // to the html) is enough for a user landing on the dashboard to find
+  // the file (Issue #387).
+  const csvBasename = basename(csvPath);
   return `<!doctype html>
 <html lang="en">
 <meta charset="utf-8" />
@@ -81,7 +89,7 @@ function buildFallbackHtml(spec: SensorSignalSpec, csvPath: string): string {
 <body style="font-family: ui-monospace, monospace; padding: 24px; background: #111; color: #f5f5f5;">
   <h1>${spec.signal} preview</h1>
   <p>Loupe was unavailable, so Wittgenstein wrote the raw CSV sidecar instead.</p>
-  <p>Open <code>${csvPath}</code> or rerun with Python 3 available to get the interactive dashboard.</p>
+  <p>Open <code>${csvBasename}</code> (next to this HTML file) or rerun with Python 3 available to get the interactive dashboard.</p>
 </body>
 </html>`;
 }


### PR DESCRIPTION
Closes #387.

## Problem

The fallback HTML dashboard baked the full absolute `csvPath` into a user-facing message:

\`\`\`html
<p>Open <code>/tmp/abs/path/to/out.csv</code> or rerun with Python 3 ...</p>
\`\`\`

Two runs of the same sensor input with different `--out` paths produced HTML files that differed **only** in this embedded path — breaking the doctrine that \"same IR + same seed → same bytes.\" Discovered while landing [PR #388](https://github.com/p-to-q/wittgenstein/pull/388) (replay command for #384): replay couldn't include sensor as a smoke target because path-divergence created false-positive hash mismatches.

## Fix

Use `path.basename(csvPath)` in the embedded `<code>` element. The basename + the colocated-files layout (csv sits next to the html in the same dir) is enough for a user landing on the dashboard to find the file. Updated the copy to say \"next to this HTML file\" so the hint stays clear.

## Verification

Two runs of \`sensor --dry-run --seed 42\` to different `--out` paths now produce byte-identical artifacts across **all three** outputs (csv / json / html):

\`\`\`
f773197c...  /tmp/sa/out.html
f773197c...  /tmp/sb/out.html
566d3cf8...  /tmp/sa/out.csv
566d3cf8...  /tmp/sb/out.csv
fb2c25cd...  /tmp/sa/out.json
fb2c25cd...  /tmp/sb/out.json
\`\`\`

The sensor codec's 18 tests (including 6 byte-stable goldens) still pass — goldens compare csv/json fixtures, not the html.

## Follow-up

When PR #388 merges, sensor joins svg-local as a canonical replay smoke target. The replay test can be extended to cover both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)