### PR TITLE
docs+feat(codec-image): M1B prep — bridge contract + 3-track research program + delivery doctrine (closes #283 prep)

### DIFF
--- a/docs/research/2026-05-13-delivery-and-componentization.md
+++ b/docs/research/2026-05-13-delivery-and-componentization.md
@@ -1,0 +1,389 @@
+---
+date: 2026-05-13
+status: research note (doctrine-shaped) — delivery / componentization doctrine
+labels: [research-derived, delivery, componentization, engineering, governance]
+tracks: [#283, #292]
+companion-to: docs/research/2026-05-13-wittgenstein-research-program.md
+---
+
+# Delivery, Engineering Quality, Componentization
+
+> **Status:** doctrine-shaped research note. Answers the maintainer
+> question: given the elite research/training/eval infrastructure
+> Wittgenstein is building (per the [research-program note](2026-05-13-wittgenstein-research-program.md)),
+> **does all of it need to ship to every user?** Answer: **no.** The
+> discipline is tiered delivery — different audiences get different
+> install surfaces. The elite infra lives in the repo and produces the
+> best results; users and reviewers get an experience proportional to
+> their need.
+>
+> This note codifies that as doctrine. Three concrete trackers fall out
+> of it (see §"Concrete follow-ups"). Any process-doctrine change
+> (e.g. mandating a new release gate) routes through ADR-0014's
+> governance lane.
+
+## Why this note exists
+
+The research-program note commits Wittgenstein to multi-month training
+runs, full-resolution eval ablations, and infrastructure (FSDP, aim,
+DVC, GPU CI). That's **what we want as a project**. The question this
+note answers is: **what do USERS get?**
+
+### Both ends — performance ceiling AND accessibility floor
+
+The maintainer's clarification (2026-05-13): we keep **both**.
+
+- **Headline performance numbers** (published benchmarks, paper / arxiv
+  results, leaderboard entries, comparisons vs LlamaGen/Open-MAGVIT2)
+  run on the **elite tier** — GPU canonical, full eval, full ablation
+  matrix. **The project's published quality claim is what the elite
+  tier produces, full stop.**
+- **User experience** is **tiered**, so a low-spec laptop user, a
+  reviewer without a GPU, and a researcher with a cluster all get
+  appropriate install footprints — but **none of them is the
+  benchmarked configuration**. The benchmark is its own thing.
+
+This is how mature engineering projects work: `llama.cpp` publishes
+benchmark numbers on the best available hardware while the runtime
+also works on a Raspberry Pi; PyTorch publishes paper-grade numbers
+on H100s while `pip install torch` works on a CPU laptop. **The
+published quality claim and the typical user's experience are
+allowed to be different**, as long as both are honest.
+
+What this means for Wittgenstein:
+
+| Surface | Configuration | Quality bar |
+|---|---|---|
+| Published benchmarks / paper | Elite tier (GPU, full ablation, own-trained models per the [research-program note](2026-05-13-wittgenstein-research-program.md)) | **SOTA-adjacent.** No compromises. |
+| Typical user experience | Tiered (Tier 0–2 per below) | "Works in 30 seconds; produces honest receipts." |
+| Reviewer verification | Reviewer-bench (Tier 0 surface + tiny ablation subset) | "Project's claims are verifiable in 5 minutes on a laptop." |
+
+The discipline below is about **the user experience**. It does **not**
+relax the published benchmark requirements — those keep the elite-tier
+contract.
+
+Without an explicit answer:
+
+- A user who wants to render a sensor signal could end up downloading
+  5 GB of frozen-decoder weights.
+- A reviewer who wants to verify the manifest-spine claim could end up
+  needing to configure CUDA.
+- A low-spec laptop user could end up unable to install ANY part of
+  Wittgenstein because the workspace install pulls onnxruntime-gpu.
+
+These would all be unforced failures. Mature projects don't do this:
+
+- `llama.cpp` ships a small runtime; weights are separate.
+- `transformers` is small on install; `from_pretrained` lazy-downloads.
+- `ollama` keeps the CLI tiny and pulls models on demand.
+- `pytorch` separates `torch-cpu` / `torch-cuda` so users only pay for
+  what they need.
+
+Wittgenstein's existing package-boundary discipline (codec packages
+already separate; `@wittgenstein/cli` is its own publish surface) means
+**we're 80% of the way to clean tiering**; this note is the doctrine
+finish.
+
+## Three audiences, three install surfaces
+
+### Audience 1 — first-time user
+
+Wants: try Wittgenstein in 30 seconds. May not care about M1B image yet.
+
+Gets:
+
+```bash
+npm i -g @wittgenstein/cli   # ~10 MB, no model weights
+wittgenstein sensor "ECG 72 bpm resting" --dry-run --out /tmp/ecg.json
+```
+
+Tier 0 covers everything that doesn't need a learned model:
+**sensor**, **svg-local**, **asciipng**, **audio (procedural runtime)**,
+**doctor**, **replay** (for sensor / svg-local / asciipng).
+
+The 30-second quickstart already in the README is Tier-0 by accident.
+This note makes it Tier-0 by **design**.
+
+### Audience 2 — image-curious user
+
+Wants: generate an image. Has a laptop.
+
+Gets:
+
+```bash
+wittgenstein doctor             # tells them they don't have image installed yet
+wittgenstein install image      # explicit opt-in. Fetches weights with progress
+                                # bar; sha256-verifies; writes receipt.
+wittgenstein image "a cat in the rain"
+```
+
+Tier 1 — Image inference CPU: adds `onnxruntime-node` (~80 MB) +
+fetched decoder weights (1-5 GB). All weights fetched from
+HuggingFace, sha256-verified against the manifest pinned in
+`packages/codec-image/decoders/<family>/manifest.json`. **The npm
+package never bundles weights.**
+
+Tier 2 — Image inference GPU: same as Tier 1 with `onnxruntime-gpu`
+or `torch-cuda` variant. Detected by doctor; opt-in via
+`wittgenstein install image --gpu`.
+
+### Audience 3 — academic / reviewer
+
+Wants: verify the project's claims without setting up infrastructure.
+
+Gets:
+
+```bash
+git clone wittgenstein && pnpm install   # workspace deps only, ~30 sec
+pnpm reviewer-bench                       # tiny eval pack: ~5 min, no GPU
+```
+
+The reviewer-bench produces a structured report:
+
+- Receipts table: which routes produce which artifacts at which
+  determinism class.
+- Replay verification: re-runs each saved manifest, asserts byte/
+  structural parity.
+- Sample eval on small subsets (200 samples per modality, not 50k).
+- Citation list back to the research notes / ADRs / RFCs.
+
+A reviewer reads ONE report, runs ONE command, and has a defensible
+position on the project's engineering claims. They do **NOT** need
+GPU, ImageNet, FFmpeg, or HyperFrames.
+
+For deeper inspection, the reviewer reads `docs/research/`,
+`docs/adrs/`, `docs/rfcs/` — all already in the repo, all already
+audit-shaped.
+
+### Audience 4 — contributor / researcher
+
+Wants: run the Phase 1 training, ablations, benchmarks.
+
+Gets:
+
+```bash
+git clone wittgenstein && pnpm install
+cd research/training
+python -m pip install -r requirements.txt    # the heavy stack
+wittgenstein train-sweep configs/phase1-ablation.yaml
+```
+
+Tier 3 is the elite infra. It does NOT live under `packages/*` — it
+lives under `research/training/`, with its own `requirements.txt`,
+its own Dockerfile, its own dataset pipeline. **`research/` is
+explicitly excluded from npm publish** (via package.json `files`).
+
+A user pip-installs `@wittgenstein/cli` and gets ZERO PyTorch in their
+dep tree. A contributor explicitly enters `research/training/` to
+pick up the heavy stack.
+
+### Audience 5 — maintainer
+
+Wants: cut a release, publish weights, run the CI sweep.
+
+Gets the full repo + Tier 3 + the release pipeline (`wittgenstein
+release-trained`, HF push, tag bump). Tier 4 — never publicly
+documented as a user-facing install; reachable only via the maintainer
+runbook in `docs/release/`.
+
+---
+
+## Architectural moves
+
+### 1. Lazy weight fetch with sha256 verification
+
+Every decoder bridge (`packages/codec-image/src/decoders/<family>/`)
+ships a `manifest.json` carrying:
+
+```json
+{
+  "repoId": "wittgenstein-harness/image-vqgan-v1",
+  "revision": "v0.4.0",
+  "weightsFilename": "decoder.onnx",
+  "weightsSha256": "abcd...",
+  "codebookFilename": "codebook.bin",
+  "codebookSha256": "ef01..."
+}
+```
+
+`load<Family>DecoderBridge(options)` consults this manifest, looks up
+the weights in `~/.cache/wittgenstein/decoders/<family>/<sha>/`, and
+on cache miss fetches + sha256-verifies before constructing the
+session.
+
+**Refuses to construct the session if verification fails** (no silent
+fallback to "well, the file is here, hope it's right"). Refuses to
+fetch from any URL other than the one in the manifest (no chain-of-
+trust expansion).
+
+Mirrors codec-audio/decoders/kokoro/index.ts — same pattern, image
+side just hasn't been wired yet.
+
+### 2. Optional/peer dependencies for runtimes
+
+Currently `@wittgenstein/codec-video` declares `@wittgenstein/core` as
+a hard dep, which is correct. But future image GPU deps (e.g.
+`onnxruntime-gpu`) should be `peerDependenciesMeta.optional: true`
+so that users not on the GPU tier don't pay for them.
+
+`@wittgenstein/cli` checks at runtime whether the peer is installed
+and emits a structured error guiding the user to
+`wittgenstein install image --gpu` if they're trying to use a tier
+without its deps.
+
+### 3. `wittgenstein install <tier>` CLI
+
+New CLI subcommand. Backed by a small `installer.ts` that:
+
+1. Looks up the tier's required deps + weights from a hard-coded
+   tier manifest in the repo.
+2. Asks npm to install peer deps if needed.
+3. Fetches + sha256-verifies weights.
+4. Writes a receipt to `~/.config/wittgenstein/installed-tiers.json`
+   so `doctor` can report it.
+5. On uninstall, removes weights but not deps (deps are user-managed).
+
+### 4. Doctor reports tier readiness
+
+`wittgenstein doctor` extends to list:
+
+```
+Tier 0 (sensor / svg-local / asciipng): ✓ ready
+Tier 1 (image CPU): ✗ not installed.
+   Install: wittgenstein install image
+Tier 2 (image GPU): ✗ not installed.
+   Install: wittgenstein install image --gpu
+   Detected GPU: NVIDIA RTX 4090 (8GB VRAM)
+Tier 3 (research/training): not relevant (use git clone)
+```
+
+Doctor is the user's compass; it tells them what's possible and what
+to do next.
+
+### 5. `examples/reviewer-bench/` one-command eval pack
+
+A self-contained directory with:
+
+- `README.md` — how a reviewer runs the bench and reads the output
+- `fixtures/` — 200 sample inputs per modality (tiny, repo-committed)
+- `expected/` — the SHA-256 of each artifact (the golden)
+- `run.ts` — the script `pnpm reviewer-bench` invokes
+
+Output: a markdown report (one page) with pass/fail per modality, a
+table of receipts, and citations into the research / ADR docs. Time
+budget: ≤ 5 minutes on a 2024-era laptop, no GPU required.
+
+### 6. `research/training/` strictly outside npm publish
+
+`packages/*/package.json` already declares a `files` whitelist that
+excludes `research/`. This needs to remain the explicit invariant:
+
+- No package ever imports from `research/training/`.
+- Training scripts may import from `packages/*` (one-way dep, contributor
+  uses the harness inside training jobs).
+- npm publish never includes `research/`, `bench/`, `examples/`, or any
+  GB-class artifact.
+
+A small CI check can guard this — a script that diffs the npm `tarball`
+contents against an expected-files manifest and fails on drift.
+
+### 7. Public benchmark page (Phase 2+)
+
+Tier 4 ships a public, auto-updated benchmark page comparing
+Wittgenstein's trained models against LlamaGen / Open-MAGVIT2 / etc.
+Auto-generated from the eval-harness ([#394](https://github.com/p-to-q/wittgenstein/issues/394))
+output. Lives at `apps/site/bench/` and rebuilds on each release.
+
+Phase 2 work; flagged here as architectural completeness.
+
+---
+
+## What does NOT happen under this doctrine
+
+- ❌ `npm install @wittgenstein/cli` never downloads a model weight.
+- ❌ Tier 0 routes (sensor / svg-local / asciipng / procedural audio)
+  never depend on a learned-model runtime.
+- ❌ A reviewer never needs CUDA / GPU drivers to verify the project's
+  claims.
+- ❌ A user on a low-spec laptop is never blocked from Tier 0 by a
+  heavy dep upstream.
+- ❌ Training code is never installable via npm.
+- ❌ Weights are never bundled in any package's tarball.
+- ❌ The procedural placeholder is never re-introduced as a "tier
+  fallback" — the image route either runs the real decoder (Tier 1+)
+  or emits a structured error pointing at `wittgenstein install image`.
+  **No silent fallback** (existing doctrine).
+
+---
+
+## Engineering-quality investments (what "top-tier engineering" means here)
+
+Beyond what's already done (typecheck/lint/test/build/golden/CI/manifest
+spine/replay/cold-checkout):
+
+| Investment | Why | Status |
+|---|---|---|
+| **Lazy weight fetch + sha256 verify** | Required for Tier 1+; closes the supply-chain hole | new tracker |
+| **Optional/peer deps for heavy runtimes** | Tier discipline at the npm layer | new tracker |
+| **`wittgenstein install <tier>` CLI + doctor tier readiness** | User-visible tier surface | new tracker |
+| **`examples/reviewer-bench/`** | Reviewer one-command verification | new tracker |
+| **`research/training/` isolation from npm publish** | Doctrine: contributor stack ≠ user stack | new tracker |
+| **Per-tier `wittgenstein doctor` info** | Compass for what's possible | rolled into install-CLI tracker |
+| **Public benchmark page** | Tier 4, auto-generated | Phase 2 |
+| **Latency budgets in CI** | Catch performance regressions | future |
+| **SBOM + signed releases** | Supply chain | post-Phase-2 |
+
+---
+
+## Doctrine compatibility
+
+- **No silent fallbacks** (hard-constraints) — preserved. Tiers are
+  explicit; failing to load a tier surfaces a structured error.
+- **Frozen decoder** (ADR-0005) — preserved. Tier 1+ decoders are
+  fetched-and-frozen-locally; not generated on demand.
+- **Manifest spine** — preserved. Tier readiness + install state
+  recorded; doctor surfaces them; replay verifies them.
+- **License posture** (ADR-0020) — preserved. The lazy-fetch path is
+  the enforcement point: research-only weights refuse to install
+  without `--allow-research-weights`.
+- **One image path** — preserved. The image route uses ONE decoder
+  family per release. Tiers determine HOW (CPU vs GPU runtime), not
+  WHICH (the family is pinned in the release manifest).
+
+## Concrete follow-ups (file as new issues this PR)
+
+| # | Tracker | Why |
+|---|---|---|
+| 1 | **Lazy weight fetch + sha256 verify for decoder bridges** | Tier 1+ canonical mechanism; ships before any image-route weight does |
+| 2 | **`wittgenstein install <tier>` CLI + doctor tier readiness** | The user-visible install surface |
+| 3 | **Optional/peer-dep declarations for heavy runtimes** | Tier discipline at the npm dep layer |
+| 4 | **`examples/reviewer-bench/` reviewer one-command verification** | The reviewer surface |
+| 5 | **`research/training/` isolation + npm-publish guard** | Doctrine: contributor stack stays out of user stack |
+
+Each is sized small/medium. None require GPU compute to implement; all
+are pure engineering. They unblock the user/reviewer surfaces in
+parallel with the Phase 1 training work, not after it.
+
+## Decision-shaped summary
+
+| Question | Answer |
+|---|---|
+| Does the elite infra ship to every user? | **No.** Tier 0 stays tiny. |
+| Does the elite infra exist in the project? | **Yes.** Under `research/training/`, with its own dep stack. |
+| Where do the **published benchmark numbers** come from? | **The elite tier.** GPU canonical, full ablation matrix, own-trained models. No compromises on the headline number. |
+| Does the user pay for the elite infra they don't use? | **No.** Lazy fetch + peer deps + tiered installer. |
+| Does the reviewer need GPU to verify? | **No.** `examples/reviewer-bench/` runs on a laptop in 5 minutes — verifies engineering claims (manifests, replay, receipts). For the **quality** claim, the reviewer reads the published benchmark page (Tier 4 artifact) — they don't have to re-run it. |
+| Does the low-spec user get any tier? | **Yes.** Tier 0 is always available. |
+| Does this create a second image path? | **No.** One image route per release; tiers determine HOW (CPU vs GPU runtime), not WHICH (the family is pinned). |
+| Does the user-facing simplicity compromise research quality? | **No.** The elite infra still produces the research; users just don't carry it. |
+| Can a user's local result match the published number? | **Not necessarily.** Tier 1 inference on CPU may have `structural-parity` divergence from the GPU-trained reference. Receipts make this explicit; users see exactly which tier produced their artifact. |
+
+## Refs
+
+- Research program note: [`2026-05-13-wittgenstein-research-program.md`](2026-05-13-wittgenstein-research-program.md)
+- M1B prep (Phase 0 floor): [`2026-05-13-m1b-prep-research.md`](2026-05-13-m1b-prep-research.md)
+- Verification ladder: [`2026-05-13-verification-ladder.md`](2026-05-13-verification-ladder.md)
+- Replay command (the verification entrypoint): [#384](https://github.com/p-to-q/wittgenstein/issues/384) / PR #388
+- License posture: [ADR-0020](../adrs/0020-code-weights-license-divergence-policy.md)
+- No-silent-fallback doctrine: [`docs/hard-constraints.md`](../hard-constraints.md)
+- Existing Kokoro lazy-load precedent: `packages/codec-audio/src/decoders/kokoro/index.ts`

--- a/docs/research/2026-05-13-m1b-prep-research.md
+++ b/docs/research/2026-05-13-m1b-prep-research.md
@@ -1,0 +1,258 @@
+---
+date: 2026-05-13
+status: research note (decision-oriented)
+labels: [research-derived, m1b-image, training, dataset, adapter, eval]
+tracks: [#283, #259, #334, #335]
+feeds-into: M1B implementation slices
+---
+
+# M1B Prep Research: Tokenizer, Dataset, Adapter, Eval
+
+> **Status:** decision-oriented research note. Surveys the empirical landscape ahead of M1B wiring so the implementation slice is a contract-fill, not a design-from-scratch. Pairs with the locked bridge contract in [`packages/codec-image/src/decoders/types.ts`](../../packages/codec-image/src/decoders/types.ts).
+> _Tracker: [#283](https://github.com/p-to-q/wittgenstein/issues/283); per-candidate audits [#329–#333](https://github.com/p-to-q/wittgenstein/issues/329); Gates C/D [#334](https://github.com/p-to-q/wittgenstein/issues/334) + [#335](https://github.com/p-to-q/wittgenstein/issues/335)._
+
+**Scope:** Targeted prep for landing M1B (image route via frozen VQ decoder bridge) in Wittgenstein. Architecture under evaluation: LLM emits Visual Seed Code (short discrete sequence) → L4 adapter expands seed to tokenizer latent grid → frozen VQ decoder produces pixels. Constraints: Node.js / ONNX-CPU runtime, permissive code+weights, deterministic per-platform, hackathon-grade.
+
+---
+
+## 1. Tokenizer landscape (beyond LlamaGen)
+
+Numbers below are reconstruction FID (rFID) on ImageNet-1k 256×256 unless noted. Lower is better. All listed candidates have permissively licensed code; weight licenses are flagged separately.
+
+### LlamaGen VQ ([FoundationVision/LlamaGen](https://github.com/FoundationVision/LlamaGen), [arXiv 2406.06525](https://arxiv.org/abs/2406.06525))
+- **Tokenizer:** VQGAN-class, codebook K=16384, embedding dim C=8, downsample p=16 (so 256×256 → 16×16 = 256 tokens) or p=8 (32×32 = 1024 tokens). 72M / 70M params.
+- **Quality:** rFID = 2.19 at 256×256 (p=16), PSNR 20.79, SSIM 0.675, **codebook usage 97.0%**. Higher-res 384×384 training reports rFID 0.94.
+- **Wins:** Apache-2.0 code + checkpoints, small tokenizer (72M, ConvNet enc/dec — cheap on CPU), training recipe public, codebook is a single index lookup (clean for ONNX export).
+- **Loses:** Embedding dim 8 means latents are very low-rank per spatial site — the AR head carries semantic load. rFID 2.19 is not SOTA in 2026.
+- **Checkpoints:** `vq_ds16_c2i.pt` (ImageNet), `vq_ds8_c2i.pt`, `vq_ds16_t2i.pt` (LAION-COCO + internal) on [huggingface.co/FoundationVision/LlamaGen](https://huggingface.co/FoundationVision/LlamaGen) and [huggingface.co/peizesun/llamagen_t2i](https://huggingface.co/peizesun/llamagen_t2i).
+
+### Open-MAGVIT2 ([arXiv 2409.04410](https://arxiv.org/abs/2409.04410), [TencentARC/Open-MAGVIT2](https://github.com/TencentARC/Open-MAGVIT2))
+- **Tokenizer:** Lookup-Free Quantization (LFQ), codebook 2^18 = 262144 codes via factorized bit decomposition. Achieves **rFID 1.17 on ImageNet 256×256** (zero-shot 1.93 at original resolution).
+- **Wins:** SOTA-class reconstruction among open weights; explicitly designed to be reproducible.
+- **Loses:** Codebook is bit-factorized (asymmetric token factorization + next-sub-token-prediction). The token grid is NOT a simple integer index per site — any adapter has to either model the sub-token correlations or operate in bit space. Weights are Apache-2.0 but the bit-decomposition scheme adds engineering surface for an ONNX-CPU port.
+
+### TiTok ([arXiv 2406.07550](https://arxiv.org/abs/2406.07550), [bytedance/1d-tokenizer](https://github.com/bytedance/1d-tokenizer))
+- **Tokenizer:** 1D tokenizer (not a 2D grid). TiTok-L-32 represents a 256×256 image in **just 32 tokens**; rFID 2.21. TiTok-B-64: rFID 1.70. TiTok-S-128: rFID 1.71. Generation: 1.97 gFID at ImageNet-256.
+- **Wins:** Extremely short sequences — the natural fit for "Visual Seed Code" if the seed and the tokenizer share a representation. If Wittgenstein can adopt a 32-token target, the seed expander can vanish entirely (deterministic identity).
+- **Loses:** Apache-2.0 license verified for code; weight license needs re-verification. The 1D tokenizer interleaves a ViT-encoder pass, so it is heavier than LlamaGen's conv tokenizer on CPU. Smaller community / fewer reference downstream stacks. RFC-0007 (1D shape discriminator) is the schema-side prerequisite.
+
+### MaskBit ([arXiv 2409.16211](https://arxiv.org/abs/2409.16211), [markweberdev/maskbit](https://github.com/markweberdev/maskbit))
+- **Tokenizer:** Modernized VQGAN with Lookup-Free Quantization producing "bit tokens" (binary representation). Implicit codebook 64× smaller than MAGVIT-v2 yet generation reaches gFID 1.65 (12 bits) / 1.52 (best, 256 steps).
+- **Wins:** Embedding-free design; the bits ARE the tokens. Generation quality is strong.
+- **Loses:** Apache-2.0 code but research-only weights (ADR-0020 classifies this as research-track, not canonical). The embedding-free design means decoder input is bit vectors, not codebook embeddings — we lose the standard "look up an embedding by ID" path.
+
+### FSQ (Finite Scalar Quantization, [arXiv 2309.15505](https://arxiv.org/abs/2309.15505))
+- **Tokenizer:** Per-channel scalar quantization with fixed levels; implicit codebook is the Cartesian product of per-dim level sets. Codebook usage is 100% by construction; no collapse, no commitment loss, no codebook re-init.
+- **Wins:** Mechanically the simplest quantizer. Per-channel quant → trivial to implement, trivial to export to ONNX, deterministic with no codebook gather op.
+- **Loses:** No off-the-shelf large pre-trained image FSQ tokenizer with Apache-2.0 weights at the LlamaGen quality bar. We would have to either train one or wrap an FSQ-quantized VAE. Higher integration cost than just downloading LlamaGen's checkpoint.
+
+### A 6th candidate to surface: **VAR multi-scale VQVAE** ([arXiv 2404.02905](https://arxiv.org/abs/2404.02905), [FoundationVision/VAR](https://github.com/FoundationVision/VAR))
+- **Tokenizer:** Multi-scale VQ where the same image is tokenized at successive resolutions (1×1, 2×2, ..., 16×16). The AR model predicts "next scale" rather than "next token". NeurIPS 2024 Best Paper.
+- **Why it matters for M1B:** This is the natural mathematical realization of "seed expansion." A short seed = the coarse-scale tokens; the adapter would simply unfold scale-by-scale, exactly mirroring VAR's inference loop. **Strong candidate for the bridge architecture even if we keep LlamaGen as the actual tokenizer.**
+- **License:** Code Apache-2.0; weights distributed publicly on the same FoundationVision org.
+- **Caveat:** The multi-scale tokenizer is more complex than LlamaGen's single-scale ds16 VQ; checkpoint sizes and the rFID/scale tradeoff need a second-pass evaluation before adopting wholesale.
+
+### Inference latency at 256×256 (CPU, ONNX-class)
+Published latency numbers for these tokenizers on CPU are sparse; most papers report GPU-only figures. Practical expectations for ONNX-CPU dequantized models:
+- LlamaGen ds16 (~72M conv): ~150–400 ms/image single-thread on a modern x86 core (educated estimate; needs measurement).
+- MAGVIT2 / Open-MAGVIT2 decoder: ~2–3× LlamaGen due to wider hidden dims and LFQ unpacking — needs measurement.
+- TiTok-L decoder (ViT): potentially heavier due to attention; needs measurement.
+- FSQ-only quantizer step: negligible (<1ms); the cost is in the conv encoder/decoder shell, not the quantizer.
+
+**Recommendation:** Stick with **LlamaGen `vq_ds16_c2i.pt`**. Reasons: code+weights Apache-2.0 already cleared; conv-based tokenizer is the cheapest CPU candidate; rFID 2.19 is "hackathon-grade good enough"; the latent is the cleanest possible 16×16 integer grid which makes the adapter math trivial. **Open-MAGVIT2 is the strong upgrade path once M1B is shipped**; **VAR is the M1C architectural option** if learned adapter becomes necessary.
+
+---
+
+## 2. Image dataset landscape (May 2026 status)
+
+| Dataset | License (data + redistribution) | Size | Tokenizer eval bench | Adapter training | End-to-end FT | Notes |
+|---|---|---|---|---|---|---|
+| **ImageNet-1k** | Custom non-commercial research license; image URLs from Flickr/etc. with original copyrights. Annotations CC. | 1.28M train / 50k val | **YES (canonical rFID/PSNR/SSIM)** | Possible but narrow | Class-conditional only | The single most defensible eval bench. Used by every paper in this note. |
+| **LAION-400M / LAION-5B (original)** | **Withdrawn** Dec 2023 after CSAM finding. Do not use the original. | n/a | No | No | No | Original 400M/5B are gone. |
+| **Re-LAION-5B** (Aug 2024 re-release) | URL list under Apache-2.0; image content under each source site's license. CSAM hashes removed. Two flavors: research, research-safe. | ~5B URLs | Possible | Possible | Yes (text-conditional) | URL-only dataset, you still scrape. Many URLs dead-link by 2026. **Recommend NOT M1B** unless an img2dataset pipeline already exists. |
+| **CC12M (Conceptual 12M)** | Google's dataset under permissive "free for any purpose" license; URL+caption list distributed; images still hosted by original publishers. | ~12M | Useful (diverse stress) | Adequate for small adapter | Adequate for small text-conditional FT | Still hosted on [google-research-datasets/conceptual-12m](https://github.com/google-research-datasets/conceptual-12m) and [pixparse/cc12m-wds](https://huggingface.co/datasets/pixparse/cc12m-wds). URL rot exists but a sizable fraction still downloadable. |
+| **OpenImages V7** | Annotations CC BY 4.0; images CC BY 2.0 per source (verify per-image). Full download ~561 GB. | ~9M train / 41k val / 125k test | Useful for "in-the-wild" eval split | Suitable | Suitable for class- or detection-conditional | Hosted on Google Cloud Storage; reliable. Heavier than needed for M1B. |
+| **DataComp-1B** | URL list CC-BY-4.0; images under their copyrights. | ~1.4B URLs (8.86 TB realized) | Overkill | Overkill | Overkill | Far past hackathon budget. |
+| **COCO 2017** | Annotations CC BY 4.0; images under per-image Flickr terms (most non-commercial; full commercial use NOT guaranteed). | ~118k train / 5k val | **YES (MS-COCO FID-30K is the standard text-to-image eval)** | Small | Yes for prompt-style FT | Standard text-to-image eval bench. License is acceptable for research/eval but commercial redistribution of images is restricted. |
+| **Flickr30K** | Images from Flickr under their per-image licenses (non-commercial in practice); annotations academic-use. | ~31k images / 158k captions | OK for small text-eval | OK | OK | Smaller cousin of COCO captions; same Flickr license caveats. |
+| **FFHQ** | Dataset wrapper CC BY-NC-SA 4.0 (NVIDIA), images CC BY / CC0 / public-domain per-image. **Non-commercial only**. | 70k images 1024×1024 | OK (face-only stress) | OK if face-only | OK if face-only | Useful as a "high-quality narrow distribution" sanity bench but license blocks commercial. |
+| **ShareGPT4V** | CC BY-NC 4.0; research only. | 1.2M image-caption pairs | Limited | Caption-quality FT only | LLaVA-style only | Mostly LLM-caption-quality dataset, not a tokenizer benchmark. Non-commercial. |
+
+**Eval-bench recommendation:** **ImageNet-1k validation (50k images)** for reconstruction metrics (rFID, PSNR, SSIM, LPIPS) and **MS-COCO 2017 val (5k images, 25k captions)** for FID-30K / CLIP-score generation evaluation. Both are de-facto standards and exactly match LlamaGen's published numbers, which keeps our results comparable to the paper.
+
+**Adapter-training recommendation:** If the L4 adapter ends up learned, train on **CC12M filtered to ImageNet aspect ratios** plus the ImageNet train split. License is friendly and the volume is comfortable for a small bridge network. **Do NOT touch Re-LAION-5B for M1B** — URL scraping and dead links blow the hackathon budget.
+
+---
+
+## 3. LlamaGen training recipe deep-dive
+
+Source: [arXiv 2406.06525](https://arxiv.org/abs/2406.06525) and [FoundationVision/LlamaGen](https://github.com/FoundationVision/LlamaGen).
+
+### Tokenizer training
+- **Architecture:** VQGAN encoder-quantizer-decoder. Codebook K=16384, embedding dim C=8 (intentionally low — L2-normalized lookups). Downsample factor p=16 → 16×16 token grid for 256×256 input.
+- **Data:** ImageNet-1k train split, 256×256 resolution (also a 384×384 high-res run for rFID 0.94).
+- **Optimizer:** AdamW, β₁=0.9, β₂=0.95, weight decay=0.05, constant LR 1e-4.
+- **Batch size:** 128.
+- **Epochs:** 40.
+- **Losses:** L2 reconstruction + LPIPS perceptual + PatchGAN adversarial (turned on after 20k iterations) + commitment loss with β=0.25. λ_G = 0.5.
+- **Hardware:** 80GB A100 GPUs (count unspecified but the recipe is small enough to fit a few A100s).
+
+### Class-conditional AR head (c2i)
+- **Data:** ImageNet, 256×256 or 384×384.
+- **Optimizer:** AdamW (same betas, wd), LR scaled at 1e-4 per 256 batch size.
+- **Regularization:** Dropout 0.1 on embeddings and attention; 10-crop augmentation with random selection per step.
+- **Distributed:** DDP / PyTorch FSDP on A100-80GB.
+- **Epochs:** ~300 (visible images by epoch 10 per author comments).
+- **Best result:** LlamaGen-3B reaches FID 2.18 at 256×256.
+
+### Text-conditional (t2i)
+- Two-stage: Stage I on **50M LAION-COCO subset** at 256×256, Stage II on a 10M internal aesthetics-filtered set at 512×512.
+- Text encoder: FLAN-T5 XL, max 120 text tokens.
+- LR 1e-4 per 256 batch size, same optimizer.
+
+### Checkpoint hosting and updates
+- **Tokenizer + class-conditional:** [huggingface.co/FoundationVision/LlamaGen](https://huggingface.co/FoundationVision/LlamaGen) (`vq_ds16_c2i.pt`, `vq_ds8_c2i.pt`, `c2i_B_256.pt`, `c2i_L_256.pt`, `c2i_XL_384L.pt`, `c2i_XXL_384.pt`, `c2i_3B_384.pt`).
+- **Text-conditional:** [huggingface.co/peizesun/llamagen_t2i](https://huggingface.co/peizesun/llamagen_t2i).
+- **Last release activity:** 2024-06-28 (t2i drop) and 2024-06-15 (vLLM support). Repo has been quiet since — no breaking checkpoint format changes to worry about, but also no upstream maintenance to free-ride on.
+
+### Inference cost (reported)
+- vLLM-integrated AR inference yields 326–414% speedup vs the naive PyTorch baseline.
+- **Tokenizer-only forward** is conv-net, cheap; no specific CPU/ONNX latency published. **This is the empirical gap to close before M1B ships** (see Open Questions).
+
+---
+
+## 4. Adapter / Seed-Expander training approaches
+
+The L4 adapter sits between the LLM's Visual Seed Code (short discrete sequence, length S << 256) and the tokenizer latent grid (16×16=256 sites). Four families surveyed.
+
+### (A) Deterministic positional unfolding
+Treat the seed code as the coarse-scale tokens. Tile / repeat / interleave deterministically to fill the 16×16 grid, then feed straight into the decoder. **No training.** The Visual Seed Code IS the latent grid at low resolution; the adapter is a fixed upsampling op (nearest-neighbor or learned-fixed PixelShuffle weights).
+
+- Closest published instantiation: **VAR** ([arXiv 2404.02905](https://arxiv.org/abs/2404.02905)) — the multi-scale VQVAE tokenizer is literally a learned deterministic-unfolding stack. Won NeurIPS 2024 Best Paper.
+- **Pros:** zero training compute; deterministic by construction; trivially exports to ONNX; the LLM "owns" the entire image semantics. Hackathon-perfect.
+- **Cons:** image quality is bounded by what 16 or 64 coarse tokens can encode through a nearest-upsampled latent. If the seed is too short the decoder will produce blocky/low-frequency outputs.
+
+### (B) MaskGIT-style iterative unmasking
+([arXiv 2202.04200](https://arxiv.org/abs/2202.04200)) Adapter is a small bidirectional transformer that fills in the masked tokens conditioned on the seed. Iterative parallel decoding (typically 8–16 steps) over the 256-token grid.
+
+- **Pros:** empirically strong — this is the spine of Muse ([arXiv 2301.00704](https://arxiv.org/abs/2301.00704), FID 7.88 on COCO zero-shot at 3B params). Bounded inference cost.
+- **Cons:** requires training a small transformer adapter on (seed, full-token-grid) pairs. Stochastic decoding works against the determinism constraint unless we fix the schedule and sampling temperature = 0.
+
+### (C) LlamaGen-style AR head
+A small causal transformer fills the 256 tokens left-to-right conditioned on the seed.
+
+- **Pros:** direct match to LlamaGen's published recipe; reuses code.
+- **Cons:** 256 sequential decode steps per image is expensive on CPU; less compatible with "small bridge network" framing. The whole point of having a separate seed is to AVOID making the LLM emit 256 tokens.
+
+### (D) Diffusion bridge (VQ-Diffusion / discrete diffusion)
+([arXiv 2111.14822](https://arxiv.org/abs/2111.14822), [arXiv 2202.04895](https://arxiv.org/abs/2202.04895)) Diffusion in discrete token space, conditioned on seed.
+
+- **Pros:** high quality at large generation budgets.
+- **Cons:** 50–100+ denoising steps; non-deterministic without aggressive schedule fixing; mismatched with the ONNX-CPU/hackathon target.
+
+### Recommendation: **start deterministic (A), keep MaskGIT (B) as the upgrade**
+
+For M1B's first cut:
+1. Define the Visual Seed Code as the LlamaGen 16×16 token grid downsampled by k=2 (so 8×8=64 seed tokens) or k=4 (4×4=16 seed tokens).
+2. The L4 adapter is a fixed PixelShuffle-style replicate to 16×16 (no learnable weights). The decoder smooths spatial discontinuities.
+3. Measure rFID, PSNR, LPIPS against the ground-truth-tokenized latent. If quality is unacceptable at k=4, fall back to k=2; if still unacceptable, promote to MaskGIT-style fill-in (path B).
+4. The learned MaskGIT adapter, when needed, trains on (seed, full-grid) pairs extracted from ImageNet via the LlamaGen tokenizer. Training set is finite (1.28M ImageNet images → 1.28M (seed, grid) pairs), bridge net is small (e.g., 6-layer transformer, 256-dim), training fits on a single GPU-day.
+
+The "start deterministic" call is load-bearing because (i) it ships M1B with zero training; (ii) it makes the per-platform determinism trivial (no sampling); (iii) it produces a hard empirical baseline against which any learned adapter must justify itself.
+
+---
+
+## 5. Quality metric ladder for shipping M1B
+
+Three rungs, each with a clear definition of "ship-ready" and the compute cost.
+
+### Rung 1: Reconstruction fidelity (tokenizer round-trip alone)
+Image → encode → quantize → decode → image. Measures how much information the frozen decoder discards.
+- **Metrics:** PSNR, SSIM, LPIPS (AlexNet backbone), rFID.
+- **Eval set:** ImageNet-1k val, 50k images, 256×256 center-cropped.
+- **Targets to ship:** PSNR ≥ 20, SSIM ≥ 0.65, LPIPS ≤ 0.20, rFID ≤ 3.0. These match LlamaGen's published baseline (PSNR 20.79 / SSIM 0.675 / rFID 2.19).
+- **Compute:** rFID requires Inception-V3 features on 50k real + 50k recon. About 5–15 minutes single-A10G; an order of magnitude longer on CPU. Budget a couple of hours per eval run on CPU, single hour on a small GPU.
+
+### Rung 2: Seed-expanded reconstruction (adapter round-trip)
+Image → encode → downsample to seed → L4 adapter → decoder → image. Measures the seed expander's information loss on top of the tokenizer's.
+- **Metrics:** Same four as Rung 1.
+- **Eval set:** Same ImageNet-1k val 50k. Optional secondary: COCO 2017 val 5k for distribution-shift signal.
+- **Targets to ship:** A reasonable bar is "no worse than 2× degradation of Rung 1 LPIPS" — e.g., LPIPS ≤ 0.40, SSIM ≥ 0.55. This is intentionally lenient because the seed is information-bottlenecked by construction.
+
+### Rung 3: Generative quality (end-to-end with the LLM speaking)
+LLM emits seed → adapter → decoder → image.
+- **Metrics:** FID-30K against MS-COCO val captions (field-standard); CLIP-score (ViT-L/14) for prompt alignment; human eyeball for sanity.
+- **Eval set:** 30,000 captions drawn from COCO val captions (the FID-30K convention) producing 30k images.
+- **Targets to ship:** Pre-register "ship if FID-30K < 50 AND CLIP-score > 0.22". This is intentionally permissive; M1B is a structural milestone, not a quality milestone.
+- **Compute:** 30k generations is the dominant cost. At ~5 sec per image on CPU, 30k images ≈ 42 hours on a single CPU. **Realistic options: (i) ship Rung 3 on a 5k FID-5K subsample, (ii) run on a one-off GPU rental, (iii) defer Rung 3 to M1C and ship M1B on Rungs 1+2 only.**
+
+### Hardware-on-a-budget plan
+- Local CPU box: all of Rung 1 and Rung 2 (slow but feasible overnight).
+- Single Colab A10G or a $5 cloud spot: Rung 3 at 30k in under an hour.
+- Reference impls: [cleanfid](https://github.com/GaParmar/clean-fid), [lpips pip](https://github.com/richzhang/PerceptualSimilarity), [open_clip](https://github.com/mlfoundations/open_clip).
+
+---
+
+## Open empirical questions (whose answer changes the M1B path)
+
+1. **What is the LlamaGen ds16 tokenizer's actual CPU latency in ONNX?** No published number; must be measured. If decode > 1 second/image single-thread, the "ONNX-CPU preferred" framing needs revisiting.
+2. **Does the ONNX export of LlamaGen's tokenizer preserve bit-identical outputs vs PyTorch?** Determinism constraint requires this. Conv + a single argmin gather should be fine but the GAN-trained decoder may have ops (e.g., GroupNorm with rare reductions) that differ across ONNX runtimes.
+3. **At what seed length S does deterministic positional unfolding break perceptual quality?** Empirical sweep: S = 4, 16, 64, 256 (= full). Determines whether path (A) ships M1B or we must promote to MaskGIT.
+4. **Is the LlamaGen ds16 c2i tokenizer (trained on ImageNet) good enough for non-ImageNet distributions** (COCO, CC12M, drawings)? Zero-shot rFID on COCO val is the test.
+5. **Codebook utilization on Wittgenstein's actual emitted seeds.** If the LLM-emitted seed touches only a small subset of the 16384-codebook in practice, we have a free quantization opportunity (collapse to a sub-codebook), reduce embedding-table memory.
+6. **Does Open-MAGVIT2 with its 2^18 codebook beat LlamaGen on perceived quality enough to justify the bit-factorization engineering overhead?**
+7. **Is the VAR multi-scale tokenizer a better fit than LlamaGen ds16 + deterministic unfolding?** Side-by-side would settle the architecture question for M1C, not just M1B.
+
+---
+
+## Recommended minimum first-cut
+
+**For M1B specifically:** Use the **LlamaGen `vq_ds16_c2i.pt` tokenizer** (Apache-2.0, 72M params, conv enc/dec, codebook K=16384 / dim 8 / downsample 16 → 16×16 token grid). Export the decoder-only path to ONNX-CPU. Define the Visual Seed Code as the 16×16 LlamaGen token grid downsampled by an integer factor (start k=2 → 8×8=64 seed tokens; iterate if quality demands). Implement the **L4 adapter as deterministic PixelShuffle-style replicate** with no learnable weights for the first cut — no adapter training, no extra GPU budget, fully deterministic by construction. Validate on **ImageNet-1k validation 50k for reconstruction (PSNR/SSIM/LPIPS/rFID)** and defer generative FID-30K to a one-off GPU rental or to M1C.
+
+**Why this and not the SOTA path:** Open-MAGVIT2 has better rFID and TiTok has shorter sequences but both add engineering surface (bit-factorization, ViT decoder, less-mature ONNX support) at a stage where Wittgenstein's project risk is in the bridge architecture, not in tokenizer fidelity. LlamaGen's tokenizer is unambiguously good enough at rFID ~2 and is the path of least resistance to a green-light M1B. **If** the first-cut quality is insufficient on the ImageNet-val Rung-1 eval, the cheap upgrade is to retrain a slightly-larger LlamaGen tokenizer on ImageNet+CC12M; the more expensive upgrade is the Open-MAGVIT2 swap, deferred to M1C. **If** the adapter quality is insufficient on the Rung-2 eval, the cheap upgrade is to extend k from 4 to 2 (more seed tokens), and the more expensive upgrade is a learned MaskGIT-style fill-in adapter trained on ImageNet (seed, grid) pairs.
+
+---
+
+## Headline decisions to act on
+
+1. **Tokenizer:** LlamaGen `vq_ds16_c2i.pt`. Defer Open-MAGVIT2 swap to M1C.
+2. **Adapter:** Deterministic PixelShuffle-replicate, no training. Promote to MaskGIT-style fill-in only if Rung-2 LPIPS/SSIM fails.
+3. **Eval bench:** ImageNet-1k val 50k (Rungs 1+2) plus COCO-val for Rung-3 generative scoring (FID-30K subsampled to 5k if budget-constrained).
+4. **Adapter training data, if needed later:** CC12M filtered + ImageNet. Avoid Re-LAION-5B for M1B.
+5. **Architectural option to surface for M1C:** VAR multi-scale tokenizer is the principled "seed expansion" baseline.
+
+---
+
+## Refs
+
+**Tokenizers and generation backbones:**
+- LlamaGen: [arXiv:2406.06525](https://arxiv.org/abs/2406.06525) · [github](https://github.com/FoundationVision/LlamaGen) · [HF weights](https://huggingface.co/FoundationVision/LlamaGen)
+- Open-MAGVIT2: [arXiv:2409.04410](https://arxiv.org/abs/2409.04410) · [github](https://github.com/TencentARC/Open-MAGVIT2)
+- MAGVIT-v2 (original): [arXiv:2310.05737](https://arxiv.org/abs/2310.05737)
+- TiTok: [arXiv:2406.07550](https://arxiv.org/abs/2406.07550) · [bytedance/1d-tokenizer](https://github.com/bytedance/1d-tokenizer)
+- MaskBit: [arXiv:2409.16211](https://arxiv.org/abs/2409.16211) · [markweberdev/maskbit](https://github.com/markweberdev/maskbit)
+- FSQ: [arXiv:2309.15505](https://arxiv.org/abs/2309.15505)
+- VAR (next-scale prediction): [arXiv:2404.02905](https://arxiv.org/abs/2404.02905) · [FoundationVision/VAR](https://github.com/FoundationVision/VAR)
+
+**Adapter / generation paradigms:**
+- MaskGIT: [arXiv:2202.04200](https://arxiv.org/abs/2202.04200)
+- Muse: [arXiv:2301.00704](https://arxiv.org/abs/2301.00704)
+- VQ-Diffusion (text-to-image): [arXiv:2111.14822](https://arxiv.org/abs/2111.14822)
+- Diffusion bridges VQ-VAE: [arXiv:2202.04895](https://arxiv.org/abs/2202.04895)
+
+**Datasets:**
+- ImageNet (ILSVRC): [image-net.org](https://www.image-net.org/)
+- Re-LAION-5B: [blog](https://laion.ai/blog/relaion-5b/)
+- CC12M: [arXiv:2102.08981](https://arxiv.org/abs/2102.08981) · [github](https://github.com/google-research-datasets/conceptual-12m) · [pixparse/cc12m-wds](https://huggingface.co/datasets/pixparse/cc12m-wds)
+- DataComp-1B: [arXiv:2304.14108](https://arxiv.org/abs/2304.14108) · [HF](https://huggingface.co/datasets/mlfoundations/datacomp_1b)
+- COCO 2017: [cocodataset.org](https://cocodataset.org/) · [HF mirror](https://huggingface.co/datasets/rafaelpadilla/coco2017)
+- Flickr30K: [hosted](https://shannon.cs.illinois.edu/DenotationGraph/)
+- OpenImages V7: [Google CS](https://storage.googleapis.com/openimages/web/factsfigures_v7.html)
+- FFHQ: [github](https://github.com/NVlabs/ffhq-dataset)
+- ShareGPT4V: [arXiv:2311.12793](https://arxiv.org/abs/2311.12793)
+
+**Evaluation infrastructure:**
+- Rethinking FID (CMMD): [arXiv:2401.09603](https://arxiv.org/abs/2401.09603)
+- LPIPS: [reference impl](https://github.com/richzhang/PerceptualSimilarity)
+- cleanfid: [github](https://github.com/GaParmar/clean-fid)
+- open_clip: [github](https://github.com/mlfoundations/open_clip)

--- a/docs/research/2026-05-13-m1b-prep-research.md
+++ b/docs/research/2026-05-13-m1b-prep-research.md
@@ -142,7 +142,7 @@ Source: [arXiv 2406.06525](https://arxiv.org/abs/2406.06525) and [FoundationVisi
 
 - **Tokenizer + class-conditional:** [huggingface.co/FoundationVision/LlamaGen](https://huggingface.co/FoundationVision/LlamaGen) (`vq_ds16_c2i.pt`, `vq_ds8_c2i.pt`, `c2i_B_256.pt`, `c2i_L_256.pt`, `c2i_XL_384L.pt`, `c2i_XXL_384.pt`, `c2i_3B_384.pt`).
 - **Text-conditional:** [huggingface.co/peizesun/llamagen_t2i](https://huggingface.co/peizesun/llamagen_t2i).
-- **Last release activity:** 2024-06-28 (t2i drop) and 2024-06-15 (vLLM support). Repo has been quiet since — no breaking checkpoint format changes to worry about, but also no upstream maintenance to free-ride on.
+- **Last release activity:** 2024-06-28 (t2i drop) and 2024-06-15 (vLLM support). Repo has been quiet since; no breaking checkpoint format changes were observed as of 2026-05-13, but re-validate before pinning weights because there is also no upstream maintenance to free-ride on.
 
 ### Inference cost (reported)
 

--- a/docs/research/2026-05-13-m1b-prep-research.md
+++ b/docs/research/2026-05-13-m1b-prep-research.md
@@ -1,17 +1,34 @@
 ---
 date: 2026-05-13
-status: research note (decision-oriented)
+status: research note (decision-oriented) — Phase 0 floor; superseded by Phase 1+ research program
 labels: [research-derived, m1b-image, training, dataset, adapter, eval]
 tracks: [#283, #259, #334, #335]
 feeds-into: M1B implementation slices
+superseded-by: docs/research/2026-05-13-wittgenstein-research-program.md
 ---
 
-# M1B Prep Research: Tokenizer, Dataset, Adapter, Eval
+# M1B Prep Research: Tokenizer, Dataset, Adapter, Eval (Phase 0 floor)
 
-> **Status:** decision-oriented research note. Surveys the empirical landscape ahead of M1B wiring so the implementation slice is a contract-fill, not a design-from-scratch. Pairs with the locked bridge contract in [`packages/codec-image/src/decoders/types.ts`](../../packages/codec-image/src/decoders/types.ts).
+> **🔁 Status update (2026-05-13, same day):** This note was drafted under
+> hackathon-grade constraints (ONNX-CPU runtime, no training compute,
+> ship-floor quality bar). **Those constraints were lifted later the same
+> day** when the maintainer confirmed GPU-rich compute and reframed the
+> project as top-tier engineering / research / hacker work.
+>
+> The canonical research direction is now
+> [`docs/research/2026-05-13-wittgenstein-research-program.md`](2026-05-13-wittgenstein-research-program.md),
+> which supersedes the recommendations below.
+>
+> This note STAYS in the tree because (a) the **Phase 0 floor** it
+> recommends is still the right shipping path if compute or budget
+> evaporates, and (b) the literature survey (§1–§5) remains accurate
+> regardless of compute posture. Read this note for the landscape; read
+> the research-program note for the chosen path.
+
+> **Status (original):** decision-oriented research note. Surveys the empirical landscape ahead of M1B wiring so the implementation slice is a contract-fill, not a design-from-scratch. Pairs with the locked bridge contract in [`packages/codec-image/src/decoders/types.ts`](../../packages/codec-image/src/decoders/types.ts).
 > _Tracker: [#283](https://github.com/p-to-q/wittgenstein/issues/283); per-candidate audits [#329–#333](https://github.com/p-to-q/wittgenstein/issues/329); Gates C/D [#334](https://github.com/p-to-q/wittgenstein/issues/334) + [#335](https://github.com/p-to-q/wittgenstein/issues/335)._
 
-**Scope:** Targeted prep for landing M1B (image route via frozen VQ decoder bridge) in Wittgenstein. Architecture under evaluation: LLM emits Visual Seed Code (short discrete sequence) → L4 adapter expands seed to tokenizer latent grid → frozen VQ decoder produces pixels. Constraints: Node.js / ONNX-CPU runtime, permissive code+weights, deterministic per-platform, hackathon-grade.
+**Scope:** Targeted prep for landing M1B (image route via frozen VQ decoder bridge) in Wittgenstein. Architecture under evaluation: LLM emits Visual Seed Code (short discrete sequence) → L4 adapter expands seed to tokenizer latent grid → frozen VQ decoder produces pixels. **Original constraints (Phase 0 floor):** Node.js / ONNX-CPU runtime, permissive code+weights, deterministic per-platform, hackathon-grade. **Reframed Phase 1+ constraints:** see the [research-program note](2026-05-13-wittgenstein-research-program.md).
 
 ---
 
@@ -230,15 +247,30 @@ LLM emits seed → adapter → decoder → image.
 
 ---
 
-## Recommended minimum first-cut
+## Recommended minimum first-cut (Phase 0 floor only)
 
-**For M1B specifically:** Use the **LlamaGen `vq_ds16_c2i.pt` tokenizer** (Apache-2.0, 72M params, conv enc/dec, codebook K=16384 / dim 8 / downsample 16 → 16×16 token grid). Export the decoder-only path to ONNX-CPU. Define the Visual Seed Code as the 16×16 LlamaGen token grid downsampled by an integer factor (start k=2 → 8×8=64 seed tokens; iterate if quality demands). Implement the **L4 adapter as deterministic PixelShuffle-style replicate** with no learnable weights for the first cut — no adapter training, no extra GPU budget, fully deterministic by construction. Validate on **ImageNet-1k validation 50k for reconstruction (PSNR/SSIM/LPIPS/rFID)** and defer generative FID-30K to a one-off GPU rental or to M1C.
+> **⚠️ Superseded:** this section is the **floor** recommendation that
+> applies only if the compute / budget / staffing situation reverts to
+> hackathon-grade. The actual chosen direction is in
+> [`2026-05-13-wittgenstein-research-program.md`](2026-05-13-wittgenstein-research-program.md) Phase 1:
+> own-trained tokenizer + learned MaskGIT-style adapter + native LLM head,
+> targeting SOTA-adjacent quality with full eval matrix.
 
-**Why this and not the SOTA path:** Open-MAGVIT2 has better rFID and TiTok has shorter sequences but both add engineering surface (bit-factorization, ViT decoder, less-mature ONNX support) at a stage where Wittgenstein's project risk is in the bridge architecture, not in tokenizer fidelity. LlamaGen's tokenizer is unambiguously good enough at rFID ~2 and is the path of least resistance to a green-light M1B. **If** the first-cut quality is insufficient on the ImageNet-val Rung-1 eval, the cheap upgrade is to retrain a slightly-larger LlamaGen tokenizer on ImageNet+CC12M; the more expensive upgrade is the Open-MAGVIT2 swap, deferred to M1C. **If** the adapter quality is insufficient on the Rung-2 eval, the cheap upgrade is to extend k from 4 to 2 (more seed tokens), and the more expensive upgrade is a learned MaskGIT-style fill-in adapter trained on ImageNet (seed, grid) pairs.
+**Phase 0 floor (for archival completeness):** Use the **LlamaGen `vq_ds16_c2i.pt` tokenizer** (Apache-2.0, 72M params, conv enc/dec, codebook K=16384 / dim 8 / downsample 16 → 16×16 token grid). Export the decoder-only path to ONNX-CPU. Define the Visual Seed Code as the 16×16 LlamaGen token grid downsampled by an integer factor (start k=2 → 8×8=64 seed tokens; iterate if quality demands). Implement the **L4 adapter as deterministic PixelShuffle-style replicate** with no learnable weights for the first cut — no adapter training, no extra GPU budget, fully deterministic by construction. Validate on **ImageNet-1k validation 50k for reconstruction (PSNR/SSIM/LPIPS/rFID)** and defer generative FID-30K to a one-off GPU rental or to M1C.
+
+**Why this and not the SOTA path (Phase 0 reasoning):** Open-MAGVIT2 has better rFID and TiTok has shorter sequences but both add engineering surface (bit-factorization, ViT decoder, less-mature ONNX support) at a stage where Wittgenstein's project risk is in the bridge architecture, not in tokenizer fidelity. LlamaGen's tokenizer is unambiguously good enough at rFID ~2 and is the path of least resistance to a green-light M1B. **If** the first-cut quality is insufficient on the ImageNet-val Rung-1 eval, the cheap upgrade is to retrain a slightly-larger LlamaGen tokenizer on ImageNet+CC12M; the more expensive upgrade is the Open-MAGVIT2 swap, deferred to M1C. **If** the adapter quality is insufficient on the Rung-2 eval, the cheap upgrade is to extend k from 4 to 2 (more seed tokens), and the more expensive upgrade is a learned MaskGIT-style fill-in adapter trained on ImageNet (seed, grid) pairs.
+
+> Under the **reframed (compute-rich) constraints**, the answer flips on
+> nearly every line: own-trained tokenizer beats LlamaGen consumption;
+> learned adapter beats deterministic replicate; full FID-30K beats 5K
+> subsample; SOTA-adjacent ship bar beats hackathon-grade. The §1 / §2 /
+> §4 / §5 survey content stays useful; the recommendations don't.
 
 ---
 
-## Headline decisions to act on
+## Headline decisions (Phase 0 floor)
+
+> Replaced by [research-program §"Phase 1 — M1B with own-trained models"](2026-05-13-wittgenstein-research-program.md). Kept here for archival comparison.
 
 1. **Tokenizer:** LlamaGen `vq_ds16_c2i.pt`. Defer Open-MAGVIT2 swap to M1C.
 2. **Adapter:** Deterministic PixelShuffle-replicate, no training. Promote to MaskGIT-style fill-in only if Rung-2 LPIPS/SSIM fails.

--- a/docs/research/2026-05-13-m1b-prep-research.md
+++ b/docs/research/2026-05-13-m1b-prep-research.md
@@ -20,6 +20,7 @@ feeds-into: M1B implementation slices
 Numbers below are reconstruction FID (rFID) on ImageNet-1k 256×256 unless noted. Lower is better. All listed candidates have permissively licensed code; weight licenses are flagged separately.
 
 ### LlamaGen VQ ([FoundationVision/LlamaGen](https://github.com/FoundationVision/LlamaGen), [arXiv 2406.06525](https://arxiv.org/abs/2406.06525))
+
 - **Tokenizer:** VQGAN-class, codebook K=16384, embedding dim C=8, downsample p=16 (so 256×256 → 16×16 = 256 tokens) or p=8 (32×32 = 1024 tokens). 72M / 70M params.
 - **Quality:** rFID = 2.19 at 256×256 (p=16), PSNR 20.79, SSIM 0.675, **codebook usage 97.0%**. Higher-res 384×384 training reports rFID 0.94.
 - **Wins:** Apache-2.0 code + checkpoints, small tokenizer (72M, ConvNet enc/dec — cheap on CPU), training recipe public, codebook is a single index lookup (clean for ONNX export).
@@ -27,33 +28,40 @@ Numbers below are reconstruction FID (rFID) on ImageNet-1k 256×256 unless noted
 - **Checkpoints:** `vq_ds16_c2i.pt` (ImageNet), `vq_ds8_c2i.pt`, `vq_ds16_t2i.pt` (LAION-COCO + internal) on [huggingface.co/FoundationVision/LlamaGen](https://huggingface.co/FoundationVision/LlamaGen) and [huggingface.co/peizesun/llamagen_t2i](https://huggingface.co/peizesun/llamagen_t2i).
 
 ### Open-MAGVIT2 ([arXiv 2409.04410](https://arxiv.org/abs/2409.04410), [TencentARC/Open-MAGVIT2](https://github.com/TencentARC/Open-MAGVIT2))
+
 - **Tokenizer:** Lookup-Free Quantization (LFQ), codebook 2^18 = 262144 codes via factorized bit decomposition. Achieves **rFID 1.17 on ImageNet 256×256** (zero-shot 1.93 at original resolution).
 - **Wins:** SOTA-class reconstruction among open weights; explicitly designed to be reproducible.
 - **Loses:** Codebook is bit-factorized (asymmetric token factorization + next-sub-token-prediction). The token grid is NOT a simple integer index per site — any adapter has to either model the sub-token correlations or operate in bit space. Weights are Apache-2.0 but the bit-decomposition scheme adds engineering surface for an ONNX-CPU port.
 
 ### TiTok ([arXiv 2406.07550](https://arxiv.org/abs/2406.07550), [bytedance/1d-tokenizer](https://github.com/bytedance/1d-tokenizer))
+
 - **Tokenizer:** 1D tokenizer (not a 2D grid). TiTok-L-32 represents a 256×256 image in **just 32 tokens**; rFID 2.21. TiTok-B-64: rFID 1.70. TiTok-S-128: rFID 1.71. Generation: 1.97 gFID at ImageNet-256.
 - **Wins:** Extremely short sequences — the natural fit for "Visual Seed Code" if the seed and the tokenizer share a representation. If Wittgenstein can adopt a 32-token target, the seed expander can vanish entirely (deterministic identity).
 - **Loses:** Apache-2.0 license verified for code; weight license needs re-verification. The 1D tokenizer interleaves a ViT-encoder pass, so it is heavier than LlamaGen's conv tokenizer on CPU. Smaller community / fewer reference downstream stacks. RFC-0007 (1D shape discriminator) is the schema-side prerequisite.
 
 ### MaskBit ([arXiv 2409.16211](https://arxiv.org/abs/2409.16211), [markweberdev/maskbit](https://github.com/markweberdev/maskbit))
+
 - **Tokenizer:** Modernized VQGAN with Lookup-Free Quantization producing "bit tokens" (binary representation). Implicit codebook 64× smaller than MAGVIT-v2 yet generation reaches gFID 1.65 (12 bits) / 1.52 (best, 256 steps).
 - **Wins:** Embedding-free design; the bits ARE the tokens. Generation quality is strong.
 - **Loses:** Apache-2.0 code but research-only weights (ADR-0020 classifies this as research-track, not canonical). The embedding-free design means decoder input is bit vectors, not codebook embeddings — we lose the standard "look up an embedding by ID" path.
 
 ### FSQ (Finite Scalar Quantization, [arXiv 2309.15505](https://arxiv.org/abs/2309.15505))
+
 - **Tokenizer:** Per-channel scalar quantization with fixed levels; implicit codebook is the Cartesian product of per-dim level sets. Codebook usage is 100% by construction; no collapse, no commitment loss, no codebook re-init.
 - **Wins:** Mechanically the simplest quantizer. Per-channel quant → trivial to implement, trivial to export to ONNX, deterministic with no codebook gather op.
 - **Loses:** No off-the-shelf large pre-trained image FSQ tokenizer with Apache-2.0 weights at the LlamaGen quality bar. We would have to either train one or wrap an FSQ-quantized VAE. Higher integration cost than just downloading LlamaGen's checkpoint.
 
 ### A 6th candidate to surface: **VAR multi-scale VQVAE** ([arXiv 2404.02905](https://arxiv.org/abs/2404.02905), [FoundationVision/VAR](https://github.com/FoundationVision/VAR))
+
 - **Tokenizer:** Multi-scale VQ where the same image is tokenized at successive resolutions (1×1, 2×2, ..., 16×16). The AR model predicts "next scale" rather than "next token". NeurIPS 2024 Best Paper.
 - **Why it matters for M1B:** This is the natural mathematical realization of "seed expansion." A short seed = the coarse-scale tokens; the adapter would simply unfold scale-by-scale, exactly mirroring VAR's inference loop. **Strong candidate for the bridge architecture even if we keep LlamaGen as the actual tokenizer.**
 - **License:** Code Apache-2.0; weights distributed publicly on the same FoundationVision org.
 - **Caveat:** The multi-scale tokenizer is more complex than LlamaGen's single-scale ds16 VQ; checkpoint sizes and the rFID/scale tradeoff need a second-pass evaluation before adopting wholesale.
 
 ### Inference latency at 256×256 (CPU, ONNX-class)
+
 Published latency numbers for these tokenizers on CPU are sparse; most papers report GPU-only figures. Practical expectations for ONNX-CPU dequantized models:
+
 - LlamaGen ds16 (~72M conv): ~150–400 ms/image single-thread on a modern x86 core (educated estimate; needs measurement).
 - MAGVIT2 / Open-MAGVIT2 decoder: ~2–3× LlamaGen due to wider hidden dims and LFQ unpacking — needs measurement.
 - TiTok-L decoder (ViT): potentially heavier due to attention; needs measurement.
@@ -65,18 +73,18 @@ Published latency numbers for these tokenizers on CPU are sparse; most papers re
 
 ## 2. Image dataset landscape (May 2026 status)
 
-| Dataset | License (data + redistribution) | Size | Tokenizer eval bench | Adapter training | End-to-end FT | Notes |
-|---|---|---|---|---|---|---|
-| **ImageNet-1k** | Custom non-commercial research license; image URLs from Flickr/etc. with original copyrights. Annotations CC. | 1.28M train / 50k val | **YES (canonical rFID/PSNR/SSIM)** | Possible but narrow | Class-conditional only | The single most defensible eval bench. Used by every paper in this note. |
-| **LAION-400M / LAION-5B (original)** | **Withdrawn** Dec 2023 after CSAM finding. Do not use the original. | n/a | No | No | No | Original 400M/5B are gone. |
-| **Re-LAION-5B** (Aug 2024 re-release) | URL list under Apache-2.0; image content under each source site's license. CSAM hashes removed. Two flavors: research, research-safe. | ~5B URLs | Possible | Possible | Yes (text-conditional) | URL-only dataset, you still scrape. Many URLs dead-link by 2026. **Recommend NOT M1B** unless an img2dataset pipeline already exists. |
-| **CC12M (Conceptual 12M)** | Google's dataset under permissive "free for any purpose" license; URL+caption list distributed; images still hosted by original publishers. | ~12M | Useful (diverse stress) | Adequate for small adapter | Adequate for small text-conditional FT | Still hosted on [google-research-datasets/conceptual-12m](https://github.com/google-research-datasets/conceptual-12m) and [pixparse/cc12m-wds](https://huggingface.co/datasets/pixparse/cc12m-wds). URL rot exists but a sizable fraction still downloadable. |
-| **OpenImages V7** | Annotations CC BY 4.0; images CC BY 2.0 per source (verify per-image). Full download ~561 GB. | ~9M train / 41k val / 125k test | Useful for "in-the-wild" eval split | Suitable | Suitable for class- or detection-conditional | Hosted on Google Cloud Storage; reliable. Heavier than needed for M1B. |
-| **DataComp-1B** | URL list CC-BY-4.0; images under their copyrights. | ~1.4B URLs (8.86 TB realized) | Overkill | Overkill | Overkill | Far past hackathon budget. |
-| **COCO 2017** | Annotations CC BY 4.0; images under per-image Flickr terms (most non-commercial; full commercial use NOT guaranteed). | ~118k train / 5k val | **YES (MS-COCO FID-30K is the standard text-to-image eval)** | Small | Yes for prompt-style FT | Standard text-to-image eval bench. License is acceptable for research/eval but commercial redistribution of images is restricted. |
-| **Flickr30K** | Images from Flickr under their per-image licenses (non-commercial in practice); annotations academic-use. | ~31k images / 158k captions | OK for small text-eval | OK | OK | Smaller cousin of COCO captions; same Flickr license caveats. |
-| **FFHQ** | Dataset wrapper CC BY-NC-SA 4.0 (NVIDIA), images CC BY / CC0 / public-domain per-image. **Non-commercial only**. | 70k images 1024×1024 | OK (face-only stress) | OK if face-only | OK if face-only | Useful as a "high-quality narrow distribution" sanity bench but license blocks commercial. |
-| **ShareGPT4V** | CC BY-NC 4.0; research only. | 1.2M image-caption pairs | Limited | Caption-quality FT only | LLaVA-style only | Mostly LLM-caption-quality dataset, not a tokenizer benchmark. Non-commercial. |
+| Dataset                               | License (data + redistribution)                                                                                                             | Size                            | Tokenizer eval bench                                         | Adapter training           | End-to-end FT                                | Notes                                                                                                                                                                                                                                                         |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- | ------------------------------------------------------------ | -------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **ImageNet-1k**                       | Custom non-commercial research license; image URLs from Flickr/etc. with original copyrights. Annotations CC.                               | 1.28M train / 50k val           | **YES (canonical rFID/PSNR/SSIM)**                           | Possible but narrow        | Class-conditional only                       | The single most defensible eval bench. Used by every paper in this note.                                                                                                                                                                                      |
+| **LAION-400M / LAION-5B (original)**  | **Withdrawn** Dec 2023 after CSAM finding. Do not use the original.                                                                         | n/a                             | No                                                           | No                         | No                                           | Original 400M/5B are gone.                                                                                                                                                                                                                                    |
+| **Re-LAION-5B** (Aug 2024 re-release) | URL list under Apache-2.0; image content under each source site's license. CSAM hashes removed. Two flavors: research, research-safe.       | ~5B URLs                        | Possible                                                     | Possible                   | Yes (text-conditional)                       | URL-only dataset, you still scrape. Many URLs dead-link by 2026. **Recommend NOT M1B** unless an img2dataset pipeline already exists.                                                                                                                         |
+| **CC12M (Conceptual 12M)**            | Google's dataset under permissive "free for any purpose" license; URL+caption list distributed; images still hosted by original publishers. | ~12M                            | Useful (diverse stress)                                      | Adequate for small adapter | Adequate for small text-conditional FT       | Still hosted on [google-research-datasets/conceptual-12m](https://github.com/google-research-datasets/conceptual-12m) and [pixparse/cc12m-wds](https://huggingface.co/datasets/pixparse/cc12m-wds). URL rot exists but a sizable fraction still downloadable. |
+| **OpenImages V7**                     | Annotations CC BY 4.0; images CC BY 2.0 per source (verify per-image). Full download ~561 GB.                                               | ~9M train / 41k val / 125k test | Useful for "in-the-wild" eval split                          | Suitable                   | Suitable for class- or detection-conditional | Hosted on Google Cloud Storage; reliable. Heavier than needed for M1B.                                                                                                                                                                                        |
+| **DataComp-1B**                       | URL list CC-BY-4.0; images under their copyrights.                                                                                          | ~1.4B URLs (8.86 TB realized)   | Overkill                                                     | Overkill                   | Overkill                                     | Far past hackathon budget.                                                                                                                                                                                                                                    |
+| **COCO 2017**                         | Annotations CC BY 4.0; images under per-image Flickr terms (most non-commercial; full commercial use NOT guaranteed).                       | ~118k train / 5k val            | **YES (MS-COCO FID-30K is the standard text-to-image eval)** | Small                      | Yes for prompt-style FT                      | Standard text-to-image eval bench. License is acceptable for research/eval but commercial redistribution of images is restricted.                                                                                                                             |
+| **Flickr30K**                         | Images from Flickr under their per-image licenses (non-commercial in practice); annotations academic-use.                                   | ~31k images / 158k captions     | OK for small text-eval                                       | OK                         | OK                                           | Smaller cousin of COCO captions; same Flickr license caveats.                                                                                                                                                                                                 |
+| **FFHQ**                              | Dataset wrapper CC BY-NC-SA 4.0 (NVIDIA), images CC BY / CC0 / public-domain per-image. **Non-commercial only**.                            | 70k images 1024×1024            | OK (face-only stress)                                        | OK if face-only            | OK if face-only                              | Useful as a "high-quality narrow distribution" sanity bench but license blocks commercial.                                                                                                                                                                    |
+| **ShareGPT4V**                        | CC BY-NC 4.0; research only.                                                                                                                | 1.2M image-caption pairs        | Limited                                                      | Caption-quality FT only    | LLaVA-style only                             | Mostly LLM-caption-quality dataset, not a tokenizer benchmark. Non-commercial.                                                                                                                                                                                |
 
 **Eval-bench recommendation:** **ImageNet-1k validation (50k images)** for reconstruction metrics (rFID, PSNR, SSIM, LPIPS) and **MS-COCO 2017 val (5k images, 25k captions)** for FID-30K / CLIP-score generation evaluation. Both are de-facto standards and exactly match LlamaGen's published numbers, which keeps our results comparable to the paper.
 
@@ -89,6 +97,7 @@ Published latency numbers for these tokenizers on CPU are sparse; most papers re
 Source: [arXiv 2406.06525](https://arxiv.org/abs/2406.06525) and [FoundationVision/LlamaGen](https://github.com/FoundationVision/LlamaGen).
 
 ### Tokenizer training
+
 - **Architecture:** VQGAN encoder-quantizer-decoder. Codebook K=16384, embedding dim C=8 (intentionally low — L2-normalized lookups). Downsample factor p=16 → 16×16 token grid for 256×256 input.
 - **Data:** ImageNet-1k train split, 256×256 resolution (also a 384×384 high-res run for rFID 0.94).
 - **Optimizer:** AdamW, β₁=0.9, β₂=0.95, weight decay=0.05, constant LR 1e-4.
@@ -98,6 +107,7 @@ Source: [arXiv 2406.06525](https://arxiv.org/abs/2406.06525) and [FoundationVisi
 - **Hardware:** 80GB A100 GPUs (count unspecified but the recipe is small enough to fit a few A100s).
 
 ### Class-conditional AR head (c2i)
+
 - **Data:** ImageNet, 256×256 or 384×384.
 - **Optimizer:** AdamW (same betas, wd), LR scaled at 1e-4 per 256 batch size.
 - **Regularization:** Dropout 0.1 on embeddings and attention; 10-crop augmentation with random selection per step.
@@ -106,16 +116,19 @@ Source: [arXiv 2406.06525](https://arxiv.org/abs/2406.06525) and [FoundationVisi
 - **Best result:** LlamaGen-3B reaches FID 2.18 at 256×256.
 
 ### Text-conditional (t2i)
+
 - Two-stage: Stage I on **50M LAION-COCO subset** at 256×256, Stage II on a 10M internal aesthetics-filtered set at 512×512.
 - Text encoder: FLAN-T5 XL, max 120 text tokens.
 - LR 1e-4 per 256 batch size, same optimizer.
 
 ### Checkpoint hosting and updates
+
 - **Tokenizer + class-conditional:** [huggingface.co/FoundationVision/LlamaGen](https://huggingface.co/FoundationVision/LlamaGen) (`vq_ds16_c2i.pt`, `vq_ds8_c2i.pt`, `c2i_B_256.pt`, `c2i_L_256.pt`, `c2i_XL_384L.pt`, `c2i_XXL_384.pt`, `c2i_3B_384.pt`).
 - **Text-conditional:** [huggingface.co/peizesun/llamagen_t2i](https://huggingface.co/peizesun/llamagen_t2i).
 - **Last release activity:** 2024-06-28 (t2i drop) and 2024-06-15 (vLLM support). Repo has been quiet since — no breaking checkpoint format changes to worry about, but also no upstream maintenance to free-ride on.
 
 ### Inference cost (reported)
+
 - vLLM-integrated AR inference yields 326–414% speedup vs the naive PyTorch baseline.
 - **Tokenizer-only forward** is conv-net, cheap; no specific CPU/ONNX latency published. **This is the empirical gap to close before M1B ships** (see Open Questions).
 
@@ -126,6 +139,7 @@ Source: [arXiv 2406.06525](https://arxiv.org/abs/2406.06525) and [FoundationVisi
 The L4 adapter sits between the LLM's Visual Seed Code (short discrete sequence, length S << 256) and the tokenizer latent grid (16×16=256 sites). Four families surveyed.
 
 ### (A) Deterministic positional unfolding
+
 Treat the seed code as the coarse-scale tokens. Tile / repeat / interleave deterministically to fill the 16×16 grid, then feed straight into the decoder. **No training.** The Visual Seed Code IS the latent grid at low resolution; the adapter is a fixed upsampling op (nearest-neighbor or learned-fixed PixelShuffle weights).
 
 - Closest published instantiation: **VAR** ([arXiv 2404.02905](https://arxiv.org/abs/2404.02905)) — the multi-scale VQVAE tokenizer is literally a learned deterministic-unfolding stack. Won NeurIPS 2024 Best Paper.
@@ -133,18 +147,21 @@ Treat the seed code as the coarse-scale tokens. Tile / repeat / interleave deter
 - **Cons:** image quality is bounded by what 16 or 64 coarse tokens can encode through a nearest-upsampled latent. If the seed is too short the decoder will produce blocky/low-frequency outputs.
 
 ### (B) MaskGIT-style iterative unmasking
+
 ([arXiv 2202.04200](https://arxiv.org/abs/2202.04200)) Adapter is a small bidirectional transformer that fills in the masked tokens conditioned on the seed. Iterative parallel decoding (typically 8–16 steps) over the 256-token grid.
 
 - **Pros:** empirically strong — this is the spine of Muse ([arXiv 2301.00704](https://arxiv.org/abs/2301.00704), FID 7.88 on COCO zero-shot at 3B params). Bounded inference cost.
 - **Cons:** requires training a small transformer adapter on (seed, full-token-grid) pairs. Stochastic decoding works against the determinism constraint unless we fix the schedule and sampling temperature = 0.
 
 ### (C) LlamaGen-style AR head
+
 A small causal transformer fills the 256 tokens left-to-right conditioned on the seed.
 
 - **Pros:** direct match to LlamaGen's published recipe; reuses code.
 - **Cons:** 256 sequential decode steps per image is expensive on CPU; less compatible with "small bridge network" framing. The whole point of having a separate seed is to AVOID making the LLM emit 256 tokens.
 
 ### (D) Diffusion bridge (VQ-Diffusion / discrete diffusion)
+
 ([arXiv 2111.14822](https://arxiv.org/abs/2111.14822), [arXiv 2202.04895](https://arxiv.org/abs/2202.04895)) Diffusion in discrete token space, conditioned on seed.
 
 - **Pros:** high quality at large generation budgets.
@@ -153,6 +170,7 @@ A small causal transformer fills the 256 tokens left-to-right conditioned on the
 ### Recommendation: **start deterministic (A), keep MaskGIT (B) as the upgrade**
 
 For M1B's first cut:
+
 1. Define the Visual Seed Code as the LlamaGen 16×16 token grid downsampled by k=2 (so 8×8=64 seed tokens) or k=4 (4×4=16 seed tokens).
 2. The L4 adapter is a fixed PixelShuffle-style replicate to 16×16 (no learnable weights). The decoder smooths spatial discontinuities.
 3. Measure rFID, PSNR, LPIPS against the ground-truth-tokenized latent. If quality is unacceptable at k=4, fall back to k=2; if still unacceptable, promote to MaskGIT-style fill-in (path B).
@@ -167,28 +185,35 @@ The "start deterministic" call is load-bearing because (i) it ships M1B with zer
 Three rungs, each with a clear definition of "ship-ready" and the compute cost.
 
 ### Rung 1: Reconstruction fidelity (tokenizer round-trip alone)
+
 Image → encode → quantize → decode → image. Measures how much information the frozen decoder discards.
+
 - **Metrics:** PSNR, SSIM, LPIPS (AlexNet backbone), rFID.
 - **Eval set:** ImageNet-1k val, 50k images, 256×256 center-cropped.
 - **Targets to ship:** PSNR ≥ 20, SSIM ≥ 0.65, LPIPS ≤ 0.20, rFID ≤ 3.0. These match LlamaGen's published baseline (PSNR 20.79 / SSIM 0.675 / rFID 2.19).
 - **Compute:** rFID requires Inception-V3 features on 50k real + 50k recon. About 5–15 minutes single-A10G; an order of magnitude longer on CPU. Budget a couple of hours per eval run on CPU, single hour on a small GPU.
 
 ### Rung 2: Seed-expanded reconstruction (adapter round-trip)
+
 Image → encode → downsample to seed → L4 adapter → decoder → image. Measures the seed expander's information loss on top of the tokenizer's.
+
 - **Metrics:** Same four as Rung 1.
 - **Eval set:** Same ImageNet-1k val 50k. Optional secondary: COCO 2017 val 5k for distribution-shift signal.
 - **Targets to ship:** A reasonable bar is "no worse than 2× degradation of Rung 1 LPIPS" — e.g., LPIPS ≤ 0.40, SSIM ≥ 0.55. This is intentionally lenient because the seed is information-bottlenecked by construction.
 
 ### Rung 3: Generative quality (end-to-end with the LLM speaking)
+
 LLM emits seed → adapter → decoder → image.
+
 - **Metrics:** FID-30K against MS-COCO val captions (field-standard); CLIP-score (ViT-L/14) for prompt alignment; human eyeball for sanity.
 - **Eval set:** 30,000 captions drawn from COCO val captions (the FID-30K convention) producing 30k images.
 - **Targets to ship:** Pre-register "ship if FID-30K < 50 AND CLIP-score > 0.22". This is intentionally permissive; M1B is a structural milestone, not a quality milestone.
 - **Compute:** 30k generations is the dominant cost. At ~5 sec per image on CPU, 30k images ≈ 42 hours on a single CPU. **Realistic options: (i) ship Rung 3 on a 5k FID-5K subsample, (ii) run on a one-off GPU rental, (iii) defer Rung 3 to M1C and ship M1B on Rungs 1+2 only.**
 
 ### Hardware-on-a-budget plan
+
 - Local CPU box: all of Rung 1 and Rung 2 (slow but feasible overnight).
-- Single Colab A10G or a $5 cloud spot: Rung 3 at 30k in under an hour.
+- Single Colab A10G or a low-cost cloud spot: estimated Rung 3 at 30k in approximately under an hour, pending the measured throughput from #394.
 - Reference impls: [cleanfid](https://github.com/GaParmar/clean-fid), [lpips pip](https://github.com/richzhang/PerceptualSimilarity), [open_clip](https://github.com/mlfoundations/open_clip).
 
 ---
@@ -226,6 +251,7 @@ LLM emits seed → adapter → decoder → image.
 ## Refs
 
 **Tokenizers and generation backbones:**
+
 - LlamaGen: [arXiv:2406.06525](https://arxiv.org/abs/2406.06525) · [github](https://github.com/FoundationVision/LlamaGen) · [HF weights](https://huggingface.co/FoundationVision/LlamaGen)
 - Open-MAGVIT2: [arXiv:2409.04410](https://arxiv.org/abs/2409.04410) · [github](https://github.com/TencentARC/Open-MAGVIT2)
 - MAGVIT-v2 (original): [arXiv:2310.05737](https://arxiv.org/abs/2310.05737)
@@ -235,12 +261,14 @@ LLM emits seed → adapter → decoder → image.
 - VAR (next-scale prediction): [arXiv:2404.02905](https://arxiv.org/abs/2404.02905) · [FoundationVision/VAR](https://github.com/FoundationVision/VAR)
 
 **Adapter / generation paradigms:**
+
 - MaskGIT: [arXiv:2202.04200](https://arxiv.org/abs/2202.04200)
 - Muse: [arXiv:2301.00704](https://arxiv.org/abs/2301.00704)
 - VQ-Diffusion (text-to-image): [arXiv:2111.14822](https://arxiv.org/abs/2111.14822)
 - Diffusion bridges VQ-VAE: [arXiv:2202.04895](https://arxiv.org/abs/2202.04895)
 
 **Datasets:**
+
 - ImageNet (ILSVRC): [image-net.org](https://www.image-net.org/)
 - Re-LAION-5B: [blog](https://laion.ai/blog/relaion-5b/)
 - CC12M: [arXiv:2102.08981](https://arxiv.org/abs/2102.08981) · [github](https://github.com/google-research-datasets/conceptual-12m) · [pixparse/cc12m-wds](https://huggingface.co/datasets/pixparse/cc12m-wds)
@@ -252,6 +280,7 @@ LLM emits seed → adapter → decoder → image.
 - ShareGPT4V: [arXiv:2311.12793](https://arxiv.org/abs/2311.12793)
 
 **Evaluation infrastructure:**
+
 - Rethinking FID (CMMD): [arXiv:2401.09603](https://arxiv.org/abs/2401.09603)
 - LPIPS: [reference impl](https://github.com/richzhang/PerceptualSimilarity)
 - cleanfid: [github](https://github.com/GaParmar/clean-fid)

--- a/docs/research/2026-05-13-m1b-prep-research.md
+++ b/docs/research/2026-05-13-m1b-prep-research.md
@@ -174,7 +174,7 @@ For M1B's first cut:
 1. Define the Visual Seed Code as the LlamaGen 16×16 token grid downsampled by k=2 (so 8×8=64 seed tokens) or k=4 (4×4=16 seed tokens).
 2. The L4 adapter is a fixed PixelShuffle-style replicate to 16×16 (no learnable weights). The decoder smooths spatial discontinuities.
 3. Measure rFID, PSNR, LPIPS against the ground-truth-tokenized latent. If quality is unacceptable at k=4, fall back to k=2; if still unacceptable, promote to MaskGIT-style fill-in (path B).
-4. The learned MaskGIT adapter, when needed, trains on (seed, full-grid) pairs extracted from ImageNet via the LlamaGen tokenizer. Training set is finite (1.28M ImageNet images → 1.28M (seed, grid) pairs), bridge net is small (e.g., 6-layer transformer, 256-dim), training fits on a single GPU-day.
+4. The learned MaskGIT adapter, when needed, trains on (seed, full-grid) pairs extracted from ImageNet via the LlamaGen tokenizer. Training set is finite (1.28M ImageNet images → 1.28M (seed, grid) pairs), bridge net is small (e.g., 6-layer transformer, 256-dim), and training is estimated to fit on a single GPU-day pending measurement in the adapter sweep.
 
 The "start deterministic" call is load-bearing because (i) it ships M1B with zero training; (ii) it makes the per-platform determinism trivial (no sampling); (iii) it produces a hard empirical baseline against which any learned adapter must justify itself.
 

--- a/docs/research/2026-05-13-wittgenstein-research-program.md
+++ b/docs/research/2026-05-13-wittgenstein-research-program.md
@@ -1,0 +1,399 @@
+---
+date: 2026-05-13
+status: canonical research-program note (decision-oriented, compute-rich)
+labels: [research-derived, m1b-image, training, dataset, adapter, eval, research-program, governance]
+tracks: [#283, #259, #292]
+supersedes-recommendation-in: docs/research/2026-05-13-m1b-prep-research.md
+---
+
+# Wittgenstein Research Program — Three-Track Plan
+
+> **Canonical research direction for Wittgenstein, written 2026-05-13.** This note replaces the hackathon-grade recommendations in [`2026-05-13-m1b-prep-research.md`](2026-05-13-m1b-prep-research.md) after the maintainer reframed the project as **top-tier engineering / research / hacker work with significant GPU compute available.** The literature survey in that earlier note remains valid; this note re-derives the choices.
+
+---
+
+## Why this note exists
+
+Earlier the same day, a maintainer-sweep research pass landed an M1B prep
+note. That note operated under hackathon-grade constraints — ONNX-CPU
+runtime, no adapter training, ship-floor quality bar — because no
+explicit compute budget had been confirmed.
+
+The maintainer then said, paraphrased:
+
+> "We're not doing hackathon work anymore. We have substantial GPU
+> compute. Think bigger — larger models, learned middle layers (adapter,
+> tokenizer), wherever high compute actually moves the needle. Take this
+> seriously as top-tier engineering, top-tier research, and top-tier
+> hacker work."
+
+This note is the answer to that reframe.
+
+## Doctrine — what stays, what shifts
+
+### What stays (load-bearing, do not weaken)
+
+- **[ADR-0005](../adrs/0005-decoder-not-generator.md) decoder ≠ generator.** We
+  TRAIN decoders, then FREEZE them at ship time. No diffusion sampling on
+  the canonical path. Reproducibility is structural, not policy.
+- **[ADR-0018](../adrs/0018-hybrid-image-code-and-visual-seed-token.md) Visual Seed Code as primary image research surface.**
+- **Manifest spine.** Every run is reproducible from `git SHA + lockfile
+  hash + seed + LLM I/O + artifact SHA-256`. **Extends to training:**
+  every training run gets a manifest with dataset hash, training step
+  count, optimizer state hash, eval-metric snapshot.
+- **[ADR-0020](../adrs/0020-code-weights-license-divergence-policy.md) license posture.** Permissive code+weights canonical. Own-trained models
+  make this *easier* to satisfy — we own the weights end-to-end.
+- **Codec Protocol v2 modality boundaries.** One codec per modality, one
+  shipping path per modality.
+- **No second image path.** Even with rich research surface, only ONE
+  configuration becomes canonical at ship time. The research surface
+  produces ablation data; canonical = chosen winner.
+- **No silent fallbacks.** Errors surface as typed receipts.
+
+### What shifts under compute-rich framing
+
+| Was (hackathon floor) | Is (canonical) |
+| --- | --- |
+| ONNX-CPU runtime preferred → cheapest tokenizer | GPU-rich → **best-quality** or **own-trained** |
+| Adapter deterministic (PixelShuffle replicate), zero training | Adapter is **the highest-leverage research surface** — must be learned (MaskGIT-style or multi-scale) |
+| Eval FID-30K deferred / 5K subsampled | Full 30K + CLIP + human eval, as CI gates |
+| "Hackathon-grade good enough" ship bar | SOTA-adjacent ship bar |
+| Skip Open-MAGVIT2 due to bit-factorization engineering cost | Adopt OR train-our-own at the quality frontier |
+| Frozen GPT-5 emits Visual Seed Code via prompt engineering | **Train native LLM head** distilled from teacher — otherwise the thesis isn't actually tested |
+| Determinism: byte-parity per platform | Determinism: **`structural-parity`** is canonical (per M2 audio precedent + [#374](https://github.com/p-to-q/wittgenstein/issues/374)) |
+
+The byte-parity downgrade is worth one sentence: trained models running
+on GPU produce platform-dependent floating-point outputs. We adopt the
+[ADR-0015](../adrs/0015-audio-decoder-family.md) precedent — `structural-parity` (same image-code receipt, same
+PNG dimensions, same dominant palette, pixel-level epsilon allowed) — for
+all learned-model code paths. Byte-parity is preserved for any path that
+doesn't run a learned model (sensor, svg-local, asciipng).
+
+---
+
+## Three-track project framing
+
+Wittgenstein simultaneously is — and should optimize for being — three
+things. Each has its own program.
+
+### Track 1: Top-tier engineering project
+
+What it means: production-shaped harness, reproducible receipts,
+contract-locked codec protocol, CI-backed quality gates, multi-modality
+coverage. Wittgenstein largely IS this today.
+
+What we invest in next:
+
+- **Distributed training infrastructure.** FSDP (PyTorch 2.x) for
+  multi-GPU adapter / tokenizer / LLM-head training. Skeleton lives
+  under `research/training/` (new). The harness itself stays inference-
+  shaped; training is a separate scaffold that emits Wittgenstein-shaped
+  manifests on each checkpoint.
+- **Experiment tracking integrated with the manifest spine.** Use
+  `aim` (open-source, self-hostable, Apache-2.0) as the primary tracker;
+  W&B as the secondary if a contributor prefers. Each training run's
+  `manifest.json` carries an `experiment.uri` field pointing at the
+  tracker entry.
+- **Data versioning.** DVC for ImageNet / CC12M / COCO eval sets;
+  dataset SHA-256 + URL + revision pinned in every training manifest.
+- **GPU CI lane.** Initially a manual sweep harness (`bench/gpu/`) that
+  a maintainer runs nightly on a Lambda Labs / RunPod instance; later
+  promoted to a managed CI runner if budget supports.
+- **Public model hub.** HuggingFace org for trained weights, with the
+  Wittgenstein training manifest committed alongside each release.
+- **Reproducible release pipeline.** A `wittgenstein release-trained`
+  CLI flow that ties manifest → checkpoint → HF push → tag bump.
+
+### Track 2: Top-tier research project
+
+What it means: Visual Seed Code as a new primitive in the multimodal
+generation literature; learned adapters as the research surface;
+published papers / open benchmarks / open weights.
+
+What we invest in next:
+
+- **Train our own VQGAN-class tokenizer** on ImageNet + CC12M, targeting
+  rFID < 2.0. Higher embedding dim than LlamaGen's 8 (we want richer
+  per-site latents because our adapter is *learned* and can use them).
+- **Train a learned MaskGIT-style L4 adapter** as the canonical seed
+  expander. ~10-50M params, bidirectional transformer.
+- **Train a native image-emitting LLM head** distilled from a teacher
+  (LlamaGen-3B). This is the load-bearing research bet — see Phase 1.
+- **Full eval matrix.** Ablations across seed length × adapter depth ×
+  tokenizer dim × decoder family. Published as a benchmark table.
+- **Publication target.** At least one tech report describing the
+  Visual Seed Code framing; an arxiv preprint when Phase 1 results
+  are ready; a workshop paper as the eventual academic stake.
+
+### Track 3: Top-tier hacker project
+
+What it means: Visual Seed Code becomes a NEW PROGRAMMING LANGUAGE for
+multimodal AI. Hackable, composable, distillable, *human-authorable*.
+
+What we bet on:
+
+- **VSC as human-authorable.** Tooling that lets a human read / write /
+  edit / compose VSC by hand. This is the reverse direction of normal
+  AI tooling and the strongest signal that VSC is "a language" rather
+  than "an opaque internal representation."
+- **VSC distillation from any teacher.** Given an arbitrary image
+  generator (LlamaGen, SDXL, Flux, future Veo), extract the
+  corresponding VSC for any image. If VSC is a universal multimodal
+  interlingua, distillation should converge across teachers; if it
+  doesn't, that's also a meaningful result.
+- **Cross-modal VSC.** Image VSC + audio VSC + sensor VSC composable in
+  one prompt. Wittgenstein's existing modality structure makes this
+  doable; the bet is that "one VSC, many modalities" is a usable
+  primitive, not a leaky abstraction.
+- **Open primitive.** Anyone can build tools on top of VSC. The way
+  `llama.cpp` / `ggml` became platforms others build on, VSC should
+  become the kind of primitive other people PICK UP because it makes
+  their tooling easier — not because Wittgenstein markets it.
+
+---
+
+## Phase 1 — M1B with own-trained models (1–3 months)
+
+Concrete Phase 1 deliverables. All assume the confirmed GPU compute.
+
+### 1.1 Train Wittgenstein-native VQGAN-class tokenizer
+
+| Field | Choice |
+| --- | --- |
+| Architecture | VQGAN-class (Conv enc / vector quantize / Conv dec); codebook K=16384 with embedding dim D=32, downsample factor p=16 (16×16 token grid for 256×256). Optionally D=64 ablation for adapter-richer latents. |
+| Data | ImageNet train (1.28M) + CC12M filtered (~6–9M usable URLs at 2026 dead-link rate) + COCO train. Hash-pinned via DVC. |
+| Losses | L2 + LPIPS + PatchGAN adversarial (after 20k iters) + commitment β=0.25, mirroring LlamaGen's recipe. |
+| Optimizer | AdamW, β1=0.9 β2=0.95 wd=0.05 lr=1e-4, batch 128 → effective 1024 via 8 GPUs. |
+| Compute budget | ~1–2 GPU-weeks on 8× A100 (LlamaGen's recipe scaled to our codebook size). |
+| Target | rFID ≤ 2.0 on ImageNet val 50k (matching Open-MAGVIT2's rFID 1.17 to LlamaGen's rFID 2.19 corridor). |
+| Output | Wittgenstein-native tokenizer checkpoint + training script + weights published to HuggingFace (Apache-2.0). |
+
+**Why not just consume LlamaGen's checkpoint?** Three reasons: (a) we
+own the weight-license story (ADR-0020 clean by construction); (b) we
+control codebook size + embedding dim to MATCH the adapter's needs
+(LlamaGen's D=8 is intentionally low because their AR head carries
+semantic load — but our adapter is BERT-shaped and benefits from richer
+per-site latents); (c) training our own forces us to build the training
+infrastructure (Track 1) which downstream training depends on anyway.
+
+### 1.2 Train learned MaskGIT-style L4 adapter
+
+| Field | Choice |
+| --- | --- |
+| Architecture | Bidirectional transformer (BERT-shaped), 12 layers, hidden 512, 8 heads (~50M params). Token-level cross-entropy over the 16384-codebook. |
+| Training pairs | (Visual Seed Code, full token grid). Bootstrap: VSC = full grid block-averaged to k×k coarse tokens (k ∈ {2, 4, 8} ablated); target = full grid. |
+| Inference schedule | 8-step parallel decoding (MaskGIT schedule), temperature 0 (deterministic) at ship time. Stochastic schedule available for sampling but not on the canonical path. |
+| Data | Token pairs extracted from ImageNet train + CC12M via the tokenizer (1.1). |
+| Compute budget | ~1–3 GPU-weeks on 4× A100. |
+| Output | Adapter checkpoint + recipe. |
+
+**Why MaskGIT and not deterministic replicate?** The Phase 0 floor uses
+deterministic replicate because no compute. With compute, the question
+becomes: is there a meaningful *learned* translation between
+LLM-emitted abstract Visual Seed Code and decoder-native latent codes?
+Deterministic replicate is the null hypothesis (the VSC == coarse
+tokens, no semantic translation needed). The learned adapter is the
+test. If the adapter doesn't beat deterministic on Rung-2 LPIPS, we've
+learned something important about the limits of the framing.
+
+### 1.3 Distill native image-emitting LLM head
+
+**This is the load-bearing bet.**
+
+| Field | Choice |
+| --- | --- |
+| Architecture | Small AR transformer (250M–1B params). Llama-shaped (RMSNorm, RoPE, SwiGLU) for compatibility. |
+| Distill from | LlamaGen-3B (Apache-2.0) text-conditional checkpoint. |
+| Training data | LAION-COCO subset (per LlamaGen's t2i recipe) + CC12M, ~50M pairs. |
+| Distillation target | Student emits Visual Seed Code (compact); teacher emits full token grid. Joint loss: KL on student's VSC distribution vs teacher's coarse-grid distribution + reconstruction loss through adapter+decoder. |
+| Compute budget | ~4–8 GPU-weeks on 8× A100. |
+| Output | Wittgenstein-native image-emitting LLM head + recipe. |
+
+**Why this is load-bearing.** Wittgenstein's central wager:
+
+> "How much multimodal capability can we recover, structure, and
+> operationalize from text-first models if we move intelligence into
+> the harness, the codec boundary, and the decoder-facing code layer?"
+
+If we test this wager only by prompting GPT-5 / Claude / Gemini to emit
+Visual Seed Code, **we're testing prompt engineering, not the thesis.**
+The thesis demands a model trained for the interface. A 250M–1B-param
+head distilled from a teacher is the minimum viable test: small enough
+to be honest about parameter count, large enough to express VSC well.
+
+### 1.4 Eval program (Phase 1)
+
+| Rung | Metric set | Eval set |
+| --- | --- | --- |
+| 1: Reconstruction (tokenizer round-trip) | PSNR / SSIM / LPIPS / rFID | ImageNet val 50k, 256×256 center-crop |
+| 2: Adapter round-trip | PSNR / SSIM / LPIPS / rFID, swept over seed length S ∈ {16, 64, 256} | Same |
+| 3: End-to-end generative | FID-30K / CLIP-score (ViT-L/14) / human eval (200 paired vs LlamaGen-3B teacher) | COCO val captions → 30k generations |
+
+**Ablation matrix to publish:**
+
+| Axis | Levels |
+| --- | --- |
+| Seed length S | 16, 64, 256 (full) |
+| Adapter depth | 6, 12 layers |
+| Tokenizer embed dim | 8, 16, 32 |
+| LLM head size | 250M, 1B |
+
+That's 3 × 2 × 3 × 2 = 36 configurations. With overlap and pruning,
+realistically 12–16 distinct training runs. Tractable in 2–3 months of
+GPU time.
+
+Every eval run writes a Wittgenstein manifest carrying:
+- The training run's checkpoint hash
+- The eval set's DVC hash
+- The metric values (PSNR / SSIM / LPIPS / rFID / FID-30K / CLIP /
+  human-score)
+- The experiment URI (aim / W&B link)
+
+---
+
+## Phase 2 — Visual Seed Code as primary research surface (3–6 months)
+
+After Phase 1 ships with own-trained models and an ablation-validated
+canonical configuration:
+
+- **Multi-scale tokenizer.** Train a VAR-style multi-scale VQVAE
+  ([arXiv 2404.02905](https://arxiv.org/abs/2404.02905), NeurIPS 2024
+  Best Paper). The multi-scale tokenizer is the natural mathematical
+  realization of "Visual Seed Code as coarse-scale tokens" — the
+  adapter literally unfolds scale-by-scale. Compare against Phase 1's
+  single-scale tokenizer on the same eval matrix.
+- **Co-train LLM head + adapter.** Phase 1 trains them separately
+  (distill the head, then train the adapter); Phase 2 trains them
+  jointly with the seed code as a learned bottleneck. Tests whether
+  the seed code's information density is bounded by the bottleneck
+  optimization or by the data.
+- **Distillation across teachers.** Extract VSC from LlamaGen + SDXL +
+  Flux on the same image. Compare VSC representations. Is there
+  convergence (universal interlingua) or divergence (each model has
+  its own VSC dialect)?
+- **Hand-authored VSC.** UX experiments: can a human write VSC by hand
+  that produces meaningful images? What does an "alphabet" of
+  human-authorable VSC components look like?
+- **Output.** Visual Seed Code paper (arxiv), open benchmark table,
+  authoring CLI + web tool, public corpus of (image, VSC) pairs.
+
+## Phase 3 — Cross-modality (6–12 months)
+
+Extend the VSC framing across modalities:
+
+- **Audio VSC.** Spectrogram seed codes; pair with our existing
+  procedural / Kokoro audio routes. Decoder-side: replace one of the
+  procedural runtimes with a learned VSC → mel-spectrogram → audio
+  pipeline.
+- **Sensor VSC.** Signal seed codes for the existing
+  ECG/temperature/gyro routes; pair with the operator-program
+  framing in [`docs/research/2026-05-08-sensor-algorithmic-research.md`](2026-05-08-sensor-algorithmic-research.md).
+- **Video VSC.** Per-frame seeds with cross-frame coherence; pair
+  with the HyperFrames-shaped renderer (M4 work, #282).
+
+Train cross-modal adapters: a single VSC → audio decoder, VSC → sensor
+decoder, VSC → video decoder. Test whether the *same* LLM head can emit
+each modality's VSC via task conditioning.
+
+Output: unified multimodal VSC spec; one paper per modality OR one
+unified multimodal paper.
+
+## Phase 4 — VSC as a programming language
+
+The hacker bet, fully realized:
+
+- VSC becomes the SHIPPING FORMAT for AI artifacts. Replaces "prompt"
+  as the human-AI multimodal interface in tools that adopt it.
+- Editor support, syntax highlighting, compositional primitives, an
+  ecosystem.
+- A small but real community of people who *write VSC by hand* for
+  specific use cases the way some people write x86 assembly.
+
+This is aspirational and not contractually committed; included for
+direction-setting.
+
+---
+
+## What this implies for the queue right now
+
+### Phase 1 trackers (file as new issues this PR)
+
+1. **Train own VQGAN-class tokenizer on ImageNet + CC12M.** (size/xl,
+   priority/p1, milestone/m1b-training)
+2. **Train learned MaskGIT-style L4 adapter.** (size/l, priority/p1,
+   milestone/m1b-training)
+3. **Distill native image-emitting LLM head from LlamaGen-3B teacher.**
+   (size/xl, priority/p1, milestone/m1b-training)
+4. **Set up `aim` (open-source) experiment tracking + integrate with
+   manifest spine.** (size/m, priority/p1, milestone/m1b-training)
+5. **Set up DVC data versioning + GPU CI sweep harness.** (size/m,
+   priority/p1, milestone/m1b-training)
+
+### Existing follow-ups (reframe in-place)
+
+- [#392](https://github.com/p-to-q/wittgenstein/issues/392) (ONNX-CPU
+  latency) → reframed as "ONNX-CPU is the optional inference target
+  for embedded deploy, not the canonical runtime. Measurement still
+  useful for that lane."
+- [#393](https://github.com/p-to-q/wittgenstein/issues/393)
+  (deterministic adapter sweep) → reframed as "baseline row in the
+  Phase 1 ablation table, not the ship configuration."
+- [#394](https://github.com/p-to-q/wittgenstein/issues/394) (quality
+  ladder eval harness) → upgraded scope: this is now CI infrastructure,
+  not a one-off eval.
+
+### Doctrine changes that may need their own ADR slots
+
+- **`structural-parity` as canonical determinism for learned-model
+  paths.** Already implied by ADR-0015 (audio) and #374 (image), but
+  worth lifting to a cross-modality doctrine ADR now that learned models
+  are the canonical path for image too.
+- **Training manifest schema.** The current `RunManifestSchema` is
+  inference-shaped. Training runs need a sibling schema with
+  `dataset.sha256`, `optimizer.state_hash`, `train.step`, `eval.metric_snapshot`.
+  This wants an RFC.
+- **The `experiment.uri` field on manifests.** Tying every receipt to a
+  remote tracker entry. Small ADR.
+
+---
+
+## Headline decisions (canonical, supersedes the Phase 0 floor)
+
+1. **Tokenizer:** Train our own VQGAN-class on ImageNet+CC12M.
+   Open-MAGVIT2 as immediate alternative if we want to ship before
+   training finishes.
+2. **Adapter:** Learned MaskGIT-style bidirectional transformer.
+   Deterministic schedule at ship time, stochastic available for
+   research.
+3. **LLM head:** Train native from LlamaGen-3B distillation. This is
+   what actually tests the project's central thesis.
+4. **Eval:** Full ImageNet val 50k (Rungs 1+2) + COCO FID-30K + CLIP +
+   human eval (Rung 3). All ablations published.
+5. **Infra:** `aim` for tracking, DVC for data, FSDP for training,
+   HuggingFace for releases.
+6. **Determinism:** `structural-parity` canonical for learned paths.
+7. **Architectural option for Phase 2:** VAR multi-scale tokenizer.
+
+## Refs
+
+- Phase 0 floor note (literature survey survives): [`2026-05-13-m1b-prep-research.md`](2026-05-13-m1b-prep-research.md)
+- Doctrine: [ADR-0005](../adrs/0005-decoder-not-generator.md),
+  [ADR-0018](../adrs/0018-hybrid-image-code-and-visual-seed-token.md),
+  [ADR-0015](../adrs/0015-audio-decoder-family.md),
+  [ADR-0020](../adrs/0020-code-weights-license-divergence-policy.md)
+- Bridge contract: [`packages/codec-image/src/decoders/types.ts`](../../packages/codec-image/src/decoders/types.ts)
+- Existing umbrellas: [#283](https://github.com/p-to-q/wittgenstein/issues/283) (M1B), [#259](https://github.com/p-to-q/wittgenstein/issues/259) (VSC slices), [#292](https://github.com/p-to-q/wittgenstein/issues/292) (v0.3 trust closeout)
+- Cross-platform parity precedent: [#374](https://github.com/p-to-q/wittgenstein/issues/374) (image PNG bytes)
+- Verification spine: [`2026-05-13-verification-ladder.md`](2026-05-13-verification-ladder.md), [#384](https://github.com/p-to-q/wittgenstein/issues/384) (replay)
+
+## Open questions for the maintainer
+
+These are choices I'd defer to a maintainer call rather than make
+unilaterally. None block this PR; they get answered as the Phase 1
+trackers move forward.
+
+1. **`aim` vs W&B vs MLFlow?** I picked `aim` (open-source, self-hostable, Apache-2.0). W&B is the most common; MLFlow is the most enterprise. Reasonable to swap if you have a preference.
+2. **HuggingFace org name for releases?** Need a stable org for the published weights. `wittgenstein-harness`?
+3. **Train tokenizer at 256×256 only, or also 384×384?** LlamaGen got rFID 0.94 at 384 but it's 2.25× the compute.
+4. **LLM head distill target: LlamaGen-3B or smaller?** 3B is the largest available open Apache-2.0 image AR. Smaller teachers exist but their quality bar is lower.
+5. **Publication venue/timing for the Phase 2 paper.** ICLR, NeurIPS, CVPR, or workshop? Affects the polish budget.

--- a/packages/codec-image/src/decoders/README.md
+++ b/packages/codec-image/src/decoders/README.md
@@ -33,11 +33,11 @@ the place where the cache-or-fetch + sha256-verify of weights happens.
 
 ## Candidate families
 
-| Family       | Status        | Tracker | Audit doc                                                                                                                 |
-| ------------ | ------------- | ------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `llamagen`   | M1B canonical target — interface locked; impl gated on #334 / #335 | #329    | [`2026-05-13-audit-vqgan-class.md`](../../../../docs/research/2026-05-13-audit-vqgan-class.md)                             |
-| `seed`      | alternate (OpenMAGVIT2 / SEED-Voken / similar) | #331    | [`2026-05-13-audits-fsq-openmagvit2-titok-maskbit.md`](../../../../docs/research/2026-05-13-audits-fsq-openmagvit2-titok-maskbit.md) |
-| `dvae`       | future — for smaller ablations + eval tooling | —       | —                                                                                                                         |
+| Family     | Status                                                             | Tracker | Audit doc                                                                                                                            |
+| ---------- | ------------------------------------------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `llamagen` | M1B canonical target — interface locked; impl gated on #334 / #335 | #329    | [`2026-05-13-audit-vqgan-class.md`](../../../../docs/research/2026-05-13-audit-vqgan-class.md)                                       |
+| `seed`     | alternate (OpenMAGVIT2 / SEED-Voken / similar)                     | #331    | [`2026-05-13-audits-fsq-openmagvit2-titok-maskbit.md`](../../../../docs/research/2026-05-13-audits-fsq-openmagvit2-titok-maskbit.md) |
+| `dvae`     | future — for smaller ablations + eval tooling                      | —       | —                                                                                                                                    |
 
 All bridges here are intended to be **frozen pretrained decoders**, not
 generators (ADR-0005). Training a decoder from scratch is out of scope
@@ -62,10 +62,10 @@ for v0.x.
    - Build ONNX session (default tier `node-onnx-cpu`).
    - Return an object satisfying `ImageDecoderBridge` with `capabilities`
      filled from the manifest + measured-at-load determinism class.
-3. Wire `../pipeline/decoder.ts` to call the bridge before falling back
-   to the procedural placeholder (the placeholder stays in place as the
-   `decoder-unavailable` fallback per the no-silent-fallbacks doctrine —
-   bridge load failure surfaces as a structured warning + receipt note).
+3. Wire `../pipeline/decoder.ts` to call the bridge and stop on bridge-load
+   failure with a structured error, manifest receipt, and warning. Do not route
+   bridge failure into the procedural placeholder; M1B must not create a second
+   raster shipping path.
 4. Add `wittgenstein replay` smoke test using the wired bridge (#388
    already supports svg-local; adding image requires the bridge).
 5. Update `docs/research/2026-05-13-m1b-prep-research.md` with the actual

--- a/packages/codec-image/src/decoders/README.md
+++ b/packages/codec-image/src/decoders/README.md
@@ -1,11 +1,72 @@
-# Frozen Decoder Candidates
+# Image decoder bridges
 
-The scaffold keeps decoder bridges close to `codec-image` because image has one path only.
+The image route has exactly one shipping path (per `docs/hard-constraints.md`):
 
-Candidate decoder families:
+```
+LLM → Visual Seed Code → L4 adapter → frozen VQ decoder → PNG
+```
 
-- `llamagen` for discrete token decoders with a clear VQ interface
-- `seed` for language-aligned image token stacks
-- `dvae`-style bridges for smaller ablations and eval tooling
+A **decoder bridge** is what fills the `frozen VQ decoder` slot. Each bridge
+encapsulates one decoder family — the ONNX session, the codebook, the
+runtime tier (CPU / GPU / external), the license posture, the determinism
+contract. The pipeline (`../pipeline/decoder.ts`) calls the bridge after
+`adaptSceneToLatents` produces `ImageLatentCodes`; the bridge returns
+`DecodedRaster` PNG bytes.
 
-All decoders here are intended to be frozen pretrained decoders, not generators.
+## Bridge contract
+
+Every bridge conforms to `ImageDecoderBridge` (see [`./types.ts`](./types.ts)).
+The contract surface is intentionally small:
+
+- `capabilities` — what shapes / codebooks / determinism class / license
+  posture the bridge advertises. Pipeline matches this against incoming
+  latents BEFORE calling `decode()`; mismatches are typed errors, not
+  runtime surprises.
+- `decode(codes)` — single-call latent → PNG. Throws `WittgensteinError`s
+  with stable codes (`DECODER_SHAPE_UNSUPPORTED`, `DECODER_CODEBOOK_MISMATCH`,
+  `DECODER_RUNTIME_UNAVAILABLE`, `DECODER_INFERENCE_FAILED`).
+- `unload()` — release weights / ONNX session. Idempotent.
+
+Every bridge is loaded via `load<family>DecoderBridge(options)`. The loader
+is the enforcement point for ADR-0020 (`allowResearchWeights` check) and
+the place where the cache-or-fetch + sha256-verify of weights happens.
+
+## Candidate families
+
+| Family       | Status        | Tracker | Audit doc                                                                                                                 |
+| ------------ | ------------- | ------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `llamagen`   | M1B canonical target — interface locked; impl gated on #334 / #335 | #329    | [`2026-05-13-audit-vqgan-class.md`](../../../../docs/research/2026-05-13-audit-vqgan-class.md)                             |
+| `seed`      | alternate (OpenMAGVIT2 / SEED-Voken / similar) | #331    | [`2026-05-13-audits-fsq-openmagvit2-titok-maskbit.md`](../../../../docs/research/2026-05-13-audits-fsq-openmagvit2-titok-maskbit.md) |
+| `dvae`       | future — for smaller ablations + eval tooling | —       | —                                                                                                                         |
+
+All bridges here are intended to be **frozen pretrained decoders**, not
+generators (ADR-0005). Training a decoder from scratch is out of scope
+for v0.x.
+
+## Files
+
+- [`./types.ts`](./types.ts) — the bridge contract; locked surface every
+  impl PR fills.
+- [`./llamagen.ts`](./llamagen.ts) — M1B canonical bridge (currently
+  throws `LLAMAGEN_BRIDGE_NOT_IMPLEMENTED`).
+- [`./seed.ts`](./seed.ts) — alternate bridge (currently throws
+  `SEED_BRIDGE_NOT_IMPLEMENTED`).
+
+## How the M1B impl PR fills this
+
+1. Drop a `decoders/llamagen/manifest.json` with pinned `weightsSha256`,
+   `codebookSha256`, `repoId`, `revision`, mirroring `codec-audio/decoders/kokoro/manifest.json`.
+2. Implement `loadLlamagenDecoderBridge`:
+   - Verify weights cache; fetch + sha256-verify on miss.
+   - Refuse if research-only + `!allowResearchWeights`.
+   - Build ONNX session (default tier `node-onnx-cpu`).
+   - Return an object satisfying `ImageDecoderBridge` with `capabilities`
+     filled from the manifest + measured-at-load determinism class.
+3. Wire `../pipeline/decoder.ts` to call the bridge before falling back
+   to the procedural placeholder (the placeholder stays in place as the
+   `decoder-unavailable` fallback per the no-silent-fallbacks doctrine —
+   bridge load failure surfaces as a structured warning + receipt note).
+4. Add `wittgenstein replay` smoke test using the wired bridge (#388
+   already supports svg-local; adding image requires the bridge).
+5. Update `docs/research/2026-05-13-m1b-prep-research.md` with the actual
+   measured numbers (quality, latency, decoder hash, determinism class).

--- a/packages/codec-image/src/decoders/README.md
+++ b/packages/codec-image/src/decoders/README.md
@@ -33,15 +33,20 @@ the place where the cache-or-fetch + sha256-verify of weights happens.
 
 ## Candidate families
 
-| Family     | Status                                                             | Tracker | Audit doc                                                                                                                            |
-| ---------- | ------------------------------------------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `llamagen` | M1B canonical target — interface locked; impl gated on #334 / #335 | #329    | [`2026-05-13-audit-vqgan-class.md`](../../../../docs/research/2026-05-13-audit-vqgan-class.md)                                       |
-| `seed`     | alternate (OpenMAGVIT2 / SEED-Voken / similar)                     | #331    | [`2026-05-13-audits-fsq-openmagvit2-titok-maskbit.md`](../../../../docs/research/2026-05-13-audits-fsq-openmagvit2-titok-maskbit.md) |
-| `dvae`     | future — for smaller ablations + eval tooling                      | —       | —                                                                                                                                    |
+| Family       | Status                                                                                                                                              | Tracker                                                                                            | Audit / training doc                                                                                                                                                                                                                                                                          |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `wittgenstein-native` (canonical M1B) | **Own-trained VQGAN-class** on ImageNet+CC12M, K=16384, embed dim 32, ds=16. Training program in the research-program note.                  | (Phase 1 training tracker to be filed)                                                             | [`2026-05-13-wittgenstein-research-program.md`](../../../../docs/research/2026-05-13-wittgenstein-research-program.md) §1.1                                                                                                                                                                  |
+| `llamagen`   | **Fallback / floor** — only if own-trained weights aren't ready at ship time. Apache-2.0; interface locked; impl gated on #334 / #335.                | #329                                                                                               | [`2026-05-13-audit-vqgan-class.md`](../../../../docs/research/2026-05-13-audit-vqgan-class.md) + [`2026-05-13-m1b-prep-research.md`](../../../../docs/research/2026-05-13-m1b-prep-research.md) (Phase 0 floor)                                                                                |
+| `seed`       | alternate research-track (OpenMAGVIT2 / SEED-Voken / similar)                                                                                       | #331                                                                                               | [`2026-05-13-audits-fsq-openmagvit2-titok-maskbit.md`](../../../../docs/research/2026-05-13-audits-fsq-openmagvit2-titok-maskbit.md)                                                                                                                                                          |
+| `var`        | Phase 2 architectural option — multi-scale VQ ([VAR](https://github.com/FoundationVision/VAR), NeurIPS 2024 Best Paper)                              | (filed in Phase 2)                                                                                 | [`2026-05-13-wittgenstein-research-program.md`](../../../../docs/research/2026-05-13-wittgenstein-research-program.md) §"Phase 2"                                                                                                                                                              |
+| `dvae`       | future — for smaller ablations + eval tooling                                                                                                       | —                                                                                                  | —                                                                                                                                                                                                                                                                                              |
 
-All bridges here are intended to be **frozen pretrained decoders**, not
-generators (ADR-0005). Training a decoder from scratch is out of scope
-for v0.x.
+All bridges here are **frozen at ship time** (ADR-0005). Per the
+[research-program note](../../../../docs/research/2026-05-13-wittgenstein-research-program.md),
+we now also **train** decoders ourselves; the freeze applies to the
+released-binary form, not to the upstream pipeline. Training scaffolding
+lives outside this directory (under `research/training/` once Phase 1
+infrastructure lands).
 
 ## Files
 
@@ -54,19 +59,33 @@ for v0.x.
 
 ## How the M1B impl PR fills this
 
-1. Drop a `decoders/llamagen/manifest.json` with pinned `weightsSha256`,
-   `codebookSha256`, `repoId`, `revision`, mirroring `codec-audio/decoders/kokoro/manifest.json`.
-2. Implement `loadLlamagenDecoderBridge`:
-   - Verify weights cache; fetch + sha256-verify on miss.
-   - Refuse if research-only + `!allowResearchWeights`.
-   - Build ONNX session (default tier `node-onnx-cpu`).
+The bridge interface is decoder-family-agnostic; the same checklist
+applies whether we ship with `wittgenstein-native` (own-trained, canonical
+Phase 1) or with `llamagen` (Phase 0 floor / fallback).
+
+1. Drop a `decoders/<family>/manifest.json` with pinned `weightsSha256`,
+   `codebookSha256`, `trainingRunId` (own-trained) or `repoId`+`revision`
+   (upstream), mirroring `codec-audio/decoders/kokoro/manifest.json`.
+2. Implement `load<Family>DecoderBridge`:
+   - Verify weights cache; fetch + sha256-verify on miss (own-trained
+     weights live on our HuggingFace org per the research-program note).
+   - Refuse if research-only + `!allowResearchWeights` (ADR-0020).
+   - Build inference session under the requested runtime tier (default
+     `node-onnx-cpu` for embedded deploy; `node-onnx-gpu` for the
+     canonical research path; new tiers require an ADR).
    - Return an object satisfying `ImageDecoderBridge` with `capabilities`
-     filled from the manifest + measured-at-load determinism class.
-3. Wire `../pipeline/decoder.ts` to call the bridge and stop on bridge-load
-   failure with a structured error, manifest receipt, and warning. Do not route
-   bridge failure into the procedural placeholder; M1B must not create a second
-   raster shipping path.
+     filled from the manifest + measured-at-load determinism class
+     (likely `structural-parity` for learned-model paths).
+3. Wire `../pipeline/decoder.ts` to call the bridge and stop on
+   bridge-load failure with a structured error, manifest receipt, and
+   warning. Do not route bridge failure into the procedural placeholder;
+   M1B must not create a second raster shipping path.
 4. Add `wittgenstein replay` smoke test using the wired bridge (#388
-   already supports svg-local; adding image requires the bridge).
-5. Update `docs/research/2026-05-13-m1b-prep-research.md` with the actual
-   measured numbers (quality, latency, decoder hash, determinism class).
+   already supports svg-local; adding image requires the bridge +
+   `structural-parity`-aware comparison).
+5. Update both research notes with the actual measured numbers:
+   - [`../../../../docs/research/2026-05-13-wittgenstein-research-program.md`](../../../../docs/research/2026-05-13-wittgenstein-research-program.md)
+     §"Phase 1 Eval program" — the canonical ablation matrix entries.
+   - [`../../../../docs/research/2026-05-13-m1b-prep-research.md`](../../../../docs/research/2026-05-13-m1b-prep-research.md)
+     §"Recommended minimum first-cut" — the Phase 0 floor receipts, if
+     LlamaGen-fallback was actually used at any release.

--- a/packages/codec-image/src/decoders/llamagen.ts
+++ b/packages/codec-image/src/decoders/llamagen.ts
@@ -1,10 +1,69 @@
-export function loadLlamagenDecoderBridge() {
-  throw createNotImplementedError("codec-image decoder bridge: llamagen");
+/**
+ * LlamaGen frozen-decoder bridge (M1B target).
+ *
+ * The signature here is the typed contract every future impl PR fills in.
+ * The actual ONNX wiring / weights fetch / decode call is gated on the M1B
+ * radar audits (#283 Gates C+D, tracked at #334 + #335) — those need local
+ * empirical compute that no PR has yet run. Until they clear, this loader
+ * throws `LLAMAGEN_BRIDGE_NOT_IMPLEMENTED` with a structured error citing
+ * the upstream artifacts and the gate trackers.
+ *
+ * Refs:
+ *   - Audit: `docs/research/2026-05-13-audit-vqgan-class.md` (Gates A+B pass)
+ *   - Upstream: https://github.com/FoundationVision/LlamaGen (Apache-2.0)
+ *   - Bridge contract: `./types.ts`
+ *   - Replay verifier for the wired path: `wittgenstein replay` (#384)
+ */
+import type { ImageDecoderBridge, LoadDecoderBridgeOptions } from "./types.js";
+
+/**
+ * Stable identifier for this bridge family. Recorded on every manifest as
+ * `decoderId` so receipts can be filtered / replayed per-family. Survives
+ * impl evolution.
+ */
+export const LLAMAGEN_DECODER_ID = "llamagen-frozen-vq-v0" as const;
+
+/**
+ * Load the LlamaGen frozen decoder bridge.
+ *
+ * Currently throws — see file header. The signature is locked so the M1B
+ * implementation PR is a contract-fill: implement `decode(codes)` against
+ * `ImageLatentCodes` (matching the codebook + grid shape the bridge
+ * advertises) and return `ImageDecoderResult` with `decoderHash` derived
+ * from weights+codebook bytes.
+ *
+ * The impl must:
+ *   1. Read `LLAMAGEN_DECODER_MANIFEST` (separate file like Kokoro's
+ *      `decoders/kokoro/manifest.json`) for pinned weights SHA-256.
+ *   2. Verify the weights cache or fetch + sha256-verify on first run.
+ *   3. Refuse to return if `weightsLicense === "research-only"` and
+ *      `options.allowResearchWeights !== true` (ADR-0020, tracked at #376).
+ *   4. Build an ONNX inference session under `options.runtimeTier`
+ *      (default `node-onnx-cpu`) and advertise `determinismClass` per
+ *      what Gate C measurement actually showed (#334).
+ */
+export async function loadLlamagenDecoderBridge(
+  _options: LoadDecoderBridgeOptions = {},
+): Promise<ImageDecoderBridge> {
+  throw createBridgeNotImplementedError();
 }
 
-function createNotImplementedError(scope: string): Error & { code: string } {
-  return Object.assign(new Error(`NotImplementedError(${scope})`), {
-    name: "NotImplementedError",
-    code: "NOT_IMPLEMENTED",
+function createBridgeNotImplementedError(): Error & { code: string; details: object } {
+  const error = new Error(
+    "LlamaGen decoder bridge is not yet wired. M1B is gated on Gates C (determinism, #334) + D (Node/ONNX/CPU feasibility, #335). See docs/research/2026-05-13-audit-vqgan-class.md for the audit + docs/research/2026-05-13-m1b-prep-research.md for the implementation plan.",
+  );
+  Object.assign(error, {
+    name: "WittgensteinError",
+    code: "LLAMAGEN_BRIDGE_NOT_IMPLEMENTED",
+    details: {
+      family: "llamagen",
+      decoderId: LLAMAGEN_DECODER_ID,
+      blockers: {
+        gateC: "https://github.com/p-to-q/wittgenstein/issues/334",
+        gateD: "https://github.com/p-to-q/wittgenstein/issues/335",
+        umbrella: "https://github.com/p-to-q/wittgenstein/issues/283",
+      },
+    },
   });
+  return error as Error & { code: string; details: object };
 }

--- a/packages/codec-image/src/decoders/seed.ts
+++ b/packages/codec-image/src/decoders/seed.ts
@@ -1,10 +1,41 @@
-export function loadSeedDecoderBridge() {
-  throw createNotImplementedError("codec-image decoder bridge: seed");
+/**
+ * Seed/SEED-family frozen-decoder bridge (M1B alternate candidate).
+ *
+ * Same shape as `./llamagen.ts` — signature locked, impl gated on M1B
+ * radar audits. The radar's per-candidate audit for OpenMAGVIT2/SEED-Voken
+ * is at #331 (Priority 3; Gate B partial pending HF URL verification);
+ * full impl waits for that to clear + Gates C+D for whichever candidate
+ * is selected.
+ *
+ * Refs:
+ *   - Audit (P3-5): `docs/research/2026-05-13-audits-fsq-openmagvit2-titok-maskbit.md`
+ *   - Bridge contract: `./types.ts`
+ */
+import type { ImageDecoderBridge, LoadDecoderBridgeOptions } from "./types.js";
+
+export const SEED_DECODER_ID = "seed-frozen-vq-v0" as const;
+
+export async function loadSeedDecoderBridge(
+  _options: LoadDecoderBridgeOptions = {},
+): Promise<ImageDecoderBridge> {
+  throw createBridgeNotImplementedError();
 }
 
-function createNotImplementedError(scope: string): Error & { code: string } {
-  return Object.assign(new Error(`NotImplementedError(${scope})`), {
-    name: "NotImplementedError",
-    code: "NOT_IMPLEMENTED",
+function createBridgeNotImplementedError(): Error & { code: string; details: object } {
+  const error = new Error(
+    "Seed-family decoder bridge is not yet wired. The seed-family candidates (OpenMAGVIT2 / SEED-Voken / similar) are tracked at #331; M1B canonical is VQGAN-class (#329).",
+  );
+  Object.assign(error, {
+    name: "WittgensteinError",
+    code: "SEED_BRIDGE_NOT_IMPLEMENTED",
+    details: {
+      family: "seed",
+      decoderId: SEED_DECODER_ID,
+      blockers: {
+        audit: "https://github.com/p-to-q/wittgenstein/issues/331",
+        umbrella: "https://github.com/p-to-q/wittgenstein/issues/283",
+      },
+    },
   });
+  return error as Error & { code: string; details: object };
 }

--- a/packages/codec-image/src/decoders/types.ts
+++ b/packages/codec-image/src/decoders/types.ts
@@ -1,0 +1,198 @@
+/**
+ * Shared decoder-bridge contract for image (M1B prep).
+ *
+ * Every image decoder bridge — `llamagen`, future `seed`, future `dvae` etc. —
+ * conforms to `ImageDecoderBridge`. The contract is the seam the procedural
+ * placeholder renderer (`../pipeline/decoder.ts`) will swap out once M1B's
+ * radar audits (#283) clear empirical Gates C+D for at least one candidate.
+ *
+ * Pinning the interface BEFORE the first real impl lands means the wiring PR
+ * for M1B is a contract-fill, not a contract-design — keeps the load-bearing
+ * design decisions in one place (this file + `README.md`) instead of smearing
+ * them across the impl PR.
+ *
+ * Tracking: [#384] (replay verifies what this produces); [#283] (M1B umbrella);
+ * RFC-0007 (1D-vs-2D shape discriminator, the load-bearing schema decision
+ * above the bridge interface).
+ */
+import type { DecoderFamily, ImageLatentCodes } from "../schema.js";
+import type { DecodedRaster } from "../pipeline/decoder.js";
+
+/**
+ * Determinism class of a decoder bridge's output.
+ *
+ * - `byte-parity` — same `ImageLatentCodes` + same bridge build → bit-identical
+ *   `pngBytes` across platforms. The strongest claim; only achievable when
+ *   the entire decode path is integer-arithmetic or platform-pinned floats
+ *   (rare in practice for trained models).
+ *
+ * - `structural-parity` — same input → same image-code receipt, same PNG
+ *   dimensions, same channel layout, same dominant palette, but pixel-level
+ *   bytes may differ across platforms by epsilon-level float noise. The
+ *   M2 audio precedent ([`docs/adrs/0015-audio-decoder-family.md`](../../../docs/adrs/0015-audio-decoder-family.md))
+ *   ratifies this as the acceptable shipping contract for cross-platform
+ *   trained-model decoders. See #374 for the image-side decision tracker.
+ */
+export type DecoderDeterminismClass = "byte-parity" | "structural-parity";
+
+/**
+ * Runtime tier the bridge runs under. Locks the doctrine that the canonical
+ * M-phase path is Node + ONNX + CPU (per `docs/hard-constraints.md`).
+ *
+ * - `node-onnx-cpu` — the only runtime tier currently a hard-constraint pass.
+ *   Bridge invocations from `wittgenstein image` run under this tier.
+ *
+ * - `node-onnx-gpu` — opt-in; surfaces if a contributor enables a GPU runtime.
+ *   Receipts mark the run as such; cross-platform parity is `structural`.
+ *
+ * - `local-python` — escape-hatch for benchmarking only; not a shipping path.
+ *   Mirror of polyglot-mini's research-grade subprocess execution.
+ *
+ * New tiers require an ADR (governance lane per ADR-0014).
+ */
+export type DecoderRuntimeTier = "node-onnx-cpu" | "node-onnx-gpu" | "local-python";
+
+/**
+ * Capabilities a bridge advertises at load time. The pipeline consults these
+ * before calling `decode()` to verify the input latents are decodable; an
+ * advertise/decode mismatch is a deterministic typed error, not a runtime
+ * surprise.
+ */
+export interface ImageDecoderCapabilities {
+  /** Which decoder family this bridge implements. Matches `DecoderFamilySchema`. */
+  readonly family: DecoderFamily;
+
+  /** Stable identifier for `manifest.image.decoder.id` and `decoderHash` (Issue #384 receipts). */
+  readonly decoderId: string;
+
+  /**
+   * Per-token-shape advertisement. The pipeline matches a candidate
+   * `ImageLatentCodes` against this list and refuses if no entry matches.
+   *
+   * For 2D shapes: `tokenGrid: [W, H]` is supported.
+   * For 1D shapes (RFC-0007): `sequenceLength: N` is supported.
+   *
+   * A bridge that handles both shapes lists both entries.
+   */
+  readonly supportedShapes: ReadonlyArray<DecoderShapeSupport>;
+
+  /**
+   * Codebook identifier + version the bridge expects on incoming latents.
+   * `ImageLatentCodes.codebook` + `codebookVersion` must match exactly.
+   * Mismatched codebooks decode to garbage; bridge MUST refuse at advertise time.
+   */
+  readonly codebook: string;
+  readonly codebookVersion: string;
+
+  /**
+   * Determinism contract. Pipeline records this on the manifest receipt; CI
+   * gates compare across runs / platforms accordingly (#374 + replay #384).
+   */
+  readonly determinismClass: DecoderDeterminismClass;
+
+  /** Runtime tier this bridge ran under. See `DecoderRuntimeTier`. */
+  readonly runtimeTier: DecoderRuntimeTier;
+
+  /**
+   * Codec + license posture. Required by ADR-0020: the canonical M-phase
+   * path needs permissive code AND weights; research-only weights are
+   * opt-in via `--allow-research-weights`.
+   */
+  readonly codeLicense: string; // e.g. "Apache-2.0"
+  readonly weightsLicense: "permissive" | "research-only";
+}
+
+/**
+ * One supported (shape, output-resolution) tuple. A bridge that only outputs
+ * 256×256 from a 16×16 token grid lists one entry; a multi-resolution bridge
+ * lists several.
+ */
+export type DecoderShapeSupport =
+  | {
+      readonly shape: "2D";
+      readonly tokenGrid: readonly [number, number];
+      readonly outputPixels: readonly [number, number];
+    }
+  | {
+      readonly shape: "1D";
+      readonly sequenceLength: number;
+      readonly outputPixels: readonly [number, number];
+    };
+
+/**
+ * Result of a single `decode()` call. The pipeline wraps this in
+ * `DecodedRaster` for downstream consumption; warnings flow into the
+ * codec's manifest sidecar so receipts stay honest (Issue #182 / #363).
+ */
+export interface ImageDecoderResult {
+  readonly raster: DecodedRaster;
+  /**
+   * Non-fatal warnings the bridge wants to surface. Format mirrors
+   * `codecV2.Sidecar.warnings` so the codec can fold them in directly.
+   */
+  readonly warnings: ReadonlyArray<{
+    readonly code: string;
+    readonly message: string;
+    readonly detail?: unknown;
+  }>;
+  /**
+   * Stable hash of the model weights + tokenizer codebook + adapter
+   * (everything that contributes to byte parity). Recorded on the manifest
+   * as `decoderHash.value`.
+   */
+  readonly decoderHash: string;
+}
+
+/**
+ * The bridge contract every image decoder family conforms to.
+ *
+ * Loading is async because real bridges fetch / mmap weights; subsequent
+ * `decode()` calls are usually fast (model resident in memory). A bridge
+ * loaded with research-only weights should refuse to be returned by
+ * `load*DecoderBridge()` unless `allowResearchWeights: true` is passed
+ * (ADR-0020 enforcement; tracked by #376).
+ */
+export interface ImageDecoderBridge {
+  readonly capabilities: ImageDecoderCapabilities;
+
+  /**
+   * Decode a single `ImageLatentCodes` value into a PNG raster.
+   *
+   * Throws `WittgensteinError`-shaped errors with a `code` field on:
+   *   - `DECODER_SHAPE_UNSUPPORTED` — latents don't match advertised shapes.
+   *   - `DECODER_CODEBOOK_MISMATCH` — `codebook` or `codebookVersion` differ.
+   *   - `DECODER_RUNTIME_UNAVAILABLE` — ONNX runtime / model missing.
+   *   - `DECODER_INFERENCE_FAILED` — model ran but produced invalid output.
+   */
+  decode(codes: ImageLatentCodes): Promise<ImageDecoderResult>;
+
+  /** Release any held resources (model weights, ONNX session). Idempotent. */
+  unload(): Promise<void>;
+}
+
+/**
+ * Options accepted by every `load*DecoderBridge()` entrypoint. Specific
+ * bridges (llamagen, seed, dvae) may extend this with bridge-specific knobs;
+ * the common fields here are what the pipeline / CLI always pass through.
+ */
+export interface LoadDecoderBridgeOptions {
+  /**
+   * If true, allow loading research-only weights (per ADR-0020). The CLI's
+   * `--allow-research-weights` flag is the user-facing surface; the bridge
+   * loader is the enforcement point. Implementation tracked at #376.
+   */
+  readonly allowResearchWeights?: boolean;
+
+  /**
+   * Cache directory for fetched model weights. Defaults to a tier-appropriate
+   * path (e.g. `~/.cache/wittgenstein/decoders/<family>`).
+   */
+  readonly cacheDir?: string;
+
+  /**
+   * Override the runtime tier. Defaults to `node-onnx-cpu`. Non-canonical
+   * tiers surface in the receipt; `local-python` requires the polyglot-mini
+   * sandbox to be present.
+   */
+  readonly runtimeTier?: DecoderRuntimeTier;
+}

--- a/packages/codec-image/src/schema.ts
+++ b/packages/codec-image/src/schema.ts
@@ -3,6 +3,7 @@ import type { ImageRequest, Result } from "@wittgenstein/schemas";
 import { ImageRequestSchema } from "@wittgenstein/schemas";
 
 export const DecoderFamilySchema = z.enum(["llamagen", "seed", "dvae"]);
+export type DecoderFamily = z.infer<typeof DecoderFamilySchema>;
 export const ImageSceneSpecVersionSchema = z.literal("witt.image.spec/v0.1");
 export const ImageSeedCodeVersionSchema = z.literal("witt.image.seed/v0.1");
 export const ImageCoarseVqVersionSchema = z.literal("witt.image.coarse-vq/v0.1");

--- a/packages/codec-image/test/decoder-bridge-contract.test.ts
+++ b/packages/codec-image/test/decoder-bridge-contract.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Contract tests for the M1B decoder bridge interface.
+ *
+ * Two goals:
+ *
+ * 1. **Stub current behavior** — the canonical M1B loader
+ *    (`loadLlamagenDecoderBridge`) and the alternate (`loadSeedDecoderBridge`)
+ *    today MUST throw a typed error with a stable error code citing the
+ *    blocker tracker issues. The CLI / pipeline reads `error.code` to
+ *    decide whether to fall back to the procedural placeholder vs. surface
+ *    the error; that contract is brittle without a regression baseline.
+ *
+ * 2. **Prove the contract is implementable** — a tiny test-only conforming
+ *    bridge (`StubBridge`) satisfies `ImageDecoderBridge`. This catches
+ *    type-level drift when someone widens the interface without updating
+ *    the impl checklist in `packages/codec-image/src/decoders/README.md`.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  LLAMAGEN_DECODER_ID,
+  loadLlamagenDecoderBridge,
+} from "../src/decoders/llamagen.js";
+import { SEED_DECODER_ID, loadSeedDecoderBridge } from "../src/decoders/seed.js";
+import type {
+  ImageDecoderBridge,
+  ImageDecoderCapabilities,
+} from "../src/decoders/types.js";
+
+describe("decoder bridge contract (M1B prep)", () => {
+  it("loadLlamagenDecoderBridge throws LLAMAGEN_BRIDGE_NOT_IMPLEMENTED with blocker links", async () => {
+    let caught: unknown;
+    try {
+      await loadLlamagenDecoderBridge();
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    const err = caught as Error & { code?: string; details?: Record<string, unknown> };
+    expect(err.code).toBe("LLAMAGEN_BRIDGE_NOT_IMPLEMENTED");
+    expect(err.details?.family).toBe("llamagen");
+    expect(err.details?.decoderId).toBe(LLAMAGEN_DECODER_ID);
+    const blockers = err.details?.blockers as Record<string, string> | undefined;
+    expect(blockers?.gateC).toMatch(/issues\/334/);
+    expect(blockers?.gateD).toMatch(/issues\/335/);
+  });
+
+  it("loadSeedDecoderBridge throws SEED_BRIDGE_NOT_IMPLEMENTED with audit link", async () => {
+    let caught: unknown;
+    try {
+      await loadSeedDecoderBridge();
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    const err = caught as Error & { code?: string; details?: Record<string, unknown> };
+    expect(err.code).toBe("SEED_BRIDGE_NOT_IMPLEMENTED");
+    expect(err.details?.family).toBe("seed");
+    expect(err.details?.decoderId).toBe(SEED_DECODER_ID);
+  });
+
+  it("the bridge contract is implementable — a stub satisfies ImageDecoderBridge", async () => {
+    const capabilities: ImageDecoderCapabilities = {
+      family: "llamagen",
+      decoderId: "stub-for-contract-test",
+      supportedShapes: [
+        { shape: "2D", tokenGrid: [16, 16], outputPixels: [256, 256] },
+      ],
+      codebook: "stub-codebook",
+      codebookVersion: "v0",
+      determinismClass: "byte-parity",
+      runtimeTier: "node-onnx-cpu",
+      codeLicense: "Apache-2.0",
+      weightsLicense: "permissive",
+    };
+
+    class StubBridge implements ImageDecoderBridge {
+      readonly capabilities = capabilities;
+      async decode() {
+        return {
+          raster: {
+            pngBytes: new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]),
+            width: 256,
+            height: 256,
+          },
+          warnings: [] as const,
+          decoderHash: "stub-hash",
+        };
+      }
+      async unload() {
+        /* no-op */
+      }
+    }
+
+    const bridge: ImageDecoderBridge = new StubBridge();
+    expect(bridge.capabilities.family).toBe("llamagen");
+    expect(bridge.capabilities.supportedShapes[0]?.shape).toBe("2D");
+
+    // Type-level sanity: a 1D-shape variant is in the discriminated union.
+    const oneDShape: ImageDecoderCapabilities["supportedShapes"][number] = {
+      shape: "1D",
+      sequenceLength: 256,
+      outputPixels: [256, 256],
+    };
+    expect(oneDShape.shape).toBe("1D");
+
+    // Functional sanity: decode() returns a PNG-shaped payload.
+    const result = await bridge.decode();
+    expect(result.raster.pngBytes[0]).toBe(0x89);
+    expect(result.raster.pngBytes[1]).toBe(0x50); // P
+    expect(result.warnings).toEqual([]);
+
+    await bridge.unload();
+  });
+});

--- a/packages/codec-image/test/decoder-bridge-contract.test.ts
+++ b/packages/codec-image/test/decoder-bridge-contract.test.ts
@@ -6,9 +6,9 @@
  * 1. **Stub current behavior** — the canonical M1B loader
  *    (`loadLlamagenDecoderBridge`) and the alternate (`loadSeedDecoderBridge`)
  *    today MUST throw a typed error with a stable error code citing the
- *    blocker tracker issues. The CLI / pipeline reads `error.code` to
- *    decide whether to fall back to the procedural placeholder vs. surface
- *    the error; that contract is brittle without a regression baseline.
+ *    blocker tracker issues. The CLI / pipeline reads `error.code` to surface
+ *    the structured failure with a receipt; that contract is brittle without a
+ *    regression baseline.
  *
  * 2. **Prove the contract is implementable** — a tiny test-only conforming
  *    bridge (`StubBridge`) satisfies `ImageDecoderBridge`. This catches
@@ -16,15 +16,9 @@
  *    the impl checklist in `packages/codec-image/src/decoders/README.md`.
  */
 import { describe, expect, it } from "vitest";
-import {
-  LLAMAGEN_DECODER_ID,
-  loadLlamagenDecoderBridge,
-} from "../src/decoders/llamagen.js";
+import { LLAMAGEN_DECODER_ID, loadLlamagenDecoderBridge } from "../src/decoders/llamagen.js";
 import { SEED_DECODER_ID, loadSeedDecoderBridge } from "../src/decoders/seed.js";
-import type {
-  ImageDecoderBridge,
-  ImageDecoderCapabilities,
-} from "../src/decoders/types.js";
+import type { ImageDecoderBridge, ImageDecoderCapabilities } from "../src/decoders/types.js";
 
 describe("decoder bridge contract (M1B prep)", () => {
   it("loadLlamagenDecoderBridge throws LLAMAGEN_BRIDGE_NOT_IMPLEMENTED with blocker links", async () => {
@@ -56,15 +50,15 @@ describe("decoder bridge contract (M1B prep)", () => {
     expect(err.code).toBe("SEED_BRIDGE_NOT_IMPLEMENTED");
     expect(err.details?.family).toBe("seed");
     expect(err.details?.decoderId).toBe(SEED_DECODER_ID);
+    const blockers = err.details?.blockers as Record<string, string> | undefined;
+    expect(blockers?.audit).toMatch(/^https:\/\/github\.com\/p-to-q\/wittgenstein\/issues\/331$/);
   });
 
   it("the bridge contract is implementable — a stub satisfies ImageDecoderBridge", async () => {
     const capabilities: ImageDecoderCapabilities = {
       family: "llamagen",
       decoderId: "stub-for-contract-test",
-      supportedShapes: [
-        { shape: "2D", tokenGrid: [16, 16], outputPixels: [256, 256] },
-      ],
+      supportedShapes: [{ shape: "2D", tokenGrid: [16, 16], outputPixels: [256, 256] }],
       codebook: "stub-codebook",
       codebookVersion: "v0",
       determinismClass: "byte-parity",


### PR DESCRIPTION
## Why this bundle

The project's load-bearing next milestone is **M1B** (image route's frozen VQ decoder bridge). The work that DOES reduce M1B implementation risk pre-compute is **(a) lock the bridge interface contract**, **(b) deliver targeted research** (datasets, training scripts, adapter strategy, quality ladder), and **(c) lock the delivery / componentization doctrine** so the elite research infrastructure doesn't bleed into the user-facing install surface.

This PR bundles all three pieces.

## Bundle content

### 1. Bridge contract (`packages/codec-image/src/decoders/`)

- **NEW** [`types.ts`](../blob/main/packages/codec-image/src/decoders/types.ts) — `ImageDecoderBridge`, `ImageDecoderCapabilities`, `ImageDecoderResult`, `LoadDecoderBridgeOptions`.
- **UPDATED** `llamagen.ts` / `seed.ts` — async loaders throw structured `LLAMAGEN_BRIDGE_NOT_IMPLEMENTED` / `SEED_BRIDGE_NOT_IMPLEMENTED` errors with `code` + `details.{family,decoderId,blockers}`.
- **UPDATED** [`README.md`](../blob/main/packages/codec-image/src/decoders/README.md) — candidate-families table lists `wittgenstein-native` (own-trained) as canonical, `llamagen` as fallback/floor, `var` as Phase 2 option.
- **UPDATED** `../schema.ts` — exports `DecoderFamily` type alias.

### 2. Phase 0 floor note ([`docs/research/2026-05-13-m1b-prep-research.md`](../blob/main/docs/research/2026-05-13-m1b-prep-research.md))

Labeled \"Phase 0 floor / superseded\" with cross-links to the research-program note. Literature survey (§1-§5) stays valid; recommendation sections flagged as superseded. Keeps the floor recommendation if compute / budget reverts.

### 3. Canonical research-program note ([`docs/research/2026-05-13-wittgenstein-research-program.md`](../blob/main/docs/research/2026-05-13-wittgenstein-research-program.md))

Three-track framing (engineering / research / hacker), four phases:
- **Phase 1 (1-3 months):** own-trained tokenizer, learned MaskGIT-style adapter, **native LLM head distilled from teacher** (the load-bearing thesis test), full ablation matrix.
- **Phase 2 (3-6 months):** VAR multi-scale tokenizer, co-trained head+adapter, distillation across teachers, hand-authored VSC.
- **Phase 3 (6-12 months):** cross-modality VSC.
- **Phase 4:** VSC as a programming language.

### 4. Delivery + componentization doctrine ([`docs/research/2026-05-13-delivery-and-componentization.md`](../blob/main/docs/research/2026-05-13-delivery-and-componentization.md))

**Both ends — performance ceiling AND accessibility floor.** Published benchmarks run on the elite tier (no compromises on the headline number). User experience is tiered:

- **Tier 0** (`npm i @wittgenstein/cli`, ~10 MB): sensor, svg-local, asciipng, procedural audio, doctor, replay.
- **Tier 1** (image CPU): `wittgenstein install image`, lazy-fetched weights with sha256 verify.
- **Tier 2** (image GPU): same with onnxruntime-gpu peer.
- **Tier 3** (`research/training/`): the elite stack, outside the npm publish surface.
- **Tier 4** (maintainer): full release pipeline.

### 5. Contract tests (`packages/codec-image/test/decoder-bridge-contract.test.ts`)

3 tests pinning the bridge contract; the third (stub `StubBridge`) proves the contract is implementable.

## Phase 1 trackers filed (10 issues)

**Training & infra (5):**
- [#396](https://github.com/p-to-q/wittgenstein/issues/396) — Train Wittgenstein-native VQGAN-class tokenizer
- [#397](https://github.com/p-to-q/wittgenstein/issues/397) — Train learned MaskGIT-style L4 adapter
- [#398](https://github.com/p-to-q/wittgenstein/issues/398) — Distill native LLM head from LlamaGen-3B (load-bearing thesis test)
- [#399](https://github.com/p-to-q/wittgenstein/issues/399) — Experiment tracking (aim) + manifest spine
- [#400](https://github.com/p-to-q/wittgenstein/issues/400) — DVC data versioning + GPU CI sweep harness

**Delivery & componentization (5):**
- [#402](https://github.com/p-to-q/wittgenstein/issues/402) — Lazy weight fetch + sha256 verify for decoder bridges
- [#403](https://github.com/p-to-q/wittgenstein/issues/403) — `wittgenstein install <tier>` CLI + doctor tier readiness
- [#404](https://github.com/p-to-q/wittgenstein/issues/404) — Optional/peer-dep declarations for heavy runtimes
- [#405](https://github.com/p-to-q/wittgenstein/issues/405) — `examples/reviewer-bench/` one-command verification
- [#406](https://github.com/p-to-q/wittgenstein/issues/406) — `research/training/` isolation + npm-publish guard

## Existing follow-ups reframed (in-place comments)

- [#392](https://github.com/p-to-q/wittgenstein/issues/392) → embedded-deploy target, drop to P3.
- [#393](https://github.com/p-to-q/wittgenstein/issues/393) → ablation baseline row.
- [#394](https://github.com/p-to-q/wittgenstein/issues/394) → canonical CI eval infrastructure, full 30K.

## Verification

- `pnpm test` ✓ — **252 tests** across 10 packages.
- `pnpm lint` ✓.
- `pnpm build` ✓.

## Doctrine impact

This PR is doc-only (research notes + README updates) plus the bridge interface types. It does not change any ratified ADR. It flags four future ADR slots:

1. `structural-parity` as canonical determinism for learned-model paths (cross-modality lift of ADR-0015 + #374).
2. Training manifest schema (sibling to `RunManifestSchema`, needed for #396/#397/#398). Wants an RFC + ADR.
3. `experiment.uri` field on manifests (tied to #399).
4. Tiered install / componentization doctrine (potentially worth an ADR if the install CLI surface ends up doctrine-shaped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)