### PR TITLE
Add image install tier planning surface

### DIFF
--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -44,6 +44,7 @@ wittgenstein audio  "prompt" --out out.wav
 wittgenstein video  "prompt" --out out.mp4
 wittgenstein sensor "prompt" --out out.json
 wittgenstein doctor
+wittgenstein install image --dry-run
 ```
 
 `doctor` now reports the tier-readiness table described in the delivery notes:
@@ -51,6 +52,11 @@ Tier 0 local codecs are ready from the npm package; Tier 1+ image decoder
 bridges remain explicit opt-in install surfaces tracked in #403. Decoder-weight
 loaders must verify SHA-256 before use and refuse research-only weights unless
 the caller opts in with `--allow-research-weights`.
+
+`wittgenstein install image --dry-run` is the current no-download planning
+surface for the Tier 1 bridge. A non-dry-run install intentionally fails with a
+structured `TIER_INSTALL_BLOCKED_BY_DECODER_MANIFEST` error until the concrete
+decoder-family manifest and fetch recipe land.
 
 ## Skill-Ready Expectations
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -29,6 +29,7 @@ wittgenstein audio  "launch audio artifact" --out out.wav
 wittgenstein sensor "stable ECG trace" --out out.json
 wittgenstein video  "architecture teaser" --out out.mp4
 wittgenstein doctor
+wittgenstein install image --dry-run
 ```
 
 ## Smoke Check
@@ -43,3 +44,4 @@ pnpm --filter @wittgenstein/cli run smoke
 - Relative `--out` paths resolve from the workspace root.
 - `tts` is a convenience alias for the `audio` codec's `speech` route.
 - `--route` remains available for one minor version as a deprecated compatibility hint.
+- `install image --dry-run` plans the optional image decoder tier without downloading weights.

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,6 +1,7 @@
 import { loadWittgensteinConfig } from "@wittgenstein/core";
 import type { Command } from "commander";
 import { resolveExecutionRoot } from "./shared.js";
+import { runtimeTierReadiness } from "../tiers.js";
 
 export function registerDoctorCommand(program: Command): void {
   program
@@ -25,29 +26,7 @@ export function registerDoctorCommand(program: Command): void {
             llmProvider: config.llm.provider,
             llmModel: config.llm.model,
             artifactsDir: config.runtime.artifactsDir,
-            tiers: {
-              tier0: {
-                label: "sensor / svg-local / asciipng",
-                ready: true,
-              },
-              tier1: {
-                label: "image CPU decoder bridge",
-                ready: false,
-                installHint: "wittgenstein install image",
-                tracker: "https://github.com/p-to-q/wittgenstein/issues/403",
-              },
-              tier2: {
-                label: "image GPU decoder bridge",
-                ready: false,
-                installHint: "wittgenstein install image --gpu",
-                tracker: "https://github.com/p-to-q/wittgenstein/issues/403",
-              },
-              tier3: {
-                label: "research / training",
-                ready: false,
-                installHint: "git checkout + repo docs; not a user install tier",
-              },
-            },
+            tiers: runtimeTierReadiness(),
           },
           null,
           2,

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -1,0 +1,74 @@
+import type { Command } from "commander";
+import { buildInstallTierPlan, resolveInstallTier } from "../tiers.js";
+
+interface InstallCommandOptions {
+  dryRun?: boolean;
+  gpu?: boolean;
+  allowResearchWeights?: boolean;
+}
+
+export function registerInstallCommand(program: Command): void {
+  program
+    .command("install")
+    .argument("<tier>", "installable runtime tier")
+    .description("Plan or install optional runtime tiers")
+    .option("--dry-run", "print the install plan without downloading or writing files")
+    .option("--gpu", "select the GPU image decoder tier")
+    .option(
+      "--allow-research-weights",
+      "allow research-only decoder weights for benchmarking per ADR-0020",
+    )
+    .action((tier: string, options: InstallCommandOptions) => {
+      const resolvedTier = resolveInstallTier(tier, { gpu: options.gpu ?? false });
+
+      if (!resolvedTier) {
+        printInstallError({
+          code: "INVALID_INSTALL_TIER",
+          message: `Unknown install tier: ${tier}`,
+          supportedTiers: ["image", "image --gpu", "image-gpu"],
+        });
+        process.exitCode = 1;
+        return;
+      }
+
+      const plan = buildInstallTierPlan(resolvedTier, {
+        allowResearchWeights: options.allowResearchWeights ?? false,
+      });
+
+      if (options.dryRun) {
+        console.log(
+          JSON.stringify(
+            {
+              ok: true,
+              action: "plan-only",
+              plan,
+            },
+            null,
+            2,
+          ),
+        );
+        return;
+      }
+
+      printInstallError({
+        code: "TIER_INSTALL_BLOCKED_BY_DECODER_MANIFEST",
+        message:
+          "Image tier installation requires a concrete decoder-family manifest before weights can be fetched.",
+        plan,
+      });
+      process.exitCode = 1;
+    });
+}
+
+function printInstallError(error: Record<string, unknown>): void {
+  console.error(
+    JSON.stringify(
+      {
+        ok: false,
+        ...error,
+      },
+      null,
+      2,
+    ),
+  );
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,16 +8,14 @@ import { registerSensorCommand } from "./commands/sensor.js";
 import { registerSvgCommand } from "./commands/svg.js";
 import { registerAsciipngCommand } from "./commands/asciipng.js";
 import { registerDoctorCommand } from "./commands/doctor.js";
+import { registerInstallCommand } from "./commands/install.js";
 import { registerAnimateHtmlCommand } from "./commands/animate-html.js";
 import { registerReplayCommand } from "./commands/replay.js";
 
 export function createProgram(): Command {
   const program = new Command();
 
-  program
-    .name("wittgenstein")
-    .description("Wittgenstein modality harness CLI")
-    .version("0.1.0");
+  program.name("wittgenstein").description("Wittgenstein modality harness CLI").version("0.1.0");
 
   registerInitCommand(program);
   registerImageCommand(program);
@@ -28,6 +26,7 @@ export function createProgram(): Command {
   registerSvgCommand(program);
   registerAsciipngCommand(program);
   registerDoctorCommand(program);
+  registerInstallCommand(program);
   registerAnimateHtmlCommand(program);
   registerReplayCommand(program);
 

--- a/packages/cli/src/tiers.ts
+++ b/packages/cli/src/tiers.ts
@@ -1,0 +1,85 @@
+export type InstallTierId = "image" | "image-gpu";
+
+export interface RuntimeTierStatus {
+  label: string;
+  ready: boolean;
+  installHint: string | null;
+  tracker?: string;
+}
+
+export interface InstallTierPlan {
+  tier: InstallTierId;
+  label: string;
+  runtimeTier: "tier1" | "tier2";
+  decoderManifestRequired: true;
+  weightsRequired: true;
+  allowResearchWeights: boolean;
+  tracker: string;
+  blockedBy: "decoder-manifest";
+}
+
+const IMAGE_INSTALL_TRACKER = "https://github.com/p-to-q/wittgenstein/issues/403";
+
+export function runtimeTierReadiness(): Record<
+  "tier0" | "tier1" | "tier2" | "tier3",
+  RuntimeTierStatus
+> {
+  return {
+    tier0: {
+      label: "sensor / svg-local / asciipng",
+      ready: true,
+      installHint: null,
+    },
+    tier1: {
+      label: "image CPU decoder bridge",
+      ready: false,
+      installHint: "wittgenstein install image",
+      tracker: IMAGE_INSTALL_TRACKER,
+    },
+    tier2: {
+      label: "image GPU decoder bridge",
+      ready: false,
+      installHint: "wittgenstein install image --gpu",
+      tracker: IMAGE_INSTALL_TRACKER,
+    },
+    tier3: {
+      label: "research / training",
+      ready: false,
+      installHint: "git checkout + repo docs; not a user install tier",
+    },
+  };
+}
+
+export function resolveInstallTier(
+  tier: string,
+  options: { gpu?: boolean } = {},
+): InstallTierId | null {
+  if (tier === "image") {
+    return options.gpu ? "image-gpu" : "image";
+  }
+
+  if (tier === "image-gpu") {
+    return "image-gpu";
+  }
+
+  return null;
+}
+
+export function buildInstallTierPlan(
+  tier: InstallTierId,
+  options: { allowResearchWeights?: boolean } = {},
+): InstallTierPlan {
+  const runtimeTier = tier === "image-gpu" ? "tier2" : "tier1";
+  const readiness = runtimeTierReadiness()[runtimeTier];
+
+  return {
+    tier,
+    label: readiness.label,
+    runtimeTier,
+    decoderManifestRequired: true,
+    weightsRequired: true,
+    allowResearchWeights: options.allowResearchWeights ?? false,
+    tracker: IMAGE_INSTALL_TRACKER,
+    blockedBy: "decoder-manifest",
+  };
+}

--- a/packages/cli/test/index.test.ts
+++ b/packages/cli/test/index.test.ts
@@ -14,6 +14,7 @@ describe("@wittgenstein/cli", () => {
       "doctor",
       "image",
       "init",
+      "install",
       "replay",
       "sensor",
       "svg",

--- a/packages/cli/test/install.test.ts
+++ b/packages/cli/test/install.test.ts
@@ -1,0 +1,77 @@
+import { spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(testDir, "..");
+const cliBin = resolve(packageRoot, "src/cli-main.ts");
+
+describe("install tier command", () => {
+  it("prints an image install plan without fetching weights", () => {
+    const install = spawnSync(
+      "node",
+      ["--import", "tsx", cliBin, "install", "image", "--dry-run"],
+      {
+        cwd: packageRoot,
+        encoding: "utf8",
+      },
+    );
+
+    expect(install.status).toBe(0);
+    const payload = JSON.parse(install.stdout) as {
+      ok: boolean;
+      action: string;
+      plan: { tier: string; runtimeTier: string; blockedBy: string };
+    };
+
+    expect(payload.ok).toBe(true);
+    expect(payload.action).toBe("plan-only");
+    expect(payload.plan.tier).toBe("image");
+    expect(payload.plan.runtimeTier).toBe("tier1");
+    expect(payload.plan.blockedBy).toBe("decoder-manifest");
+  });
+
+  it("maps --gpu to the image GPU tier", () => {
+    const install = spawnSync(
+      "node",
+      ["--import", "tsx", cliBin, "install", "image", "--gpu", "--dry-run"],
+      {
+        cwd: packageRoot,
+        encoding: "utf8",
+      },
+    );
+
+    expect(install.status).toBe(0);
+    const payload = JSON.parse(install.stdout) as { plan: { tier: string; runtimeTier: string } };
+
+    expect(payload.plan.tier).toBe("image-gpu");
+    expect(payload.plan.runtimeTier).toBe("tier2");
+  });
+
+  it("refuses real installation until a decoder manifest exists", () => {
+    const install = spawnSync("node", ["--import", "tsx", cliBin, "install", "image"], {
+      cwd: packageRoot,
+      encoding: "utf8",
+    });
+
+    expect(install.status).toBe(1);
+    const payload = JSON.parse(install.stderr) as { ok: boolean; code: string };
+
+    expect(payload.ok).toBe(false);
+    expect(payload.code).toBe("TIER_INSTALL_BLOCKED_BY_DECODER_MANIFEST");
+  });
+
+  it("rejects unknown install tiers with a structured error", () => {
+    const install = spawnSync("node", ["--import", "tsx", cliBin, "install", "audio"], {
+      cwd: packageRoot,
+      encoding: "utf8",
+    });
+
+    expect(install.status).toBe(1);
+    const payload = JSON.parse(install.stderr) as { ok: boolean; code: string };
+
+    expect(payload.ok).toBe(false);
+    expect(payload.code).toBe("INVALID_INSTALL_TIER");
+  });
+});


### PR DESCRIPTION
## Summary
- add a real `wittgenstein install` command so doctor no longer points at a missing surface
- share tier readiness metadata between doctor and install planning
- keep installation no-download for now: dry-run prints the plan, non-dry-run exits with structured `TIER_INSTALL_BLOCKED_BY_DECODER_MANIFEST` until #402 supplies a concrete decoder manifest
- update CLI/distribution docs and tests

## Verification
- `pnpm --filter @wittgenstein/cli test -- install doctor index`
- `pnpm --filter @wittgenstein/cli typecheck`
- `pnpm prettier --check packages/cli/src/tiers.ts packages/cli/src/commands/install.ts packages/cli/src/commands/doctor.ts packages/cli/src/index.ts packages/cli/test/index.test.ts packages/cli/test/install.test.ts packages/cli/README.md docs/distribution.md`
- earlier before README sync: `pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm --filter @wittgenstein/cli run build`

Refs #403
Refs #402