### PR TITLE
fix(workflow): only mark closing issue refs as has-pr

### DIFF
--- a/.github/workflows/status-labeler.yml
+++ b/.github/workflows/status-labeler.yml
@@ -245,10 +245,22 @@ jobs:
               };
             }
 
-            async function referencedOpenIssues(pr) {
+            function closingIssueNumbers(pr) {
               const text = `${pr.title || ""}\n${pr.body || ""}`;
-              const numbers = [...text.matchAll(/#(\d+)/g)].map((match) => Number(match[1]));
-              const uniqueNumbers = [...new Set(numbers)].filter((number) => number !== pr.number);
+              const closingReferencePattern =
+                /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+(?:[\w.-]+\/[\w.-]+)?#(\d+)/gi;
+
+              return [
+                ...new Set(
+                  [...text.matchAll(closingReferencePattern)]
+                    .map((match) => Number(match[1]))
+                    .filter((number) => number !== pr.number),
+                ),
+              ];
+            }
+
+            async function closingReferencedOpenIssues(pr) {
+              const uniqueNumbers = closingIssueNumbers(pr);
               const issues = [];
 
               for (const issue_number of uniqueNumbers) {
@@ -272,11 +284,19 @@ jobs:
                 per_page: 20,
               });
 
-              return data.items.some((item) => item.number !== excludedPullRequestNumber);
+              for (const item of data.items) {
+                if (item.number === excludedPullRequestNumber) continue;
+                const pr = await pullRequestPayload(item.number);
+                if (pr && closingIssueNumbers(pr).includes(issue_number)) {
+                  return true;
+                }
+              }
+
+              return false;
             }
 
             async function refreshReferencedIssueStatusAfterPullRequestClosed(pr) {
-              for (const issue_number of await referencedOpenIssues(pr)) {
+              for (const issue_number of await closingReferencedOpenIssues(pr)) {
                 if (await hasOpenPullRequestReference(issue_number, pr.number)) {
                   await setStatus(issue_number, "status/has-pr");
                   continue;
@@ -334,7 +354,7 @@ jobs:
 
               await setStatus(pr.number, await statusForPullRequest(pr.number, pr));
 
-              for (const issue_number of await referencedOpenIssues(pr)) {
+              for (const issue_number of await closingReferencedOpenIssues(pr)) {
                 await setStatus(issue_number, "status/has-pr");
               }
             }
@@ -364,7 +384,7 @@ jobs:
                   await addLabels(pr.number, labelsFromText(pr.title || ""));
                   await addPullRequestSizeIfMissing(pr);
                   await setStatus(pr.number, await statusForPullRequest(pr.number, pr));
-                  for (const issue_number of await referencedOpenIssues(pr)) {
+                  for (const issue_number of await closingReferencedOpenIssues(pr)) {
                     await setStatus(issue_number, "status/has-pr");
                   }
                 }

--- a/.github/workflows/status-labeler.yml
+++ b/.github/workflows/status-labeler.yml
@@ -248,7 +248,7 @@ jobs:
             function closingIssueNumbers(pr) {
               const text = `${pr.title || ""}\n${pr.body || ""}`;
               const closingReferencePattern =
-                /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+(?:[\w.-]+\/[\w.-]+)?#(\d+)/gi;
+                /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*(?:[\w.-]+\/[\w.-]+)?#(\d+)/gi;
 
               return [
                 ...new Set(


### PR DESCRIPTION
## Why

The queue labeler currently treats every `#123` in an open PR title/body as an issue being handled by that PR. That over-labels follow-up, sibling, tracker, and reference links as `status/has-pr`. The current M1B queue shows the failure mode: #395 references many future work issues, and those issues became `status/has-pr` even though the PR does not implement them.

## What changed

- Replaces all-`#number` parsing with closing-keyword parsing (`closes`, `fixes`, `resolves`, etc.).
- Uses the same closing-reference parser when deciding whether a closed PR should leave an issue in `status/has-pr` because another open PR is still handling it.
- Keeps PR status labeling and title-token labels unchanged.

## Verification

- `pnpm prettier --check .github/workflows/status-labeler.yml`

After this lands, I will relabel the currently polluted issues back to `status/ready` / `status/parked` as appropriate.