### PR TITLE
Add codec error path tests

### DIFF
--- a/packages/codec-svg/test/codec.test.ts
+++ b/packages/codec-svg/test/codec.test.ts
@@ -10,6 +10,42 @@ describe("@wittgenstein/codec-svg", () => {
     expect(svgCodec.modality).toBe("svg");
   });
 
+  it("returns a structured parse error for non-JSON output", () => {
+    const parsed = svgCodec.parse("definitely not json");
+    expect(parsed.ok).toBe(false);
+    if (parsed.ok) {
+      return;
+    }
+    expect(parsed.error.code).toBe("SVG_SCHEMA_PARSE_FAILED");
+    expect(parsed.error.message).toBe("SVG IR was not valid JSON.");
+  });
+
+  it("returns a structured validation error for missing svg field", () => {
+    const parsed = svgCodec.parse(JSON.stringify({}));
+    expect(parsed.ok).toBe(false);
+    if (parsed.ok) {
+      return;
+    }
+    expect(parsed.error.code).toBe("SVG_SCHEMA_INVALID");
+    expect(parsed.error.details?.issues).toEqual(
+      expect.arrayContaining([expect.objectContaining({ path: ["svg"] })]),
+    );
+  });
+
+  it("rejects non-root SVG documents without silently rendering", () => {
+    const parsed = svgCodec.parse(JSON.stringify({ svg: "<rect />" }));
+    expect(parsed.ok).toBe(false);
+    if (parsed.ok) {
+      return;
+    }
+    expect(parsed.error.code).toBe("SVG_SCHEMA_INVALID");
+    expect(parsed.error.details?.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ message: 'Expected a root "<svg" document.' }),
+      ]),
+    );
+  });
+
   it("parses and renders a minimal SVG document", async () => {
     const doc =
       '<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8"><rect width="8" height="8" fill="black"/></svg>';

--- a/packages/codec-video/test/codec.test.ts
+++ b/packages/codec-video/test/codec.test.ts
@@ -25,6 +25,52 @@ describe("@wittgenstein/codec-video", () => {
     expect(videoCodec.parse("{}").ok).toBe(true);
   });
 
+  it("returns a structured parse error for non-JSON output", () => {
+    const parsed = videoCodec.parse("not json");
+    expect(parsed.ok).toBe(false);
+    if (parsed.ok) {
+      return;
+    }
+    expect(parsed.error.code).toBe("VIDEO_SCHEMA_PARSE_FAILED");
+    expect(parsed.error.message).toBe("Video composition was not valid JSON.");
+  });
+
+  it("returns a structured validation error for invalid timing", () => {
+    const parsed = videoCodec.parse(JSON.stringify({ durationSec: 0, fps: -1 }));
+    expect(parsed.ok).toBe(false);
+    if (parsed.ok) {
+      return;
+    }
+    expect(parsed.error.code).toBe("VIDEO_SCHEMA_INVALID");
+    expect(parsed.error.details?.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: ["durationSec"] }),
+        expect.objectContaining({ path: ["fps"] }),
+      ]),
+    );
+  });
+
+  it("rejects malformed inline SVG slides at parse time", () => {
+    const parsed = videoCodec.parse(
+      JSON.stringify({
+        inlineSvgs: ["<svg><rect /></svg>", "<div>not svg</div>"],
+      }),
+    );
+    expect(parsed.ok).toBe(false);
+    if (parsed.ok) {
+      return;
+    }
+    expect(parsed.error.code).toBe("VIDEO_SCHEMA_INVALID");
+    expect(parsed.error.details?.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          message: "inlineSvgs[1] must be a full SVG document (<svg …>…</svg>).",
+          path: ["inlineSvgs", 1],
+        }),
+      ]),
+    );
+  });
+
   it("renders a HyperFrames-shaped HTML composition", async () => {
     const parsed = videoCodec.parse(
       JSON.stringify({

--- a/packages/codec-video/test/playable-slideshow-html.test.ts
+++ b/packages/codec-video/test/playable-slideshow-html.test.ts
@@ -25,4 +25,22 @@ describe("playable-slideshow-html", () => {
     expect(html).toContain("linear 1 both");
     expect(html).not.toContain("linear infinite both");
   });
+
+  it("refuses an empty slide list", () => {
+    expect(() => buildPlayableSlideshowHtml({ svgs: [] })).toThrow(
+      "buildPlayableSlideshowHtml requires at least one SVG.",
+    );
+  });
+
+  it("refuses mismatched slide duration lists", () => {
+    expect(() =>
+      buildPlayableSlideshowHtml({
+        svgs: [
+          '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2 2"><rect width="2" height="2"/></svg>',
+          '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2 2"><circle cx="1" cy="1" r="1"/></svg>',
+        ],
+        durationsSec: [1],
+      }),
+    ).toThrow("buildPlayableSlideshowHtml: durationsSec length must match svgs length.");
+  });
 });


### PR DESCRIPTION
## Summary

- add structured parse and validation failure coverage for codec-svg
- add structured parse, invalid timing, and malformed inline-SVG coverage for codec-video
- add direct refusal coverage for the video slideshow HTML builder

## Notes

This is a small #367 slice. It deliberately avoids editing operating docs because the repo routes operating-doc doctrine through the governance/ADR lane.

## Tests

- pnpm --filter @wittgenstein/codec-svg test
- pnpm --filter @wittgenstein/codec-video test
- pnpm --filter @wittgenstein/codec-svg lint
- pnpm --filter @wittgenstein/codec-video lint
- pnpm --filter @wittgenstein/codec-svg typecheck
- pnpm --filter @wittgenstein/codec-video typecheck
- pnpm lint
- pnpm typecheck
- pnpm test

Refs #367