### PR TITLE
Refresh maintainer truth surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,19 +47,22 @@ Image, audio, and sensor produce real artifacts today; video is post-v0.3 work. 
 
 The image codec's split between **Visual Seed Code** (primary, decoder-facing) and **`Semantic IR`** (support: concept activation, user inspection, optional conditioning) is a doctrine correction ratified by [ADR-0018](docs/adrs/0018-hybrid-image-code-and-visual-seed-token.md). `Semantic IR` is important support — pure seed output can be opaque, brittle, or hard to diagnose — but it is not the main image research object.
 
-> **🧪 Project status — early-stage, doctrine-locked, v0.3 prerelease.**
-> Wittgenstein is a prerelease (`v0.3.0-alpha.2`) with a working Python
+> **🧪 Project status — early-stage, doctrine-locked, post-alpha.2 M1B follow-through.**
+> Wittgenstein is an early prerelease (`v0.3.0-alpha.2` cut is already out) with a working Python
 > surface, a production-shaped TypeScript harness, and a few intentionally
 > unfinished surfaces clearly flagged with ⚠️ or 🔴 in
 > [`docs/implementation-status.md`](docs/implementation-status.md). The v0.2
 > cut locks the thesis, vocabulary, and codec protocol (RFC-0001 / ADR-0008);
 > **M0, M1A, M2 audio, and M3 sensor have landed**, and the image doctrine
 > has been reframed around Visual Seed Code ([ADR-0018](docs/adrs/0018-hybrid-image-code-and-visual-seed-token.md)).
-> v0.3 is packaged against
+> The engineering source of truth remains
 > [`docs/exec-plans/active/codec-v2-port.md`](docs/exec-plans/active/codec-v2-port.md);
-> the **current mainline blocker is M1B** (image trained projector), gated
+> the **current mainline blocker is still M1B** (image trained projector), gated
 > on per-candidate radar audits in
-> [#283](https://github.com/p-to-q/wittgenstein/issues/283).
+> [#283](https://github.com/p-to-q/wittgenstein/issues/283). The current maintainer
+> hubs are [#402](https://github.com/p-to-q/wittgenstein/issues/402) for the
+> decoder-delivery decision and [#435](https://github.com/p-to-q/wittgenstein/issues/435)
+> for model-owner review across training, weights, and eval.
 > Breaking changes are still possible before a stable release. **We are
 > actively looking for early adopters and contributors** — see
 > [How to help](#how-to-help) below.

--- a/docs/contributor-map.md
+++ b/docs/contributor-map.md
@@ -27,6 +27,13 @@ If you keep that frame, the repo reads cleanly.
 
 That order gets you from doctrine → review model → decisions → execution.
 
+Current maintainer map after the post-#433 sweep:
+
+- `docs/exec-plans/active/codec-v2-port.md` is still the engineering source of truth.
+- [#402](https://github.com/p-to-q/wittgenstein/issues/402) is the current decoder-delivery decision.
+- [#435](https://github.com/p-to-q/wittgenstein/issues/435) is the owner-review hub for the M1B training / weights / eval line.
+- `moapacha` and `koriyoshi2041` are the explicit co-owners on that model/training line.
+
 One extra rule now applies across all doctrine-bearing work: the author does not count as the sole reviewer. If a PR changes doctrine, exec plans, shared contracts, or codec-shape assumptions, it needs a second independent review pass before merge. (Locked in ADR-0013.)
 
 One more rule matters just as much: contributors are expected to bring agency, not just compliance. A plan, issue, or agent prompt defines the starting slice; it does not forbid you from correcting a stale assumption, widening to a tightly-coupled fix, or proposing a better engineering path when the evidence is strong.
@@ -108,6 +115,15 @@ Success criterion:
 
 - the image path proves the protocol shape;
 - audio inherits it cleanly without re-opening doctrine.
+
+### Line B, current sub-state
+
+The image line has moved past the earlier "port the protocol" phase. The current split is:
+
+- delivery and runtime follow-through: PRs #427–#434 plus [#402](https://github.com/p-to-q/wittgenstein/issues/402)
+- owner review and training sequencing: [#435](https://github.com/p-to-q/wittgenstein/issues/435)
+
+If you land cold and need the next concrete thing, read those before widening scope.
 
 ## 5. How to add a new thing
 

--- a/docs/exec-plans/active/v0.3-roadmap.md
+++ b/docs/exec-plans/active/v0.3-roadmap.md
@@ -1,8 +1,9 @@
 # v0.3 Roadmap — index
 
 **Date opened:** 2026-05-04
-**Status:** 🟡 Active — thin index over already-tracked work; **not a parallel exec plan**.
-**Engineering source of truth:** [`codec-v2-port.md`](codec-v2-port.md) §M2 — that's where M-phase gates and rollback criteria live; this file does not duplicate them.
+**Last refreshed:** 2026-05-16
+**Status:** 🟡 Active as a maintainer-facing truth surface. v0.3 gates are closed; the repo is now in post-alpha.2 M1B owner-review and delivery follow-through, not generic prerelease triage.
+**Engineering source of truth:** [`codec-v2-port.md`](codec-v2-port.md) — that file owns the M-phase contract, current blocker, and rollback criteria. This page is the maintainer-facing index.
 
 ---
 
@@ -31,12 +32,36 @@ Five concrete checks, lifted from the audit's "from doctrinal claim to checkable
 | 4   | README "Receipts" table evidentiary-only (each row CI-gated)                       | ✅     | Initial pass via PR #134; tightened to 3 strict CI-gated rows + Engineering subsection via PR #135                                                                                                                        |
 | 5   | Supply-chain CI gating (dep-review fail-on-high; CodeQL extended)                  | ✅     | PR #132 landed config; PR #138 made `dependency-review-action` a real gate after Dependency graph was enabled in repo Settings → Security & analysis (2026-05-04)                                                         |
 
-When all five rows reach ✅ and `CHANGELOG.md` has a `0.3.0-alpha.1` entry, the
-v0.3 prerelease can be tagged.
+All five rows are now closed. This page remains live because the repo still needs a
+maintainer-readable map from "what landed" to "what is next."
 
 ---
 
-## Active engineering line
+## Current mainline
+
+The current mainline is not "finish v0.3 packaging." It is the M1B image line after the
+recent delivery / harness / reproducibility foundations landed in PRs #427–#434.
+
+Use this split when landing cold:
+
+- **Owner-review hub:** [#435](https://github.com/p-to-q/wittgenstein/issues/435)
+  This is the current maintainer/model-owner pack for `moapacha` + `koriyoshi2041`.
+- **Current decoder-delivery decision:** [#402](https://github.com/p-to-q/wittgenstein/issues/402)
+  This is the concrete "which decoder-family manifest do we actually bless and fetch"
+  question. `#403` stays parked behind it.
+- **Planning-surface cleanup:** [#436](https://github.com/p-to-q/wittgenstein/issues/436)
+  This is the docs / roadmap / maintainer-map truth-surface follow-through issue.
+
+Recommended execution order before any owner override:
+
+1. Close the VQGAN-class candidate audits: [#334](https://github.com/p-to-q/wittgenstein/issues/334) and [#335](https://github.com/p-to-q/wittgenstein/issues/335).
+2. Use that result to settle [#402](https://github.com/p-to-q/wittgenstein/issues/402).
+3. Keep [#399](https://github.com/p-to-q/wittgenstein/issues/399) and [#400](https://github.com/p-to-q/wittgenstein/issues/400) moving in parallel.
+4. Start the first real training slices: [#396](https://github.com/p-to-q/wittgenstein/issues/396), [#393](https://github.com/p-to-q/wittgenstein/issues/393), [#397](https://github.com/p-to-q/wittgenstein/issues/397), [#394](https://github.com/p-to-q/wittgenstein/issues/394), then [#398](https://github.com/p-to-q/wittgenstein/issues/398).
+
+---
+
+## Historical v0.3 line
 
 **M2 audio port — release closeout.** Source of truth: [`codec-v2-port.md`](codec-v2-port.md) §M2. Slices A/B/C1/D + C2/C3 and Sweep E are complete. Remaining work is release packaging:
 
@@ -69,7 +94,7 @@ See:
 
 ---
 
-## Open backlog (not gating v0.3 but staying tracked)
+## Open backlog (not gating the current M1B line but staying tracked)
 
 | Issue | Title                                         | Status                                                                                             |
 | ----- | --------------------------------------------- | -------------------------------------------------------------------------------------------------- |

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,13 @@ Read these two files before any task:
 
 For doctrine-bearing PRs, also remember the review rule now locked in `engineering-discipline.md`: authoring a PR does not count as ratifying it; a second independent review pass is required before merge.
 
+Current maintainer pointers:
+
+- Engineering source of truth: [`exec-plans/active/codec-v2-port.md`](exec-plans/active/codec-v2-port.md)
+- Current M1B owner-review hub: [Issue #435](https://github.com/p-to-q/wittgenstein/issues/435)
+- Current decoder-delivery decision: [Issue #402](https://github.com/p-to-q/wittgenstein/issues/402)
+- Current truth-surface cleanup tracker: [Issue #436](https://github.com/p-to-q/wittgenstein/issues/436)
+
 ## Then understand the thesis and governance
 
 - [`THESIS.md`](THESIS.md) — smallest locked statement of the project


### PR DESCRIPTION
## Summary

- update the maintainer-facing roadmap index to reflect the post-alpha.2 M1B line rather than generic v0.3 prerelease framing
- add explicit pointers to #402 as the decoder-delivery decision, #435 as the M1B owner-review hub, and #436 as the planning-surface cleanup tracker
- refresh the contributor and docs entry points so a new maintainer lands on the current map instead of reconstructing it from merged PRs

## Notes

This is a docs-only truth-surface cleanup. It does not introduce new doctrine or change the engineering source of truth; it makes the existing source-of-truth surfaces easier to find.

## Validation

- pnpm prettier --check README.md docs/contributor-map.md docs/index.md docs/exec-plans/active/v0.3-roadmap.md
- pnpm lint

Refs #436