### PR TITLE
Add repo-owned video MP4 renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Repo-owned HyperFrames-shaped video MP4 renderer: `codec-video` now captures
+  deterministic HTML frames through local Chrome/Chromium (`puppeteer-core`) and
+  encodes MP4 with local FFmpeg when `WITTGENSTEIN_HYPERFRAMES_RENDER=1`.
+- Explicit upstream HyperFrames CLI backend for parity / experiments via
+  `WITTGENSTEIN_HYPERFRAMES_BACKEND=npx-cli`; default MP4 backend remains
+  `distilled-internal`.
+- `videoRender` manifest receipts for video outputs, plus
+  `research/validation/video_mp4_renderer_validate.ts` for HTML receipt checks and
+  opt-in double-render MP4 validation.
+
+### Changed
+
+- `wittgenstein doctor` video checks now report the selected backend and only
+  require the upstream HyperFrames CLI when `WITTGENSTEIN_HYPERFRAMES_BACKEND=npx-cli`.
+
 ## [0.3.0-alpha.3] — 2026-05-13 — maintainer-onboarding sweep, M1B prep, tier doctrine
 
 This prerelease packages the May-2026 maintainer-onboarding session: an

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ text-first LLM
 | 🖼️ Image  | Visual Seed Code (primary) + optional `Semantic IR`                  | Seed expander → frozen VQ decoder¹                                  | PNG                    |
 | 🔊 Audio  | Route-specific audio code (speech / soundscape / music)              | Procedural synth (default) + opt-in Kokoro speech                   | WAV                    |
 | 📡 Sensor | Operator program (with `patchGrammar` for local-context composition) | Deterministic signal expansion                                      | CSV + interactive HTML |
-| 🎞️ Video  | Composition spec                                                     | HyperFrames-shaped local render (M4 stub today; ratified lead path) | MP4 / HTML             |
+| 🎞️ Video  | Composition spec                                                     | HyperFrames-shaped local render (HTML default, MP4 opt-in)          | MP4 / HTML             |
 
-Image, audio, and sensor produce real artifacts today; video is post-v0.3 work. Per-modality maturity is in [`docs/implementation-status.md`](docs/implementation-status.md); the full five-layer mapping is in the [Architecture](#architecture-five-layers) section below; the [30-second sensor quickstart](#quickstart-30-seconds-no-api-key) is the smallest no-API-key proof.
+Image, audio, sensor, and video HTML produce real artifacts today; video MP4 is an opt-in local-render path requiring Chrome/Chromium + FFmpeg. Per-modality maturity is in [`docs/implementation-status.md`](docs/implementation-status.md); the full five-layer mapping is in the [Architecture](#architecture-five-layers) section below; the [30-second sensor quickstart](#quickstart-30-seconds-no-api-key) is the smallest no-API-key proof.
 
 > ¹ **Image today renders a procedural placeholder.** The frozen VQ decoder bridge is the M1B blocker tracked in [#283](https://github.com/p-to-q/wittgenstein/issues/283); `wittgenstein image --dry-run` runs end-to-end and produces a PNG, but the path between seed code and pixels is procedural until M1B lands. See the **Project status** block immediately below for the full picture.
 
@@ -382,7 +382,7 @@ is visible, but **do not depend on them in production** until the status matrix 
 | Surface                                       | State             | What works today                                                                      | What's missing                                                                 |
 | --------------------------------------------- | ----------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
 | TS `codec-image` adapter + decoder            | ⚠️ Partial        | Scene JSON, placeholder latents, MLP loader, `renderSky` / `renderTerrain` primitives | Frozen VQ decoder bridge (LlamaGen / SEED); trained adapter weights            |
-| TS `codec-video`                              | 🔴 Stub           | Schema + typed interface                                                              | HyperFrames integration, MP4 encoder                                           |
+| TS `codec-video`                              | ⚠️ Partial        | Schema, HTML renderer, opt-in repo-owned MP4 renderer                                  | M5b video metrics / richer composition features                                |
 | Benchmark quality scores                      | ⚠️ Proxy          | Structural smoke checks, cost/latency timing                                          | CLIPScore, Whisper WER, UTMOS, discriminative score runners                    |
 | `polyglot-mini` image code-as-painter sandbox | ⚠️ Research-grade | `subprocess` with 20 s timeout + safe globals                                         | Kernel-level isolation for multi-tenant use (see [`SECURITY.md`](SECURITY.md)) |
 

--- a/docs/codecs/video.md
+++ b/docs/codecs/video.md
@@ -1,18 +1,18 @@
 # Video Codec
 
-Video owns a composition-first JSON IR and a render seam for HyperFrames.
+Video owns a composition-first JSON IR and a HyperFrames-shaped render seam.
 
 ## IR
 
 The model emits scene blocks, timing, and composition metadata.
 
-Optional `inlineSvgs` is an array of **full** `<svg>…</svg>` documents. When present, the HyperFrames HTML renderer shows **one slide per SVG** on a black stage (no title cards). Timing:
+Optional `inlineSvgs` is an array of **full** `<svg>…</svg>` documents. When present, the renderer shows **one slide per SVG** on a black stage (no title cards). Timing:
 
 - If `scenes.length` matches `inlineSvgs.length`, use each `scenes[i].durationSec`.
 - Else if `durationSec` is set, split it evenly across slides.
 - Else default **3 seconds per slide**.
 
-## CLI: playable animation HTML (no HyperFrames)
+## CLI: playable animation HTML
 
 `wittgenstein animate-html` writes a **single HTML file** that plays in any browser: SVG slides cross-fade on a timer using **CSS `animation`**, default **`animation-iteration-count: infinite`**.
 
@@ -39,7 +39,7 @@ pnpm exec wittgenstein video "unused" --svg ./output/a.svg --svg ./output/b.svg 
 
 `packages/codec-video/src/hyperframes-wrapper.ts` is the integration seam for **HyperFrames-shaped** HTML compositions and optional local MP4 encoding.
 
-> **HyperFrames-shaped, not HyperFrames-vendored.** Per PR #277 ratification + the #282 follow-up, the upstream `heygen-com/hyperframes` package is the inspiration / reference design, not a runtime dependency. The codec borrows the *spirit* (timeline + inline-SVG composition with `data-*` timing attributes; local FFmpeg + headless-Chrome render) but the implementation must be **repo-owned**: no `heygen-com/hyperframes` import as a runtime dep, no wholesale vendoring of the package into this repo, no preserving upstream modules just because they exist. The distillation work itself is tracked in #282; the verification gates (license clearance, behavioral test corpus, doctor coverage, manifest receipts) are listed there.
+> **HyperFrames-shaped, not HyperFrames-vendored.** Per PR #277 ratification + the #282 follow-up, the upstream `heygen-com/hyperframes` package is the inspiration / reference design, not a runtime dependency. The codec borrows the *spirit* (timeline + inline-SVG composition with `data-*` timing attributes; local FFmpeg + headless-Chrome render) but the implementation is **repo-owned**: no `heygen-com/hyperframes` import as a runtime dep, no wholesale vendoring of the package into this repo, no preserving upstream modules just because they exist.
 
 ### HTML (default)
 
@@ -47,9 +47,21 @@ The codec writes a deterministic HTML file using HyperFrames-style `data-*` timi
 
 Note: the harness default output path for video is still `output.mp4`, but **without** local encode enabled the codec writes `output.hyperframes.html` next to that basename so the artifact type matches what was generated.
 
-### MP4 (opt-in, local HyperFrames CLI)
+### MP4 (opt-in, repo-owned local renderer)
 
-HyperFrames is **not** “an API you must call” for basic rendering: the open-source CLI renders **locally** with **FFmpeg + headless Chrome** (see upstream `hyperframes doctor`). Optional network traffic may occur for `npx` package download or CLI update notices unless disabled with `HYPERFRAMES_NO_UPDATE_CHECK=1` (Wittgenstein defaults telemetry/update noise off when spawning).
+The default MP4 path renders the same HTML composition through `puppeteer-core` + a local Chrome/Chromium binary, captures one PNG per frame with a deterministic `?wittgensteinFrameTime=` hook, then encodes those frames with local `ffmpeg`. It does not call `npx hyperframes` or import upstream HyperFrames code.
+
+For cross-checking and temporary upstream parity, an explicit CLI backend is available:
+
+```bash
+export WITTGENSTEIN_HYPERFRAMES_BACKEND=npx-cli
+```
+
+The default remains `distilled-internal` so M4 stays repo-owned. The `npx-cli` backend is useful for validation against upstream HyperFrames and for local experiments when the upstream CLI works better on a given machine.
+
+Note: the upstream `hyperframes` npm package currently advertises Node.js >=22,
+while Wittgenstein's repo baseline is Node 20.19+. `wittgenstein doctor` reports
+that mismatch when `WITTGENSTEIN_HYPERFRAMES_BACKEND=npx-cli` is selected.
 
 To emit a real `.mp4` artifact at the harness `outPath`, enable:
 
@@ -61,16 +73,42 @@ Optional tuning:
 
 - `WITTGENSTEIN_HYPERFRAMES_RENDER_TIMEOUT_MS` (default `600000`)
 - `WITTGENSTEIN_HYPERFRAMES_QUALITY` (`draft` | `standard` | `high`, default `standard`)
+- `WITTGENSTEIN_HYPERFRAMES_BACKEND` (`distilled-internal` | `npx-cli`, default `distilled-internal`)
+- `PUPPETEER_EXECUTABLE_PATH` when Chrome/Chromium is not in a standard location
+
+Each render emits a `videoRender` manifest receipt with renderer backend, FPS, quality, dimensions, duration, frame count, output kind, and available Chrome / FFmpeg version strings. HTML output is marked `byte-parity-on-platform`; MP4 output is currently marked `structural-parity-cross-platform` because browser / font / FFmpeg versions can affect bytes.
+
+## Research validation
+
+Run the lightweight validation script:
+
+```bash
+node --import tsx research/validation/video_mp4_renderer_validate.ts
+```
+
+By default it validates the HTML path and receipt. To run the local-compute MP4 gate, install Chrome/Chromium + FFmpeg and set:
+
+```bash
+export WITTGENSTEIN_VALIDATE_VIDEO_MP4=1
+export WITTGENSTEIN_HYPERFRAMES_RENDER=1
+node --import tsx research/validation/video_mp4_renderer_validate.ts
+```
+
+The MP4 validation renders the same fixed inline-SVG composition twice and requires
+both SHA-256 equality (`byte-parity-on-platform`) and ffprobe structural metadata
+for the fixture. It exits non-zero when a requested backend fails the gate. Set
+`WITTGENSTEIN_VALIDATE_VIDEO_BACKENDS=distilled-internal,npx-cli` to compare both
+backends.
 
 ## Benchmark Direction
 
-Once the MP4 branch is merged, video should align with common evaluation practice instead of ad-hoc scores:
+With the opt-in MP4 branch wired, video should align with common evaluation practice instead of ad-hoc scores once the local-compute gate is run:
 
 - `FVD` for distribution-level video quality
 - `Video-Bench` style multi-dimensional evaluation for prompt adherence, visual quality, temporal consistency, and motion fidelity
 - motion-specific metrics such as `FVMD` when motion realism matters
 
-The package exists now so video is a first-class codec, not an afterthought, but the current main branch is still a scaffold rather than a runnable MP4 benchmark target.
+The package exists now so video is a first-class codec, not an afterthought. The renderer is intentionally composition-shaped rather than text-to-video generative; M5b quality metrics remain downstream.
 
 ## Lineage receipt
 
@@ -83,6 +121,7 @@ For agents reading this doc cold, the lineage from the v0.2 stub to today's main
 | Backend comparison ratification | PR #277 | HyperFrames-shaped lead path **conditional on license verification + repo-owned distillation** |
 | Distillation work commission | #282 | Six slice issues named (#282A–#282F): license audit / behavioral corpus / pure-TS HTML emitter / MP4 opt-in / doctor coverage / manifest receipt block |
 | Exec plan annotation | PR #293 | Codec v2 port plan annotated to reflect that #277 / #282 activate M4 video work post-v0.2 |
-| M4 implementation | (gated on #282 slices) | Repo-owned renderer; videoRender manifest block analogous to audioRender |
+| Refactor seam | PR #339 / #401 | Composition builders extracted; `ProcessRunner` moved to a leaf package |
+| M4 implementation | current | Repo-owned Chrome + FFmpeg renderer; `videoRender` manifest receipt analogous to `audioRender` |
 
-The distinction matters because of the doctrine line in `docs/hard-constraints.md`: the harness ships under Apache-2.0, and any external dependency we import or vendor needs license + receipt clarity before it ships in a release artifact. HyperFrames-shaped distillation lets video M4 land without taking on that gate work for an upstream package whose license + maintenance posture haven't been audited locally.
+The distinction matters because of the doctrine line in `docs/hard-constraints.md`: the harness ships under Apache-2.0, and any external dependency we import or vendor needs license + receipt clarity before it ships in a release artifact. HyperFrames-shaped distillation lets video M4 land without shipping upstream HyperFrames code.

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -103,10 +103,13 @@ codecs are wired. Image and video codecs are typed stubs — intentional until t
 
 ### @wittgenstein/codec-video
 
-| Component                | Status   | Notes                                                     |
-| ------------------------ | -------- | --------------------------------------------------------- |
-| Schema + Zod             | ✅ Ships |                                                           |
-| `hyperframes-wrapper.ts` | 🔴 Stub  | Throws `NotImplementedError` — HyperFrames not yet forked |
+| Component                  | Status     | Notes                                                                                          |
+| -------------------------- | ---------- | ---------------------------------------------------------------------------------------------- |
+| Schema + Zod               | ✅ Ships   | Validates `VideoComposition`                                                                   |
+| HTML composition renderer  | ✅ Ships   | Emits self-contained HyperFrames-shaped HTML via `scene-card` / `svg-slide` compositions       |
+| Distilled MP4 renderer     | ⚠️ Opt-in  | Default MP4 backend with `WITTGENSTEIN_HYPERFRAMES_RENDER=1`; local Chrome/Chromium + FFmpeg required |
+| Upstream CLI backend       | ⚠️ Opt-in  | `WITTGENSTEIN_HYPERFRAMES_BACKEND=npx-cli` keeps an explicit parity / experiment path          |
+| `videoRender` receipts     | ✅ Ships   | Records backend, FPS, quality, dimensions, frame count / duration, output kind, tool versions  |
 
 ### @wittgenstein/cli
 
@@ -115,8 +118,8 @@ codecs are wired. Image and video codecs are typed stubs — intentional until t
 | `wittgenstein image`  | ✅ Ships | Calls codec-image; renders with available adapter/decoder |
 | `wittgenstein audio`  | ✅ Ships | Full speech + soundscape + music routes                   |
 | `wittgenstein sensor` | ✅ Ships | Full signal expand + Loupe dashboard                      |
-| `wittgenstein video`  | 🔴 Stub  | Codec throws `NotImplementedError`                        |
-| `wittgenstein doctor` | ✅ Ships | Checks node, pnpm, env vars, package links                |
+| `wittgenstein video`  | ⚠️ Partial | Emits HTML by default; MP4 encode is repo-owned local renderer opt-in |
+| `wittgenstein doctor` | ✅ Ships | Checks node, pnpm, env vars, package links, optional video MP4 deps |
 
 ### @wittgenstein/sandbox
 
@@ -140,7 +143,9 @@ These are explicit scope decisions, not omissions:
 
 - **LlamaGen / SEED VQ-VAE decoder weights** — neural image codec requires a trained adapter;
   stubs are typed and ready to wire. See `docs/codecs/image.md`.
-- **HyperFrames video integration** — reserved post-hackathon. Schema and codec interface are locked.
+- **Video quality metrics** — the HyperFrames-shaped renderer now emits HTML by default
+  and opt-in MP4 via repo-owned Chrome + FFmpeg code, but M5b scoring (clip-frame-drift,
+  FVD / Video-Bench-style heavy paths) remains downstream.
 - **Real LLM fine-tuning** — the only trained models are the two tiny MLPs (image style adapter +
   audio ambient classifier). No fine-tuning of base models.
 - **Cloud render APIs** — no DALL·E, ElevenLabs, or Runway calls anywhere in the stack.

--- a/docs/research/2026-05-26-video-mp4-renderer-validation.md
+++ b/docs/research/2026-05-26-video-mp4-renderer-validation.md
@@ -1,0 +1,99 @@
+---
+date: 2026-05-26
+status: validation note
+labels: [research-derived, m4-video]
+tracks: [#282, #359, #360, #361, #362]
+---
+
+# Video MP4 renderer validation
+
+## Context
+
+The earlier video backend comparison (`docs/research/2026-05-08-video-backend-comparison.md`)
+picked a HyperFrames-shaped path: JSON composition + inline SVG / scene timing,
+browser-native HTML, and local Chrome + FFmpeg for MP4. The implementation constraint
+was distillation, not vendoring: repo-owned code should carry the default path, while
+upstream HyperFrames remains a useful reference and parity target.
+
+## Horizontal comparison
+
+The current implementation follows the same pattern used by the stronger local paths:
+
+| Path | Useful precedent | Video application |
+|---|---|---|
+| Audio Kokoro / procedural routes | Renderer emits explicit `audioRender` receipts and marks determinism class honestly | Video now emits `videoRender` receipts with backend, FPS, quality, dimensions, duration, frame count, output kind, and tool versions when available |
+| Sensor Loupe renderer | Deterministic local artifact plus optional richer HTML side surface | Video keeps deterministic HTML as the default artifact when MP4 is not requested |
+| ProcessRunner extraction | Subprocess timeout + bounded stderr/stdout belongs in a leaf package, not codec/core cycles | Both the distilled FFmpeg encode path and upstream CLI path use `@wittgenstein/process-runner` |
+| HyperFrames upstream | Agent-friendly HTML timeline + local Chrome/FFmpeg render | Retained as explicit `WITTGENSTEIN_HYPERFRAMES_BACKEND=npx-cli` parity backend, not the default |
+
+## Practical features kept
+
+- Default `distilled-internal` backend: Chrome screenshot frames + FFmpeg MP4 encode.
+- Explicit `npx-cli` backend: local upstream HyperFrames path for parity checks and experiments. The npm package currently advertises Node.js >=22, so this backend is a Node-version-sensitive comparison path rather than the repo default.
+- `?wittgensteinFrameTime=` hook: freezes the CSS timeline at a specific timestamp so screenshots do not depend on wall-clock animation timing.
+- Validation script: `research/validation/video_mp4_renderer_validate.ts` validates HTML receipts by default and becomes a hard MP4 gate when local dependencies exist: each requested backend must pass same-platform byte parity and ffprobe structural checks.
+- `doctor` now reports the selected backend and only checks the upstream CLI when the user selects it.
+
+## Validation run
+
+Ran locally on 2026-05-26:
+
+```bash
+node --import tsx research/validation/video_mp4_renderer_validate.ts
+```
+
+Result: HTML-only validation passed. The fixed three-slide inline-SVG fixture emitted
+a byte-stable HTML artifact with a `videoRender` receipt and the frame-time hook present.
+
+Then ran the local-compute MP4 gate on the same machine:
+
+```bash
+export WITTGENSTEIN_VALIDATE_VIDEO_MP4=1
+export WITTGENSTEIN_HYPERFRAMES_RENDER=1
+export WITTGENSTEIN_VALIDATE_VIDEO_BACKENDS=distilled-internal,npx-cli
+export WITTGENSTEIN_KEEP_VIDEO_VALIDATION_ARTIFACTS=1
+node --import tsx research/validation/video_mp4_renderer_validate.ts
+```
+
+Environment:
+
+- Node.js: 22.20.0
+- FFmpeg / ffprobe: 8.1.1
+- Chrome: `Chrome/148.0.7778.179`
+- HyperFrames CLI: 0.6.46
+
+HTML fixture:
+
+- SHA-256: `e8cc3f665892ca0152c63bef568543cf2dfa972d8bcbe07829e82f30f84c14b1`
+- Receipt: `renderPath=hyperframes-html`, `backend=distilled-internal`, `outputKind=html`, `durationSec=3`, `fps=24`, `width=1920`, `height=1080`
+- Frame-time hook: present
+
+MP4 double-render results:
+
+| Requested backend | Receipt backend | SHA-256 | Bytes | ffprobe structure | Verdict |
+|---|---|---:|---:|---|---|
+| `distilled-internal` | `distilled-internal` | `277c710281aa4b2474266fb2b86353294f93100a42b1cdcc207f7332168e7d94` | 17489 | H.264, 1920x1080, 24fps, 3.000000s, 72 frames | byte parity on platform |
+| `npx-cli` | `npx-hyperframes-cli` | `9b7161a3b64dc6940d0ff9e49c9f909fbd4ca0302759b1aab844cfd08bf0a857` | 12093 | H.264, 1920x1080, 24fps, 3.000000s, 72 frames | byte parity on platform |
+
+The two backends are structurally equivalent for the validation fixture but do not
+produce byte-identical MP4s across backend implementations. That is expected: the
+repo-owned renderer and upstream CLI have separate encode paths. The meaningful
+floor is per-backend byte parity on the same platform plus matching structural
+metadata across backends.
+
+The validation script writes temporary run material under
+`artifacts/tmp/video-mp4-renderer/` by default, or under
+`WITTGENSTEIN_VIDEO_VALIDATION_DIR` when that environment variable is set.
+By default it removes the run directory after success; set
+`WITTGENSTEIN_KEEP_VIDEO_VALIDATION_ARTIFACTS=1` to retain the files for manual
+inspection.
+
+## Verdict
+
+The practical wiring is now in place: HTML default, repo-owned MP4 as the default
+opt-in backend, upstream CLI as an explicit parity backend, and receipts / doctor /
+validation hooks to keep future changes honest. The empirical MP4 gate passed on
+this machine for both the distilled internal renderer and the upstream CLI parity
+backend. Future portability work should treat cross-machine MP4 bytes as unstable
+unless measured again, but must preserve the manifest receipt and ffprobe
+structural floor.

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,7 +1,29 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
 import { loadWittgensteinConfig } from "@wittgenstein/core";
 import type { Command } from "commander";
 import { resolveExecutionRoot } from "./shared.js";
 import { runtimeTierReadiness } from "../tiers.js";
+
+type DoctorCheckStatus = "ok" | "missing" | "skipped";
+
+interface DoctorCheck {
+  status: DoctorCheckStatus;
+  version?: string;
+  path?: string;
+  message?: string;
+}
+
+const OPTIONAL_DEPENDENCY_CHECK_TIMEOUT_MS = 1_000;
+
+interface VideoRenderDoctor {
+  enabled: boolean;
+  backend: "distilled-internal" | "npx-cli";
+  hyperframesNode: DoctorCheck;
+  hyperframesCli: DoctorCheck;
+  ffmpeg: DoctorCheck;
+  chrome: DoctorCheck;
+}
 
 export function registerDoctorCommand(program: Command): void {
   program
@@ -27,10 +49,169 @@ export function registerDoctorCommand(program: Command): void {
             llmModel: config.llm.model,
             artifactsDir: config.runtime.artifactsDir,
             tiers: runtimeTierReadiness(),
+            videoRender: checkVideoRenderDependencies(),
           },
           null,
           2,
         ),
       );
     });
+}
+
+function checkVideoRenderDependencies(): VideoRenderDoctor {
+  const enabled = process.env.WITTGENSTEIN_HYPERFRAMES_RENDER === "1";
+  if (!enabled) {
+    const skipped: DoctorCheck = {
+      status: "skipped",
+      message: "Set WITTGENSTEIN_HYPERFRAMES_RENDER=1 to enable MP4 render dependency checks.",
+    };
+    return {
+      enabled,
+      backend: readVideoBackend(),
+      hyperframesNode: skipped,
+      hyperframesCli: skipped,
+      ffmpeg: skipped,
+      chrome: skipped,
+    };
+  }
+
+  const backend = readVideoBackend();
+  return {
+    enabled,
+    backend,
+    hyperframesNode:
+      backend === "npx-cli"
+        ? checkNodeForHyperframesCli()
+        : { status: "skipped", message: "Only checked when WITTGENSTEIN_HYPERFRAMES_BACKEND=npx-cli." },
+    hyperframesCli:
+      backend === "npx-cli"
+        ? checkHyperframesCli()
+        : { status: "skipped", message: "Only checked when WITTGENSTEIN_HYPERFRAMES_BACKEND=npx-cli." },
+    ffmpeg: checkCommandVersion("ffmpeg", ["-version"], "Install FFmpeg for video MP4 rendering."),
+    chrome: checkChrome(),
+  };
+}
+
+function checkNodeForHyperframesCli(): DoctorCheck {
+  const major = Number.parseInt(process.versions.node.split(".")[0] ?? "0", 10);
+  if (major >= 22) {
+    return {
+      status: "ok",
+      version: process.version,
+    };
+  }
+  return {
+    status: "missing",
+    version: process.version,
+    message:
+      "HyperFrames CLI currently requires Node.js >=22. Use the distilled internal backend on Node 20, or run the npx backend under Node 22+.",
+  };
+}
+
+function readVideoBackend(): "distilled-internal" | "npx-cli" {
+  return process.env.WITTGENSTEIN_HYPERFRAMES_BACKEND === "npx-cli"
+    ? "npx-cli"
+    : "distilled-internal";
+}
+
+function checkHyperframesCli(): DoctorCheck {
+  const result = spawnSync("npx", ["--no-install", "hyperframes", "--version"], {
+    encoding: "utf8",
+    timeout: OPTIONAL_DEPENDENCY_CHECK_TIMEOUT_MS,
+    env: {
+      ...process.env,
+      HYPERFRAMES_NO_TELEMETRY: process.env.HYPERFRAMES_NO_TELEMETRY ?? "1",
+      HYPERFRAMES_NO_UPDATE_CHECK: process.env.HYPERFRAMES_NO_UPDATE_CHECK ?? "1",
+    },
+  });
+
+  if (result.status === 0) {
+    return {
+      status: "ok",
+      version: firstOutputLine(result.stdout, result.stderr),
+    };
+  }
+
+  return {
+    status: "missing",
+    message:
+      "Install HyperFrames locally, or unset WITTGENSTEIN_HYPERFRAMES_BACKEND to use the distilled internal renderer.",
+  };
+}
+
+function checkCommandVersion(command: string, args: string[], missingMessage: string): DoctorCheck {
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    timeout: OPTIONAL_DEPENDENCY_CHECK_TIMEOUT_MS,
+  });
+
+  if (result.status === 0) {
+    return {
+      status: "ok",
+      version: firstOutputLine(result.stdout, result.stderr),
+    };
+  }
+
+  return {
+    status: "missing",
+    message: missingMessage,
+  };
+}
+
+function checkChrome(): DoctorCheck {
+  const envPath = process.env.PUPPETEER_EXECUTABLE_PATH;
+  if (envPath) {
+    if (!existsSync(envPath)) {
+      return {
+        status: "missing",
+        path: envPath,
+        message: "PUPPETEER_EXECUTABLE_PATH is set but does not point to an existing file.",
+      };
+    }
+
+    return checkChromeCandidate(envPath);
+  }
+
+  const candidates = [
+    "google-chrome",
+    "chromium",
+    "chromium-browser",
+    "chrome",
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/Applications/Chromium.app/Contents/MacOS/Chromium",
+  ];
+
+  for (const candidate of candidates) {
+    const check = checkChromeCandidate(candidate);
+    if (check.status === "ok") {
+      return check;
+    }
+  }
+
+  return {
+    status: "missing",
+    message:
+      "Install Chrome/Chromium or set PUPPETEER_EXECUTABLE_PATH for video MP4 rendering.",
+  };
+}
+
+function checkChromeCandidate(candidate: string): DoctorCheck {
+  const result = spawnSync(candidate, ["--version"], {
+    encoding: "utf8",
+    timeout: OPTIONAL_DEPENDENCY_CHECK_TIMEOUT_MS,
+  });
+
+  if (result.status === 0) {
+    return {
+      status: "ok",
+      path: candidate,
+      version: firstOutputLine(result.stdout, result.stderr),
+    };
+  }
+
+  return { status: "missing" };
+}
+
+function firstOutputLine(stdout: string, stderr: string): string {
+  return (stdout || stderr).split(/\r?\n/).find((line) => line.trim().length > 0)?.trim() ?? "";
 }

--- a/packages/cli/test/doctor.test.ts
+++ b/packages/cli/test/doctor.test.ts
@@ -20,9 +20,80 @@ describe("doctor tier readiness", () => {
         tier0: { ready: boolean };
         tier1: { ready: boolean; installHint: string };
       };
+      videoRender: {
+        enabled: boolean;
+        backend: string;
+        hyperframesNode: { status: string };
+        hyperframesCli: { status: string };
+        ffmpeg: { status: string };
+        chrome: { status: string };
+      };
     };
     expect(payload.tiers.tier0.ready).toBe(true);
     expect(payload.tiers.tier1.ready).toBe(false);
     expect(payload.tiers.tier1.installHint).toBe("wittgenstein install image");
+    expect(payload.videoRender.enabled).toBe(false);
+    expect(payload.videoRender.backend).toBe("distilled-internal");
+    expect(payload.videoRender.hyperframesNode.status).toBe("skipped");
+    expect(payload.videoRender.hyperframesCli.status).toBe("skipped");
+    expect(payload.videoRender.ffmpeg.status).toBe("skipped");
+    expect(payload.videoRender.chrome.status).toBe("skipped");
+  });
+
+  it("prints structured video dependency checks when HyperFrames MP4 rendering is enabled", () => {
+    const doctor = spawnSync("node", ["--import", "tsx", cliBin, "doctor"], {
+      cwd: packageRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        WITTGENSTEIN_HYPERFRAMES_RENDER: "1",
+      },
+    });
+
+    expect(doctor.status).toBe(0);
+    const payload = JSON.parse(doctor.stdout) as {
+      videoRender: {
+        enabled: boolean;
+        backend: string;
+        hyperframesNode: { status: string };
+        hyperframesCli: { status: string };
+        ffmpeg: { status: string };
+        chrome: { status: string };
+      };
+    };
+
+    expect(payload.videoRender.enabled).toBe(true);
+    expect(payload.videoRender.backend).toBe("distilled-internal");
+    expect(payload.videoRender.hyperframesNode.status).toBe("skipped");
+    expect(payload.videoRender.hyperframesCli.status).toBe("skipped");
+    expect(["ok", "missing"]).toContain(payload.videoRender.ffmpeg.status);
+    expect(["ok", "missing"]).toContain(payload.videoRender.chrome.status);
+  });
+
+  it("checks HyperFrames CLI when the npx backend is selected", () => {
+    const doctor = spawnSync("node", ["--import", "tsx", cliBin, "doctor"], {
+      cwd: packageRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        WITTGENSTEIN_HYPERFRAMES_RENDER: "1",
+        WITTGENSTEIN_HYPERFRAMES_BACKEND: "npx-cli",
+      },
+    });
+
+    expect(doctor.status).toBe(0);
+    const payload = JSON.parse(doctor.stdout) as {
+      videoRender: {
+        enabled: boolean;
+        backend: string;
+        hyperframesNode: { status: string };
+        hyperframesCli: { status: string };
+      };
+    };
+
+    expect(payload.videoRender.enabled).toBe(true);
+    expect(payload.videoRender.backend).toBe("npx-cli");
+    expect(["ok", "missing"]).toContain(payload.videoRender.hyperframesNode.status);
+    expect(["ok", "missing"]).toContain(payload.videoRender.hyperframesCli.status);
   });
 });

--- a/packages/codec-video/package.json
+++ b/packages/codec-video/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@wittgenstein/process-runner": "workspace:*",
     "@wittgenstein/schemas": "workspace:*",
+    "puppeteer-core": "^24.31.0",
     "zod": "^3.23.8"
   }
 }

--- a/packages/codec-video/src/compositions/scene-card.ts
+++ b/packages/codec-video/src/compositions/scene-card.ts
@@ -8,8 +8,10 @@ import type { VideoComposition } from "../schema.js";
 import { buildClipTimelineCss } from "../slideshow-timeline-css.js";
 import {
   BASE_CSS,
+  FRAME_TIME_SCRIPT,
   STAGE_HEIGHT,
   STAGE_WIDTH,
+  buildFrameTimeCss,
   escapeHtml,
   sanitizeCompositionId,
 } from "./shared.js";
@@ -59,6 +61,10 @@ export function buildSceneCardHtml(
     totalDurationSec,
     { iterationCount: 1 },
   );
+  const frameTimeCss = buildFrameTimeCss(
+    clips.map((c) => ({ index: c.index, start: c.start, durationSec: c.scene.durationSec })),
+    totalDurationSec,
+  );
 
   const bodyInner = clips.map(({ scene, index, start }) => {
     const trackIndex = index % 8;
@@ -101,6 +107,7 @@ export function buildSceneCardHtml(
     `.hf-body { margin: 0; font-size: 34px; line-height: 1.35; color: rgba(255,255,255,0.78); white-space: pre-wrap; }`,
     `.hf-meta { margin-top: 34px; font-size: 18px; color: rgba(255,255,255,0.45); }`,
     clipTimelineCss,
+    frameTimeCss,
     `</style>`,
     `</head>`,
     `<body>`,
@@ -114,6 +121,7 @@ export function buildSceneCardHtml(
     `>`,
     ...bodyInner,
     `</div>`,
+    `<script>${FRAME_TIME_SCRIPT}</script>`,
     `</body>`,
     `</html>`,
     "",

--- a/packages/codec-video/src/compositions/shared.ts
+++ b/packages/codec-video/src/compositions/shared.ts
@@ -27,3 +27,53 @@ export const BASE_CSS = [
   `:root { color-scheme: dark; }`,
   `html, body { height: 100%; margin: 0; }`,
 ].join("\n");
+
+export interface FrameTimeClip {
+  index: number;
+  start: number;
+  durationSec: number;
+}
+
+export function buildFrameTimeCss(
+  clips: readonly FrameTimeClip[],
+  totalDurationSec: number,
+): string {
+  const lines = [
+    `body[data-wittgenstein-frame-time] .hf-clip { animation: none !important; opacity: 0; transform: scale(0.99); }`,
+  ];
+  for (const clip of clips) {
+    const end = clip.start + clip.durationSec;
+    lines.push(
+      `body[data-wittgenstein-frame-time="${frameBucket(clip.start, end, totalDurationSec)}"] .hf-clip--${clip.index} { opacity: 1 !important; transform: scale(1) !important; }`,
+    );
+  }
+  return lines.join("\n");
+}
+
+export const FRAME_TIME_SCRIPT = String.raw`
+(function () {
+  var params = new URLSearchParams(window.location.search);
+  var raw = params.get("wittgensteinFrameTime");
+  if (raw === null) return;
+  var time = Number(raw);
+  if (!Number.isFinite(time)) return;
+  var stage = document.getElementById("stage");
+  var total = Number(stage && stage.dataset.duration || "0");
+  document.body.setAttribute("data-wittgenstein-frame-time", "");
+  var clips = Array.from(document.querySelectorAll(".hf-clip"));
+  for (var i = 0; i < clips.length; i += 1) {
+    var el = clips[i];
+    var start = Number(el.getAttribute("data-start") || "0");
+    var duration = Number(el.getAttribute("data-duration") || "0");
+    var end = start + duration;
+    if (time >= start && (time < end || (total > 0 && time >= total && end >= total))) {
+      document.body.setAttribute("data-wittgenstein-frame-time", start.toFixed(3) + "-" + Math.min(end, total || end).toFixed(3));
+      return;
+    }
+  }
+})();
+`;
+
+function frameBucket(start: number, end: number, totalDurationSec: number): string {
+  return `${start.toFixed(3)}-${Math.min(end, totalDurationSec).toFixed(3)}`;
+}

--- a/packages/codec-video/src/compositions/svg-slide.ts
+++ b/packages/codec-video/src/compositions/svg-slide.ts
@@ -7,8 +7,10 @@ import type { VideoComposition } from "../schema.js";
 import { buildClipTimelineCss } from "../slideshow-timeline-css.js";
 import {
   BASE_CSS,
+  FRAME_TIME_SCRIPT,
   STAGE_HEIGHT,
   STAGE_WIDTH,
+  buildFrameTimeCss,
   escapeHtml,
   sanitizeCompositionId,
 } from "./shared.js";
@@ -45,6 +47,7 @@ export function buildSvgSlideHtml(
     totalDurationSec,
     { iterationCount: 1 },
   );
+  const frameTimeCss = buildFrameTimeCss(svgClips, totalDurationSec);
 
   const bodyInner = svgClips.map(({ svg, index, start, durationSec, label }) => {
     const trackIndex = index % 8;
@@ -78,6 +81,7 @@ export function buildSvgSlideHtml(
     `.hf-svg-slide { width: 100%; height: 100%; display: grid; place-items: center; box-sizing: border-box; }`,
     `.hf-svg-slide > svg { width: auto; height: auto; max-width: 1720px; max-height: 940px; display: block; }`,
     clipTimelineCss,
+    frameTimeCss,
     `</style>`,
     `</head>`,
     `<body>`,
@@ -91,6 +95,7 @@ export function buildSvgSlideHtml(
     `>`,
     ...bodyInner,
     `</div>`,
+    `<script>${FRAME_TIME_SCRIPT}</script>`,
     `</body>`,
     `</html>`,
     "",

--- a/packages/codec-video/src/hyperframes-cli-renderer.ts
+++ b/packages/codec-video/src/hyperframes-cli-renderer.ts
@@ -1,0 +1,96 @@
+import { spawnSync } from "node:child_process";
+import { stat } from "node:fs/promises";
+import { runProcess } from "@wittgenstein/process-runner";
+import type { VideoRenderManifest } from "@wittgenstein/schemas";
+import { STAGE_HEIGHT, STAGE_WIDTH } from "./compositions/shared.js";
+import type { InternalMp4RenderParams, InternalMp4RenderResult } from "./mp4-renderer.js";
+
+export async function renderHtmlToMp4WithHyperframesCli(
+  params: InternalMp4RenderParams,
+): Promise<InternalMp4RenderResult> {
+  const args = buildHyperframesCliRenderArgs({
+    outputMp4: params.outputMp4,
+    fps: params.fps,
+    quality: params.quality,
+  });
+
+  await runProcess(
+    "npx",
+    args,
+    {
+      cwd: params.runDir,
+      env: {
+        ...process.env,
+        HYPERFRAMES_NO_TELEMETRY: process.env.HYPERFRAMES_NO_TELEMETRY ?? "1",
+        HYPERFRAMES_NO_UPDATE_CHECK: process.env.HYPERFRAMES_NO_UPDATE_CHECK ?? "1",
+      },
+      timeoutHint: "(set WITTGENSTEIN_HYPERFRAMES_RENDER_TIMEOUT_MS).",
+    },
+    params.timeoutMs,
+    "hyperframes cli render",
+  );
+
+  const bytes = (await stat(params.outputMp4)).size;
+  return {
+    bytes,
+    receipt: buildHyperframesCliReceipt(params),
+  };
+}
+
+export function buildHyperframesCliRenderArgs(params: {
+  outputMp4: string;
+  fps: 24 | 30 | 60;
+  quality: "draft" | "standard" | "high";
+}): string[] {
+  return [
+    "--no-install",
+    "hyperframes",
+    "render",
+    ".",
+    "--composition",
+    "index.html",
+    "-o",
+    params.outputMp4,
+    "--fps",
+    String(params.fps),
+    "--quality",
+    params.quality,
+    "--quiet",
+  ];
+}
+
+export function readHyperframesCliVersion(): string {
+  const result = spawnSync("npx", ["--no-install", "hyperframes", "--version"], {
+    encoding: "utf8",
+    timeout: 10_000,
+    env: {
+      ...process.env,
+      HYPERFRAMES_NO_TELEMETRY: process.env.HYPERFRAMES_NO_TELEMETRY ?? "1",
+      HYPERFRAMES_NO_UPDATE_CHECK: process.env.HYPERFRAMES_NO_UPDATE_CHECK ?? "1",
+    },
+  });
+  if (result.status === 0) {
+    return firstOutputLine(result.stdout, result.stderr) || "hyperframes";
+  }
+  return "hyperframes";
+}
+
+function buildHyperframesCliReceipt(params: InternalMp4RenderParams): VideoRenderManifest {
+  return {
+    renderPath: "hyperframes-mp4",
+    backend: "npx-hyperframes-cli",
+    backendVersion: readHyperframesCliVersion(),
+    determinismClass: "structural-parity-cross-platform",
+    fps: params.fps,
+    quality: params.quality,
+    frameCount: Math.max(1, Math.ceil(params.durationSec * params.fps)),
+    width: STAGE_WIDTH,
+    height: STAGE_HEIGHT,
+    durationSec: params.durationSec,
+    outputKind: "mp4",
+  };
+}
+
+function firstOutputLine(stdout: string, stderr: string): string {
+  return (stdout || stderr).split(/\r?\n/).find((line) => line.trim().length > 0)?.trim() ?? "";
+}

--- a/packages/codec-video/src/hyperframes-wrapper.ts
+++ b/packages/codec-video/src/hyperframes-wrapper.ts
@@ -1,7 +1,7 @@
-// HyperFrames wrapper — orchestrator for the video codec's MP4 / HTML output.
-// Builds the composition HTML (delegating to the per-composition modules
-// under `./compositions/`) and, when `WITTGENSTEIN_HYPERFRAMES_RENDER=1`,
-// invokes `npx hyperframes render` to encode the MP4.
+// HyperFrames-shaped wrapper — orchestrator for the video codec's MP4 / HTML
+// output. Builds the composition HTML (delegating to the per-composition
+// modules under `./compositions/`) and, when
+// `WITTGENSTEIN_HYPERFRAMES_RENDER=1`, invokes the repo-owned MP4 renderer.
 //
 // Per-composition HTML builders live in `./compositions/{svg-slide,scene-card}.ts`
 // (extracted per #327 / #288). The subprocess plumbing lives in
@@ -12,19 +12,25 @@
 import { mkdir, writeFile, stat } from "node:fs/promises";
 import { dirname, extname, join } from "node:path";
 import type { RenderCtx, RenderResult } from "@wittgenstein/schemas";
-import { runProcess } from "@wittgenstein/process-runner";
+import { STAGE_HEIGHT, STAGE_WIDTH } from "./compositions/shared.js";
 import type { VideoComposition } from "./schema.js";
 import { buildSvgSlideHtml } from "./compositions/svg-slide.js";
 import { buildSceneCardHtml } from "./compositions/scene-card.js";
+import { renderHtmlToMp4 } from "./mp4-renderer.js";
+import { renderHtmlToMp4WithHyperframesCli } from "./hyperframes-cli-renderer.js";
 
 export async function renderWithHyperFrames(
   composition: VideoComposition,
   ctx: RenderCtx,
 ): Promise<RenderResult> {
   const startedAt = Date.now();
-  const html = buildHyperFramesHtml(composition, ctx);
+  const compositionHtml = buildHyperFramesHtml(composition, ctx);
+  const html = compositionHtml.html;
   const wantsMp4 = extname(ctx.outPath).toLowerCase() === ".mp4";
   const encodeMp4 = process.env.WITTGENSTEIN_HYPERFRAMES_RENDER === "1";
+  const fps = snapHyperframesFps(composition.fps);
+  const quality = readHyperframesQuality();
+  const backend = readHyperframesBackend();
 
   if (wantsMp4 && encodeMp4) {
     const indexPath = join(ctx.runDir, "index.html");
@@ -32,23 +38,30 @@ export async function renderWithHyperFrames(
     await mkdir(dirname(ctx.outPath), { recursive: true });
     await writeFile(indexPath, html, "utf8");
 
-    ctx.logger.info("hyperframes: running local MP4 encode (npx hyperframes render)", {
+    ctx.logger.info("hyperframes: running local MP4 encode", {
       cwd: ctx.runDir,
       output: ctx.outPath,
+      backend,
     });
 
-    await runHyperframesRenderToMp4({
-      cwd: ctx.runDir,
+    const params = {
+      htmlPath: indexPath,
+      runDir: ctx.runDir,
       outputMp4: ctx.outPath,
-      fps: composition.fps,
-    });
-
-    const bytes = (await stat(ctx.outPath)).size;
+      durationSec: compositionHtml.totalDurationSec,
+      fps,
+      quality,
+      timeoutMs: renderTimeoutMs(),
+    };
+    const render =
+      backend === "npx-cli"
+        ? await renderHtmlToMp4WithHyperframesCli(params)
+        : await renderHtmlToMp4(params);
 
     return {
       artifactPath: ctx.outPath,
       mimeType: "video/mp4",
-      bytes,
+      bytes: render.bytes,
       metadata: {
         codec: "video",
         route: "hyperframes-mp4",
@@ -56,6 +69,8 @@ export async function renderWithHyperFrames(
         costUsd: 0,
         durationMs: Date.now() - startedAt,
         seed: ctx.seed,
+        renderPath: "hyperframes-mp4",
+        videoRender: render.receipt,
       },
     };
   }
@@ -78,56 +93,22 @@ export async function renderWithHyperFrames(
       costUsd: 0,
       durationMs: Date.now() - startedAt,
       seed: ctx.seed,
+      renderPath: "hyperframes-html",
+      videoRender: {
+        renderPath: "hyperframes-html",
+        backend: "distilled-internal",
+        backendVersion: "internal",
+        determinismClass: "byte-parity-on-platform",
+        fps,
+        quality,
+        frameCount: 0,
+        width: STAGE_WIDTH,
+        height: STAGE_HEIGHT,
+        durationSec: compositionHtml.totalDurationSec,
+        outputKind: "html",
+      },
     },
   };
-}
-
-async function runHyperframesRenderToMp4(params: {
-  cwd: string;
-  outputMp4: string;
-  fps: number;
-}): Promise<void> {
-  const fps = snapHyperframesFps(params.fps);
-  const timeoutMs = Number.parseInt(
-    process.env.WITTGENSTEIN_HYPERFRAMES_RENDER_TIMEOUT_MS ?? "600000",
-    10,
-  );
-  const args = [
-    "-y",
-    "hyperframes",
-    "render",
-    "--output",
-    params.outputMp4,
-    "--fps",
-    String(fps),
-    "--quality",
-    process.env.WITTGENSTEIN_HYPERFRAMES_QUALITY?.trim() || "standard",
-    "--quiet",
-  ];
-
-  await runProcess(
-    "npx",
-    args,
-    {
-      cwd: params.cwd,
-      env: {
-        ...process.env,
-        HYPERFRAMES_NO_TELEMETRY: process.env.HYPERFRAMES_NO_TELEMETRY ?? "1",
-        HYPERFRAMES_NO_UPDATE_CHECK: process.env.HYPERFRAMES_NO_UPDATE_CHECK ?? "1",
-      },
-      timeoutHint: "(set WITTGENSTEIN_HYPERFRAMES_RENDER_TIMEOUT_MS).",
-    },
-    timeoutMs,
-    "hyperframes render",
-  );
-
-  try {
-    await stat(params.outputMp4);
-  } catch {
-    throw new Error(
-      "hyperframes render exited but output MP4 was not found. Install HyperFrames + FFmpeg + Chrome, run `npx hyperframes doctor`, or unset WITTGENSTEIN_HYPERFRAMES_RENDER to emit HTML only.",
-    );
-  }
 }
 
 function snapHyperframesFps(fps: number): 24 | 30 | 60 {
@@ -141,6 +122,35 @@ function snapHyperframesFps(fps: number): 24 | 30 | 60 {
     return 30;
   }
   return 60;
+}
+
+function renderTimeoutMs(): number {
+  const fallback = 600_000;
+  const raw = process.env.WITTGENSTEIN_HYPERFRAMES_RENDER_TIMEOUT_MS;
+  if (raw === undefined) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return Math.floor(parsed);
+}
+
+function readHyperframesQuality(): "draft" | "standard" | "high" {
+  const value = process.env.WITTGENSTEIN_HYPERFRAMES_QUALITY?.trim();
+  if (value === "draft" || value === "standard" || value === "high") {
+    return value;
+  }
+  return "standard";
+}
+
+function readHyperframesBackend(): "distilled-internal" | "npx-cli" {
+  const value = process.env.WITTGENSTEIN_HYPERFRAMES_BACKEND?.trim();
+  if (value === "npx-cli") {
+    return "npx-cli";
+  }
+  return "distilled-internal";
 }
 
 function resolveHyperFramesArtifactPath(outPath: string): string {
@@ -158,12 +168,15 @@ function resolveHyperFramesArtifactPath(outPath: string): string {
   return `${outPath}.hyperframes.html`;
 }
 
-function buildHyperFramesHtml(composition: VideoComposition, ctx: RenderCtx): string {
+function buildHyperFramesHtml(
+  composition: VideoComposition,
+  ctx: RenderCtx,
+): { html: string; totalDurationSec: number } {
   const inlineSvgs =
     composition.inlineSvgs && composition.inlineSvgs.length > 0 ? composition.inlineSvgs : null;
 
   if (inlineSvgs) {
-    return buildSvgSlideHtml(composition, ctx, inlineSvgs).html;
+    return buildSvgSlideHtml(composition, ctx, inlineSvgs);
   }
-  return buildSceneCardHtml(composition, ctx).html;
+  return buildSceneCardHtml(composition, ctx);
 }

--- a/packages/codec-video/src/mp4-renderer.ts
+++ b/packages/codec-video/src/mp4-renderer.ts
@@ -1,0 +1,237 @@
+import { statSync } from "node:fs";
+import { mkdir, readdir, stat } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { runProcess } from "@wittgenstein/process-runner";
+import type { VideoRenderManifest } from "@wittgenstein/schemas";
+import { STAGE_HEIGHT, STAGE_WIDTH } from "./compositions/shared.js";
+
+export interface InternalMp4RenderParams {
+  htmlPath: string;
+  outputMp4: string;
+  runDir: string;
+  durationSec: number;
+  fps: 24 | 30 | 60;
+  quality: "draft" | "standard" | "high";
+  timeoutMs: number;
+}
+
+export interface InternalMp4RenderResult {
+  bytes: number;
+  receipt: VideoRenderManifest;
+}
+
+export class VideoMp4RendererError extends Error {
+  readonly code: string;
+  readonly details?: Record<string, unknown>;
+
+  constructor(code: string, message: string, details?: Record<string, unknown>) {
+    super(message);
+    this.name = "VideoMp4RendererError";
+    this.code = code;
+    if (details !== undefined) {
+      this.details = details;
+    }
+  }
+}
+
+export async function renderHtmlToMp4(
+  params: InternalMp4RenderParams,
+): Promise<InternalMp4RenderResult> {
+  const frameDir = join(params.runDir, "video-frames");
+  await mkdir(frameDir, { recursive: true });
+
+  const frameCount = Math.max(1, Math.ceil(params.durationSec * params.fps));
+  const chromeVersion = await captureFrames({
+    ...params,
+    frameDir,
+    frameCount,
+  });
+  const ffmpegVersion = await encodeFrames({
+    ...params,
+    frameDir,
+    frameCount,
+  });
+  const bytes = (await stat(params.outputMp4)).size;
+
+  return {
+    bytes,
+    receipt: {
+      renderPath: "hyperframes-mp4",
+      backend: "distilled-internal",
+      backendVersion: "internal",
+      determinismClass: "structural-parity-cross-platform",
+      fps: params.fps,
+      quality: params.quality,
+      frameCount,
+      width: STAGE_WIDTH,
+      height: STAGE_HEIGHT,
+      durationSec: params.durationSec,
+      outputKind: "mp4",
+      ffmpegVersion,
+      chromeVersion,
+    },
+  };
+}
+
+async function captureFrames(params: InternalMp4RenderParams & {
+  frameDir: string;
+  frameCount: number;
+}): Promise<string> {
+  const puppeteer = await import("puppeteer-core");
+  const executablePath = resolveChromeExecutable();
+  const browser = await puppeteer.launch({
+    executablePath,
+    headless: true,
+    args: ["--no-sandbox", "--disable-dev-shm-usage"],
+  });
+  try {
+    const page = await browser.newPage();
+    await page.setViewport({ width: STAGE_WIDTH, height: STAGE_HEIGHT, deviceScaleFactor: 1 });
+    for (let index = 0; index < params.frameCount; index += 1) {
+      const time = Math.min(params.durationSec, index / params.fps);
+      const url = `${pathToFileURL(resolve(params.htmlPath)).href}?wittgensteinFrameTime=${time.toFixed(6)}`;
+      await page.goto(url, { waitUntil: "networkidle0" });
+      const stage = await page.$("#stage");
+      if (!stage) {
+        throw new VideoMp4RendererError(
+          "MP4_RENDERER_MISSING_STAGE",
+          "Video MP4 renderer could not find #stage in composition HTML.",
+          { htmlPath: params.htmlPath, frameIndex: index, frameTimeSec: time },
+        );
+      }
+      await stage.screenshot({
+        path: join(params.frameDir, `${String(index).padStart(6, "0")}.png`),
+        omitBackground: false,
+      });
+    }
+    return await browser.version();
+  } finally {
+    await browser.close();
+  }
+}
+
+async function encodeFrames(params: InternalMp4RenderParams & {
+  frameDir: string;
+  frameCount: number;
+}): Promise<string> {
+  await mkdir(dirname(params.outputMp4), { recursive: true });
+  const version = await readFfmpegVersion(params.runDir, params.timeoutMs);
+  const args = [
+    "-y",
+    "-framerate",
+    String(params.fps),
+    "-i",
+    join(params.frameDir, "%06d.png"),
+    "-frames:v",
+    String(params.frameCount),
+    "-c:v",
+    "libx264",
+    "-pix_fmt",
+    "yuv420p",
+    "-movflags",
+    "+faststart",
+    "-preset",
+    ffmpegPreset(params.quality),
+    "-crf",
+    ffmpegCrf(params.quality),
+    params.outputMp4,
+  ];
+
+  await runProcess(
+    "ffmpeg",
+    args,
+    {
+      cwd: params.runDir,
+      env: process.env,
+      timeoutHint: "(set WITTGENSTEIN_HYPERFRAMES_RENDER_TIMEOUT_MS).",
+    },
+    params.timeoutMs,
+    "wittgenstein video ffmpeg encode",
+  );
+
+  const generatedFrames = await readdir(params.frameDir);
+  if (generatedFrames.length < params.frameCount) {
+    throw new VideoMp4RendererError(
+      "MP4_RENDERER_FRAME_COUNT_MISMATCH",
+      `Video MP4 renderer expected ${params.frameCount} PNG frames, found ${generatedFrames.length}.`,
+      {
+        frameDir: params.frameDir,
+        expectedFrameCount: params.frameCount,
+        actualFrameCount: generatedFrames.length,
+      },
+    );
+  }
+  return version;
+}
+
+async function readFfmpegVersion(cwd: string, timeoutMs: number): Promise<string> {
+  try {
+    const { spawnSync } = await import("node:child_process");
+    const result = spawnSync("ffmpeg", ["-version"], {
+      cwd,
+      env: process.env,
+      encoding: "utf8",
+      timeout: timeoutMs,
+    });
+    if (result.status === 0) {
+      return firstLine(result.stdout || result.stderr) || "ffmpeg";
+    }
+  } catch {
+    // The encode step below will raise the structured process error.
+  }
+  return "ffmpeg";
+}
+
+function resolveChromeExecutable(): string {
+  const explicit = process.env.PUPPETEER_EXECUTABLE_PATH;
+  if (explicit && explicit.trim().length > 0) {
+    return explicit;
+  }
+  const candidates = [
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/Applications/Chromium.app/Contents/MacOS/Chromium",
+    "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+    "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
+    "/usr/bin/google-chrome",
+    "/usr/bin/chromium",
+    "/usr/bin/chromium-browser",
+  ];
+  for (const candidate of candidates) {
+    try {
+      statSync(candidate);
+      return candidate;
+    } catch {
+      // Try the next platform-specific path.
+    }
+  }
+  throw new VideoMp4RendererError(
+    "MP4_RENDERER_CHROME_NOT_FOUND",
+    "Video MP4 renderer requires Chrome/Chromium. Install Chrome or set PUPPETEER_EXECUTABLE_PATH.",
+    { checkedCandidates: candidates },
+  );
+}
+
+function firstLine(value: string): string {
+  return value.split(/\r?\n/).find((line) => line.trim().length > 0)?.trim() ?? "";
+}
+
+function ffmpegPreset(quality: InternalMp4RenderParams["quality"]): string {
+  if (quality === "draft") {
+    return "veryfast";
+  }
+  if (quality === "high") {
+    return "slow";
+  }
+  return "medium";
+}
+
+function ffmpegCrf(quality: InternalMp4RenderParams["quality"]): string {
+  if (quality === "draft") {
+    return "28";
+  }
+  if (quality === "high") {
+    return "18";
+  }
+  return "23";
+}

--- a/packages/codec-video/test/codec.test.ts
+++ b/packages/codec-video/test/codec.test.ts
@@ -3,13 +3,17 @@ import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { videoCodec } from "../src/index.js";
+import { buildHyperframesCliRenderArgs } from "../src/hyperframes-cli-renderer.js";
 
 describe("@wittgenstein/codec-video", () => {
   let prevHyperframesRender: string | undefined;
+  let prevHyperframesBackend: string | undefined;
 
   beforeEach(() => {
     prevHyperframesRender = process.env.WITTGENSTEIN_HYPERFRAMES_RENDER;
+    prevHyperframesBackend = process.env.WITTGENSTEIN_HYPERFRAMES_BACKEND;
     process.env.WITTGENSTEIN_HYPERFRAMES_RENDER = "0";
+    delete process.env.WITTGENSTEIN_HYPERFRAMES_BACKEND;
   });
 
   afterEach(() => {
@@ -17,6 +21,11 @@ describe("@wittgenstein/codec-video", () => {
       delete process.env.WITTGENSTEIN_HYPERFRAMES_RENDER;
     } else {
       process.env.WITTGENSTEIN_HYPERFRAMES_RENDER = prevHyperframesRender;
+    }
+    if (prevHyperframesBackend === undefined) {
+      delete process.env.WITTGENSTEIN_HYPERFRAMES_BACKEND;
+    } else {
+      process.env.WITTGENSTEIN_HYPERFRAMES_BACKEND = prevHyperframesBackend;
     }
   });
 
@@ -102,10 +111,19 @@ describe("@wittgenstein/codec-video", () => {
 
       expect(result.mimeType).toContain("text/html");
       expect(result.artifactPath.endsWith(".hyperframes.html")).toBe(true);
+      expect(result.metadata.renderPath).toBe("hyperframes-html");
+      expect(result.metadata.videoRender).toMatchObject({
+        renderPath: "hyperframes-html",
+        backend: "distilled-internal",
+        determinismClass: "byte-parity-on-platform",
+        outputKind: "html",
+        fps: 24,
+      });
 
       const html = await readFile(result.artifactPath, "utf8");
       expect(html).toContain('data-composition-id="wittgenstein-test-run"');
       expect(html).toContain('data-duration="2"');
+      expect(html).toContain("wittgensteinFrameTime");
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -152,8 +170,61 @@ describe("@wittgenstein/codec-video", () => {
       expect(html).toContain('fill="red"');
       expect(html).toContain('fill="blue"');
       expect(html).toContain('data-duration="4"');
+      expect(result.metadata.videoRender?.durationSec).toBe(4);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
+  });
+
+  it("keeps HTML output on the distilled backend by default", async () => {
+    const parsed = videoCodec.parse(JSON.stringify({ durationSec: 1, fps: 60 }));
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) {
+      return;
+    }
+
+    const dir = await mkdtemp(join(tmpdir(), "wittgenstein-video-backend-"));
+    try {
+      const result = await videoCodec.render(parsed.value, {
+        runId: "backend-default",
+        runDir: dir,
+        seed: 4,
+        outPath: join(dir, "out.html"),
+        logger: {
+          debug: () => {},
+          info: () => {},
+          warn: () => {},
+          error: () => {},
+        },
+      });
+      expect(result.metadata.videoRender?.backend).toBe("distilled-internal");
+      expect(result.metadata.videoRender?.fps).toBe(60);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("builds the documented HyperFrames CLI render command shape", () => {
+    expect(
+      buildHyperframesCliRenderArgs({
+        outputMp4: "/tmp/out.mp4",
+        fps: 24,
+        quality: "standard",
+      }),
+    ).toEqual([
+      "--no-install",
+      "hyperframes",
+      "render",
+      ".",
+      "--composition",
+      "index.html",
+      "-o",
+      "/tmp/out.mp4",
+      "--fps",
+      "24",
+      "--quality",
+      "standard",
+      "--quiet",
+    ]);
   });
 });

--- a/packages/core/src/runtime/harness.ts
+++ b/packages/core/src/runtime/harness.ts
@@ -347,6 +347,9 @@ export class Wittgenstein {
     if (rendered.metadata.renderPath !== undefined) {
       manifest.renderPath = rendered.metadata.renderPath;
     }
+    if (rendered.metadata.videoRender !== undefined) {
+      manifest.videoRender = rendered.metadata.videoRender;
+    }
     if (rendered.metadata.sidecars !== undefined) {
       manifest.artifactSidecars = rendered.metadata.sidecars;
     }

--- a/packages/schemas/src/codec.ts
+++ b/packages/schemas/src/codec.ts
@@ -25,6 +25,8 @@ export interface RenderCtx {
 
 import type { CostUsdReason } from "./manifest.js";
 import type { LicenseManifest } from "./manifest.js";
+import type { VideoRenderManifest } from "./manifest.js";
+import { VideoRenderManifestSchema } from "./manifest.js";
 
 export interface RenderSidecar {
   role: string;
@@ -60,6 +62,7 @@ export interface RenderResult {
      * the truth about which renderer actually fired (Issue #223).
      */
     renderPath?: string;
+    videoRender?: VideoRenderManifest;
   };
 }
 
@@ -95,6 +98,7 @@ export const RenderResultSchema = z.object({
       })
       .optional(),
     renderPath: z.string().optional(),
+    videoRender: VideoRenderManifestSchema.optional(),
   }),
 });
 

--- a/packages/schemas/src/manifest.ts
+++ b/packages/schemas/src/manifest.ts
@@ -11,6 +11,34 @@ export const AudioRenderManifestSchema = z.object({
   decoderHash: z.string().optional(),
 });
 
+export const VideoRenderManifestSchema = z
+  .object({
+    renderPath: z.enum(["hyperframes-html", "hyperframes-mp4"]),
+    backend: z.enum(["distilled-internal", "npx-hyperframes-cli"]),
+    backendVersion: z.string(),
+    determinismClass: z.enum(["byte-parity-on-platform", "structural-parity-cross-platform"]),
+    fps: z.union([z.literal(24), z.literal(30), z.literal(60)]),
+    quality: z.enum(["draft", "standard", "high"]),
+    frameCount: z.number().int().nonnegative(),
+    width: z.number().int().positive(),
+    height: z.number().int().positive(),
+    durationSec: z.number().nonnegative(),
+    outputKind: z.enum(["html", "mp4"]),
+    ffmpegVersion: z.string().optional(),
+    chromeVersion: z.string().optional(),
+  })
+  .superRefine((receipt, ctx) => {
+    const expectedOutputKind = receipt.renderPath === "hyperframes-html" ? "html" : "mp4";
+    if (receipt.outputKind !== expectedOutputKind) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["outputKind"],
+        message:
+          "VideoRenderManifestSchema outputKind must match renderPath (hyperframes-html -> html, hyperframes-mp4 -> mp4).",
+      });
+    }
+  });
+
 const AudioRouteSchema = z.enum(["speech", "soundscape", "music"]);
 const ImageRouteSchema = z.enum(["raster"]);
 const SensorRouteSchema = z.enum(["ecg", "temperature", "gyro"]);
@@ -85,6 +113,7 @@ export const RunManifestSchema = z
     artifactSha256: z.string().nullable(),
     artifactSidecars: z.array(ArtifactSidecarSchema).optional(),
     audioRender: AudioRenderManifestSchema.optional(),
+    videoRender: VideoRenderManifestSchema.optional(),
 
     /**
      * Optional codec-internal path identifier preserved from
@@ -180,6 +209,27 @@ export const RunManifestSchema = z
       }
     }
 
+    if (manifest.codec === "video" && manifest.ok && manifest.videoRender === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["videoRender"],
+        message: "Successful video manifests must record videoRender receipts.",
+      });
+    }
+
+    if (
+      manifest.codec === "video" &&
+      manifest.route !== undefined &&
+      manifest.videoRender !== undefined &&
+      manifest.route !== manifest.videoRender.renderPath
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["videoRender", "renderPath"],
+        message: "Video manifests must keep route and videoRender.renderPath in sync.",
+      });
+    }
+
     if (manifest.costUsd === null && manifest.costUsdReason === undefined) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
@@ -206,6 +256,7 @@ export const RunManifestSchema = z
   });
 
 export type AudioRenderManifest = z.infer<typeof AudioRenderManifestSchema>;
+export type VideoRenderManifest = z.infer<typeof VideoRenderManifestSchema>;
 export type ArtifactSidecar = z.infer<typeof ArtifactSidecarSchema>;
 export type LicenseManifest = z.infer<typeof LicenseManifestSchema>;
 export type WeightsRestriction = z.infer<typeof WeightsRestrictionSchema>;

--- a/packages/schemas/test/contract.test.ts
+++ b/packages/schemas/test/contract.test.ts
@@ -70,6 +70,43 @@ describe("@wittgenstein/schemas", () => {
     ).toBe(true);
   });
 
+  it("rejects malformed videoRender metadata at the render-result boundary", () => {
+    const parsed = RenderResultSchema.safeParse({
+      artifactPath: "/tmp/out.mp4",
+      mimeType: "video/mp4",
+      bytes: 1,
+      metadata: {
+        codec: "video",
+        llmTokens: { input: 0, output: 0 },
+        costUsd: 0,
+        durationMs: 0,
+        seed: null,
+        videoRender: {
+          renderPath: "hyperframes-mp4",
+          backend: "made-up-backend",
+          backendVersion: "internal",
+          determinismClass: "structural-parity-cross-platform",
+          fps: 24,
+          quality: "standard",
+          frameCount: 1,
+          width: 1920,
+          height: 1080,
+          durationSec: 1,
+          outputKind: "mp4",
+        },
+      },
+    });
+
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ path: ["metadata", "videoRender", "backend"] }),
+        ]),
+      );
+    }
+  });
+
   it("requires artifact evidence on successful manifests", () => {
     const parsed = RunManifestSchema.safeParse({
       runId: "run-success",
@@ -108,6 +145,43 @@ describe("@wittgenstein/schemas", () => {
     });
 
     expect(parsed.success).toBe(false);
+  });
+
+  it("rejects inconsistent videoRender output kinds", () => {
+    const parsed = RunManifestSchema.safeParse({
+      ...videoManifestFields("hyperframes-html"),
+      videoRender: {
+        ...videoManifestFields("hyperframes-html").videoRender,
+        outputKind: "mp4",
+      },
+    });
+
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.issues).toEqual(
+        expect.arrayContaining([expect.objectContaining({ path: ["videoRender", "outputKind"] })]),
+      );
+    }
+  });
+
+  it("rejects mismatched video route and videoRender renderPath", () => {
+    const parsed = RunManifestSchema.safeParse({
+      ...videoManifestFields("hyperframes-mp4"),
+      videoRender: {
+        ...videoManifestFields("hyperframes-mp4").videoRender,
+        renderPath: "hyperframes-html",
+        outputKind: "html",
+      },
+    });
+
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ path: ["videoRender", "renderPath"] }),
+        ]),
+      );
+    }
   });
 
   it("requires failed manifests to carry an error payload", () => {
@@ -338,35 +412,23 @@ describe("@wittgenstein/schemas", () => {
     expect(parsed.success).toBe(false);
   });
 
+  it("requires videoRender receipts on successful video manifests (Issue #361)", () => {
+    const parsed = RunManifestSchema.safeParse({
+      ...videoManifestFields("hyperframes-mp4"),
+      videoRender: undefined,
+    });
+
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.issues).toEqual(
+        expect.arrayContaining([expect.objectContaining({ path: ["videoRender"] })]),
+      );
+    }
+  });
+
   it("accepts canonical video route literals (Issue #190)", () => {
     for (const route of ["hyperframes-mp4", "hyperframes-html"]) {
-      const parsed = RunManifestSchema.safeParse({
-        runId: `run-video-route-${route}`,
-        gitSha: "abc123",
-        lockfileHash: "def456",
-        nodeVersion: process.version,
-        wittgensteinVersion: "0.0.0",
-        command: "wittgenstein video",
-        args: ["hello"],
-        seed: 7,
-        codec: "video",
-        route,
-        license: { weightsRestriction: "permissive" },
-        llmProvider: "anthropic",
-        llmModel: "claude-opus-4-7",
-        llmTokens: { input: 10, output: 20 },
-        costUsd: 0,
-        promptRaw: "hello",
-        promptExpanded: "hello",
-        llmOutputRaw: "{}",
-        llmOutputParsed: {},
-        artifactPath: "/tmp/out.mp4",
-        artifactSha256: "sha256",
-        startedAt: new Date().toISOString(),
-        durationMs: 10,
-        ok: true,
-        error: null,
-      });
+      const parsed = RunManifestSchema.safeParse(videoManifestFields(route));
       expect(parsed.success).toBe(true);
     }
   });
@@ -555,6 +617,48 @@ describe("@wittgenstein/schemas", () => {
     llmOutputParsed: {},
     artifactPath: "/tmp/out.png",
     artifactSha256: "sha256",
+    startedAt: new Date().toISOString(),
+    durationMs: 10,
+    ok: true,
+    error: null,
+  });
+
+  const videoManifestFields = (route: string) => ({
+    runId: `run-video-route-${route}`,
+    gitSha: "abc123",
+    lockfileHash: "def456",
+    nodeVersion: process.version,
+    wittgensteinVersion: "0.0.0",
+    command: "wittgenstein video",
+    args: ["hello"],
+    seed: 7,
+    codec: "video",
+    route,
+    license: { weightsRestriction: "permissive" },
+    llmProvider: "anthropic",
+    llmModel: "claude-opus-4-7",
+    llmTokens: { input: 10, output: 20 },
+    costUsd: 0,
+    promptRaw: "hello",
+    promptExpanded: "hello",
+    llmOutputRaw: "{}",
+    llmOutputParsed: {},
+    artifactPath: route === "hyperframes-html" ? "/tmp/out.html" : "/tmp/out.mp4",
+    artifactSha256: "sha256",
+    videoRender: {
+      renderPath: route,
+      backend: "distilled-internal",
+      backendVersion: "internal",
+      determinismClass:
+        route === "hyperframes-html" ? "byte-parity-on-platform" : "structural-parity-cross-platform",
+      fps: 24,
+      quality: "standard",
+      frameCount: route === "hyperframes-html" ? 0 : 72,
+      width: 1920,
+      height: 1080,
+      durationSec: 3,
+      outputKind: route === "hyperframes-html" ? "html" : "mp4",
+    },
     startedAt: new Date().toISOString(),
     durationMs: 10,
     ok: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -358,6 +358,9 @@ importers:
       '@wittgenstein/schemas':
         specifier: workspace:*
         version: link:../schemas
+      puppeteer-core:
+        specifier: ^24.31.0
+        version: 24.43.1
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -1128,6 +1131,11 @@ packages:
 
   '@protobufjs/utf8@1.1.1':
     resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
+
+  '@puppeteer/browsers@2.13.2':
+    resolution: {integrity: sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -1965,6 +1973,9 @@ packages:
   '@tailwindcss/postcss@4.3.0':
     resolution: {integrity: sha512-Jm05Tjx+9yCLGv5qw1c+84Psds8MnyrEQYCB+FFk2lgGiUjlRqdxke4mVTuYrj2xnVZqKim2Apr5ySuQRYAw/w==}
 
+  '@tootallnate/quickjs-emscripten@0.23.0':
+    resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
+
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
@@ -2044,6 +2055,9 @@ packages:
 
   '@types/webxr@0.5.24':
     resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
+
+  '@types/yauzl@2.10.3':
+    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
   '@typescript-eslint/eslint-plugin@8.59.3':
     resolution: {integrity: sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==}
@@ -2212,6 +2226,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
@@ -2244,12 +2262,24 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  ast-types@0.13.4:
+    resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
+    engines: {node: '>=4'}
+
   autoprefixer@10.5.0:
     resolution: {integrity: sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==}
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
       postcss: ^8.1.0
+
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -2258,10 +2288,55 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  bare-events@2.8.3:
+    resolution: {integrity: sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  bare-fs@4.7.1:
+    resolution: {integrity: sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==}
+    engines: {bare: '>=1.16.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-os@3.9.1:
+    resolution: {integrity: sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==}
+    engines: {bare: '>=1.14.0'}
+
+  bare-path@3.0.0:
+    resolution: {integrity: sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==}
+
+  bare-stream@2.13.1:
+    resolution: {integrity: sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.4.3:
+    resolution: {integrity: sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==}
+
   baseline-browser-mapping@2.10.20:
     resolution: {integrity: sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  basic-ftp@5.3.1:
+    resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
+    engines: {node: '>=10.0.0'}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -2286,6 +2361,9 @@ packages:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -2314,8 +2392,17 @@ packages:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
 
+  chromium-bidi@14.0.0:
+    resolution: {integrity: sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==}
+    peerDependencies:
+      devtools-protocol: '*'
+
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -2408,6 +2495,10 @@ packages:
     resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
     engines: {node: '>=12'}
 
+  data-uri-to-buffer@6.0.2:
+    resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
+    engines: {node: '>= 14'}
+
   date-fns-jalali@4.1.0-0:
     resolution: {integrity: sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==}
 
@@ -2437,6 +2528,10 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  degenerator@5.0.1:
+    resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
+    engines: {node: '>= 14'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -2446,6 +2541,9 @@ packages:
 
   detect-node@2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
+
+  devtools-protocol@0.0.1608973:
+    resolution: {integrity: sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==}
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
@@ -2475,6 +2573,12 @@ packages:
 
   embla-carousel@8.6.0:
     resolution: {integrity: sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enhanced-resolve@5.21.3:
     resolution: {integrity: sha512-QyL119InA+XXEkNLNTPCXPugSvOfhwv0JOlGNzvxs0hZaiHLNvXSpudUWsOlsXGWJh8G6ckCScEkVHfX3kw/2Q==}
@@ -2511,6 +2615,11 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  escodegen@2.1.0:
+    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
+    engines: {node: '>=6.0'}
+    hasBin: true
 
   eslint-config-prettier@10.1.8:
     resolution: {integrity: sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==}
@@ -2573,6 +2682,11 @@ packages:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
@@ -2595,9 +2709,17 @@ packages:
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
 
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  extract-zip@2.0.1:
+    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
+    engines: {node: '>= 10.17.0'}
+    hasBin: true
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -2605,6 +2727,9 @@ packages:
   fast-equals@5.4.0:
     resolution: {integrity: sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==}
     engines: {node: '>=6.0.0'}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -2618,6 +2743,9 @@ packages:
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  fd-slicer@1.1.0:
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -2679,12 +2807,24 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
 
+  get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
+
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  get-uri@6.0.5:
+    resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
+    engines: {node: '>= 14'}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -2748,6 +2888,14 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -2781,6 +2929,10 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
     engines: {node: '>=8'}
@@ -2792,6 +2944,10 @@ packages:
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
 
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -2952,6 +3108,10 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lru-cache@7.18.3:
+    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
+    engines: {node: '>=12'}
+
   lucide-react@1.14.0:
     resolution: {integrity: sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA==}
     peerDependencies:
@@ -2990,6 +3150,9 @@ packages:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
 
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -3003,6 +3166,10 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  netmask@2.1.1:
+    resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
+    engines: {node: '>= 0.4.0'}
 
   next-themes@0.4.6:
     resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
@@ -3060,6 +3227,14 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  pac-proxy-agent@7.2.0:
+    resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
+    engines: {node: '>= 14'}
+
+  pac-resolver@7.0.1:
+    resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
+    engines: {node: '>= 14'}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -3081,6 +3256,9 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
   phonemizer@1.2.1:
     resolution: {integrity: sha512-v0KJ4mi2T4Q7eJQ0W15Xd4G9k4kICSXE8bpDeJ8jisL4RyJhNWsweKTOi88QXFc4r4LZlz5jVL5lCHhkpdT71A==}
@@ -3167,6 +3345,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -3174,9 +3356,23 @@ packages:
     resolution: {integrity: sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==}
     engines: {node: '>=12.0.0'}
 
+  proxy-agent@6.5.0:
+    resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
+    engines: {node: '>= 14'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  puppeteer-core@24.43.1:
+    resolution: {integrity: sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw==}
+    engines: {node: '>=18'}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -3283,9 +3479,14 @@ packages:
   recharts@2.15.4:
     resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
     engines: {node: '>=14'}
+    deprecated: 1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -3362,6 +3563,18 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  socks-proxy-agent@8.0.5:
+    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+    engines: {node: '>= 14'}
+
+  socks@2.8.9:
+    resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
   sonner@2.0.7:
     resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
     peerDependencies:
@@ -3372,6 +3585,10 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
@@ -3380,6 +3597,13 @@ packages:
 
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  streamx@2.25.0:
+    resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -3425,9 +3649,21 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  tar-fs@3.1.2:
+    resolution: {integrity: sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==}
+
+  tar-stream@3.2.0:
+    resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
+
   tar@7.5.13:
     resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
     engines: {node: '>=18'}
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
@@ -3495,6 +3731,9 @@ packages:
   type-fest@0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
+
+  typed-query-selector@2.12.2:
+    resolution: {integrity: sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==}
 
   typescript-eslint@8.59.4:
     resolution: {integrity: sha512-Rw6+44QNFaXtgHSjPy+Kw8hrJniMYzR85E9yLmOLcfZ91/rz+JXQbDTCmc6ccxMPY6K6PgAq26f0JCBfR7LIPQ==}
@@ -3645,6 +3884,9 @@ packages:
       jsdom:
         optional: true
 
+  webdriver-bidi-protocol@0.4.1:
+    resolution: {integrity: sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -3659,8 +3901,28 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -3668,6 +3930,17 @@ packages:
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
+
+  yauzl@2.10.0:
+    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -4263,6 +4536,21 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.1': {}
+
+  '@puppeteer/browsers@2.13.2':
+    dependencies:
+      debug: 4.4.3
+      extract-zip: 2.0.1
+      progress: 2.0.3
+      proxy-agent: 6.5.0
+      semver: 7.8.0
+      tar-fs: 3.1.2
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
 
   '@radix-ui/number@1.1.1': {}
 
@@ -5067,6 +5355,8 @@ snapshots:
       postcss: 8.5.15
       tailwindcss: 4.3.0
 
+  '@tootallnate/quickjs-emscripten@0.23.0': {}
+
   '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
@@ -5156,6 +5446,11 @@ snapshots:
       meshoptimizer: 0.18.1
 
   '@types/webxr@0.5.24': {}
+
+  '@types/yauzl@2.10.3':
+    dependencies:
+      '@types/node': 25.7.0
+    optional: true
 
   '@typescript-eslint/eslint-plugin@8.59.3(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
@@ -5400,6 +5695,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv@6.14.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -5430,6 +5727,10 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  ast-types@0.13.4:
+    dependencies:
+      tslib: 2.8.1
+
   autoprefixer@10.5.0(postcss@8.5.15):
     dependencies:
       browserslist: 4.28.2
@@ -5439,11 +5740,47 @@ snapshots:
       postcss: 8.5.15
       postcss-value-parser: 4.2.0
 
+  b4a@1.8.1: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
 
+  bare-events@2.8.3: {}
+
+  bare-fs@4.7.1:
+    dependencies:
+      bare-events: 2.8.3
+      bare-path: 3.0.0
+      bare-stream: 2.13.1(bare-events@2.8.3)
+      bare-url: 2.4.3
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  bare-os@3.9.1: {}
+
+  bare-path@3.0.0:
+    dependencies:
+      bare-os: 3.9.1
+
+  bare-stream@2.13.1(bare-events@2.8.3):
+    dependencies:
+      streamx: 2.25.0
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.8.3
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  bare-url@2.4.3:
+    dependencies:
+      bare-path: 3.0.0
+
   baseline-browser-mapping@2.10.20: {}
+
+  basic-ftp@5.3.1: {}
 
   binary-extensions@2.3.0: {}
 
@@ -5469,6 +5806,8 @@ snapshots:
       electron-to-chromium: 1.5.340
       node-releases: 2.0.37
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  buffer-crc32@0.2.13: {}
 
   callsites@3.1.0: {}
 
@@ -5497,9 +5836,21 @@ snapshots:
 
   chownr@3.0.0: {}
 
+  chromium-bidi@14.0.0(devtools-protocol@0.0.1608973):
+    dependencies:
+      devtools-protocol: 0.0.1608973
+      mitt: 3.0.1
+      zod: 3.25.76
+
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
 
   clsx@2.1.1: {}
 
@@ -5579,6 +5930,8 @@ snapshots:
 
   d3-timer@3.0.1: {}
 
+  data-uri-to-buffer@6.0.2: {}
+
   date-fns-jalali@4.1.0-0: {}
 
   date-fns@4.1.0: {}
@@ -5603,11 +5956,19 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  degenerator@5.0.1:
+    dependencies:
+      ast-types: 0.13.4
+      escodegen: 2.1.0
+      esprima: 4.0.1
+
   detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
 
   detect-node@2.1.0: {}
+
+  devtools-protocol@0.0.1608973: {}
 
   didyoumean@1.2.2: {}
 
@@ -5635,6 +5996,12 @@ snapshots:
       embla-carousel: 8.6.0
 
   embla-carousel@8.6.0: {}
+
+  emoji-regex@8.0.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   enhanced-resolve@5.21.3:
     dependencies:
@@ -5710,6 +6077,14 @@ snapshots:
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
+
+  escodegen@2.1.0:
+    dependencies:
+      esprima: 4.0.1
+      estraverse: 5.3.0
+      esutils: 2.0.3
+    optionalDependencies:
+      source-map: 0.6.1
 
   eslint-config-prettier@10.1.8(eslint@8.57.1):
     dependencies:
@@ -5842,6 +6217,8 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 3.4.3
 
+  esprima@4.0.1: {}
+
   esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
@@ -5860,11 +6237,29 @@ snapshots:
 
   eventemitter3@4.0.7: {}
 
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.8.3
+    transitivePeerDependencies:
+      - bare-abort-controller
+
   expect-type@1.3.0: {}
+
+  extract-zip@2.0.1:
+    dependencies:
+      debug: 4.4.3
+      get-stream: 5.2.0
+      yauzl: 2.10.0
+    optionalDependencies:
+      '@types/yauzl': 2.10.3
+    transitivePeerDependencies:
+      - supports-color
 
   fast-deep-equal@3.1.3: {}
 
   fast-equals@5.4.0: {}
+
+  fast-fifo@1.3.2: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -5881,6 +6276,10 @@ snapshots:
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
+
+  fd-slicer@1.1.0:
+    dependencies:
+      pend: 1.2.0
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -5931,11 +6330,25 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  get-caller-file@2.0.5: {}
+
   get-nonce@1.0.1: {}
+
+  get-stream@5.2.0:
+    dependencies:
+      pump: 3.0.4
 
   get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  get-uri@6.0.5:
+    dependencies:
+      basic-ftp: 5.3.1
+      data-uri-to-buffer: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   glob-parent@5.1.2:
     dependencies:
@@ -6000,6 +6413,20 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -6025,6 +6452,8 @@ snapshots:
 
   internmap@2.0.3: {}
 
+  ip-address@10.2.0: {}
+
   is-binary-path@2.1.0:
     dependencies:
       binary-extensions: 2.3.0
@@ -6034,6 +6463,8 @@ snapshots:
       hasown: 2.0.3
 
   is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
 
   is-glob@4.0.3:
     dependencies:
@@ -6152,6 +6583,8 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lru-cache@7.18.3: {}
+
   lucide-react@1.14.0(react@19.2.6):
     dependencies:
       react: 19.2.6
@@ -6187,6 +6620,8 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
+  mitt@3.0.1: {}
+
   ms@2.1.3: {}
 
   mz@2.7.0:
@@ -6198,6 +6633,8 @@ snapshots:
   nanoid@3.3.12: {}
 
   natural-compare@1.4.0: {}
+
+  netmask@2.1.1: {}
 
   next-themes@0.4.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
@@ -6256,6 +6693,24 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  pac-proxy-agent@7.2.0:
+    dependencies:
+      '@tootallnate/quickjs-emscripten': 0.23.0
+      agent-base: 7.1.4
+      debug: 4.4.3
+      get-uri: 6.0.5
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      pac-resolver: 7.0.1
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  pac-resolver@7.0.1:
+    dependencies:
+      degenerator: 5.0.1
+      netmask: 2.1.1
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -6269,6 +6724,8 @@ snapshots:
   path-parse@1.0.7: {}
 
   pathe@2.0.3: {}
+
+  pend@1.2.0: {}
 
   phonemizer@1.2.1: {}
 
@@ -6328,6 +6785,8 @@ snapshots:
 
   prettier@3.8.3: {}
 
+  progress@2.0.3: {}
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -6349,7 +6808,44 @@ snapshots:
       '@types/node': 25.7.0
       long: 5.3.2
 
+  proxy-agent@6.5.0:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      lru-cache: 7.18.3
+      pac-proxy-agent: 7.2.0
+      proxy-from-env: 1.1.0
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  proxy-from-env@1.1.0: {}
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   punycode@2.3.1: {}
+
+  puppeteer-core@24.43.1:
+    dependencies:
+      '@puppeteer/browsers': 2.13.2
+      chromium-bidi: 14.0.0(devtools-protocol@0.0.1608973)
+      debug: 4.4.3
+      devtools-protocol: 0.0.1608973
+      typed-query-selector: 2.12.2
+      webdriver-bidi-protocol: 0.4.1
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - react-native-b4a
+      - supports-color
+      - utf-8-validate
 
   queue-microtask@1.2.3: {}
 
@@ -6460,6 +6956,8 @@ snapshots:
       tiny-invariant: 1.3.3
       victory-vendor: 36.9.2
 
+  require-directory@2.1.1: {}
+
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -6566,6 +7064,21 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  smart-buffer@4.2.0: {}
+
+  socks-proxy-agent@8.0.5:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      socks: 2.8.9
+    transitivePeerDependencies:
+      - supports-color
+
+  socks@2.8.9:
+    dependencies:
+      ip-address: 10.2.0
+      smart-buffer: 4.2.0
+
   sonner@2.0.7(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       react: 19.2.6
@@ -6573,11 +7086,29 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  source-map@0.6.1:
+    optional: true
+
   sprintf-js@1.1.3: {}
 
   stackback@0.0.2: {}
 
   std-env@4.1.0: {}
+
+  streamx@2.25.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
 
   strip-ansi@6.0.1:
     dependencies:
@@ -6641,6 +7172,29 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  tar-fs@3.1.2:
+    dependencies:
+      pump: 3.0.4
+      tar-stream: 3.2.0
+    optionalDependencies:
+      bare-fs: 4.7.1
+      bare-path: 3.0.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  tar-stream@3.2.0:
+    dependencies:
+      b4a: 1.8.1
+      bare-fs: 4.7.1
+      fast-fifo: 1.3.2
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
   tar@7.5.13:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
@@ -6648,6 +7202,19 @@ snapshots:
       minipass: 7.1.3
       minizlib: 3.1.0
       yallist: 5.0.0
+
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
 
   text-table@0.2.0: {}
 
@@ -6702,6 +7269,8 @@ snapshots:
   type-fest@0.13.1: {}
 
   type-fest@0.20.2: {}
+
+  typed-query-selector@2.12.2: {}
 
   typescript-eslint@8.59.4(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3):
     dependencies:
@@ -6832,6 +7401,8 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
+  webdriver-bidi-protocol@0.4.1: {}
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -6843,11 +7414,38 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrappy@1.0.2: {}
+
+  ws@8.21.0: {}
+
+  y18n@5.0.8: {}
 
   yallist@3.1.1: {}
 
   yallist@5.0.0: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+
+  yauzl@2.10.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      fd-slicer: 1.1.0
 
   yocto-queue@0.1.0: {}
 

--- a/research/validation/video_mp4_renderer_validate.ts
+++ b/research/validation/video_mp4_renderer_validate.ts
@@ -1,0 +1,217 @@
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { mkdir, readFile, rm, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { mkdtemp } from "node:fs/promises";
+import { videoCodec } from "../../packages/codec-video/src/index.js";
+import type { VideoComposition } from "../../packages/codec-video/src/schema.js";
+
+const composition = {
+  durationSec: 3,
+  fps: 24,
+  scenes: [
+    { name: "red", description: "red slide", durationSec: 1 },
+    { name: "green", description: "green slide", durationSec: 1 },
+    { name: "blue", description: "blue slide", durationSec: 1 },
+  ],
+  inlineSvgs: [
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1080"><rect width="1920" height="1080" fill="#d72638"/><text x="960" y="560" text-anchor="middle" font-size="120" fill="white">red</text></svg>',
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1080"><rect width="1920" height="1080" fill="#1b998b"/><text x="960" y="560" text-anchor="middle" font-size="120" fill="white">green</text></svg>',
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1080"><rect width="1920" height="1080" fill="#2e294e"/><text x="960" y="560" text-anchor="middle" font-size="120" fill="white">blue</text></svg>',
+  ],
+};
+
+const logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+async function main(): Promise<void> {
+  const parsed = videoCodec.parse(JSON.stringify(composition));
+  if (!parsed.ok) {
+    throw new Error(`Fixture failed to parse: ${parsed.error.message}`);
+  }
+
+  const dir = await createValidationDir();
+  const previousRender = process.env.WITTGENSTEIN_HYPERFRAMES_RENDER;
+  const previousBackend = process.env.WITTGENSTEIN_HYPERFRAMES_BACKEND;
+  try {
+    process.env.WITTGENSTEIN_HYPERFRAMES_RENDER = "0";
+    const html = await videoCodec.render(parsed.value, {
+      runId: "validation-html",
+      runDir: join(dir, "html"),
+      seed: 11,
+      outPath: join(dir, "html", "out.mp4"),
+      logger,
+    });
+    const htmlText = await readFile(html.artifactPath, "utf8");
+    const htmlReceipt = {
+      artifactPath: html.artifactPath,
+      sha256: sha256(Buffer.from(htmlText)),
+      bytes: html.bytes,
+      videoRender: html.metadata.videoRender,
+      hasFrameTimeHook: htmlText.includes("wittgensteinFrameTime"),
+    };
+
+    if (process.env.WITTGENSTEIN_VALIDATE_VIDEO_MP4 !== "1") {
+      console.log(
+        JSON.stringify(
+          {
+            ok: true,
+            mode: "html-only",
+            skippedMp4:
+              "Set WITTGENSTEIN_VALIDATE_VIDEO_MP4=1 and WITTGENSTEIN_HYPERFRAMES_RENDER=1 with Chrome + FFmpeg installed to run MP4 validation.",
+            html: htmlReceipt,
+          },
+          null,
+          2,
+        ),
+      );
+      return;
+    }
+
+    process.env.WITTGENSTEIN_HYPERFRAMES_RENDER = "1";
+    const backends = (process.env.WITTGENSTEIN_VALIDATE_VIDEO_BACKENDS ?? "distilled-internal")
+      .split(",")
+      .map((value) => value.trim())
+      .filter((value) => value === "distilled-internal" || value === "npx-cli");
+    const mp4 = [];
+    for (const backend of backends) {
+      process.env.WITTGENSTEIN_HYPERFRAMES_BACKEND = backend;
+      const first = await renderMp4(parsed.value, dir, `${backend}-first`);
+      const second = await renderMp4(parsed.value, dir, `${backend}-second`);
+      const verdict = validateMp4Pair(first, second);
+      mp4.push({
+        backend,
+        first,
+        second,
+        verdict,
+      });
+    }
+    const failed = mp4.filter((result) => result.verdict !== "byte-parity-on-platform");
+    const ok = failed.length === 0 && mp4.length > 0;
+    console.log(
+      JSON.stringify(
+        {
+          ok,
+          mode: "mp4-double-render",
+          validatedBackends: mp4.length,
+          html: htmlReceipt,
+          mp4,
+        },
+        null,
+        2,
+      ),
+    );
+    if (!ok) {
+      process.exitCode = 1;
+    }
+  } finally {
+    restoreEnv("WITTGENSTEIN_HYPERFRAMES_RENDER", previousRender);
+    restoreEnv("WITTGENSTEIN_HYPERFRAMES_BACKEND", previousBackend);
+    if (process.env.WITTGENSTEIN_KEEP_VIDEO_VALIDATION_ARTIFACTS !== "1") {
+      await rm(dir, { recursive: true, force: true });
+    }
+  }
+}
+
+async function renderMp4(value: VideoComposition, dir: string, label: string) {
+  const outPath = join(dir, label, "out.mp4");
+  const result = await videoCodec.render(value, {
+    runId: `validation-${label}`,
+    runDir: join(dir, label),
+    seed: 11,
+    outPath,
+    logger,
+  });
+  const data = await readFile(result.artifactPath);
+  const file = await stat(result.artifactPath);
+  return {
+    artifactPath: result.artifactPath,
+    sha256: sha256(data),
+    bytes: file.size,
+    structure: probeVideo(result.artifactPath),
+    videoRender: result.metadata.videoRender,
+  };
+}
+
+function validateMp4Pair(
+  first: Awaited<ReturnType<typeof renderMp4>>,
+  second: Awaited<ReturnType<typeof renderMp4>>,
+): "byte-parity-on-platform" | "failed" {
+  if (first.sha256 !== second.sha256) {
+    return "failed";
+  }
+  if (!validVideoStructure(first.structure) || !validVideoStructure(second.structure)) {
+    return "failed";
+  }
+  return "byte-parity-on-platform";
+}
+
+function validVideoStructure(structure: ReturnType<typeof probeVideo>): boolean {
+  if (!structure.ok) {
+    return false;
+  }
+  const stream = structure.value.streams?.[0];
+  return (
+    stream?.codec_name === "h264" &&
+    stream.width === 1920 &&
+    stream.height === 1080 &&
+    stream.r_frame_rate === "24/1" &&
+    stream.duration === "3.000000" &&
+    stream.nb_frames === "72"
+  );
+}
+
+function sha256(data: Buffer): string {
+  return createHash("sha256").update(data).digest("hex");
+}
+
+function probeVideo(path: string) {
+  const result = spawnSync(
+    "ffprobe",
+    [
+      "-v",
+      "error",
+      "-select_streams",
+      "v:0",
+      "-show_entries",
+      "stream=width,height,nb_frames,r_frame_rate,duration,codec_name",
+      "-of",
+      "json",
+      path,
+    ],
+    { encoding: "utf8", timeout: 30_000 },
+  );
+  if (result.status !== 0) {
+    return {
+      ok: false,
+      message: result.stderr.trim() || "ffprobe failed or is not installed.",
+    };
+  }
+  try {
+    return { ok: true, value: JSON.parse(result.stdout) };
+  } catch {
+    return { ok: false, message: "ffprobe returned non-JSON output." };
+  }
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}
+
+async function createValidationDir(): Promise<string> {
+  const baseDir =
+    process.env.WITTGENSTEIN_VIDEO_VALIDATION_DIR ??
+    join(process.cwd(), "artifacts", "tmp", "video-mp4-renderer");
+  await mkdir(baseDir, { recursive: true });
+  return mkdtemp(join(baseDir, "run-"));
+}
+
+void main();


### PR DESCRIPTION
## Summary

This PR completes the M4 video MP4 renderer line as a repo-owned, HyperFrames-shaped implementation rather than a vendored upstream dependency.

It adds:

- a default `distilled-internal` MP4 renderer for `packages/codec-video`
  - writes the same HyperFrames-shaped HTML composition to `index.html`
  - captures deterministic frame screenshots through `puppeteer-core` + local Chrome/Chromium
  - encodes H.264 MP4 through local `ffmpeg`
- an explicit upstream parity backend behind `WITTGENSTEIN_HYPERFRAMES_BACKEND=npx-cli`
  - uses `npx --no-install hyperframes render . --composition index.html ...`
  - does not implicitly download HyperFrames
  - keeps upstream CLI useful for comparison / experiments without becoming the default implementation
- `videoRender` receipts in render metadata and run manifests
- doctor coverage for selected video backend, ffmpeg, Chrome/Chromium, and upstream HyperFrames CLI when selected
- a hard research validation gate for HTML receipts and opt-in MP4 double-render checks
- docs and implementation status updates for the new video surface

## Why

This follows the previously ratified HyperFrames-shaped path while keeping the implementation repo-owned:

- #282: HyperFrames-shaped renderer distillation umbrella
- #359: determinism floor measurement
- #360: doctor coverage
- #361: `videoRender` manifest receipts
- #362: distilled renderer implementation

The core design remains composition/spec -> local renderer/decoder. This is not a text-to-video generator and does not add a new modality doctrine path.

## Engineering Notes

### Default backend

`WITTGENSTEIN_HYPERFRAMES_RENDER=1` with an `.mp4` output now uses `distilled-internal` by default. The renderer:

1. emits the existing HyperFrames-shaped HTML composition
2. freezes the timeline using `?wittgensteinFrameTime=<seconds>`
3. screenshots `#stage` once per frame
4. invokes local `ffmpeg` to encode H.264 MP4
5. returns a structured `videoRender` receipt

### Upstream parity backend

`WITTGENSTEIN_HYPERFRAMES_BACKEND=npx-cli` selects the upstream CLI backend. This is intentionally opt-in because upstream `hyperframes@0.6.46` currently advertises Node.js >=22 while the repo baseline remains Node 20.19+.

The doctor command reports that mismatch when the npx backend is selected.

### Manifest / schema

Successful video manifests now require `videoRender`. The render-result boundary validates `metadata.videoRender` with `VideoRenderManifestSchema` instead of accepting unknown metadata.

### Validation

Added `research/validation/video_mp4_renderer_validate.ts`.

Default HTML receipt check:

```bash
node --import tsx research/validation/video_mp4_renderer_validate.ts
```

Local MP4 hard gate:

```bash
WITTGENSTEIN_VALIDATE_VIDEO_MP4=1 \
WITTGENSTEIN_HYPERFRAMES_RENDER=1 \
WITTGENSTEIN_VALIDATE_VIDEO_BACKENDS=distilled-internal,npx-cli \
node --import tsx research/validation/video_mp4_renderer_validate.ts
```

The MP4 gate requires same-platform byte parity per backend plus ffprobe structural metadata for the fixture. It exits non-zero on failure.

Temporary validation material is written under `artifacts/tmp/video-mp4-renderer/` by default and cleaned after success unless `WITTGENSTEIN_KEEP_VIDEO_VALIDATION_ARTIFACTS=1` is set.

## Research Validation Recorded

See `docs/research/2026-05-26-video-mp4-renderer-validation.md`.

Local validation on 2026-05-26:

- Node.js: 22.20.0
- FFmpeg / ffprobe: 8.1.1
- Chrome: 148.0.7778.179
- HyperFrames CLI: 0.6.46

Observed fixture output:

- HTML SHA-256: `e8cc3f665892ca0152c63bef568543cf2dfa972d8bcbe07829e82f30f84c14b1`
- `distilled-internal` MP4: H.264, 1920x1080, 24fps, 3.000000s, 72 frames, byte parity on platform
- `npx-cli` MP4: H.264, 1920x1080, 24fps, 3.000000s, 72 frames, byte parity on platform

The two backend outputs are structurally equivalent but not byte-identical across backend implementations, which is expected because their encode paths differ. The intended floor is per-backend byte parity on the same platform plus structural parity across backend implementations.

## Tests

```bash
pnpm --filter @wittgenstein/codec-video test
pnpm --filter @wittgenstein/codec-video typecheck
pnpm --filter @wittgenstein/schemas test
pnpm --filter @wittgenstein/schemas typecheck
pnpm --filter @wittgenstein/cli test -- doctor.test.ts
pnpm --filter @wittgenstein/cli typecheck
pnpm lint:deps
pnpm lint:npm-publish-tarball
node --import tsx research/validation/video_mp4_renderer_validate.ts
WITTGENSTEIN_VALIDATE_VIDEO_MP4=1 WITTGENSTEIN_HYPERFRAMES_RENDER=1 WITTGENSTEIN_VALIDATE_VIDEO_BACKENDS=distilled-internal,npx-cli node --import tsx research/validation/video_mp4_renderer_validate.ts
```

All passed locally.

## PR Boundary

This PR intentionally excludes parallel image decoder / M1B / VQGAN / install-preflight work currently present in the local workspace. The staged commit only carries the video MP4 renderer line, the `videoRender` manifest spine, doctor coverage for video, validation, and docs.

## Doctrine Guardrail Note

This PR is execution / drift correction for the already-ratified video M4 direction, not a new doctrine change.

Relevant prior decisions / lineage:

- Codec Protocol v2: RFC-0001 / ADR-0008
- HyperFrames-shaped video direction: PR #277 / #282 follow-up line
- Manifest receipt discipline: existing manifest spine, extended here with `videoRender` for #361

The README / schema edits are inline status and contract updates required by the implementation. They do not introduce a new modality doctrine or a new video decision lane.
