### PR TITLE
fix: move process runner out of core cycle

### DIFF
--- a/packages/codec-video/src/hyperframes-wrapper.ts
+++ b/packages/codec-video/src/hyperframes-wrapper.ts
@@ -5,14 +5,14 @@
 //
 // Per-composition HTML builders live in `./compositions/{svg-slide,scene-card}.ts`
 // (extracted per #327 / #288). The subprocess plumbing lives in
-// `@wittgenstein/core` (lifted from this package per #356 so future codec
-// subprocess work — audio's Kokoro path — can reuse it). This file owns
-// dispatch + MP4 wiring only.
+// `@wittgenstein/process-runner` (lifted from this package per #356 so future
+// codec subprocess work — audio's Kokoro path — can reuse it without coupling
+// codecs back to the core package). This file owns dispatch + MP4 wiring only.
 
 import { mkdir, writeFile, stat } from "node:fs/promises";
 import { dirname, extname, join } from "node:path";
 import type { RenderCtx, RenderResult } from "@wittgenstein/schemas";
-import { runProcess } from "@wittgenstein/core";
+import { runProcess } from "@wittgenstein/process-runner";
 import type { VideoComposition } from "./schema.js";
 import { buildSvgSlideHtml } from "./compositions/svg-slide.js";
 import { buildSceneCardHtml } from "./compositions/scene-card.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,5 +36,3 @@ export { loadWittgensteinConfig } from "./runtime/config.js";
  * `docs/rfcs/0001-codec-protocol-v2.md`.
  */
 export { codecV2 } from "@wittgenstein/schemas";
-
-export * from "./utils/process-runner.js";

--- a/packages/process-runner/package.json
+++ b/packages/process-runner/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@wittgenstein/codec-video",
+  "name": "@wittgenstein/process-runner",
   "version": "0.0.0",
   "private": true,
   "type": "module",
@@ -12,12 +12,6 @@
     "typecheck": "tsc -b",
     "lint": "eslint src test --ext .ts",
     "test": "vitest run",
-    "test:golden": "vitest run test/golden.test.ts",
     "build": "tsc"
-  },
-  "dependencies": {
-    "@wittgenstein/process-runner": "workspace:*",
-    "@wittgenstein/schemas": "workspace:*",
-    "zod": "^3.23.8"
   }
 }

--- a/packages/process-runner/src/index.ts
+++ b/packages/process-runner/src/index.ts
@@ -1,8 +1,7 @@
 // Generic subprocess runner with timeout + stdout/stderr buffering. Lifted
 // from `packages/codec-video/src/process-runner.ts` per Issue #356 so future
-// codec subprocess work (e.g. audio's Kokoro path) can reuse the timeout
-// boundary, bounded output capture, and structured-error extraction without
-// re-implementing them. Original extraction context: #327 / #288.
+// codec subprocess work can reuse the timeout boundary, bounded output capture,
+// and structured-error extraction without creating codec/core dependency cycles.
 
 import { spawn } from "node:child_process";
 

--- a/packages/process-runner/test/process-runner.test.ts
+++ b/packages/process-runner/test/process-runner.test.ts
@@ -5,7 +5,7 @@
  * timeout + bounded-capture + structured-error invariants directly.
  */
 import { describe, expect, it } from "vitest";
-import { runProcess } from "../src/utils/process-runner.js";
+import { runProcess } from "../src/index.js";
 
 const baseOptions = {
   cwd: process.cwd(),

--- a/packages/process-runner/tsconfig.json
+++ b/packages/process-runner/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -349,9 +349,9 @@ importers:
 
   packages/codec-video:
     dependencies:
-      '@wittgenstein/core':
+      '@wittgenstein/process-runner':
         specifier: workspace:*
-        version: link:../core
+        version: link:../process-runner
       '@wittgenstein/schemas':
         specifier: workspace:*
         version: link:../schemas
@@ -388,6 +388,8 @@ importers:
       zod:
         specifier: ^3.23.8
         version: 3.25.76
+
+  packages/process-runner: {}
 
   packages/sandbox: {}
 


### PR DESCRIPTION
## Why

Follow-up to #379 after merge. The merged shape put `@wittgenstein/codec-video` back onto `@wittgenstein/core` while core already depends on codec-video for registration. `pnpm install` warns about the resulting cyclic workspace dependency, and it makes a generic subprocess helper part of the core/codec cycle.

## What changed

- Adds a leaf package: `@wittgenstein/process-runner`.
- Moves `runProcess` and its tests from core into that leaf package.
- Updates codec-video to depend on the leaf helper instead of core.
- Removes the process-runner export from core.

## Verification

- `CI=true pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm lint:deps`
- `pnpm --filter @wittgenstein/codec-video test`
- `pnpm --filter @wittgenstein/process-runner test`
- `pnpm --filter @wittgenstein/codec-video typecheck`
- `pnpm --filter @wittgenstein/process-runner typecheck`
- `pnpm --filter @wittgenstein/core typecheck`
