### PR TITLE
Clarify training DVC setup status

### DIFF
--- a/docs/contributing/training-setup.md
+++ b/docs/contributing/training-setup.md
@@ -65,9 +65,10 @@ spine is the canonical record and Aim stays local + offline-friendly.
 Datasets will be pinned with [DVC](https://dvc.org/) so a training receipt
 points to an exact data SHA, not a moving HF dataset id.
 
-**TODO:** the DVC remote setup is described in `_shared/dvc.md` and is
-tracked under the data-versioning Phase-1 issue. Configure that remote
-before running:
+The DVC remote does not exist yet. It is tracked by
+[#400](https://github.com/p-to-q/wittgenstein/issues/400), which owns the
+dataset snapshots, remote-storage choice, and sweep-manifest shape for
+Phase 1 training. Once #400 lands, configure the remote before running:
 
 ```bash
 cd research/training


### PR DESCRIPTION
## Summary
- replace the stale reference to a non-existent research/training/_shared/dvc.md file
- point contributors to #400 as the owner for DVC remote, dataset snapshot, and sweep-manifest setup

## Validation
- pnpm prettier --check docs/contributing/training-setup.md
- git diff --check