### PR TITLE
Verify decoder codebook assets

### DIFF
--- a/packages/codec-image/src/decoders/weights.ts
+++ b/packages/codec-image/src/decoders/weights.ts
@@ -4,33 +4,51 @@ import { dirname, resolve } from "node:path";
 import { z } from "zod";
 import type { LoadDecoderBridgeOptions } from "./types.js";
 
-export const DecoderWeightsManifestSchema = z.object({
-  family: z.string().min(1),
-  repoId: z.string().min(1),
-  revision: z.string().min(1),
-  weightsFilename: z.string().min(1),
-  weightsSha256: z.string().regex(/^[a-f0-9]{64}$/),
-  codebookFilename: z.string().min(1).optional(),
-  codebookSha256: z
-    .string()
-    .regex(/^[a-f0-9]{64}$/)
-    .optional(),
-  license: z.object({
-    code: z.string().min(1),
-    weights: z.enum(["permissive", "research-only"]),
-  }),
-});
+export const DecoderWeightsManifestSchema = z
+  .object({
+    family: z.string().min(1),
+    repoId: z.string().min(1),
+    revision: z.string().min(1),
+    weightsFilename: z.string().min(1),
+    weightsSha256: z.string().regex(/^[a-f0-9]{64}$/),
+    codebookFilename: z.string().min(1).optional(),
+    codebookSha256: z
+      .string()
+      .regex(/^[a-f0-9]{64}$/)
+      .optional(),
+    license: z.object({
+      code: z.string().min(1),
+      weights: z.enum(["permissive", "research-only"]),
+    }),
+  })
+  .refine((manifest) => Boolean(manifest.codebookFilename) === Boolean(manifest.codebookSha256), {
+    message: "codebookFilename and codebookSha256 must be provided together",
+    path: ["codebookFilename"],
+  });
 
 export type DecoderWeightsManifest = z.infer<typeof DecoderWeightsManifestSchema>;
 
+export type DecoderWeightsAssetKind = "weights" | "codebook";
+
+export interface DecoderWeightsAsset {
+  readonly kind: DecoderWeightsAssetKind;
+  readonly filename: string;
+  readonly sha256: string;
+}
+
 export interface ResolveDecoderWeightsOptions extends LoadDecoderBridgeOptions {
   readonly manifest: DecoderWeightsManifest;
-  readonly fetcher?: (manifest: DecoderWeightsManifest) => Promise<Uint8Array>;
+  readonly fetcher?: (
+    asset: DecoderWeightsAsset,
+    manifest: DecoderWeightsManifest,
+  ) => Promise<Uint8Array>;
 }
 
 export interface ResolvedDecoderWeights {
   readonly weightsPath: string;
+  readonly codebookPath?: string;
   readonly weightsSha256: string;
+  readonly codebookSha256?: string;
   readonly weightsRestriction: "permissive" | "research-only";
   readonly source: "cache-hit" | "fetched";
 }
@@ -58,14 +76,17 @@ export class DecoderWeightsNotInstalledError extends Error {
   readonly code = "WEIGHTS_NOT_INSTALLED";
   readonly details: Record<string, unknown>;
 
-  constructor(manifest: DecoderWeightsManifest, cachePath: string) {
+  constructor(manifest: DecoderWeightsManifest, asset: DecoderWeightsAsset, cachePath: string) {
     super(
-      `Decoder weights for ${manifest.family} are not installed. Run \`wittgenstein install image\` to fetch and verify them.`,
+      `Decoder ${asset.kind} for ${manifest.family} is not installed. Run \`wittgenstein install image\` to fetch and verify it.`,
     );
     this.name = "WittgensteinError";
     this.details = {
       family: manifest.family,
       repoId: manifest.repoId,
+      assetKind: asset.kind,
+      filename: asset.filename,
+      assetSha256: asset.sha256,
       weightsSha256: manifest.weightsSha256,
       cachePath,
       installHint: "wittgenstein install image",
@@ -78,15 +99,36 @@ export class DecoderWeightsSha256MismatchError extends Error {
   readonly code = "WEIGHTS_SHA256_MISMATCH";
   readonly details: Record<string, unknown>;
 
-  constructor(manifest: DecoderWeightsManifest, actualSha256: string) {
+  constructor(manifest: DecoderWeightsManifest, asset: DecoderWeightsAsset, actualSha256: string) {
     super(
-      `Decoder weights for ${manifest.family} failed sha256 verification; refusing to cache or load mismatched bytes.`,
+      `Decoder ${asset.kind} for ${manifest.family} failed sha256 verification; refusing to cache or load mismatched bytes.`,
     );
     this.name = "WittgensteinError";
     this.details = {
       family: manifest.family,
-      expectedSha256: manifest.weightsSha256,
+      assetKind: asset.kind,
+      filename: asset.filename,
+      expectedSha256: asset.sha256,
       actualSha256,
+      tracker: "https://github.com/p-to-q/wittgenstein/issues/402",
+    };
+  }
+}
+
+export class DecoderWeightsFetchFailedError extends Error {
+  readonly code = "WEIGHTS_FETCH_FAILED";
+  readonly details: Record<string, unknown>;
+
+  constructor(manifest: DecoderWeightsManifest, asset: DecoderWeightsAsset, cause: unknown) {
+    super(`Failed to fetch decoder ${asset.kind} for ${manifest.family}.`);
+    this.name = "WittgensteinError";
+    this.cause = cause;
+    this.details = {
+      family: manifest.family,
+      repoId: manifest.repoId,
+      revision: manifest.revision,
+      assetKind: asset.kind,
+      filename: asset.filename,
       tracker: "https://github.com/p-to-q/wittgenstein/issues/402",
     };
   }
@@ -102,42 +144,64 @@ export async function resolveDecoderWeights(
     manifest.family,
     manifest.weightsSha256,
   );
-  const weightsPath = resolve(cacheDir, manifest.weightsFilename);
+  const assets = assetsForManifest(manifest);
+  const assetPaths = new Map(
+    assets.map((asset) => [asset.kind, resolve(cacheDir, asset.filename)] as const),
+  );
+  const missingAssets: DecoderWeightsAsset[] = [];
 
-  try {
-    await verifyFileSha256(weightsPath, manifest);
-    return {
-      weightsPath,
-      weightsSha256: manifest.weightsSha256,
-      weightsRestriction: manifest.license.weights,
-      source: "cache-hit",
-    };
-  } catch (error) {
-    if (!(error instanceof DecoderWeightsSha256MismatchError)) {
-      if (!options.fetcher) {
-        throw new DecoderWeightsNotInstalledError(manifest, weightsPath);
+  for (const asset of assets) {
+    const assetPath = assetPaths.get(asset.kind)!;
+    try {
+      await verifyFileSha256(assetPath, manifest, asset);
+    } catch (error) {
+      // A sha mismatch means corrupted bytes; other verification errors mean the asset is missing.
+      if (error instanceof DecoderWeightsSha256MismatchError) {
+        throw error;
       }
-    } else {
+      missingAssets.push(asset);
+    }
+  }
+
+  if (missingAssets.length === 0) {
+    return resolvedWeights(manifest, assetPaths, "cache-hit");
+  }
+
+  if (!options.fetcher) {
+    const missingAsset = missingAssets[0]!;
+    throw new DecoderWeightsNotInstalledError(
+      manifest,
+      missingAsset,
+      assetPaths.get(missingAsset.kind)!,
+    );
+  }
+
+  for (const asset of missingAssets) {
+    let bytes: Uint8Array;
+    try {
+      bytes = await options.fetcher(asset, manifest);
+    } catch (error) {
+      throw new DecoderWeightsFetchFailedError(manifest, asset, error);
+    }
+
+    const actualSha256 = sha256(bytes);
+    if (actualSha256 !== asset.sha256) {
+      throw new DecoderWeightsSha256MismatchError(manifest, asset, actualSha256);
+    }
+
+    const assetPath = assetPaths.get(asset.kind)!;
+    const tmpPath = `${assetPath}.tmp-${Date.now()}`;
+    await mkdir(dirname(assetPath), { recursive: true });
+    try {
+      await writeFile(tmpPath, bytes);
+      await rename(tmpPath, assetPath);
+    } catch (error) {
+      await rm(tmpPath, { force: true });
       throw error;
     }
   }
 
-  const bytes = await options.fetcher!(manifest);
-  const actualSha256 = sha256(bytes);
-  if (actualSha256 !== manifest.weightsSha256) {
-    throw new DecoderWeightsSha256MismatchError(manifest, actualSha256);
-  }
-
-  const tmpPath = `${weightsPath}.tmp-${Date.now()}`;
-  await mkdir(dirname(weightsPath), { recursive: true });
-  await writeFile(tmpPath, bytes);
-  await rename(tmpPath, weightsPath);
-  return {
-    weightsPath,
-    weightsSha256: manifest.weightsSha256,
-    weightsRestriction: manifest.license.weights,
-    source: "fetched",
-  };
+  return resolvedWeights(manifest, assetPaths, "fetched");
 }
 
 function enforceResearchWeightsOptIn(
@@ -149,7 +213,11 @@ function enforceResearchWeightsOptIn(
   }
 }
 
-async function verifyFileSha256(path: string, manifest: DecoderWeightsManifest): Promise<void> {
+async function verifyFileSha256(
+  path: string,
+  manifest: DecoderWeightsManifest,
+  asset: DecoderWeightsAsset,
+): Promise<void> {
   let bytes: Uint8Array;
   try {
     bytes = await readFile(path);
@@ -158,10 +226,53 @@ async function verifyFileSha256(path: string, manifest: DecoderWeightsManifest):
   }
 
   const actualSha256 = sha256(bytes);
-  if (actualSha256 !== manifest.weightsSha256) {
+  if (actualSha256 !== asset.sha256) {
     await rm(path, { force: true });
-    throw new DecoderWeightsSha256MismatchError(manifest, actualSha256);
+    throw new DecoderWeightsSha256MismatchError(manifest, asset, actualSha256);
   }
+}
+
+function assetsForManifest(manifest: DecoderWeightsManifest): DecoderWeightsAsset[] {
+  const assets: DecoderWeightsAsset[] = [
+    {
+      kind: "weights",
+      filename: manifest.weightsFilename,
+      sha256: manifest.weightsSha256,
+    },
+  ];
+
+  if (manifest.codebookFilename && manifest.codebookSha256) {
+    assets.push({
+      kind: "codebook",
+      filename: manifest.codebookFilename,
+      sha256: manifest.codebookSha256,
+    });
+  }
+
+  return assets;
+}
+
+function resolvedWeights(
+  manifest: DecoderWeightsManifest,
+  assetPaths: ReadonlyMap<DecoderWeightsAssetKind, string>,
+  source: "cache-hit" | "fetched",
+): ResolvedDecoderWeights {
+  const result: ResolvedDecoderWeights = {
+    weightsPath: assetPaths.get("weights")!,
+    weightsSha256: manifest.weightsSha256,
+    weightsRestriction: manifest.license.weights,
+    source,
+  };
+
+  if (manifest.codebookSha256) {
+    return {
+      ...result,
+      codebookPath: assetPaths.get("codebook")!,
+      codebookSha256: manifest.codebookSha256,
+    };
+  }
+
+  return result;
 }
 
 function sha256(bytes: Uint8Array): string {

--- a/packages/codec-image/test/decoder-weights.test.ts
+++ b/packages/codec-image/test/decoder-weights.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  DecoderWeightsFetchFailedError,
   DecoderWeightsManifestSchema,
   DecoderWeightsNotInstalledError,
   DecoderWeightsSha256MismatchError,
@@ -62,6 +63,44 @@ describe("decoder weight resolver", () => {
     expect(resolved.weightsSha256).toBe(manifest.weightsSha256);
   });
 
+  it("resolves paired codebook assets from cache", async () => {
+    const weights = new TextEncoder().encode("cached-weights");
+    const codebook = new TextEncoder().encode("cached-codebook");
+    const manifest = manifestFor(weights, "permissive", codebook);
+    const cacheDir = join(tmp, manifest.family, manifest.weightsSha256);
+    const weightsPath = join(cacheDir, manifest.weightsFilename);
+    const codebookPath = join(cacheDir, manifest.codebookFilename!);
+    await mkdir(cacheDir, { recursive: true });
+    await writeFile(weightsPath, weights);
+    await writeFile(codebookPath, codebook);
+
+    const resolved = await resolveDecoderWeights({ manifest, cacheDir: tmp });
+
+    expect(resolved).toEqual({
+      weightsPath,
+      codebookPath,
+      weightsSha256: manifest.weightsSha256,
+      codebookSha256: manifest.codebookSha256,
+      weightsRestriction: "permissive",
+      source: "cache-hit",
+    });
+  });
+
+  it("fetches missing codebook assets through the injected fetcher", async () => {
+    const weights = new TextEncoder().encode("fetched-weights");
+    const codebook = new TextEncoder().encode("fetched-codebook");
+    const manifest = manifestFor(weights, "permissive", codebook);
+
+    const resolved = await resolveDecoderWeights({
+      manifest,
+      cacheDir: tmp,
+      fetcher: async (asset) => (asset.kind === "weights" ? weights : codebook),
+    });
+
+    expect(resolved.source).toBe("fetched");
+    expect(resolved.codebookSha256).toBe(manifest.codebookSha256);
+  });
+
   it("rejects mismatched fetched bytes without caching them", async () => {
     const manifest = manifestFor(new TextEncoder().encode("expected"));
 
@@ -72,6 +111,34 @@ describe("decoder weight resolver", () => {
         fetcher: async () => new TextEncoder().encode("actual"),
       }),
     ).rejects.toBeInstanceOf(DecoderWeightsSha256MismatchError);
+  });
+
+  it("rejects a mismatched cached codebook", async () => {
+    const weights = new TextEncoder().encode("cached-weights");
+    const codebook = new TextEncoder().encode("expected-codebook");
+    const manifest = manifestFor(weights, "permissive", codebook);
+    const cacheDir = join(tmp, manifest.family, manifest.weightsSha256);
+    await mkdir(cacheDir, { recursive: true });
+    await writeFile(join(cacheDir, manifest.weightsFilename), weights);
+    await writeFile(join(cacheDir, manifest.codebookFilename!), new TextEncoder().encode("actual"));
+
+    await expect(resolveDecoderWeights({ manifest, cacheDir: tmp })).rejects.toBeInstanceOf(
+      DecoderWeightsSha256MismatchError,
+    );
+  });
+
+  it("wraps fetcher failures in a structured error", async () => {
+    const manifest = manifestFor(new TextEncoder().encode("expected"));
+
+    await expect(
+      resolveDecoderWeights({
+        manifest,
+        cacheDir: tmp,
+        fetcher: async () => {
+          throw new Error("network unavailable");
+        },
+      }),
+    ).rejects.toBeInstanceOf(DecoderWeightsFetchFailedError);
   });
 
   it("reports not-installed when cache is empty and no fetcher is provided", async () => {
@@ -87,13 +154,23 @@ describe("decoder weight resolver", () => {
       true,
     );
   });
+
+  it("requires codebook filename and sha256 to be provided together", () => {
+    const manifest = {
+      ...manifestFor(new Uint8Array([1])),
+      codebookFilename: "codebook.bin",
+    };
+
+    expect(DecoderWeightsManifestSchema.safeParse(manifest).success).toBe(false);
+  });
 });
 
 function manifestFor(
   bytes: Uint8Array,
   weights: "permissive" | "research-only" = "permissive",
+  codebook?: Uint8Array,
 ): DecoderWeightsManifest {
-  return {
+  const manifest: DecoderWeightsManifest = {
     family: "llamagen",
     repoId: "wittgenstein-harness/test-decoder",
     revision: "test",
@@ -101,4 +178,14 @@ function manifestFor(
     weightsSha256: createHash("sha256").update(bytes).digest("hex"),
     license: { code: "MIT", weights },
   };
+
+  if (codebook) {
+    return {
+      ...manifest,
+      codebookFilename: "codebook.bin",
+      codebookSha256: createHash("sha256").update(codebook).digest("hex"),
+    };
+  }
+
+  return manifest;
 }


### PR DESCRIPTION
## Summary

- upgrade decoder weight resolution from single weights-file handling to a small asset resolver for weights plus optional codebooks
- require `codebookFilename` and `codebookSha256` to appear together in decoder manifests
- verify/cache/fetch codebook assets with the same sha256 discipline as weights
- add structured `WEIGHTS_FETCH_FAILED` wrapping for future installer/fetcher integration

This deliberately does not add a concrete LlamaGen manifest or download weights. It closes a real contract gap first: if a decoder manifest names a codebook, the resolver must verify and receipt that asset before any bridge can honestly load.

## Verification

- `pnpm --filter @wittgenstein/codec-image test -- decoder-weights`
- `pnpm --filter @wittgenstein/codec-image typecheck`
- `pnpm prettier --check packages/codec-image/src/decoders/weights.ts packages/codec-image/test/decoder-weights.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

Refs #402
