### PR TITLE
fix(cli): mirror optional runtime peers in npm artifact

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,7 +46,9 @@
     "lint": "eslint src test --ext .ts",
     "test": "vitest run",
     "build": "tsc",
+    "bundle": "node scripts/bundle.mjs",
     "prepack": "pnpm run build",
+    "release:npm": "pnpm run build && pnpm run bundle && node scripts/prepare-npm-artifact.mjs",
     "smoke": "node ./bin/wittgenstein.js doctor"
   },
   "dependencies": {

--- a/packages/cli/scripts/bundle.mjs
+++ b/packages/cli/scripts/bundle.mjs
@@ -14,6 +14,7 @@ await esbuild.build({
   target: "node20",
   format: "cjs",
   outfile: out,
+  external: ["onnxruntime-node"],
   banner: { js: "#!/usr/bin/env node\n" },
   logLevel: "info",
 });

--- a/packages/cli/scripts/prepare-npm-artifact.mjs
+++ b/packages/cli/scripts/prepare-npm-artifact.mjs
@@ -10,9 +10,11 @@ const cliRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const outDir = resolve(cliRoot, "npm-publish");
 const bundleSrc = resolve(cliRoot, "dist/bundle.cjs");
 const readmeSrc = resolve(cliRoot, "README.md");
+const optionalPeerSources = [resolve(cliRoot, "../codec-image/package.json")];
 
 const pkg = JSON.parse(await readFile(resolve(cliRoot, "package.json"), "utf8"));
 const version = pkg.version === "0.0.0" ? "0.1.0" : pkg.version;
+const optionalPeerContract = await loadOptionalPeerContract(optionalPeerSources);
 
 const binStub = `#!/usr/bin/env node
 import { spawnSync } from "node:child_process";
@@ -40,6 +42,7 @@ const slim = {
     node: ">=20.19.0",
   },
   keywords: ["wittgenstein", "cli", "llm", "codec", "minimax"],
+  ...optionalPeerContract,
 };
 
 await mkdir(resolve(outDir, "dist"), { recursive: true });
@@ -55,4 +58,29 @@ try {
   await writeFile(resolve(outDir, "README.md"), "# wittgenstein-cli\n\nSee repository docs.\n");
 }
 await writeFile(resolve(outDir, "package.json"), `${JSON.stringify(slim, null, 2)}\n`);
-console.log(`Prepared ${outDir} (${slim.name}@${slim.version}). Run: cd npm-publish && npm publish`);
+console.log(
+  `Prepared ${outDir} (${slim.name}@${slim.version}). Run: cd npm-publish && npm publish`,
+);
+
+async function loadOptionalPeerContract(packageJsonPaths) {
+  const peerDependencies = {};
+  const peerDependenciesMeta = {};
+
+  for (const packageJsonPath of packageJsonPaths) {
+    const source = JSON.parse(await readFile(packageJsonPath, "utf8"));
+    for (const [name, range] of Object.entries(source.peerDependencies ?? {})) {
+      if (source.peerDependenciesMeta?.[name]?.optional !== true) continue;
+      peerDependencies[name] = range;
+      peerDependenciesMeta[name] = { optional: true };
+    }
+  }
+
+  if (Object.keys(peerDependencies).length === 0) {
+    return {};
+  }
+
+  return {
+    peerDependencies,
+    peerDependenciesMeta,
+  };
+}

--- a/packages/codec-audio/src/decoders/kokoro/index.ts
+++ b/packages/codec-audio/src/decoders/kokoro/index.ts
@@ -1,10 +1,8 @@
 import { createHash } from "node:crypto";
-import { createReadStream, readFileSync } from "node:fs";
+import { createReadStream } from "node:fs";
 import { createRequire } from "node:module";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
-
-const manifestPath = fileURLToPath(new URL("./manifest.json", import.meta.url));
+import { dirname, join, resolve } from "node:path";
+import manifestJson from "./manifest.json" with { type: "json" };
 
 export interface KokoroDecoderManifest {
   readonly repoId: string;
@@ -18,9 +16,7 @@ export interface KokoroDecoderManifest {
   readonly kokoroJsVersion: string;
 }
 
-export const KOKORO_MANIFEST: KokoroDecoderManifest = JSON.parse(
-  readFileSync(manifestPath, "utf8"),
-) as KokoroDecoderManifest;
+export const KOKORO_MANIFEST = manifestJson as KokoroDecoderManifest;
 
 interface RawAudioLike {
   readonly audio: Float32Array;
@@ -51,11 +47,7 @@ type TransformersEnvModule = {
 
 export interface KokoroDecoder {
   /** Synthesize `text` and write a WAV file to `outPath`. */
-  synthesize(
-    text: string,
-    voice: string,
-    outPath: string,
-  ): Promise<{ sampleRate: number }>;
+  synthesize(text: string, voice: string, outPath: string): Promise<{ sampleRate: number }>;
   /** Stable identifier suitable for `audioRender.decoderId`. */
   readonly decoderId: string;
   /** Pinned manifest values used to construct this decoder. */
@@ -114,10 +106,8 @@ export async function getKokoroDecoder(): Promise<KokoroDecoder> {
 
   await ensureProxyDispatcher();
 
-  const kokoroMod = (await import("kokoro-js")) as unknown as KokoroTtsLoader;
-  const transformersMod = (await import(
-    "@huggingface/transformers"
-  )) as unknown as TransformersEnvModule;
+  const kokoroMod = await importRuntime<KokoroTtsLoader>("kokoro-js");
+  const transformersMod = await importRuntime<TransformersEnvModule>("@huggingface/transformers");
 
   const tts = await kokoroMod.KokoroTTS.from_pretrained(KOKORO_MANIFEST.repoId, {
     dtype: KOKORO_MANIFEST.dtype,
@@ -141,9 +131,12 @@ export async function getKokoroDecoder(): Promise<KokoroDecoder> {
   return cachedDecoder;
 }
 
-async function verifyCachedAssetIntegrity(
-  transformersMod: TransformersEnvModule,
-): Promise<void> {
+async function importRuntime<T>(moduleId: string): Promise<T> {
+  const dynamicImport = new Function("id", "return import(id)") as (id: string) => Promise<T>;
+  return dynamicImport(moduleId);
+}
+
+async function verifyCachedAssetIntegrity(transformersMod: TransformersEnvModule): Promise<void> {
   const weightsPath = join(
     transformersMod.env.cacheDir,
     KOKORO_MANIFEST.repoId,
@@ -190,10 +183,20 @@ function resolveBundledVoicePath(): string {
   // sibling of dist/. Walk up two dirs from the resolved entry to land on
   // the package root. `createRequire` works in both Node CLI and the vitest
   // SSR environment; `import.meta.resolve` is CLI-only.
-  const requireFromHere = createRequire(import.meta.url);
+  const requireFromHere = createRequireFromRuntime();
   const entryPath = requireFromHere.resolve("kokoro-js");
   const packageRoot = dirname(dirname(entryPath));
   return join(packageRoot, KOKORO_MANIFEST.voicesFilename);
+}
+
+function createRequireFromRuntime(): NodeRequire {
+  if (typeof import.meta.url === "string") {
+    return createRequire(import.meta.url);
+  }
+  const cjsFilename = new Function(
+    "return typeof __filename === 'string' ? __filename : undefined",
+  )() as string | undefined;
+  return createRequire(cjsFilename ?? resolve(process.cwd(), "index.js"));
 }
 
 async function sha256OfFile(filePath: string): Promise<string> {

--- a/packages/codec-sensor/src/loupe-renderer.ts
+++ b/packages/codec-sensor/src/loupe-renderer.ts
@@ -17,7 +17,14 @@ export interface LoupeRenderResult {
   renderPath: SensorRenderPath;
 }
 
-const moduleDir = dirname(fileURLToPath(import.meta.url));
+function resolveModuleDir(): string {
+  if (typeof import.meta.url === "string") {
+    return dirname(fileURLToPath(import.meta.url));
+  }
+  return process.cwd();
+}
+
+const moduleDir = resolveModuleDir();
 
 /**
  * Default candidate locations for `loupe.py`, ordered from most-likely to

--- a/scripts/check-npm-publish-tarball.mjs
+++ b/scripts/check-npm-publish-tarball.mjs
@@ -25,6 +25,8 @@ import { fileURLToPath } from "node:url";
 const execFileAsync = promisify(execFile);
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(scriptDir, "..");
+const bundledCliManifestPath = resolve(repoRoot, "packages/cli/npm-publish/package.json");
+const optionalPeerSourcePaths = [resolve(repoRoot, "packages/codec-image/package.json")];
 const npmCacheDir = mkdtempSync(join(tmpdir(), "wittgenstein-npm-pack-cache-"));
 let npmCacheRemoved = false;
 
@@ -75,7 +77,7 @@ async function findPublishablePackages() {
     const pkgJsonPath = resolve(dir, entry.name, "package.json");
     let pkg;
     try {
-      pkg = JSON.parse(await readFile(pkgJsonPath, "utf8"));
+      pkg = await readJson(pkgJsonPath);
     } catch {
       continue;
     }
@@ -84,6 +86,10 @@ async function findPublishablePackages() {
     out.push({ name: pkg.name, dir: resolve(dir, entry.name) });
   }
   return out;
+}
+
+async function readJson(path) {
+  return JSON.parse(await readFile(path, "utf8"));
 }
 
 async function tarballFiles(packageDir) {
@@ -122,6 +128,70 @@ async function buildPackageClosure(packageName) {
     encoding: "utf8",
     maxBuffer: 32 * 1024 * 1024,
   });
+}
+
+async function prepareBundledCliArtifact() {
+  await execFileAsync("pnpm", ["--filter", "@wittgenstein/cli", "run", "release:npm"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    maxBuffer: 32 * 1024 * 1024,
+  });
+}
+
+async function expectedBundledOptionalPeerContract() {
+  const peerDependencies = {};
+  const peerDependenciesMeta = {};
+
+  for (const packageJsonPath of optionalPeerSourcePaths) {
+    const source = await readJson(packageJsonPath);
+    for (const [name, range] of Object.entries(source.peerDependencies ?? {})) {
+      if (source.peerDependenciesMeta?.[name]?.optional !== true) continue;
+      peerDependencies[name] = range;
+      peerDependenciesMeta[name] = { optional: true };
+    }
+  }
+
+  return { peerDependencies, peerDependenciesMeta };
+}
+
+async function bundledCliManifestFailures() {
+  const manifest = await readJson(bundledCliManifestPath);
+  const expected = await expectedBundledOptionalPeerContract();
+  const failures = [];
+
+  for (const [name, range] of Object.entries(expected.peerDependencies)) {
+    if (manifest.peerDependencies?.[name] !== range) {
+      failures.push(
+        `peerDependencies.${name} must mirror optional runtime peer range ${range} from codec package manifests.`,
+      );
+    }
+    if (manifest.peerDependenciesMeta?.[name]?.optional !== true) {
+      failures.push(
+        `peerDependenciesMeta.${name}.optional must be true in the bundled CLI manifest.`,
+      );
+    }
+  }
+
+  for (const name of Object.keys(manifest.peerDependencies ?? {})) {
+    if (expected.peerDependencies[name] === undefined) {
+      failures.push(
+        `peerDependencies.${name} is not sourced from a bundled optional runtime peer.`,
+      );
+    }
+  }
+
+  if (manifest.dependencies !== undefined) {
+    failures.push(
+      "bundled CLI manifest must not add runtime dependencies to the default install path.",
+    );
+  }
+  if (manifest.optionalDependencies !== undefined) {
+    failures.push(
+      "bundled CLI manifest must use optional peer metadata, not optionalDependencies, for tiered runtimes.",
+    );
+  }
+
+  return failures;
 }
 
 async function main() {
@@ -183,6 +253,27 @@ async function main() {
         });
       }
     }
+  }
+
+  try {
+    await prepareBundledCliArtifact();
+    for (const error of await bundledCliManifestFailures()) {
+      packFailures.push({
+        package: "wittgenstein-cli",
+        phase: "generated manifest",
+        error,
+        stdout: "",
+        stderr: "",
+      });
+    }
+  } catch (error) {
+    packFailures.push({
+      package: "wittgenstein-cli",
+      phase: "release:npm artifact generation",
+      error: error?.message ?? String(error),
+      stdout: error?.stdout ?? "",
+      stderr: error?.stderr ?? "",
+    });
   }
 
   if (packFailures.length > 0) {


### PR DESCRIPTION
## Summary

Closes #414.

- adds the missing CLI package release script used by the root npm release command
- keeps onnxruntime-node external in the CLI bundle and mirrors codec-image optional peer metadata into the generated wittgenstein-cli manifest
- extends the publish-surface guard to generate the bundled CLI artifact and verify its manifest keeps tiered runtimes as optional peers, not default dependencies
- keeps CLI startup clean by ensuring Kokoro runtime modules stay dynamically loaded and the CJS bundle can start without optional runtime packages installed

## Validation

- pnpm --filter @wittgenstein/cli run release:npm
- node packages/cli/npm-publish/bin/wittgenstein.mjs doctor
- pnpm lint:publish-surface
- pnpm typecheck
- pnpm --filter @wittgenstein/cli test
- pnpm --filter @wittgenstein/codec-audio test
- pnpm --filter @wittgenstein/codec-audio typecheck
- pnpm --filter @wittgenstein/codec-sensor test
- pnpm lint:deps
- pnpm prettier --check packages/codec-audio/src/decoders/kokoro/index.ts packages/codec-sensor/src/loupe-renderer.ts packages/cli/scripts/bundle.mjs packages/cli/scripts/prepare-npm-artifact.mjs packages/cli/package.json scripts/check-npm-publish-tarball.mjs
- git diff --check