### PR TITLE
Stabilize image dry-run PNG bytes

### DIFF
--- a/packages/codec-image/src/pipeline/decoder.ts
+++ b/packages/codec-image/src/pipeline/decoder.ts
@@ -8,7 +8,6 @@
 // what eventually replaces the placeholder path here; M1B is gated on the
 // per-candidate radar audits in #283.
 
-import { deflateSync } from "node:zlib";
 import type { RenderCtx } from "@wittgenstein/schemas";
 import type { ImageLatentCodes } from "../schema.js";
 
@@ -252,7 +251,7 @@ function encodeRgbaAsPng(width: number, height: number, rgba: Uint8Array): Uint8
     raw.set(rgba.subarray(sourceStart, sourceStart + width * 4), rowStart + 1);
   }
 
-  const idat = deflateSync(raw);
+  const idat = encodeZlibStored(raw);
   const ihdrChunk = createChunk("IHDR", ihdr);
   const idatChunk = createChunk("IDAT", idat);
   const iendChunk = createChunk("IEND", new Uint8Array(0));
@@ -289,6 +288,52 @@ function writeU32(target: Uint8Array, offset: number, value: number): void {
   target[offset + 1] = (value >>> 16) & 255;
   target[offset + 2] = (value >>> 8) & 255;
   target[offset + 3] = value & 255;
+}
+
+function writeU16Le(target: Uint8Array, offset: number, value: number): void {
+  target[offset] = value & 255;
+  target[offset + 1] = (value >>> 8) & 255;
+}
+
+function encodeZlibStored(raw: Uint8Array): Uint8Array {
+  const maxBlockLength = 65_535;
+  const blockCount = Math.max(1, Math.ceil(raw.length / maxBlockLength));
+  const output = new Uint8Array(2 + blockCount * 5 + raw.length + 4);
+  let cursor = 0;
+
+  // CMF/FLG for zlib + deflate with the fastest algorithm. The subsequent
+  // stored blocks avoid platform-specific compressor choices while remaining
+  // a standards-compliant PNG IDAT payload.
+  output[cursor] = 0x78;
+  output[cursor + 1] = 0x01;
+  cursor += 2;
+
+  for (let block = 0; block < blockCount; block += 1) {
+    const start = block * maxBlockLength;
+    const end = Math.min(raw.length, start + maxBlockLength);
+    const length = end - start;
+    const finalBlock = block === blockCount - 1;
+    output[cursor] = finalBlock ? 0x01 : 0x00;
+    writeU16Le(output, cursor + 1, length);
+    writeU16Le(output, cursor + 3, (~length) & 0xffff);
+    cursor += 5;
+    output.set(raw.subarray(start, end), cursor);
+    cursor += length;
+  }
+
+  writeU32(output, cursor, adler32(raw));
+  return output;
+}
+
+function adler32(data: Uint8Array): number {
+  const modulus = 65_521;
+  let a = 1;
+  let b = 0;
+  for (const byte of data) {
+    a = (a + byte) % modulus;
+    b = (b + a) % modulus;
+  }
+  return ((b << 16) | a) >>> 0;
 }
 
 function crc32(data: Uint8Array): number {

--- a/packages/codec-image/test/golden.test.ts
+++ b/packages/codec-image/test/golden.test.ts
@@ -1,16 +1,11 @@
 /**
  * Structural-stable golden coverage for codec-image (Issue #347).
  *
- * The dry-run produce() pipeline is deterministic per-platform, but the
- * emitted PNG bytes currently differ between darwin/arm64 and linux/x64 —
- * a real cross-platform reproducibility gap in the procedural placeholder
- * renderer (filed forward from this audit). Until that gap closes, this
- * golden locks the structural metadata that IS stable cross-platform:
- * mime type, route, image-code shape, manifest row keys, PNG magic bytes.
- *
- * When the procedural renderer becomes byte-deterministic across
- * platforms, switch this to a `createHash(...).digest("hex")` lock.
+ * The dry-run PNG path uses a repo-owned PNG/zlib stored-block encoder so
+ * the placeholder preview does not inherit platform-specific compressor
+ * output. This golden locks both the receipt structure and full PNG digest.
  */
+import { createHash } from "node:crypto";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
@@ -73,6 +68,9 @@ describe("codec-image golden parity (Issue #347)", () => {
     expect(bytes[1]).toBe(0x50); // P
     expect(bytes[2]).toBe(0x4e); // N
     expect(bytes[3]).toBe(0x47); // G
+    expect(createHash("sha256").update(bytes).digest("hex")).toBe(
+      "1c641aa5f57d0b00afe0ae53a86476ff3cb19e6a03eee3cf6fc1d0e7cfdeb796",
+    );
 
     // Image-code metadata is the doctrine surface — drift here means the
     // codec's path/mode/seed-family identity has changed.


### PR DESCRIPTION
## Summary

- replace the dry-run placeholder PNG IDAT compressor with a repo-owned zlib stored-block encoder
- lock the image dry-run golden to a full PNG SHA-256 digest again
- keep the receipt and PNG structural assertions alongside the byte-stable golden

## Why

This closes the #374 class of drift where identical image dry-run inputs produced different PNG bytes on darwin/arm64 and linux/x64 because the PNG encoder inherited platform zlib compressor choices.

## Tests

- pnpm --filter @wittgenstein/codec-image test
- pnpm --filter @wittgenstein/codec-image typecheck
- pnpm --filter @wittgenstein/codec-image lint
- pnpm lint
- pnpm typecheck
- pnpm test

Closes #374