### PR TITLE
[codex] advance M1B delivery foundations

### DIFF
--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -38,12 +38,19 @@ Requires `npm login` (or a publish token) on that machine. The published name is
 ```bash
 wittgenstein init
 wittgenstein image  "prompt" --out out.png
+wittgenstein image  "prompt" --allow-research-weights --out out.png # benchmarking-only opt-in; see ADR-0020
 wittgenstein tts    "prompt" --out out.wav
 wittgenstein audio  "prompt" --out out.wav
 wittgenstein video  "prompt" --out out.mp4
 wittgenstein sensor "prompt" --out out.json
 wittgenstein doctor
 ```
+
+`doctor` now reports the tier-readiness table described in the delivery notes:
+Tier 0 local codecs are ready from the npm package; Tier 1+ image decoder
+bridges remain explicit opt-in install surfaces tracked in #403. Decoder-weight
+loaders must verify SHA-256 before use and refuse research-only weights unless
+the caller opts in with `--allow-research-weights`.
 
 ## Skill-Ready Expectations
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -25,6 +25,29 @@ export function registerDoctorCommand(program: Command): void {
             llmProvider: config.llm.provider,
             llmModel: config.llm.model,
             artifactsDir: config.runtime.artifactsDir,
+            tiers: {
+              tier0: {
+                label: "sensor / svg-local / asciipng",
+                ready: true,
+              },
+              tier1: {
+                label: "image CPU decoder bridge",
+                ready: false,
+                installHint: "wittgenstein install image",
+                tracker: "https://github.com/p-to-q/wittgenstein/issues/403",
+              },
+              tier2: {
+                label: "image GPU decoder bridge",
+                ready: false,
+                installHint: "wittgenstein install image --gpu",
+                tracker: "https://github.com/p-to-q/wittgenstein/issues/403",
+              },
+              tier3: {
+                label: "research / training",
+                ready: false,
+                installHint: "git checkout + repo docs; not a user install tier",
+              },
+            },
           },
           null,
           2,

--- a/packages/cli/src/commands/image.ts
+++ b/packages/cli/src/commands/image.ts
@@ -6,6 +6,7 @@ interface ImageCommandOptions extends CommandRuntimeOptions {
   showImageCode?: boolean;
   showSemantic?: boolean;
   showSeedSummary?: boolean;
+  allowResearchWeights?: boolean;
 }
 
 export function registerImageCommand(program: Command): void {
@@ -19,6 +20,10 @@ export function registerImageCommand(program: Command): void {
     .option("--show-image-code", "print the imageCode receipt that records the fired VSC path")
     .option("--show-semantic", "print the emitted/effective Semantic IR for inspection")
     .option("--show-seed-summary", "print a compact seed/VQ execution summary")
+    .option(
+      "--allow-research-weights",
+      "allow research-only decoder weights for benchmarking per ADR-0020",
+    )
     .option("--config <path>", "config path")
     .action(async (prompt: string, options: ImageCommandOptions) => {
       await runCodecCommand(
@@ -27,6 +32,7 @@ export function registerImageCommand(program: Command): void {
           prompt,
           out: options.out,
           seed: parseOptionalSeed(options.seed),
+          allowResearchWeights: options.allowResearchWeights,
         },
         "wittgenstein image",
         process.argv.slice(2),

--- a/packages/cli/src/commands/shared.ts
+++ b/packages/cli/src/commands/shared.ts
@@ -8,6 +8,7 @@ export interface CommandRuntimeOptions {
   seed?: string;
   dryRun?: boolean;
   config?: string;
+  allowResearchWeights?: boolean;
 }
 
 export interface CommandInspectionContext {

--- a/packages/cli/test/doctor.test.ts
+++ b/packages/cli/test/doctor.test.ts
@@ -1,0 +1,28 @@
+import { spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(testDir, "..");
+const cliBin = resolve(packageRoot, "src/cli-main.ts");
+
+describe("doctor tier readiness", () => {
+  it("prints the current tier readiness table", () => {
+    const doctor = spawnSync("node", ["--import", "tsx", cliBin, "doctor"], {
+      cwd: packageRoot,
+      encoding: "utf8",
+    });
+
+    expect(doctor.status).toBe(0);
+    const payload = JSON.parse(doctor.stdout) as {
+      tiers: {
+        tier0: { ready: boolean };
+        tier1: { ready: boolean; installHint: string };
+      };
+    };
+    expect(payload.tiers.tier0.ready).toBe(true);
+    expect(payload.tiers.tier1.ready).toBe(false);
+    expect(payload.tiers.tier1.installHint).toBe("wittgenstein install image");
+  });
+});

--- a/packages/cli/test/image.test.ts
+++ b/packages/cli/test/image.test.ts
@@ -7,6 +7,7 @@ describe("image command inspection flags", () => {
   it("registers the image receipt inspection surface", () => {
     const image = createProgram().commands.find((command) => command.name() === "image");
     expect(image?.options.map((option) => option.long).sort()).toEqual([
+      "--allow-research-weights",
       "--config",
       "--dry-run",
       "--out",
@@ -73,6 +74,7 @@ function baseManifest(): RunManifest {
     codec: "image",
     tier: null,
     route: "raster",
+    license: { weightsRestriction: "permissive" },
     llmProvider: "none",
     llmModel: "dry-run",
     llmTokens: { input: 0, output: 0 },

--- a/packages/cli/test/replay.test.ts
+++ b/packages/cli/test/replay.test.ts
@@ -113,6 +113,7 @@ describe("@wittgenstein/cli replay (Issue #384)", () => {
         args: ["prompt"],
         seed: 7,
         codec: "image",
+        license: { weightsRestriction: "permissive" },
         llmProvider: "anthropic",
         llmModel: "claude-opus-4-7",
         llmTokens: { input: 1, output: 2 },
@@ -158,6 +159,7 @@ describe("@wittgenstein/cli replay (Issue #384)", () => {
         seed: 7,
         codec: "sensor",
         route: "ecg",
+        license: { weightsRestriction: "permissive" },
         llmProvider: "anthropic",
         llmModel: "claude-opus-4-7",
         llmTokens: { input: 0, output: 0 },
@@ -184,5 +186,4 @@ describe("@wittgenstein/cli replay (Issue #384)", () => {
     const errOutput = JSON.parse(replay.stderr) as { code: string };
     expect(errOutput.code).toBe("MANIFEST_MISSING_REQUEST");
   });
-
 });

--- a/packages/codec-image/src/decoders/README.md
+++ b/packages/codec-image/src/decoders/README.md
@@ -56,6 +56,9 @@ infrastructure lands).
   bridge calls before building an inference session. Turns missing-peer
   failures into typed `DECODER_RUNTIME_UNAVAILABLE` errors instead of
   leaking Node's `ERR_MODULE_NOT_FOUND`.
+- [`./weights.ts`](./weights.ts) — cache/sha256/license helper for #402.
+  It verifies already-cached bytes, supports injected fetchers for tests and
+  future installers, and enforces ADR-0020 before any runtime session starts.
 - [`./llamagen.ts`](./llamagen.ts) — M1B canonical bridge (currently
   throws `LLAMAGEN_BRIDGE_NOT_IMPLEMENTED`).
 - [`./seed.ts`](./seed.ts) — alternate bridge (currently throws

--- a/packages/codec-image/src/decoders/weights.ts
+++ b/packages/codec-image/src/decoders/weights.ts
@@ -1,0 +1,177 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { z } from "zod";
+import type { LoadDecoderBridgeOptions } from "./types.js";
+
+export const DecoderWeightsManifestSchema = z.object({
+  family: z.string().min(1),
+  repoId: z.string().min(1),
+  revision: z.string().min(1),
+  weightsFilename: z.string().min(1),
+  weightsSha256: z.string().regex(/^[a-f0-9]{64}$/),
+  codebookFilename: z.string().min(1).optional(),
+  codebookSha256: z
+    .string()
+    .regex(/^[a-f0-9]{64}$/)
+    .optional(),
+  license: z.object({
+    code: z.string().min(1),
+    weights: z.enum(["permissive", "research-only"]),
+  }),
+});
+
+export type DecoderWeightsManifest = z.infer<typeof DecoderWeightsManifestSchema>;
+
+export interface ResolveDecoderWeightsOptions extends LoadDecoderBridgeOptions {
+  readonly manifest: DecoderWeightsManifest;
+  readonly fetcher?: (manifest: DecoderWeightsManifest) => Promise<Uint8Array>;
+}
+
+export interface ResolvedDecoderWeights {
+  readonly weightsPath: string;
+  readonly weightsSha256: string;
+  readonly weightsRestriction: "permissive" | "research-only";
+  readonly source: "cache-hit" | "fetched";
+}
+
+export class ResearchWeightsRequiresOptInError extends Error {
+  readonly code = "RESEARCH_WEIGHTS_REQUIRES_OPT_IN";
+  readonly details: Record<string, unknown>;
+
+  constructor(manifest: DecoderWeightsManifest) {
+    super(
+      `Decoder weights for ${manifest.family} are research-only. Re-run with --allow-research-weights to opt in per ADR-0020.`,
+    );
+    this.name = "WittgensteinError";
+    this.details = {
+      family: manifest.family,
+      repoId: manifest.repoId,
+      weightsRestriction: manifest.license.weights,
+      adr: "docs/adrs/0020-code-weights-license-divergence-policy.md",
+      tracker: "https://github.com/p-to-q/wittgenstein/issues/376",
+    };
+  }
+}
+
+export class DecoderWeightsNotInstalledError extends Error {
+  readonly code = "WEIGHTS_NOT_INSTALLED";
+  readonly details: Record<string, unknown>;
+
+  constructor(manifest: DecoderWeightsManifest, cachePath: string) {
+    super(
+      `Decoder weights for ${manifest.family} are not installed. Run \`wittgenstein install image\` to fetch and verify them.`,
+    );
+    this.name = "WittgensteinError";
+    this.details = {
+      family: manifest.family,
+      repoId: manifest.repoId,
+      weightsSha256: manifest.weightsSha256,
+      cachePath,
+      installHint: "wittgenstein install image",
+      tracker: "https://github.com/p-to-q/wittgenstein/issues/402",
+    };
+  }
+}
+
+export class DecoderWeightsSha256MismatchError extends Error {
+  readonly code = "WEIGHTS_SHA256_MISMATCH";
+  readonly details: Record<string, unknown>;
+
+  constructor(manifest: DecoderWeightsManifest, actualSha256: string) {
+    super(
+      `Decoder weights for ${manifest.family} failed sha256 verification; refusing to cache or load mismatched bytes.`,
+    );
+    this.name = "WittgensteinError";
+    this.details = {
+      family: manifest.family,
+      expectedSha256: manifest.weightsSha256,
+      actualSha256,
+      tracker: "https://github.com/p-to-q/wittgenstein/issues/402",
+    };
+  }
+}
+
+export async function resolveDecoderWeights(
+  options: ResolveDecoderWeightsOptions,
+): Promise<ResolvedDecoderWeights> {
+  const manifest = DecoderWeightsManifestSchema.parse(options.manifest);
+  enforceResearchWeightsOptIn(manifest, options);
+  const cacheDir = resolve(
+    options.cacheDir ?? defaultDecoderCacheDir(),
+    manifest.family,
+    manifest.weightsSha256,
+  );
+  const weightsPath = resolve(cacheDir, manifest.weightsFilename);
+
+  try {
+    await verifyFileSha256(weightsPath, manifest);
+    return {
+      weightsPath,
+      weightsSha256: manifest.weightsSha256,
+      weightsRestriction: manifest.license.weights,
+      source: "cache-hit",
+    };
+  } catch (error) {
+    if (!(error instanceof DecoderWeightsSha256MismatchError)) {
+      if (!options.fetcher) {
+        throw new DecoderWeightsNotInstalledError(manifest, weightsPath);
+      }
+    } else {
+      throw error;
+    }
+  }
+
+  const bytes = await options.fetcher!(manifest);
+  const actualSha256 = sha256(bytes);
+  if (actualSha256 !== manifest.weightsSha256) {
+    throw new DecoderWeightsSha256MismatchError(manifest, actualSha256);
+  }
+
+  const tmpPath = `${weightsPath}.tmp-${Date.now()}`;
+  await mkdir(dirname(weightsPath), { recursive: true });
+  await writeFile(tmpPath, bytes);
+  await rename(tmpPath, weightsPath);
+  return {
+    weightsPath,
+    weightsSha256: manifest.weightsSha256,
+    weightsRestriction: manifest.license.weights,
+    source: "fetched",
+  };
+}
+
+function enforceResearchWeightsOptIn(
+  manifest: DecoderWeightsManifest,
+  options: LoadDecoderBridgeOptions,
+): void {
+  if (manifest.license.weights === "research-only" && options.allowResearchWeights !== true) {
+    throw new ResearchWeightsRequiresOptInError(manifest);
+  }
+}
+
+async function verifyFileSha256(path: string, manifest: DecoderWeightsManifest): Promise<void> {
+  let bytes: Uint8Array;
+  try {
+    bytes = await readFile(path);
+  } catch {
+    return Promise.reject(new Error("missing"));
+  }
+
+  const actualSha256 = sha256(bytes);
+  if (actualSha256 !== manifest.weightsSha256) {
+    await rm(path, { force: true });
+    throw new DecoderWeightsSha256MismatchError(manifest, actualSha256);
+  }
+}
+
+function sha256(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function defaultDecoderCacheDir(): string {
+  return resolve(
+    process.env.XDG_CACHE_HOME ?? resolve(process.env.HOME ?? process.cwd(), ".cache"),
+    "wittgenstein",
+    "decoders",
+  );
+}

--- a/packages/codec-image/test/decoder-weights.test.ts
+++ b/packages/codec-image/test/decoder-weights.test.ts
@@ -1,0 +1,104 @@
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  DecoderWeightsManifestSchema,
+  DecoderWeightsNotInstalledError,
+  DecoderWeightsSha256MismatchError,
+  ResearchWeightsRequiresOptInError,
+  resolveDecoderWeights,
+  type DecoderWeightsManifest,
+} from "../src/decoders/weights.js";
+
+let tmp: string;
+
+beforeEach(async () => {
+  tmp = await mkdtemp(join(tmpdir(), "witt-image-weights-"));
+});
+
+afterEach(async () => {
+  await rm(tmp, { recursive: true, force: true });
+});
+
+describe("decoder weight resolver", () => {
+  it("resolves cached weights after sha256 verification", async () => {
+    const bytes = new TextEncoder().encode("cached-weights");
+    const manifest = manifestFor(bytes);
+    const cachePath = join(tmp, manifest.family, manifest.weightsSha256, manifest.weightsFilename);
+    await mkdir(join(tmp, manifest.family, manifest.weightsSha256), { recursive: true });
+    await writeFile(cachePath, bytes);
+
+    const resolved = await resolveDecoderWeights({ manifest, cacheDir: tmp });
+
+    expect(resolved).toEqual({
+      weightsPath: cachePath,
+      weightsSha256: manifest.weightsSha256,
+      weightsRestriction: "permissive",
+      source: "cache-hit",
+    });
+  });
+
+  it("refuses research-only weights without explicit opt-in", async () => {
+    const manifest = manifestFor(new TextEncoder().encode("research"), "research-only");
+
+    await expect(resolveDecoderWeights({ manifest, cacheDir: tmp })).rejects.toBeInstanceOf(
+      ResearchWeightsRequiresOptInError,
+    );
+  });
+
+  it("fetches and caches verified bytes through an injected fetcher", async () => {
+    const bytes = new TextEncoder().encode("fetched-weights");
+    const manifest = manifestFor(bytes);
+
+    const resolved = await resolveDecoderWeights({
+      manifest,
+      cacheDir: tmp,
+      fetcher: async () => bytes,
+    });
+
+    expect(resolved.source).toBe("fetched");
+    expect(resolved.weightsSha256).toBe(manifest.weightsSha256);
+  });
+
+  it("rejects mismatched fetched bytes without caching them", async () => {
+    const manifest = manifestFor(new TextEncoder().encode("expected"));
+
+    await expect(
+      resolveDecoderWeights({
+        manifest,
+        cacheDir: tmp,
+        fetcher: async () => new TextEncoder().encode("actual"),
+      }),
+    ).rejects.toBeInstanceOf(DecoderWeightsSha256MismatchError);
+  });
+
+  it("reports not-installed when cache is empty and no fetcher is provided", async () => {
+    const manifest = manifestFor(new TextEncoder().encode("expected"));
+
+    await expect(resolveDecoderWeights({ manifest, cacheDir: tmp })).rejects.toBeInstanceOf(
+      DecoderWeightsNotInstalledError,
+    );
+  });
+
+  it("validates decoder-weight manifest shape", () => {
+    expect(DecoderWeightsManifestSchema.safeParse(manifestFor(new Uint8Array([1]))).success).toBe(
+      true,
+    );
+  });
+});
+
+function manifestFor(
+  bytes: Uint8Array,
+  weights: "permissive" | "research-only" = "permissive",
+): DecoderWeightsManifest {
+  return {
+    family: "llamagen",
+    repoId: "wittgenstein-harness/test-decoder",
+    revision: "test",
+    weightsFilename: "decoder.onnx",
+    weightsSha256: createHash("sha256").update(bytes).digest("hex"),
+    license: { code: "MIT", weights },
+  };
+}

--- a/packages/core/src/runtime/harness.ts
+++ b/packages/core/src/runtime/harness.ts
@@ -1,6 +1,7 @@
 import { resolve } from "node:path";
 import type {
   CostUsdReason,
+  LicenseManifest,
   WittgensteinRequest,
   RenderCtx,
   RenderResult,
@@ -15,7 +16,7 @@ import { routeRequest } from "./router.js";
 import { CodecRegistry } from "./registry.js";
 import { createRunId, resolveSeed } from "./seed.js";
 import { RunTelemetry } from "./telemetry.js";
-import { serializeError, ValidationError } from "./errors.js";
+import { serializeError, ValidationError, WittgensteinError } from "./errors.js";
 import { injectSchemaPreamble } from "../schema/preamble.js";
 import type { LlmAdapter, LlmGenerationResult } from "../llm/adapter.js";
 import { OpenAICompatibleLlmAdapter } from "../llm/openai-compatible.js";
@@ -105,6 +106,7 @@ export class Wittgenstein {
       codec: "name" in codec ? codec.name : codec.id,
       tier: null,
       route: "route" in request ? request.route : undefined,
+      license: { weightsRestriction: "permissive" },
       llmProvider: this.config.llm.provider,
       llmModel: this.config.llm.model,
       llmTokens: {
@@ -174,6 +176,7 @@ export class Wittgenstein {
             llmOutputRaw?: string | null;
             llmOutputParsed?: unknown;
             artifactSha256?: string | null;
+            license?: LicenseManifest;
           };
         };
         const artMeta = produced.metadata;
@@ -202,143 +205,26 @@ export class Wittgenstein {
         }
         manifest.artifactPath = produced.outPath;
         manifest.artifactSha256 = artMeta.artifactSha256 ?? null;
+        applyLicenseReceipt(manifest, request, artMeta.license);
         foldManifestRows(manifest, codec.manifestRows(art));
         result = toRenderResult(produced);
         manifest.ok = true;
         manifest.durationMs = Date.now() - startedAt.getTime();
       } else {
-        // ====================================================================
-        // v1 legacy codec pipeline (#300 modality-blind invariant exception)
-        // ====================================================================
-        // Every `request.modality === "..."` branch in this `else` block is
-        // v1-codec compatibility scaffolding for asciipng / svg / video — the
-        // three modalities whose codec hasn't yet ported to Codec Protocol v2.
-        // When the last v1 codec ports to v2 (#300), this entire `else` arm
-        // disappears: the harness reduces to the v2 path above, which dispatches
-        // through `codec.produce(req, ctx)` without inspecting `request.modality`.
-        //
-        // DO NOT add new modality branches here. New modalities ship as v2
-        // codecs (the `if (isV2Codec(codec))` branch above) and never touch
-        // this block. The bounded-count test in `harness-modality-references.test.ts`
-        // will trip if a new branch sneaks in.
-        // ====================================================================
-        const v1Codec = codec;
-        const generation =
-          request.modality === "asciipng" && request.source === "minimax" && !options.dryRun
-            ? await generateAsciipngFromMinimax(
-                request,
-                promptExpanded ?? request.prompt,
-                seed,
-                this.config.llm,
-              )
-            : request.modality === "asciipng"
-              ? buildAsciiPngGeneration(request)
-              : request.modality === "video" &&
-                  Array.isArray(request.inlineSvgs) &&
-                  request.inlineSvgs.length > 0
-                ? buildVideoCompositionFromInlineSvgs(request)
-                : request.modality === "svg" && request.source === "local"
-                  ? buildSvgLocalGeneration(request)
-                  : options.dryRun
-                    ? createDryRunGeneration(request)
-                    : request.modality === "svg"
-                      ? await generateSvgFromEngine(
-                          promptExpanded ?? request.prompt,
-                          seed,
-                          this.config.svg,
-                        )
-                      : await this.generateStructured(promptExpanded ?? request.prompt, seed);
-
-        if (request.modality === "svg") {
-          const raw = generation.raw;
-          if (
-            raw &&
-            typeof raw === "object" &&
-            "svgLocal" in raw &&
-            (raw as { svgLocal?: boolean }).svgLocal === true
-          ) {
-            manifest.llmProvider = "svg-local";
-            manifest.llmModel = "geometry-from-prompt";
-          } else {
-            manifest.llmProvider = "svg-engine";
-            manifest.llmModel = this.config.svg.inferenceUrl;
-          }
-        }
-
-        if (request.modality === "asciipng" && request.source === "minimax") {
-          manifest.llmProvider = "minimax";
-          manifest.llmModel =
-            request.minimaxModel?.trim() ||
-            process.env.WITTGENSTEIN_MINIMAX_MODEL?.trim() ||
-            "abab6.5s-chat-h";
-        } else if (request.modality === "asciipng") {
-          manifest.llmProvider = "local-asciipng";
-          manifest.llmModel = "pseudo-ascii-raster";
-        }
-
-        if (request.modality === "video") {
-          const raw = generation.raw;
-          if (
-            raw &&
-            typeof raw === "object" &&
-            "videoInlineSvgs" in raw &&
-            (raw as { videoInlineSvgs?: boolean }).videoInlineSvgs === true
-          ) {
-            manifest.llmProvider = "inline-svgs";
-            manifest.llmModel = "filesystem";
-          }
-        }
-
-        budget.consume(generation.tokens.input + generation.tokens.output, generation.costUsd ?? 0);
-
-        manifest.llmOutputRaw = generation.text;
-        manifest.llmTokens = generation.tokens;
-        manifest.costUsd = generation.costUsd;
-        manifest.costUsdReason = generation.costUsdReason;
-        await telemetry.writeText("llm-output.txt", generation.text);
-
-        const parsed = v1Codec.parse(generation.text);
-        if (!parsed.ok) {
-          throw new ValidationError("Codec output could not be parsed", {
-            details: {
-              codec: v1Codec.name,
-              error: parsed.error,
-            },
-          });
-        }
-
-        manifest.llmOutputParsed = parsed.value;
-
-        const renderCtx: RenderCtx = {
+        result = await this.runLegacyCodecPipeline({
+          codec,
+          request,
+          options,
+          cwd,
           runId,
           runDir,
           seed,
-          outPath: resolve(options.outPath ?? defaultOutputPathFor(request.modality, cwd, runId)),
-          logger: createRunLogger(runId),
-        };
-
-        const rendered = await v1Codec.render(parsed.value, renderCtx);
-        result = rendered;
-        manifest.artifactPath = rendered.artifactPath;
-        manifest.artifactSha256 = await hashFileOrThrow(rendered.artifactPath);
-        manifest.ok = true;
-        manifest.durationMs = Date.now() - startedAt.getTime();
-        manifest.llmTokens = rendered.metadata.llmTokens;
-        // Render-step cost is informational. The authoritative cost was set
-        // by the generation step above (line 289-290); the render step only
-        // updates the manifest if it explicitly asserts a reason — otherwise
-        // the generation-step truth (which may be null for no-LLM paths)
-        // is preserved (Issue #363).
-        if (rendered.metadata.costUsdReason !== undefined) {
-          manifest.costUsd = rendered.metadata.costUsd;
-          manifest.costUsdReason = rendered.metadata.costUsdReason;
-        }
-        if (rendered.metadata.renderPath !== undefined) {
-          manifest.renderPath = rendered.metadata.renderPath;
-        }
-        if (rendered.metadata.sidecars !== undefined) {
-          manifest.artifactSidecars = rendered.metadata.sidecars;
-        }
+          promptExpanded,
+          startedAt,
+          manifest,
+          telemetry,
+          budget,
+        });
       }
     } catch (caughtError) {
       error = serializeError(caughtError);
@@ -382,6 +268,233 @@ export class Wittgenstein {
         },
       ],
     });
+  }
+
+  private async runLegacyCodecPipeline(options: {
+    codec: LegacyCodec;
+    request: WittgensteinRequest;
+    options: HarnessRunOptions;
+    cwd: string;
+    runId: string;
+    runDir: string;
+    seed: number | null;
+    promptExpanded: string | null;
+    startedAt: Date;
+    manifest: RunManifest;
+    telemetry: RunTelemetry;
+    budget: BudgetTracker;
+  }): Promise<RenderResult> {
+    const {
+      codec,
+      request,
+      options: runOptions,
+      cwd,
+      runId,
+      runDir,
+      seed,
+      promptExpanded,
+      startedAt,
+      manifest,
+      telemetry,
+      budget,
+    } = options;
+    const generation = await this.generateLegacyCodecInput(
+      request,
+      runOptions,
+      promptExpanded,
+      seed,
+    );
+    applyLegacyProviderReceipt(manifest, request, generation, this.config.svg.inferenceUrl);
+
+    budget.consume(generation.tokens.input + generation.tokens.output, generation.costUsd ?? 0);
+
+    manifest.llmOutputRaw = generation.text;
+    manifest.llmTokens = generation.tokens;
+    manifest.costUsd = generation.costUsd;
+    manifest.costUsdReason = generation.costUsdReason;
+    await telemetry.writeText("llm-output.txt", generation.text);
+
+    const parsed = codec.parse(generation.text);
+    if (!parsed.ok) {
+      throw new ValidationError("Codec output could not be parsed", {
+        details: {
+          codec: codec.name,
+          error: parsed.error,
+        },
+      });
+    }
+
+    manifest.llmOutputParsed = parsed.value;
+
+    const renderCtx: RenderCtx = {
+      runId,
+      runDir,
+      seed,
+      outPath: resolve(runOptions.outPath ?? defaultOutputPathFor(request.modality, cwd, runId)),
+      logger: createRunLogger(runId),
+    };
+
+    const rendered = await codec.render(parsed.value, renderCtx);
+    manifest.artifactPath = rendered.artifactPath;
+    manifest.artifactSha256 = await hashFileOrThrow(rendered.artifactPath);
+    manifest.ok = true;
+    manifest.durationMs = Date.now() - startedAt.getTime();
+    manifest.llmTokens = rendered.metadata.llmTokens;
+    if (rendered.metadata.costUsdReason !== undefined) {
+      manifest.costUsd = rendered.metadata.costUsd;
+      manifest.costUsdReason = rendered.metadata.costUsdReason;
+    }
+    if (rendered.metadata.renderPath !== undefined) {
+      manifest.renderPath = rendered.metadata.renderPath;
+    }
+    if (rendered.metadata.sidecars !== undefined) {
+      manifest.artifactSidecars = rendered.metadata.sidecars;
+    }
+    applyLicenseReceipt(manifest, request, rendered.metadata.license);
+    return rendered;
+  }
+
+  private async generateLegacyCodecInput(
+    request: WittgensteinRequest,
+    options: HarnessRunOptions,
+    promptExpanded: string | null,
+    seed: number | null,
+  ): Promise<LlmGenerationResult> {
+    return generateLegacyCodecInput(request, options, promptExpanded, seed, {
+      llmConfig: this.config.llm,
+      svgConfig: this.config.svg,
+      generateStructured: (prompt, resolvedSeed) => this.generateStructured(prompt, resolvedSeed),
+    });
+  }
+}
+
+interface LegacyCodec {
+  readonly name: string;
+  parse(
+    text: string,
+  ):
+    | { readonly ok: true; readonly value: unknown }
+    | { readonly ok: false; readonly error: unknown };
+  render(value: unknown, ctx: RenderCtx): Promise<RenderResult>;
+}
+
+function applyLicenseReceipt(
+  manifest: RunManifest,
+  request: WittgensteinRequest,
+  license: LicenseManifest | undefined,
+): void {
+  manifest.license = license ?? manifest.license ?? { weightsRestriction: "permissive" };
+  if (
+    manifest.license.weightsRestriction === "research-only" &&
+    request.allowResearchWeights !== true
+  ) {
+    throw new WittgensteinError(
+      "RESEARCH_WEIGHTS_REQUIRES_OPT_IN",
+      "This run would load research-only weights. Re-run with --allow-research-weights to opt in per ADR-0020.",
+      {
+        details: {
+          adr: "docs/adrs/0020-code-weights-license-divergence-policy.md",
+          weightsRestriction: manifest.license.weightsRestriction,
+        },
+      },
+    );
+  }
+}
+
+async function generateLegacyCodecInput(
+  request: WittgensteinRequest,
+  options: HarnessRunOptions,
+  promptExpanded: string | null,
+  seed: number | null,
+  services: {
+    llmConfig: Awaited<ReturnType<typeof loadWittgensteinConfig>>["llm"];
+    svgConfig: Awaited<ReturnType<typeof loadWittgensteinConfig>>["svg"];
+    generateStructured: (
+      promptExpanded: string,
+      seed: number | null,
+    ) => Promise<LlmGenerationResult>;
+  },
+): Promise<LlmGenerationResult> {
+  if (request.modality === "asciipng" && request.source === "minimax" && !options.dryRun) {
+    return generateAsciipngFromMinimax(
+      request,
+      promptExpanded ?? request.prompt,
+      seed,
+      services.llmConfig,
+    );
+  }
+
+  if (request.modality === "asciipng") {
+    return buildAsciiPngGeneration(request);
+  }
+
+  if (
+    request.modality === "video" &&
+    Array.isArray(request.inlineSvgs) &&
+    request.inlineSvgs.length > 0
+  ) {
+    return buildVideoCompositionFromInlineSvgs(request);
+  }
+
+  if (request.modality === "svg" && request.source === "local") {
+    return buildSvgLocalGeneration(request);
+  }
+
+  if (options.dryRun) {
+    return createDryRunGeneration(request);
+  }
+
+  if (request.modality === "svg") {
+    return generateSvgFromEngine(promptExpanded ?? request.prompt, seed, services.svgConfig);
+  }
+
+  return services.generateStructured(promptExpanded ?? request.prompt, seed);
+}
+
+function applyLegacyProviderReceipt(
+  manifest: RunManifest,
+  request: WittgensteinRequest,
+  generation: LlmGenerationResult,
+  svgInferenceUrl: string,
+): void {
+  if (request.modality === "svg") {
+    const raw = generation.raw;
+    if (
+      raw &&
+      typeof raw === "object" &&
+      "svgLocal" in raw &&
+      (raw as { svgLocal?: boolean }).svgLocal === true
+    ) {
+      manifest.llmProvider = "svg-local";
+      manifest.llmModel = "geometry-from-prompt";
+    } else {
+      manifest.llmProvider = "svg-engine";
+      manifest.llmModel = svgInferenceUrl;
+    }
+  }
+
+  if (request.modality === "asciipng" && request.source === "minimax") {
+    manifest.llmProvider = "minimax";
+    manifest.llmModel =
+      request.minimaxModel?.trim() ||
+      process.env.WITTGENSTEIN_MINIMAX_MODEL?.trim() ||
+      "abab6.5s-chat-h";
+  } else if (request.modality === "asciipng") {
+    manifest.llmProvider = "local-asciipng";
+    manifest.llmModel = "pseudo-ascii-raster";
+  }
+
+  if (request.modality === "video") {
+    const raw = generation.raw;
+    if (
+      raw &&
+      typeof raw === "object" &&
+      "videoInlineSvgs" in raw &&
+      (raw as { videoInlineSvgs?: boolean }).videoInlineSvgs === true
+    ) {
+      manifest.llmProvider = "inline-svgs";
+      manifest.llmModel = "filesystem";
+    }
   }
 }
 
@@ -478,6 +591,7 @@ function toRenderResult(
       costUsdReason?: CostUsdReason;
       durationMs?: number;
       seed?: number | null;
+      license?: LicenseManifest;
     };
   },
 ): RenderResult {
@@ -491,6 +605,7 @@ function toRenderResult(
       costUsd: art.metadata.costUsd ?? 0,
       durationMs: art.metadata.durationMs ?? 0,
       seed: art.metadata.seed ?? null,
+      ...(art.metadata.license ? { license: art.metadata.license } : {}),
       ...(art.metadata.route ? { route: art.metadata.route } : {}),
     },
   };

--- a/packages/core/test/harness-modality-blind.test.ts
+++ b/packages/core/test/harness-modality-blind.test.ts
@@ -20,6 +20,17 @@ describe("harness modality blindness", () => {
     expect(source.includes('request.modality === "audio"')).toBe(false);
   });
 
+  it("keeps modality-specific legacy branching outside the main run body", async () => {
+    const source = await readHarnessSource();
+    const runBody = source.slice(
+      source.indexOf("  public async run("),
+      source.indexOf("  private async generateStructured("),
+    );
+
+    expect(runBody).not.toMatch(/request\.modality\s*[!=]==/);
+    expect(runBody).toContain("runLegacyCodecPipeline");
+  });
+
   // Bounded count of `request.modality` references (in CODE, not comments)
   // — #300 modality-blind invariant guard. The current 16 references are
   // classified inline in harness.ts (separate from the modality-as-parameter
@@ -36,9 +47,7 @@ describe("harness modality blindness", () => {
     const source = await readHarnessSource();
     // Strip line comments and block comments so prose references inside the
     // classifying comments don't inflate the count.
-    const stripped = source
-      .replace(/\/\*[\s\S]*?\*\//g, "")
-      .replace(/\/\/.*$/gm, "");
+    const stripped = source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
     const matches = stripped.match(/request\.modality/g) ?? [];
     // 16 is the audited baseline as of 2026-05-13 cross-section health check.
     // Reduce this number when v1 codecs retire (#300). Increase only with

--- a/packages/core/test/manifest.test.ts
+++ b/packages/core/test/manifest.test.ts
@@ -197,6 +197,66 @@ describe("Wittgenstein.run — v1 artifact-hash race regression (Issue #345)", (
       },
     ]);
   });
+
+  it("refuses research-only weight receipts unless the request opts in", async () => {
+    const { Wittgenstein } = await import("../src/runtime/harness.js");
+    const { CodecRegistry } = await import("../src/runtime/registry.js");
+    const { DEFAULT_WITTGENSTEIN_CONFIG } = await import("@wittgenstein/schemas");
+
+    const artifactPath = join(tmp, "image.png");
+    await writeFile(artifactPath, "png");
+
+    const stubCodec = {
+      name: "stub-image",
+      modality: "image" as const,
+      schemaPreamble: () => "",
+      requestSchema: { parse: (v: unknown) => v } as never,
+      outputSchema: { parse: (v: unknown) => v } as never,
+      parse: () => ({ ok: true as const, value: {} as never }),
+      render: async () => ({
+        artifactPath,
+        mimeType: "image/png",
+        bytes: 3,
+        metadata: {
+          codec: "stub-image",
+          llmTokens: { input: 0, output: 0 },
+          costUsd: 0,
+          durationMs: 0,
+          seed: null,
+          license: { weightsRestriction: "research-only" as const },
+        },
+      }),
+    };
+
+    const registry = new CodecRegistry();
+    registry.register(stubCodec as never);
+    const harness = new Wittgenstein(DEFAULT_WITTGENSTEIN_CONFIG, registry, null);
+
+    const refused = await harness.run(
+      {
+        modality: "image",
+        prompt: "research-only weights",
+        source: "local",
+      } as never,
+      { command: "test", args: [], cwd: tmp, dryRun: true },
+    );
+
+    expect(refused.manifest.ok).toBe(false);
+    expect(refused.manifest.error?.code).toBe("RESEARCH_WEIGHTS_REQUIRES_OPT_IN");
+
+    const allowed = await harness.run(
+      {
+        modality: "image",
+        prompt: "research-only weights",
+        source: "local",
+        allowResearchWeights: true,
+      } as never,
+      { command: "test", args: [], cwd: tmp, dryRun: true },
+    );
+
+    expect(allowed.manifest.ok).toBe(true);
+    expect(allowed.manifest.license.weightsRestriction).toBe("research-only");
+  });
 });
 
 describe("collectRuntimeFingerprint", () => {

--- a/packages/schemas/src/codec.ts
+++ b/packages/schemas/src/codec.ts
@@ -24,6 +24,7 @@ export interface RenderCtx {
 }
 
 import type { CostUsdReason } from "./manifest.js";
+import type { LicenseManifest } from "./manifest.js";
 
 export interface RenderSidecar {
   role: string;
@@ -52,6 +53,7 @@ export interface RenderResult {
      * than hiding CSV and JSON as undocumented filesystem neighbors.
      */
     sidecars?: RenderSidecar[];
+    license?: LicenseManifest;
     /**
      * Optional codec-internal path identifier — e.g. for sensor it discriminates
      * `loupe-script` / `loupe-cli` / `fallback-static-html` so the manifest tells
@@ -86,6 +88,11 @@ export const RenderResultSchema = z.object({
           sha256: z.string(),
         }),
       )
+      .optional(),
+    license: z
+      .object({
+        weightsRestriction: z.enum(["permissive", "research-only"]),
+      })
       .optional(),
     renderPath: z.string().optional(),
   }),

--- a/packages/schemas/src/manifest.ts
+++ b/packages/schemas/src/manifest.ts
@@ -17,6 +17,11 @@ const SensorRouteSchema = z.enum(["ecg", "temperature", "gyro"]);
 const VideoRouteSchema = z.enum(["hyperframes-mp4", "hyperframes-html"]);
 
 const CostUsdReasonSchema = z.enum(["computed", "unknown-model", "missing-usage", "no-llm-call"]);
+const WeightsRestrictionSchema = z.enum(["permissive", "research-only"]);
+
+export const LicenseManifestSchema = z.object({
+  weightsRestriction: WeightsRestrictionSchema,
+});
 
 export const ArtifactSidecarSchema = z.object({
   role: z.string(),
@@ -41,6 +46,7 @@ export const RunManifestSchema = z
     codec: z.string(),
     tier: z.string().nullable().optional(),
     route: z.string().optional(),
+    license: LicenseManifestSchema,
 
     llmProvider: z.string(),
     llmModel: z.string(),
@@ -201,5 +207,7 @@ export const RunManifestSchema = z
 
 export type AudioRenderManifest = z.infer<typeof AudioRenderManifestSchema>;
 export type ArtifactSidecar = z.infer<typeof ArtifactSidecarSchema>;
+export type LicenseManifest = z.infer<typeof LicenseManifestSchema>;
+export type WeightsRestriction = z.infer<typeof WeightsRestrictionSchema>;
 export type RunManifest = z.infer<typeof RunManifestSchema>;
 export type CostUsdReason = z.infer<typeof CostUsdReasonSchema>;

--- a/packages/schemas/src/modality.ts
+++ b/packages/schemas/src/modality.ts
@@ -17,6 +17,7 @@ export const BaseRequestSchema = z.object({
   prompt: z.string().min(1),
   out: z.string().optional(),
   seed: z.number().int().nullable().optional(),
+  allowResearchWeights: z.boolean().optional(),
 });
 
 export type BaseRequest = z.infer<typeof BaseRequestSchema>;

--- a/packages/schemas/test/contract.test.ts
+++ b/packages/schemas/test/contract.test.ts
@@ -38,6 +38,7 @@ describe("@wittgenstein/schemas", () => {
         args: ["prompt"],
         seed: null,
         codec: "image",
+        license: { weightsRestriction: "permissive" },
         llmProvider: "openai-compatible",
         llmModel: "gpt-4.1-mini",
         llmTokens: { input: 0, output: 0 },
@@ -222,6 +223,7 @@ describe("@wittgenstein/schemas", () => {
       seed: 7,
       codec: "image",
       route: "raster",
+      license: { weightsRestriction: "permissive" },
       llmProvider: "anthropic",
       llmModel: "claude-opus-4-7",
       llmTokens: { input: 10, output: 20 },
@@ -285,6 +287,7 @@ describe("@wittgenstein/schemas", () => {
         seed: 7,
         codec: "sensor",
         route,
+        license: { weightsRestriction: "permissive" },
         llmProvider: "anthropic",
         llmModel: "claude-opus-4-7",
         llmTokens: { input: 10, output: 20 },
@@ -348,6 +351,7 @@ describe("@wittgenstein/schemas", () => {
         seed: 7,
         codec: "video",
         route,
+        license: { weightsRestriction: "permissive" },
         llmProvider: "anthropic",
         llmModel: "claude-opus-4-7",
         llmTokens: { input: 10, output: 20 },
@@ -378,6 +382,7 @@ describe("@wittgenstein/schemas", () => {
       args: ["test"],
       seed: 7,
       codec: "image",
+      license: { weightsRestriction: "permissive" },
       llmProvider: "anthropic",
       llmModel: "claude-future-2030",
       llmTokens: { input: 500, output: 250 },
@@ -409,6 +414,7 @@ describe("@wittgenstein/schemas", () => {
       args: ["test"],
       seed: 7,
       codec: "image",
+      license: { weightsRestriction: "permissive" },
       llmProvider: "anthropic",
       llmModel: "claude-future-2030",
       llmTokens: { input: 500, output: 250 },
@@ -440,6 +446,7 @@ describe("@wittgenstein/schemas", () => {
       args: ["test"],
       seed: 7,
       codec: "image",
+      license: { weightsRestriction: "permissive" },
       llmProvider: "anthropic",
       llmModel: "claude-opus-4-7",
       llmTokens: { input: 0, output: 0 },
@@ -537,6 +544,7 @@ describe("@wittgenstein/schemas", () => {
     args: ["test"],
     seed: 7,
     codec: "image",
+    license: { weightsRestriction: "permissive" },
     llmProvider: "anthropic",
     llmModel: "claude-opus-4-7",
     llmTokens: { input: 1, output: 2 },
@@ -635,6 +643,23 @@ describe("@wittgenstein/schemas", () => {
           sha256: "deadbeef",
         },
       ],
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+
+  it("requires manifest weight-license receipts", () => {
+    const fields = okManifestFields();
+    delete (fields as Partial<ReturnType<typeof okManifestFields>>).license;
+
+    const parsed = RunManifestSchema.safeParse(fields);
+    expect(parsed.success).toBe(false);
+  });
+
+  it("accepts research-only weight-license receipts", () => {
+    const parsed = RunManifestSchema.safeParse({
+      ...okManifestFields(),
+      license: { weightsRestriction: "research-only" },
     });
 
     expect(parsed.success).toBe(true);


### PR DESCRIPTION
## Summary
- add ADR-0020 `license.weightsRestriction` receipts to the manifest schema and default harness manifests to permissive
- plumb `wittgenstein image --allow-research-weights` into requests and enforce research-only opt-in at the harness boundary
- add a pure image decoder weight resolver for #402: cache hit verification, injected fetcher support, sha256 mismatch refusal, not-installed errors, and ADR-0020 license refusal
- isolate the v1 legacy codec pipeline out of the main `run()` body and strengthen #300 harness-shape tests
- extend `doctor` with the first tier-readiness table for #403
- update distribution docs and reconcile #263/#390 issue state

## Validation
- touched-file `prettier --check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`

## Scope notes
- This does not download weights, instantiate ONNX, or call external compute.
- #402/#403 are advanced but not closed; real fetch/install still needs the concrete decoder manifest and installer command.
- #300 is advanced but not closed; remaining v1 codecs still need porting before the harness can be v2-only.
