### PR TITLE
Isolate legacy codec pipeline

### DIFF
--- a/packages/core/src/runtime/harness.ts
+++ b/packages/core/src/runtime/harness.ts
@@ -27,10 +27,10 @@ import { registerVideoCodec } from "../codecs/video.js";
 import { registerSensorCodec } from "../codecs/sensor.js";
 import { registerSvgCodec } from "../codecs/svg.js";
 import { registerAsciipngCodec } from "../codecs/asciipng.js";
-import { generateSvgFromEngine } from "./svg-generation.js";
-import { buildSvgLocalGeneration } from "./svg-local.js";
-import { buildVideoCompositionFromInlineSvgs } from "./video-inline-svgs.js";
-import { generateAsciipngFromMinimax } from "./asciipng-minimax.js";
+import {
+  applyLegacyProviderReceipt,
+  generateLegacyCodecInput as generateLegacyCodecInputForLegacyPipeline,
+} from "./legacy-codec-pipeline.js";
 
 export interface HarnessRunOptions {
   command: string;
@@ -360,7 +360,7 @@ export class Wittgenstein {
     promptExpanded: string | null,
     seed: number | null,
   ): Promise<LlmGenerationResult> {
-    return generateLegacyCodecInput(request, options, promptExpanded, seed, {
+    return generateLegacyCodecInputForLegacyPipeline(request, options, promptExpanded, seed, {
       llmConfig: this.config.llm,
       svgConfig: this.config.svg,
       generateStructured: (prompt, resolvedSeed) => this.generateStructured(prompt, resolvedSeed),
@@ -398,103 +398,6 @@ function applyLicenseReceipt(
         },
       },
     );
-  }
-}
-
-async function generateLegacyCodecInput(
-  request: WittgensteinRequest,
-  options: HarnessRunOptions,
-  promptExpanded: string | null,
-  seed: number | null,
-  services: {
-    llmConfig: Awaited<ReturnType<typeof loadWittgensteinConfig>>["llm"];
-    svgConfig: Awaited<ReturnType<typeof loadWittgensteinConfig>>["svg"];
-    generateStructured: (
-      promptExpanded: string,
-      seed: number | null,
-    ) => Promise<LlmGenerationResult>;
-  },
-): Promise<LlmGenerationResult> {
-  if (request.modality === "asciipng" && request.source === "minimax" && !options.dryRun) {
-    return generateAsciipngFromMinimax(
-      request,
-      promptExpanded ?? request.prompt,
-      seed,
-      services.llmConfig,
-    );
-  }
-
-  if (request.modality === "asciipng") {
-    return buildAsciiPngGeneration(request);
-  }
-
-  if (
-    request.modality === "video" &&
-    Array.isArray(request.inlineSvgs) &&
-    request.inlineSvgs.length > 0
-  ) {
-    return buildVideoCompositionFromInlineSvgs(request);
-  }
-
-  if (request.modality === "svg" && request.source === "local") {
-    return buildSvgLocalGeneration(request);
-  }
-
-  if (options.dryRun) {
-    return createDryRunGeneration(request);
-  }
-
-  if (request.modality === "svg") {
-    return generateSvgFromEngine(promptExpanded ?? request.prompt, seed, services.svgConfig);
-  }
-
-  return services.generateStructured(promptExpanded ?? request.prompt, seed);
-}
-
-function applyLegacyProviderReceipt(
-  manifest: RunManifest,
-  request: WittgensteinRequest,
-  generation: LlmGenerationResult,
-  svgInferenceUrl: string,
-): void {
-  if (request.modality === "svg") {
-    const raw = generation.raw;
-    if (
-      raw &&
-      typeof raw === "object" &&
-      "svgLocal" in raw &&
-      (raw as { svgLocal?: boolean }).svgLocal === true
-    ) {
-      manifest.llmProvider = "svg-local";
-      manifest.llmModel = "geometry-from-prompt";
-    } else {
-      manifest.llmProvider = "svg-engine";
-      manifest.llmModel = svgInferenceUrl;
-    }
-  }
-
-  if (request.modality === "asciipng" && request.source === "minimax") {
-    manifest.llmProvider = "minimax";
-    manifest.llmModel =
-      request.minimaxModel?.trim() ||
-      process.env.WITTGENSTEIN_MINIMAX_MODEL?.trim() ||
-      "abab6.5s-chat-h";
-  } else if (request.modality === "asciipng") {
-    manifest.llmProvider = "local-asciipng";
-    manifest.llmModel = "pseudo-ascii-raster";
-  }
-
-  if (request.modality === "video") {
-    const raw = generation.raw;
-    if (
-      raw &&
-      typeof raw === "object" &&
-      "videoInlineSvgs" in raw &&
-      (raw as { videoInlineSvgs?: boolean }).videoInlineSvgs === true
-    ) {
-      manifest.llmProvider = "inline-svgs";
-      manifest.llmModel = "filesystem";
-    }
   }
 }
 
@@ -630,95 +533,6 @@ function createLlmAdapter(
   }
 
   return new OpenAICompatibleLlmAdapter(llmConfig);
-}
-
-// v1-compat guard: this builder is asciipng-specific and exists only because
-// codec-asciipng hasn't ported to v2 yet. The modality check is a type narrower
-// for callers, not a real dispatch — it's a defensive assertion that retires
-// with the v1 pipeline.
-function buildAsciiPngGeneration(request: WittgensteinRequest): LlmGenerationResult {
-  if (request.modality !== "asciipng") {
-    throw new ValidationError("buildAsciiPngGeneration called for non-asciipng request.");
-  }
-  const ir = {
-    text: request.prompt.slice(0, 2000),
-    columns: request.columns,
-    rows: request.rows,
-    cell: request.cell,
-    glyphMode: "pseudo" as const,
-  };
-  return {
-    text: JSON.stringify(ir),
-    tokens: { input: 0, output: 0 },
-    costUsd: null,
-    costUsdReason: "no-llm-call",
-    raw: { asciiPngLocal: true },
-  };
-}
-
-// v1-compat: dry-run generation shapes are modality-aware because v1 codecs
-// expect modality-specific JSON shapes. v2 codecs construct their own dry-run
-// payloads via `codec.expand(req, ctx)` and never call this function. Retires
-// with the v1 pipeline (#300).
-function createDryRunGeneration(request: WittgensteinRequest): LlmGenerationResult {
-  if (request.modality === "svg") {
-    return {
-      ...buildSvgLocalGeneration(request),
-      raw: { dryRun: true, svgLocal: true },
-    };
-  }
-
-  if (
-    request.modality !== "video" &&
-    request.modality !== "sensor" &&
-    request.modality !== "asciipng"
-  ) {
-    const scene = {
-      intent: "Photorealistic wildlife portrait suitable for print",
-      subject: request.prompt,
-      composition: {
-        framing: "tight portrait on subject",
-        camera: "telephoto compression, shallow depth of field",
-        depthPlan: ["sharp subject", "soft bokeh", "clean background"],
-      },
-      lighting: { mood: "natural soft daylight", key: "diffused key, gentle fill" },
-      style: {
-        references: ["wildlife photography", "fine-art nature print"],
-        palette: ["neutral grey", "natural fur tones", "cool water highlights"],
-      },
-      decoder: {
-        family: "llamagen" as const,
-        codebook: "stub-codebook",
-        latentResolution: [32, 32] as [number, number],
-      },
-    };
-
-    return {
-      text: JSON.stringify(scene),
-      tokens: {
-        input: 0,
-        output: 0,
-      },
-      costUsd: null,
-      costUsdReason: "no-llm-call",
-      raw: {
-        dryRun: true,
-      },
-    };
-  }
-
-  return {
-    text: "{}",
-    tokens: {
-      input: 0,
-      output: 0,
-    },
-    costUsd: null,
-    costUsdReason: "no-llm-call",
-    raw: {
-      dryRun: true,
-    },
-  };
 }
 
 // LEGITIMATE modality-aware routing (NOT v1-compat; stays even after #300).

--- a/packages/core/src/runtime/legacy-codec-pipeline.ts
+++ b/packages/core/src/runtime/legacy-codec-pipeline.ts
@@ -1,0 +1,193 @@
+import type {
+  LlmConfig,
+  RunManifest,
+  SvgEngineConfig,
+  WittgensteinRequest,
+} from "@wittgenstein/schemas";
+import type { LlmGenerationResult } from "../llm/adapter.js";
+import { generateAsciipngFromMinimax } from "./asciipng-minimax.js";
+import { ValidationError } from "./errors.js";
+import { generateSvgFromEngine } from "./svg-generation.js";
+import { buildSvgLocalGeneration } from "./svg-local.js";
+import { buildVideoCompositionFromInlineSvgs } from "./video-inline-svgs.js";
+
+interface LegacyCodecRunOptions {
+  readonly dryRun?: boolean;
+}
+
+export interface LegacyCodecGenerationServices {
+  readonly llmConfig: LlmConfig;
+  readonly svgConfig: SvgEngineConfig;
+  generateStructured(promptExpanded: string, seed: number | null): Promise<LlmGenerationResult>;
+}
+
+export async function generateLegacyCodecInput(
+  request: WittgensteinRequest,
+  options: LegacyCodecRunOptions,
+  promptExpanded: string | null,
+  seed: number | null,
+  services: LegacyCodecGenerationServices,
+): Promise<LlmGenerationResult> {
+  if (request.modality === "asciipng" && request.source === "minimax" && !options.dryRun) {
+    return generateAsciipngFromMinimax(
+      request,
+      promptExpanded ?? request.prompt,
+      seed,
+      services.llmConfig,
+    );
+  }
+
+  if (request.modality === "asciipng") {
+    return buildAsciiPngGeneration(request);
+  }
+
+  if (
+    request.modality === "video" &&
+    Array.isArray(request.inlineSvgs) &&
+    request.inlineSvgs.length > 0
+  ) {
+    return buildVideoCompositionFromInlineSvgs(request);
+  }
+
+  if (request.modality === "svg" && request.source === "local") {
+    return buildSvgLocalGeneration(request);
+  }
+
+  if (options.dryRun) {
+    return createDryRunGeneration(request);
+  }
+
+  if (request.modality === "svg") {
+    return generateSvgFromEngine(promptExpanded ?? request.prompt, seed, services.svgConfig);
+  }
+
+  return services.generateStructured(promptExpanded ?? request.prompt, seed);
+}
+
+export function applyLegacyProviderReceipt(
+  manifest: RunManifest,
+  request: WittgensteinRequest,
+  generation: LlmGenerationResult,
+  svgInferenceUrl: string,
+): void {
+  if (request.modality === "svg") {
+    const raw = generation.raw;
+    if (
+      raw &&
+      typeof raw === "object" &&
+      "svgLocal" in raw &&
+      (raw as { svgLocal?: boolean }).svgLocal === true
+    ) {
+      manifest.llmProvider = "svg-local";
+      manifest.llmModel = "geometry-from-prompt";
+    } else {
+      manifest.llmProvider = "svg-engine";
+      manifest.llmModel = svgInferenceUrl;
+    }
+  }
+
+  if (request.modality === "asciipng" && request.source === "minimax") {
+    manifest.llmProvider = "minimax";
+    manifest.llmModel =
+      request.minimaxModel?.trim() ||
+      process.env.WITTGENSTEIN_MINIMAX_MODEL?.trim() ||
+      "abab6.5s-chat-h";
+  } else if (request.modality === "asciipng") {
+    manifest.llmProvider = "local-asciipng";
+    manifest.llmModel = "pseudo-ascii-raster";
+  }
+
+  if (request.modality === "video") {
+    const raw = generation.raw;
+    if (
+      raw &&
+      typeof raw === "object" &&
+      "videoInlineSvgs" in raw &&
+      (raw as { videoInlineSvgs?: boolean }).videoInlineSvgs === true
+    ) {
+      manifest.llmProvider = "inline-svgs";
+      manifest.llmModel = "filesystem";
+    }
+  }
+}
+
+function buildAsciiPngGeneration(request: WittgensteinRequest): LlmGenerationResult {
+  if (request.modality !== "asciipng") {
+    throw new ValidationError("buildAsciiPngGeneration called for non-asciipng request.");
+  }
+  const ir = {
+    text: request.prompt.slice(0, 2000),
+    columns: request.columns,
+    rows: request.rows,
+    cell: request.cell,
+    glyphMode: "pseudo" as const,
+  };
+  return {
+    text: JSON.stringify(ir),
+    tokens: { input: 0, output: 0 },
+    costUsd: null,
+    costUsdReason: "no-llm-call",
+    raw: { asciiPngLocal: true },
+  };
+}
+
+function createDryRunGeneration(request: WittgensteinRequest): LlmGenerationResult {
+  if (request.modality === "svg") {
+    return {
+      ...buildSvgLocalGeneration(request),
+      raw: { dryRun: true, svgLocal: true },
+    };
+  }
+
+  if (
+    request.modality !== "video" &&
+    request.modality !== "sensor" &&
+    request.modality !== "asciipng"
+  ) {
+    const scene = {
+      intent: "Photorealistic wildlife portrait suitable for print",
+      subject: request.prompt,
+      composition: {
+        framing: "tight portrait on subject",
+        camera: "telephoto compression, shallow depth of field",
+        depthPlan: ["sharp subject", "soft bokeh", "clean background"],
+      },
+      lighting: { mood: "natural soft daylight", key: "diffused key, gentle fill" },
+      style: {
+        references: ["wildlife photography", "fine-art nature print"],
+        palette: ["neutral grey", "natural fur tones", "cool water highlights"],
+      },
+      decoder: {
+        family: "llamagen" as const,
+        codebook: "stub-codebook",
+        latentResolution: [32, 32] as [number, number],
+      },
+    };
+
+    return {
+      text: JSON.stringify(scene),
+      tokens: {
+        input: 0,
+        output: 0,
+      },
+      costUsd: null,
+      costUsdReason: "no-llm-call",
+      raw: {
+        dryRun: true,
+      },
+    };
+  }
+
+  return {
+    text: "{}",
+    tokens: {
+      input: 0,
+      output: 0,
+    },
+    costUsd: null,
+    costUsdReason: "no-llm-call",
+    raw: {
+      dryRun: true,
+    },
+  };
+}

--- a/packages/core/test/harness-modality-blind.test.ts
+++ b/packages/core/test/harness-modality-blind.test.ts
@@ -29,17 +29,15 @@ describe("harness modality blindness", () => {
 
     expect(runBody).not.toMatch(/request\.modality\s*[!=]==/);
     expect(runBody).toContain("runLegacyCodecPipeline");
+    expect(source).toContain("./legacy-codec-pipeline.js");
   });
 
   // Bounded count of `request.modality` references (in CODE, not comments)
-  // — #300 modality-blind invariant guard. The current 15 references are
-  // classified inline in harness.ts (separate from the modality-as-parameter
-  // references inside `defaultOutputPathFor`'s body, which use the
-  // `modality` parameter directly rather than `request.modality`):
-  //   - 1 is legitimate modality-keyed routing (legacy outPath defaulting; v2
-  //     keeps these — the registry IS keyed by modality)
-  //   - 14 are v1-compat scaffolding (asciipng / svg / video legacy pipeline
-  //     + helper guards) that retires when the last v1 codec ports to v2
+  // - #300 modality-blind invariant guard. The remaining reference is
+  // legitimate modality-keyed routing for legacy outPath defaulting; v2 uses
+  // the routed codec's registry modality. Modality-specific v1 scaffolding now
+  // lives in `legacy-codec-pipeline.ts` and retires when the last v1 codec
+  // ports to v2.
   // If this count changes, the new reference must be classified inline in
   // harness.ts AND the expected count updated here (or the new reference
   // removed if it's drift).
@@ -49,10 +47,6 @@ describe("harness modality blindness", () => {
     // classifying comments don't inflate the count.
     const stripped = source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
     const matches = stripped.match(/request\.modality/g) ?? [];
-    // 15 is the audited baseline after v2 outPath defaulting stopped reading
-    // from the request and instead uses the routed codec's registry modality.
-    // Reduce this number when v1 codecs retire (#300). Increase only with
-    // explicit classification in this test's comment + harness.ts inline note.
-    expect(matches.length).toBe(15);
+    expect(matches.length).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

- move v1 codec input generation and provider receipt overrides out of the main harness into an explicit legacy pipeline module
- keep the main harness modality-blind guard focused on the single remaining legacy output-path defaulting reference
- update the #300 guard to assert the legacy branch lives behind the extracted module boundary

## Tests

- pnpm --filter @wittgenstein/core test -- harness-modality-blind harness manifest
- pnpm --filter @wittgenstein/core typecheck
- pnpm lint
- pnpm typecheck
- pnpm test

Refs #300, #288