### PR TITLE
[codex] ship sensor sidecar receipts and bundled loupe

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The receipt set is intentionally narrow. Adding a row requires a script + a CI g
 
 - Workspace gates from a clean checkout: `pnpm install --frozen-lockfile`, `pnpm typecheck`, `pnpm lint`, `pnpm test`, `pnpm test:golden`, and `pnpm smoke:cli` all pass. Verified 2026-05-06 in [`docs/research/2026-05-06-v0.3-cold-checkout-rerun.md`](docs/research/2026-05-06-v0.3-cold-checkout-rerun.md).
 - Codec independence: `pnpm lint:deps` enforces no cross-codec imports across 6 codec packages ([PR #126](https://github.com/p-to-q/wittgenstein/pull/126)).
-- Self-contained loupe HTML dashboard: ~ 117 KB, zero external CDN dependencies (run the [Quickstart](#quickstart-30-seconds-no-api-key) below, then `wc -c /tmp/ecg.html`).
+- Self-contained loupe HTML dashboard: zero external CDN dependencies; size varies with row count and is ~40 KB for the current dry-run ECG quickstart (run the [Quickstart](#quickstart-30-seconds-no-api-key) below, then `wc -c /tmp/ecg.html`).
 
 ---
 
@@ -218,7 +218,7 @@ What you get:
 ├── ecg.json    operator spec + 2,500 samples
 ├── ecg.csv     timeSec,value
 ├── ecg.png     matplotlib chart
-└── ecg.html    117 KB interactive loupe dashboard
+└── ecg.html    self-contained interactive loupe dashboard
 ```
 
 Full tour: [`docs/quickstart.md`](docs/quickstart.md).

--- a/docs/benchmark-standards.md
+++ b/docs/benchmark-standards.md
@@ -167,12 +167,12 @@ Score range: 0.0 – 1.0.
 
 ECG dry-run · 250 Hz · 10 s:
 
-| Metric             | Value                                                |
-| ------------------ | ---------------------------------------------------- |
-| Signal expand time | < 2 ms (pure numpy, no I/O)                          |
-| Sample count       | 2,500                                                |
-| Loupe HTML size    | ~117 KB (self-contained, zero external dependencies) |
-| Loupe render time  | ~0.8 s (Python subprocess, one-time startup cost)    |
+| Metric             | Value                                                                                              |
+| ------------------ | -------------------------------------------------------------------------------------------------- |
+| Signal expand time | < 2 ms (pure numpy, no I/O)                                                                        |
+| Sample count       | 2,500                                                                                              |
+| Loupe HTML size    | ~40 KB for current dry-run ECG; varies with row count (self-contained, zero external dependencies) |
+| Loupe render time  | ~0.8 s (Python subprocess, one-time startup cost)                                                  |
 
 ---
 

--- a/docs/codecs/sensor.md
+++ b/docs/codecs/sensor.md
@@ -31,15 +31,15 @@ The LLM does not emit raw samples, NumPy arrays, or waveform binaries. It emits 
 
 The library is deliberately small. Adding an operator requires an RFC.
 
-| Operator       | Use                                                              | Parameters                                                        |
-| -------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------- |
-| `oscillator`   | sine / square / triangle base waves                              | `freqHz`, `amplitude`, `phase`                                    |
-| `noise`        | white / pink / brown noise overlay                               | `kind`, `amplitude`                                               |
-| `drift`        | low-frequency baseline drift                                     | `slope`, `period`                                                 |
-| `pulse`        | event-rate Poisson or fixed-period                               | `rateHz`, `width`, `shape`                                        |
-| `step`         | discrete level changes                                           | `levels`, `times`                                                 |
-| `ecgTemplate`  | clinical-shape ECG cycle (P-QRS-T)                               | `bpm`, `morphology`, `noiseFloor`                                 |
-| `patchGrammar` | higher-order: split duration into patches, recurse per-patch ops | `patchLengthSec`, `patches[]: { operators[], affineNormalize? }`  |
+| Operator       | Use                                                              | Parameters                                                       |
+| -------------- | ---------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `oscillator`   | sine / square / triangle base waves                              | `freqHz`, `amplitude`, `phase`                                   |
+| `noise`        | white / pink / brown noise overlay                               | `kind`, `amplitude`                                              |
+| `drift`        | low-frequency baseline drift                                     | `slope`, `period`                                                |
+| `pulse`        | event-rate Poisson or fixed-period                               | `rateHz`, `width`, `shape`                                       |
+| `step`         | discrete level changes                                           | `levels`, `times`                                                |
+| `ecgTemplate`  | clinical-shape ECG cycle (P-QRS-T)                               | `bpm`, `morphology`, `noiseFloor`                                |
+| `patchGrammar` | higher-order: split duration into patches, recurse per-patch ops | `patchLengthSec`, `patches[]: { operators[], affineNormalize? }` |
 
 The runtime composes operators by addition into a single sample buffer. Composition order is recorded in the manifest for replay.
 
@@ -107,7 +107,7 @@ The fast path emits three files per run:
 - `signal.csv` — flat sidecar for spreadsheet tools.
 - `loupe.html` — single-page dashboard for visual inspection.
 
-All three are recorded in the manifest with their SHA-256 hashes.
+All three are recorded in the manifest `artifactSidecars` list with byte counts and SHA-256 hashes; the primary `artifactPath` remains the HTML dashboard when Loupe renders successfully.
 
 ## Goldens
 
@@ -133,17 +133,17 @@ Sensor's quality risk is small but real:
 
 For agents reading this doc cold, the full sensor lineage from M3 closure to today's main HEAD:
 
-| Step | Surface | Note |
-|---|---|---|
-| Codec-sensor M3 port | `docs/exec-plans/active/codec-v2-port.md` §M3 | The "confirmation case": no L4 adapter, deterministic L3, three signal types (ecg / gyro / temperature) |
-| Three sensor goldens | `fixtures/golden/sensor/{ecg,temperature,gyro}.csv` + `manifest.json` | Byte-pinned per signal family; CI-gated via `pnpm test:golden` |
-| patchGrammar research | PR #239 (closes #221) | TimesFM-inspired patching / local-affine-normalization / chunked expansion; concept-only borrow, no model dep |
-| patchGrammar implementation | PR #244 | Higher-order operator added; recursion via `z.lazy + z.union`; existing 3 sensor goldens unchanged |
-| patchGrammar contract honesty | PR #249 (closes #247) | Patch-local time semantics; recursion-depth cap; `affineNormalize` bound validation; lineage receipt structure documented in this doc's patchGrammar section |
-| patchGrammar goldens | `fixtures/golden/sensor/{ecg,temperature,gyro}-patch-grammar.csv` | New byte-pinned fixtures; `gyro-patch-grammar.csv` SHA equals `gyro.csv` SHA (single-patch full-duration recursion-seam invariant) |
-| Route enum tightening | PR #245 | `RunManifest.route` enforces `ecg` / `temperature` / `gyro` per #190 partial closeout |
-| Sensor algorithmic research | PR #276 (closes #262) | TimesFM concept-borrow without model dep; chaos / shapelets / reservoir surveyed; concrete measurement gate proposed for #155 |
+| Step                          | Surface                                                                                       | Note                                                                                                                                                                                                                            |
+| ----------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Codec-sensor M3 port          | `docs/exec-plans/active/codec-v2-port.md` §M3                                                 | The "confirmation case": no L4 adapter, deterministic L3, three signal types (ecg / gyro / temperature)                                                                                                                         |
+| Three sensor goldens          | `fixtures/golden/sensor/{ecg,temperature,gyro}.csv` + `manifest.json`                         | Byte-pinned per signal family; CI-gated via `pnpm test:golden`                                                                                                                                                                  |
+| patchGrammar research         | PR #239 (closes #221)                                                                         | TimesFM-inspired patching / local-affine-normalization / chunked expansion; concept-only borrow, no model dep                                                                                                                   |
+| patchGrammar implementation   | PR #244                                                                                       | Higher-order operator added; recursion via `z.lazy + z.union`; existing 3 sensor goldens unchanged                                                                                                                              |
+| patchGrammar contract honesty | PR #249 (closes #247)                                                                         | Patch-local time semantics; recursion-depth cap; `affineNormalize` bound validation; lineage receipt structure documented in this doc's patchGrammar section                                                                    |
+| patchGrammar goldens          | `fixtures/golden/sensor/{ecg,temperature,gyro}-patch-grammar.csv`                             | New byte-pinned fixtures; `gyro-patch-grammar.csv` SHA equals `gyro.csv` SHA (single-patch full-duration recursion-seam invariant)                                                                                              |
+| Route enum tightening         | PR #245                                                                                       | `RunManifest.route` enforces `ecg` / `temperature` / `gyro` per #190 partial closeout                                                                                                                                           |
+| Sensor algorithmic research   | PR #276 (closes #262)                                                                         | TimesFM concept-borrow without model dep; chaos / shapelets / reservoir surveyed; concrete measurement gate proposed for #155                                                                                                   |
 | patchGrammar measurement plan | [PR #321](https://github.com/p-to-q/wittgenstein/pull/321) (revised + merged version of #295) | Ratified dataset / metric / protocol for the #284 measurement gate. NOAA LCD (temperature) + PhysioNet/CinC (ECG) + UCI HAR (gyro); Welch spectral distance + augmentation F1 lift; pre-registered sample-size escalation rule. |
-| Implementation slices (gated) | #263 | Awaits #284 measurement results; #153 (chaos) un-parked only on patchGrammar pass per family |
+| Implementation slices (gated) | #263                                                                                          | Awaits #284 measurement results; #153 (chaos) un-parked only on patchGrammar pass per family                                                                                                                                    |
 
 The lineage is intentionally additive: each step is reversible (no commit erased the prior framing) and citation-backed (every claim above resolves to a PR or doc path). New work that touches the sensor surface should extend this table, not silently rewrite earlier rows.

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -5,7 +5,7 @@ Wittgenstein is designed to be installable and skill-friendly, not just a local 
 ## Delivery Surface
 
 - `@wittgenstein/cli` exposes `wittgenstein` in the monorepo
-- Public npm package **`wittgenstein-cli`** (no scope) is produced from `packages/cli/npm-publish/` after `pnpm run release:npm` — single bundled binary, no `workspace:*` in the published manifest
+- Public npm package **`wittgenstein-cli`** (no scope) is produced from `packages/cli/npm-publish/` after `pnpm run release:npm` — single bundled binary plus the sensor Loupe renderer, no `workspace:*` in the published manifest
 
 ## npm (public registry)
 
@@ -27,6 +27,7 @@ cd packages/cli && pnpm run release:npm && cd npm-publish && npm publish
 ```
 
 Requires `npm login` (or a publish token) on that machine. The published name is **`wittgenstein-cli`**; install with `npm install -g wittgenstein-cli`. If npm reports that **OTP / 2FA** is required for publish, append `--otp=…` to the `npm publish` command for that account only.
+
 - `scripts/install.sh` is the future `curl | sh` seam
 - `AGENTS.md` is the short agent primer; `packages/agent-contact-text/` holds extended narrative primers (00–03) for coding agents
 - output conventions are stable under `artifacts/runs/*`

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -128,9 +128,9 @@ codecs are wired. Image and video codecs are typed stubs — intentional until t
 
 ## Loupe dashboard renderer
 
-| Component                                  | Status   | Notes                                                                              |
-| ------------------------------------------ | -------- | ---------------------------------------------------------------------------------- |
-| CSV / JSON → self-contained HTML dashboard | ✅ Ships | `packages/codec-sensor/loupe.py`; 117 KB HTML, zero external deps, dark/light mode |
+| Component                                  | Status   | Notes                                                                                      |
+| ------------------------------------------ | -------- | ------------------------------------------------------------------------------------------ |
+| CSV / JSON → self-contained HTML dashboard | ✅ Ships | `packages/codec-sensor/loupe.py`; self-contained HTML, zero external deps, dark/light mode |
 
 ---
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -26,7 +26,7 @@ open /tmp/ecg.html     # macOS; or xdg-open on Linux
 
 What you get: `/tmp/ecg.json` (operator spec) + `/tmp/ecg.csv` (2,500 samples)
 
-- `/tmp/ecg.png` (matplotlib chart) + `/tmp/ecg.html` (~117 KB interactive loupe dashboard,
+- `/tmp/ecg.png` (matplotlib chart) + `/tmp/ecg.html` (interactive loupe dashboard,
   zero external dependencies).
 
 The dashboard has sortable tables, summary stats, and dark/light mode. The whole thing is

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -100,7 +100,7 @@ Procedural ambient synthesis (pink noise, gaussian pulses, tonal layers) in pure
 ### ❤️ Sensor — ECG
 
 Each entry ships JSON (operator spec + samples) + CSV (`timeSec,value`) + an interactive
-Loupe HTML dashboard (~117 KB, zero external deps).
+Loupe HTML dashboard (self-contained, zero external deps; size varies with row count).
 
 | #   | JSON                                                                          | CSV                                                                         | HTML (interactive)                                                                           |
 | --- | ----------------------------------------------------------------------------- | --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |

--- a/packages/cli/scripts/bundle.mjs
+++ b/packages/cli/scripts/bundle.mjs
@@ -1,11 +1,13 @@
 import * as esbuild from "esbuild";
-import { chmod } from "node:fs/promises";
+import { chmod, copyFile } from "node:fs/promises";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = dirname(fileURLToPath(import.meta.url));
 const pkgRoot = resolve(root, "..");
 const out = resolve(pkgRoot, "dist/bundle.cjs");
+const loupeSrc = resolve(pkgRoot, "../codec-sensor/loupe.py");
+const loupeOut = resolve(pkgRoot, "dist/loupe.py");
 
 await esbuild.build({
   entryPoints: [resolve(pkgRoot, "src/cli-main.ts")],
@@ -20,4 +22,5 @@ await esbuild.build({
 });
 
 await chmod(out, 0o755);
+await copyFile(loupeSrc, loupeOut);
 console.log("wrote", out);

--- a/packages/cli/scripts/prepare-npm-artifact.mjs
+++ b/packages/cli/scripts/prepare-npm-artifact.mjs
@@ -9,6 +9,7 @@ import { fileURLToPath } from "node:url";
 const cliRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const outDir = resolve(cliRoot, "npm-publish");
 const bundleSrc = resolve(cliRoot, "dist/bundle.cjs");
+const loupeSrc = resolve(cliRoot, "dist/loupe.py");
 const readmeSrc = resolve(cliRoot, "README.md");
 const optionalPeerSources = [resolve(cliRoot, "../codec-image/package.json")];
 
@@ -37,7 +38,7 @@ const slim = {
   bin: {
     wittgenstein: "./bin/wittgenstein.mjs",
   },
-  files: ["dist/bundle.cjs", "bin/wittgenstein.mjs", "README.md"],
+  files: ["dist/bundle.cjs", "dist/loupe.py", "bin/wittgenstein.mjs", "README.md"],
   engines: {
     node: ">=20.19.0",
   },
@@ -49,6 +50,7 @@ await mkdir(resolve(outDir, "dist"), { recursive: true });
 await mkdir(resolve(outDir, "bin"), { recursive: true });
 await copyFile(bundleSrc, resolve(outDir, "dist/bundle.cjs"));
 await chmod(resolve(outDir, "dist/bundle.cjs"), 0o755);
+await copyFile(loupeSrc, resolve(outDir, "dist/loupe.py"));
 const binPath = resolve(outDir, "bin/wittgenstein.mjs");
 await writeFile(binPath, binStub, "utf8");
 await chmod(binPath, 0o755);

--- a/packages/cli/src/commands/shared.ts
+++ b/packages/cli/src/commands/shared.ts
@@ -55,6 +55,7 @@ export async function runCodecCommand(
         runId: outcome.manifest.runId,
         runDir: outcome.runDir,
         artifactPath: outcome.manifest.artifactPath,
+        artifactSidecars: outcome.manifest.artifactSidecars,
         error: outcome.error,
         ...(extra ?? {}),
       },

--- a/packages/codec-image/test/codec.test.ts
+++ b/packages/codec-image/test/codec.test.ts
@@ -50,10 +50,6 @@ function captureWarnLogger(warnings: string[]): RenderCtx["logger"] {
   };
 }
 
-// Two-pass acceptance-ledger cross-reference, lifted out of the inline
-// comment per #354 so the ledger location stays greppable from one place.
-const TWO_PASS_ACCEPTANCE_LEDGER_DOC = "docs/research/2026-05-07-vsc-acceptance-cases.md (#207)";
-
 describe("@wittgenstein/codec-image", () => {
   it("parses and enriches scene contract defaults", () => {
     expect(imageCodec.name).toBe("image");
@@ -269,8 +265,8 @@ describe("@wittgenstein/codec-image", () => {
     }
   });
 
-  // Cases below cover the two-pass acceptance ledger — see
-  // `TWO_PASS_ACCEPTANCE_LEDGER_DOC` at the top of the file. They lock the
+  // Cases below cover the two-pass acceptance ledger:
+  // docs/research/2026-05-07-vsc-acceptance-cases.md (#207). They lock the
   // current codec contract: `mode` is preserved on the receipt as the
   // declared lane, while `imageCodePath` reflects which decoder-facing
   // layer actually fired. Mode-driven runtime short-circuit (true two-pass

--- a/packages/codec-sensor/loupe.py
+++ b/packages/codec-sensor/loupe.py
@@ -10,6 +10,7 @@ Usage:
 
 import argparse
 import csv
+import html
 import json
 import os
 import sys
@@ -144,6 +145,26 @@ header{
   white-space:nowrap;
 }
 .btn:hover{border-color:var(--accent);color:var(--text)}
+.dashboard-grid{display:grid;grid-template-columns:minmax(0,1.4fr) minmax(260px,.6fr);gap:16px;padding:18px 24px 0}
+.chart-card{
+  background:var(--bg2);border:1px solid var(--border);border-radius:var(--radius);
+  padding:16px;min-width:0;
+}
+.chart-head{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;margin-bottom:12px}
+.chart-title{font-size:13px;font-weight:700;color:var(--text)}
+.chart-meta{font-family:var(--mono);font-size:11px;color:var(--muted);margin-top:3px}
+.chart-canvas{
+  display:block;width:100%;height:260px;border-radius:8px;
+  background:linear-gradient(180deg,var(--bg),var(--bg3));border:1px solid var(--border);
+}
+.profile-card{
+  background:var(--bg2);border:1px solid var(--border);border-radius:var(--radius);
+  padding:16px;display:flex;flex-direction:column;gap:10px;min-width:0;
+}
+.profile-row{display:flex;justify-content:space-between;gap:12px;border-bottom:1px solid var(--border);padding-bottom:8px}
+.profile-row:last-child{border-bottom:0;padding-bottom:0}
+.profile-label{font-size:11px;text-transform:uppercase;letter-spacing:.07em;color:var(--muted)}
+.profile-value{font-family:var(--mono);font-size:12px;color:var(--text);text-align:right;overflow:hidden;text-overflow:ellipsis}
 .stats-row{
   display:flex;gap:12px;padding:16px 24px;flex-wrap:wrap;
   border-bottom:1px solid var(--border);background:var(--bg);
@@ -192,6 +213,15 @@ footer{
 .page-btn:hover{border-color:var(--accent);color:var(--text)}
 .page-btn.active{background:var(--accent);border-color:var(--accent);color:#fff}
 .empty{text-align:center;padding:48px;color:var(--muted)}
+@media (max-width: 820px){
+  header{padding:14px 16px}
+  .dashboard-grid{grid-template-columns:1fr;padding:14px 16px 0}
+  .stats-row{padding:14px 16px}
+  .table-wrap{padding:0 16px 18px}
+  .chart-canvas{height:220px}
+  th{top:58px}
+  footer{padding:12px 16px}
+}
 """
 
 JS = r"""
@@ -207,9 +237,21 @@ let query = "";
 const tbody = document.querySelector("tbody");
 const footer_info = document.getElementById("footer-info");
 const search = document.getElementById("search");
+const chart = document.getElementById("chart");
+const chartTitle = document.getElementById("chart-title");
+const chartMeta = document.getElementById("chart-meta");
 
 function parseNum(v) {
   return parseFloat(String(v).replace(/[,$%€£]/g, "")) || 0;
+}
+
+function escapeHtml(v) {
+  return String(v)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 }
 
 function sort(col) {
@@ -268,13 +310,13 @@ function render() {
         const n = parseNum(v);
         const {min, max} = numMeta[c];
         const pct = max !== min ? Math.round((n - min) / (max - min) * 60) : 60;
-        return `<td class="num">${v}<span class="mini-bar" style="width:${pct}px"></span></td>`;
+        return `<td class="num">${escapeHtml(v)}<span class="mini-bar" style="width:${pct}px"></span></td>`;
       }
       if (t === "boolean") {
         const b = ["true","yes","1","t","y"].includes(String(v).toLowerCase());
         return `<td class="bool-${b}">${b ? "✓" : "✗"}</td>`;
       }
-      return `<td title="${String(v).replace(/"/g,'&quot;')}">${v}</td>`;
+      return `<td title="${escapeHtml(v)}">${escapeHtml(v)}</td>`;
     }).join("")}
     </tr>`).join("") : `<tr><td class="empty" colspan="${COLS.length}">No results found</td></tr>`;
 
@@ -283,6 +325,75 @@ function render() {
     : `${total.toLocaleString()} matches · showing ${start}–${end}`;
 
   renderPager(total);
+  renderChart(rows);
+}
+
+function renderChart(rows) {
+  if (!chart) return;
+  const ctx = chart.getContext("2d");
+  const ratio = window.devicePixelRatio || 1;
+  const rect = chart.getBoundingClientRect();
+  chart.width = Math.max(1, Math.floor(rect.width * ratio));
+  chart.height = Math.max(1, Math.floor(rect.height * ratio));
+  ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
+  const w = rect.width, h = rect.height;
+  ctx.clearRect(0, 0, w, h);
+
+  const yCol = COLS.find(c => c !== "timeSec" && TYPES[c] === "number") ||
+    COLS.find(c => TYPES[c] === "number");
+  if (!yCol || rows.length === 0) {
+    chartTitle.textContent = "No numeric preview";
+    chartMeta.textContent = "Add a numeric column to draw a signal.";
+    return;
+  }
+
+  const xCol = COLS.includes("timeSec") ? "timeSec" : null;
+  const points = rows.map((row, i) => ({
+    x: xCol ? parseNum(row[xCol]) : i,
+    y: parseNum(row[yCol]),
+  })).filter(p => Number.isFinite(p.x) && Number.isFinite(p.y));
+
+  if (points.length === 0) return;
+  const xs = points.map(p => p.x), ys = points.map(p => p.y);
+  const minX = Math.min(...xs), maxX = Math.max(...xs);
+  const minY = Math.min(...ys), maxY = Math.max(...ys);
+  const pad = { left: 42, right: 16, top: 18, bottom: 30 };
+  const innerW = Math.max(1, w - pad.left - pad.right);
+  const innerH = Math.max(1, h - pad.top - pad.bottom);
+  const xSpan = maxX !== minX ? maxX - minX : 1;
+  const ySpan = maxY !== minY ? maxY - minY : 1;
+  const sx = x => pad.left + ((x - minX) / xSpan) * innerW;
+  const sy = y => pad.top + innerH - ((y - minY) / ySpan) * innerH;
+
+  ctx.strokeStyle = getComputedStyle(document.documentElement).getPropertyValue("--border").trim();
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  for (let i = 0; i <= 4; i++) {
+    const y = pad.top + (innerH / 4) * i;
+    ctx.moveTo(pad.left, y);
+    ctx.lineTo(w - pad.right, y);
+  }
+  ctx.stroke();
+
+  ctx.strokeStyle = getComputedStyle(document.documentElement).getPropertyValue("--accent").trim();
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  points.forEach((p, i) => {
+    const x = sx(p.x), y = sy(p.y);
+    if (i === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  });
+  ctx.stroke();
+
+  ctx.fillStyle = getComputedStyle(document.documentElement).getPropertyValue("--sub").trim();
+  ctx.font = "11px " + getComputedStyle(document.documentElement).getPropertyValue("--mono");
+  ctx.fillText(minY.toFixed(3), 8, sy(minY));
+  ctx.fillText(maxY.toFixed(3), 8, sy(maxY) + 4);
+  ctx.fillText(String(minX), pad.left, h - 10);
+  ctx.fillText(String(maxX), w - pad.right - 42, h - 10);
+
+  chartTitle.textContent = `${yCol} over ${xCol || "row"}`;
+  chartMeta.textContent = `${points.length.toLocaleString()} point preview · min ${minY.toFixed(4)} · max ${maxY.toFixed(4)}`;
 }
 
 function renderPager(total) {
@@ -315,9 +426,11 @@ function toggleTheme() {
   const t = document.documentElement.dataset.theme === "light" ? "dark" : "light";
   document.documentElement.dataset.theme = t === "dark" ? "" : "light";
   document.getElementById("theme-btn").textContent = t === "light" ? "☀" : "◑";
+  render();
 }
 
 search.addEventListener("input", e => filter(e.target.value));
+window.addEventListener("resize", () => render());
 document.querySelectorAll("th[data-col]").forEach(th =>
   th.addEventListener("click", () => sort(th.dataset.col)));
 
@@ -340,7 +453,7 @@ def generate_html(columns, rows, filename, col_types):
                                   max(stats["max"] - stats["min"], 1) * 100))
                 card = (
                     f'<div class="stat-card">'
-                    f'<div class="stat-label">{col}</div>'
+                    f'<div class="stat-label">{html.escape(col)}</div>'
                     f'<div class="stat-val">{stats["mean"]:.1f}</div>'
                     f'<div class="stat-sub">avg · {stats["min"]:.0f}–{stats["max"]:.0f}</div>'
                     f'<div class="bar"><div class="bar-fill" style="width:{pct}%"></div></div>'
@@ -352,7 +465,7 @@ def generate_html(columns, rows, filename, col_types):
 
     # Table header
     headers = "".join(
-        f'<th data-col="{col}">{col}<span class="sort-icon">↕</span></th>'
+        f'<th data-col="{html.escape(col, quote=True)}">{html.escape(col)}<span class="sort-icon">↕</span></th>'
         for col in columns
     )
 
@@ -371,6 +484,7 @@ def generate_html(columns, rows, filename, col_types):
           .replace("/*TYPES*/", types_json))
 
     short_name = os.path.basename(filename)
+    safe_short_name = html.escape(short_name)
     title = f"{short_name} — loupe"
 
     return f"""<!DOCTYPE html>
@@ -378,16 +492,33 @@ def generate_html(columns, rows, filename, col_types):
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>{title}</title>
+  <title>{html.escape(title)}</title>
   <style>{CSS}</style>
 </head>
 <body>
 <header>
   <div class="logo">⊙ loupe</div>
-  <div class="meta">{short_name} · {nc} col{"s" if nc!=1 else ""} · {n:,} row{"s" if n!=1 else ""}</div>
+  <div class="meta">{safe_short_name} · {nc} col{"s" if nc!=1 else ""} · {n:,} row{"s" if n!=1 else ""}</div>
   <input class="search" id="search" type="search" placeholder="Search all columns…" autocomplete="off">
   <button class="btn" id="theme-btn" onclick="toggleTheme()">◑</button>
 </header>
+<section class="dashboard-grid" aria-label="Data preview">
+  <div class="chart-card">
+    <div class="chart-head">
+      <div>
+        <div class="chart-title" id="chart-title">Signal preview</div>
+        <div class="chart-meta" id="chart-meta">Rendering numeric columns…</div>
+      </div>
+    </div>
+    <canvas class="chart-canvas" id="chart"></canvas>
+  </div>
+  <aside class="profile-card" aria-label="Dataset profile">
+    <div class="profile-row"><span class="profile-label">File</span><span class="profile-value">{safe_short_name}</span></div>
+    <div class="profile-row"><span class="profile-label">Rows</span><span class="profile-value">{n:,}</span></div>
+    <div class="profile-row"><span class="profile-label">Columns</span><span class="profile-value">{nc}</span></div>
+    <div class="profile-row"><span class="profile-label">Numeric</span><span class="profile-value">{sum(1 for c in columns if col_types[c] == "number")}</span></div>
+  </aside>
+</section>
 {stats_html}
 <div class="table-wrap">
   <table>

--- a/packages/codec-sensor/src/loupe-renderer.ts
+++ b/packages/codec-sensor/src/loupe-renderer.ts
@@ -6,7 +6,6 @@
 
 import { access, writeFile } from "node:fs/promises";
 import { dirname, resolve as resolvePath } from "node:path";
-import { fileURLToPath } from "node:url";
 import { spawn } from "node:child_process";
 import type { SensorSignalSpec } from "./schema.js";
 
@@ -18,13 +17,19 @@ export interface LoupeRenderResult {
 }
 
 function resolveModuleDir(): string {
-  if (typeof import.meta.url === "string") {
-    return dirname(fileURLToPath(import.meta.url));
+  if (typeof __dirname === "string") {
+    return __dirname;
   }
   return process.cwd();
 }
 
 const moduleDir = resolveModuleDir();
+
+function resolveEntrypointDir(): string | null {
+  const entrypoint = process.argv[1];
+  if (!entrypoint) return null;
+  return dirname(resolvePath(entrypoint));
+}
 
 /**
  * Default candidate locations for `loupe.py`, ordered from most-likely to
@@ -32,9 +37,13 @@ const moduleDir = resolveModuleDir();
  * `loupe_cli` PATH lookup if none exist.
  */
 function defaultLoupeSearchPaths(): string[] {
+  const entrypointDir = resolveEntrypointDir();
   return [
+    ...(entrypointDir ? [resolvePath(entrypointDir, "loupe.py")] : []), // bundled CLI dist/
+    ...(entrypointDir ? [resolvePath(entrypointDir, "../loupe.py")] : []), // adjacent to bin/
     resolvePath(moduleDir, "../loupe.py"), // package root
     resolvePath(process.cwd(), "loupe.py"), // cwd
+    resolvePath(process.cwd(), "packages/codec-sensor/loupe.py"), // repo root
     resolvePath(process.cwd(), "polyglot-mini/loupe.py"), // sub-project
   ];
 }

--- a/packages/codec-sensor/src/render.ts
+++ b/packages/codec-sensor/src/render.ts
@@ -7,9 +7,10 @@
 // orchestration only; the per-operator math and the dashboard plumbing are
 // no longer mixed into the same module.
 
-import { mkdir, stat, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { dirname, extname } from "node:path";
-import type { RenderCtx, RenderResult } from "@wittgenstein/schemas";
+import type { RenderCtx, RenderResult, RenderSidecar } from "@wittgenstein/schemas";
 import type { SensorSignalSpec } from "./schema.js";
 import { dispatchOperator } from "./operators/index.js";
 import { renderLoupeDashboard, type SensorRenderPath } from "./loupe-renderer.js";
@@ -58,6 +59,11 @@ export async function renderSignalBundle(
   const dashboardOutcome = await renderLoupeDashboard(csvPath, htmlPath, spec);
   const artifactPath = dashboardOutcome.htmlReady ? htmlPath : jsonPath;
   const info = await stat(artifactPath);
+  const sidecars = await Promise.all([
+    describeSidecar("sensor-json", jsonPath, "application/json"),
+    describeSidecar("sensor-csv", csvPath, "text/csv"),
+    describeSidecar("sensor-html", htmlPath, "text/html"),
+  ]);
 
   return {
     artifactPath,
@@ -70,6 +76,7 @@ export async function renderSignalBundle(
       costUsd: 0,
       durationMs: Date.now() - startedAt,
       seed: ctx.seed,
+      sidecars,
       renderPath: dashboardOutcome.renderPath,
     },
   };
@@ -195,6 +202,21 @@ function ensureExtension(path: string, ext: string): string {
 
 function replaceExtension(path: string, ext: string): string {
   return extname(path) ? path.slice(0, -extname(path).length) + ext : `${path}${ext}`;
+}
+
+async function describeSidecar(
+  role: string,
+  path: string,
+  mimeType: string,
+): Promise<RenderSidecar> {
+  const [info, data] = await Promise.all([stat(path), readFile(path)]);
+  return {
+    role,
+    path,
+    mimeType,
+    bytes: info.size,
+    sha256: createHash("sha256").update(data).digest("hex"),
+  };
 }
 
 function createRng(seed: number): () => number {

--- a/packages/codec-sensor/test/codec.test.ts
+++ b/packages/codec-sensor/test/codec.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { mkdtemp, readFile, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -36,6 +37,16 @@ describe("@wittgenstein/codec-sensor", () => {
 
     expect(["text/html", "application/json"]).toContain(result.mimeType);
     expect((await stat(result.artifactPath)).size).toBeGreaterThan(10);
+    expect(result.metadata.sidecars?.map((sidecar) => sidecar.role).sort()).toEqual([
+      "sensor-csv",
+      "sensor-html",
+      "sensor-json",
+    ]);
+    for (const sidecar of result.metadata.sidecars ?? []) {
+      const data = await readFile(sidecar.path);
+      expect(sidecar.bytes).toBe(data.byteLength);
+      expect(sidecar.sha256).toBe(createHash("sha256").update(data).digest("hex"));
+    }
   });
 });
 
@@ -157,10 +168,7 @@ describe("sensor patchGrammar operator", () => {
         {
           type: "patchGrammar",
           patchLengthSec: 1,
-          patches: [
-            { operators: [] },
-            { operators: [{ type: "step", atSec: 0.3, amplitude: 7 }] },
-          ],
+          patches: [{ operators: [] }, { operators: [{ type: "step", atSec: 0.3, amplitude: 7 }] }],
         },
       ],
       notes: [],
@@ -359,8 +367,10 @@ async function renderRows(
 ): Promise<Array<{ timeSec: number; value: number }>> {
   const csv = (await renderToCsv(spec, seed)).toString("utf8");
   const lines = csv.split("\n").slice(1); // drop header
-  return lines.filter((line) => line.length > 0).map((line) => {
-    const [timeSec, value] = line.split(",");
-    return { timeSec: Number(timeSec), value: Number(value) };
-  });
+  return lines
+    .filter((line) => line.length > 0)
+    .map((line) => {
+      const [timeSec, value] = line.split(",");
+      return { timeSec: Number(timeSec), value: Number(value) };
+    });
 }

--- a/packages/core/src/runtime/harness.ts
+++ b/packages/core/src/runtime/harness.ts
@@ -196,8 +196,7 @@ export class Wittgenstein {
         if (artMeta.costUsd !== undefined) {
           manifest.costUsd = artMeta.costUsd;
           manifest.costUsdReason =
-            artMeta.costUsdReason ??
-            (artMeta.costUsd === null ? "missing-usage" : "computed");
+            artMeta.costUsdReason ?? (artMeta.costUsd === null ? "missing-usage" : "computed");
         } else if (artMeta.costUsdReason !== undefined) {
           manifest.costUsdReason = artMeta.costUsdReason;
         }
@@ -290,10 +289,7 @@ export class Wittgenstein {
           }
         }
 
-        budget.consume(
-          generation.tokens.input + generation.tokens.output,
-          generation.costUsd ?? 0,
-        );
+        budget.consume(generation.tokens.input + generation.tokens.output, generation.costUsd ?? 0);
 
         manifest.llmOutputRaw = generation.text;
         manifest.llmTokens = generation.tokens;
@@ -339,6 +335,9 @@ export class Wittgenstein {
         }
         if (rendered.metadata.renderPath !== undefined) {
           manifest.renderPath = rendered.metadata.renderPath;
+        }
+        if (rendered.metadata.sidecars !== undefined) {
+          manifest.artifactSidecars = rendered.metadata.sidecars;
         }
       }
     } catch (caughtError) {

--- a/packages/core/test/manifest.test.ts
+++ b/packages/core/test/manifest.test.ts
@@ -4,11 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { WittgensteinError } from "../src/runtime/errors.js";
-import {
-  collectRuntimeFingerprint,
-  hashFile,
-  hashFileOrThrow,
-} from "../src/runtime/manifest.js";
+import { collectRuntimeFingerprint, hashFile, hashFileOrThrow } from "../src/runtime/manifest.js";
 
 let tmp: string;
 
@@ -132,6 +128,74 @@ describe("Wittgenstein.run — v1 artifact-hash race regression (Issue #345)", (
     // The hash must never be silently nulled into a success manifest — the
     // throw aborts before manifest.ok flips to true.
     expect(outcome.manifest.artifactSha256).toBeNull();
+  });
+
+  it("copies codec-authored artifact sidecars into the run manifest", async () => {
+    const { Wittgenstein } = await import("../src/runtime/harness.js");
+    const { CodecRegistry } = await import("../src/runtime/registry.js");
+    const { DEFAULT_WITTGENSTEIN_CONFIG } = await import("@wittgenstein/schemas");
+
+    const artifactPath = join(tmp, "sensor.html");
+    const sidecarPath = join(tmp, "sensor.csv");
+    const artifactContent = "<!doctype html><title>sensor</title>";
+    const sidecarContent = "timeSec,value\n0,1\n";
+    await writeFile(artifactPath, artifactContent);
+    await writeFile(sidecarPath, sidecarContent);
+
+    const sidecarSha256 = createHash("sha256").update(sidecarContent).digest("hex");
+    const stubCodec = {
+      name: "stub-sensor",
+      modality: "sensor" as const,
+      schemaPreamble: () => "",
+      requestSchema: { parse: (v: unknown) => v } as never,
+      outputSchema: { parse: (v: unknown) => v } as never,
+      parse: () => ({ ok: true as const, value: {} as never }),
+      render: async () => ({
+        artifactPath,
+        mimeType: "text/html",
+        bytes: Buffer.byteLength(artifactContent),
+        metadata: {
+          codec: "stub-sensor",
+          llmTokens: { input: 0, output: 0 },
+          costUsd: 0,
+          durationMs: 0,
+          seed: null,
+          sidecars: [
+            {
+              role: "sensor-csv",
+              path: sidecarPath,
+              mimeType: "text/csv",
+              bytes: Buffer.byteLength(sidecarContent),
+              sha256: sidecarSha256,
+            },
+          ],
+        },
+      }),
+    };
+
+    const registry = new CodecRegistry();
+    registry.register(stubCodec as never);
+    const harness = new Wittgenstein(DEFAULT_WITTGENSTEIN_CONFIG, registry, null);
+
+    const outcome = await harness.run(
+      {
+        modality: "sensor",
+        prompt: "sidecar manifest regression",
+        source: "local",
+      } as never,
+      { command: "test", args: [], cwd: tmp, dryRun: true },
+    );
+
+    expect(outcome.manifest.ok).toBe(true);
+    expect(outcome.manifest.artifactSidecars).toEqual([
+      {
+        role: "sensor-csv",
+        path: sidecarPath,
+        mimeType: "text/csv",
+        bytes: Buffer.byteLength(sidecarContent),
+        sha256: sidecarSha256,
+      },
+    ]);
   });
 });
 

--- a/packages/schemas/src/codec.ts
+++ b/packages/schemas/src/codec.ts
@@ -1,9 +1,7 @@
 import { z } from "zod";
 import type { Modality } from "./modality.js";
 
-export type Result<T, E = CodecError> =
-  | { ok: true; value: T }
-  | { ok: false; error: E };
+export type Result<T, E = CodecError> = { ok: true; value: T } | { ok: false; error: E };
 
 export interface CodecError {
   code: string;
@@ -27,6 +25,14 @@ export interface RenderCtx {
 
 import type { CostUsdReason } from "./manifest.js";
 
+export interface RenderSidecar {
+  role: string;
+  path: string;
+  mimeType: string;
+  bytes: number;
+  sha256: string;
+}
+
 export interface RenderResult {
   artifactPath: string;
   mimeType: string;
@@ -40,6 +46,12 @@ export interface RenderResult {
     costUsdReason?: CostUsdReason;
     durationMs: number;
     seed: number | null;
+    /**
+     * Optional artifact bundle members emitted alongside the primary artifact.
+     * Sensor uses this to make its JSON / CSV / HTML triple explicit rather
+     * than hiding CSV and JSON as undocumented filesystem neighbors.
+     */
+    sidecars?: RenderSidecar[];
     /**
      * Optional codec-internal path identifier — e.g. for sensor it discriminates
      * `loupe-script` / `loupe-cli` / `fallback-static-html` so the manifest tells
@@ -61,11 +73,20 @@ export const RenderResultSchema = z.object({
       output: z.number().int().nonnegative(),
     }),
     costUsd: z.number().nonnegative(),
-    costUsdReason: z
-      .enum(["computed", "unknown-model", "missing-usage", "no-llm-call"])
-      .optional(),
+    costUsdReason: z.enum(["computed", "unknown-model", "missing-usage", "no-llm-call"]).optional(),
     durationMs: z.number().nonnegative(),
     seed: z.number().int().nullable(),
+    sidecars: z
+      .array(
+        z.object({
+          role: z.string(),
+          path: z.string(),
+          mimeType: z.string(),
+          bytes: z.number().int().nonnegative(),
+          sha256: z.string(),
+        }),
+      )
+      .optional(),
     renderPath: z.string().optional(),
   }),
 });

--- a/packages/schemas/src/manifest.ts
+++ b/packages/schemas/src/manifest.ts
@@ -16,12 +16,15 @@ const ImageRouteSchema = z.enum(["raster"]);
 const SensorRouteSchema = z.enum(["ecg", "temperature", "gyro"]);
 const VideoRouteSchema = z.enum(["hyperframes-mp4", "hyperframes-html"]);
 
-const CostUsdReasonSchema = z.enum([
-  "computed",
-  "unknown-model",
-  "missing-usage",
-  "no-llm-call",
-]);
+const CostUsdReasonSchema = z.enum(["computed", "unknown-model", "missing-usage", "no-llm-call"]);
+
+export const ArtifactSidecarSchema = z.object({
+  role: z.string(),
+  path: z.string(),
+  mimeType: z.string(),
+  bytes: z.number().int().nonnegative(),
+  sha256: z.string(),
+});
 
 export const RunManifestSchema = z
   .object({
@@ -74,6 +77,7 @@ export const RunManifestSchema = z
 
     artifactPath: z.string().nullable(),
     artifactSha256: z.string().nullable(),
+    artifactSidecars: z.array(ArtifactSidecarSchema).optional(),
     audioRender: AudioRenderManifestSchema.optional(),
 
     /**
@@ -196,5 +200,6 @@ export const RunManifestSchema = z
   });
 
 export type AudioRenderManifest = z.infer<typeof AudioRenderManifestSchema>;
+export type ArtifactSidecar = z.infer<typeof ArtifactSidecarSchema>;
 export type RunManifest = z.infer<typeof RunManifestSchema>;
 export type CostUsdReason = z.infer<typeof CostUsdReasonSchema>;

--- a/packages/schemas/test/contract.test.ts
+++ b/packages/schemas/test/contract.test.ts
@@ -622,4 +622,21 @@ describe("@wittgenstein/schemas", () => {
     const parsed = RunManifestSchema.safeParse(okManifestFields());
     expect(parsed.success).toBe(true);
   });
+
+  it("accepts artifact sidecar receipts on successful manifests", () => {
+    const parsed = RunManifestSchema.safeParse({
+      ...okManifestFields(),
+      artifactSidecars: [
+        {
+          role: "sensor-csv",
+          path: "/tmp/out.csv",
+          mimeType: "text/csv",
+          bytes: 17,
+          sha256: "deadbeef",
+        },
+      ],
+    });
+
+    expect(parsed.success).toBe(true);
+  });
 });

--- a/scripts/check-npm-publish-tarball.mjs
+++ b/scripts/check-npm-publish-tarball.mjs
@@ -190,6 +190,9 @@ async function bundledCliManifestFailures() {
       "bundled CLI manifest must use optional peer metadata, not optionalDependencies, for tiered runtimes.",
     );
   }
+  if (!manifest.files?.includes("dist/loupe.py")) {
+    failures.push("bundled CLI manifest must include dist/loupe.py for sensor CSV→HTML rendering.");
+  }
 
   return failures;
 }


### PR DESCRIPTION
## Summary
- add manifest/CLI receipts for sensor JSON, CSV, and HTML sidecars with bytes + SHA-256
- improve the embedded Loupe dashboard with a first-screen signal chart, dataset profile, escaping, and responsive spacing
- bundle `loupe.py` into the npm CLI publish artifact and guard that delivery path
- update sensor/docs truth surfaces and remove one lint warning in image tests

## Validation
- `pnpm --filter @wittgenstein/schemas test`
- `pnpm --filter @wittgenstein/core test`
- `pnpm --filter @wittgenstein/codec-sensor test`
- `pnpm --filter @wittgenstein/codec-image test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:publish-surface`
- touched-file `prettier --check`
- `python3 packages/codec-sensor/loupe.py /tmp/witt-npm-loupe-final/ecg.csv -o /tmp/witt-loupe-ui-check.html`
- `pnpm --filter @wittgenstein/cli run release:npm` plus `/tmp` execution of `packages/cli/npm-publish/bin/wittgenstein.mjs sensor ...`

## Notes
- `pnpm format:check:full` still fails on broad pre-existing repository formatting drift, so this PR only formatted touched files.
