### PR TITLE
Update maintainer attribution references

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -25,8 +25,9 @@ channels, demo venues, and any one-on-one communication about the project.
 
 1. Open a private security advisory on the repo ("Report a vulnerability" flow) **if the
    incident also involves a security concern.**
-2. Otherwise, email the maintainer listed in `CODEOWNERS` (`@max`) via the address in your
-   GitHub profile, or DM on the project's primary chat channel.
+2. Otherwise, contact the current maintainer pair (`@Jah-yee @Moapacha`) via
+   the address in their GitHub profiles, or DM on the project's primary chat
+   channel.
 3. We aim to acknowledge within 5 business days.
 
 Retaliation against a reporter is itself a violation.

--- a/docs/adrs/0013-independent-ratification-for-doctrine-prs.md
+++ b/docs/adrs/0013-independent-ratification-for-doctrine-prs.md
@@ -26,7 +26,7 @@ For any PR that touches a **doctrine-bearing surface**, authorship and ratificat
    - any change that materially alters the `BaseCodec` lifecycle
 
 2. **Independent ratification rule**: the author of a doctrine-bearing PR is not its sole reviewer. A second independent pass — distinct from the authoring context — is required before merge.
-   - The default reviewer pair is **Max + Moapacha**. Equivalent agent-assisted work counts only if the two passes are genuinely independent (the second reviewer can disagree, request changes, or block).
+   - The default reviewer pair is **@Jah-yee @Moapacha**. Equivalent agent-assisted work counts only if the two passes are genuinely independent (the second reviewer can disagree, request changes, or block).
    - "Independent" excludes self-review by the same agent, even with different prompts.
    - A formal GitHub Review (`Approve` / `Request changes`), not a PR comment, is the mechanism. Where the same GitHub identity is used by multiple agents (e.g. Jah-yee fork shared by Codex + Claude), the ratification is recorded in the PR body by the human maintainer naming the reviewers explicitly.
 
@@ -39,4 +39,4 @@ For any PR that touches a **doctrine-bearing surface**, authorship and ratificat
 - The PR template carries a doctrine-bearing checkbox; checking it off without a second review is a process violation.
 - Doctrine PRs that have already merged without independent ratification (specifically #71, #72) are not retroactively void — but the doctrine they introduced is now retroactively ratified by ADRs 0012 and 0014, which **are** going through the chain.
 - Future doctrine-bearing PRs should pair with the ratifying ADR in the same PR (or land the ADR first), eliminating the "doctrine without audit trail" failure mode.
-- Kill criterion: if independent review becomes a merge bottleneck (queue > 5 doctrine PRs waiting on Max), reopen this ADR to delegate ratification authority to a named non-author agent / contributor pool.
+- Kill criterion: if independent review becomes a merge bottleneck (queue > 5 doctrine PRs waiting on @Jah-yee @Moapacha), reopen this ADR to delegate ratification authority to a named non-author agent / contributor pool.

--- a/docs/engineering-discipline.md
+++ b/docs/engineering-discipline.md
@@ -200,7 +200,7 @@ For Wittgenstein's doctrine-bearing work, authorship and ratification must be se
 
 - The person or agent who writes a PR does **not** count as the sole reviewer of that PR.
 - Any PR that changes doctrine, exec plans, port guides, shared protocol contracts, or codec-shape assumptions requires a **second independent review pass** before merge.
-- In the current maintainer setup, the default pair is **Max + Moapacha**. Equivalent agent-assisted work is acceptable only if the two review passes are genuinely independent.
+- In the current maintainer setup, the default pair is **@Jah-yee @Moapacha**. Equivalent agent-assisted work is acceptable only if the two review passes are genuinely independent.
 - "Independent" means the second pass can disagree, request changes, or block merge; it is not a rubber stamp from the same authoring context.
 - If a second reviewer is unavailable, the PR can be prepared and validated, but it should not be treated as ratified.
 

--- a/docs/research/briefs/A_vq_vlm_lineage_audit.md
+++ b/docs/research/briefs/A_vq_vlm_lineage_audit.md
@@ -1,7 +1,7 @@
 # Brief A — VQ / VLM Lineage Audit
 
 **Date:** 2026-04-23 (v0.1) · amended 2026-04-26 (v0.2 — VAR + FlexTok lineage refresh)
-**Author:** research (max.zhuang.yan@gmail.com)
+**Author:** research (@Jah-yee @Moapacha)
 **Status:** Draft v0.2
 **Summary:** Audits whether Wittgenstein's "LLM plans in symbols → trained adapter → frozen pretrained VQ decoder → pixels" bet still holds in April 2026 against Chameleon, MAGVIT-v2 / LFQ, Emu3, SPAE, DeepSeek-VL2, TA-TiTok, **VAR (NeurIPS 2024 Best Paper, added v0.2)**, and **FlexTok (ICML 2025, added v0.2)**. Verdict: bet still right, with one forced revision to the word "codebook" and one forced extension to the word "raster" — next-scale and flexible-length 1D token sequences are now part of the LFQ-family lineage Wittgenstein bets on.
 

--- a/docs/research/briefs/C_unproven_horizon.md
+++ b/docs/research/briefs/C_unproven_horizon.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-04-23 (v0.1) · amended 2026-04-26 (v0.2 — added H9, H10)
 **Status:** Draft v0.2
-**Author:** research pass, max.zhuang.yan@gmail.com
+**Author:** research pass, @Jah-yee @Moapacha
 **One-line summary:** Ten load-bearing hypotheses that are neither settled science (Brief A) nor live theoretical tension (Brief B) but, if they resolve the way we suspect, each flips one decision in Wittgenstein's 18-month roadmap — we name them, price them, and mark which ones to bet on now.
 
 > **v0.2 amendment scope.** Two horizon hypotheses surfaced from a 2026-04-26 conversation pass — H9 (patch-grid / next-scale IR) and H10 (long-code clarity via test-time caption expansion). Both grew out of the user's "ViT global-relations" and "short-code → long-code compiler" framings; both are operational (each names a specific live experiment hook in RFC-0001 / Brief E) so they belong in this scan rather than Brief A or B. v0.1 hypotheses H1–H8 are unchanged. See cross-link in Brief A's lineage refresh (separate PR).

--- a/docs/research/briefs/D_cli_and_sdk_conventions.md
+++ b/docs/research/briefs/D_cli_and_sdk_conventions.md
@@ -1,7 +1,7 @@
 # Brief D — CLI / SDK / harness conventions
 
 **Date:** 2026-04-23
-**Author:** research (max.zhuang.yan@gmail.com)
+**Author:** research (@Jah-yee @Moapacha)
 **Status:** Draft v0.1
 **Summary:** Surveys what a modern AI CLI / SDK looks like in April 2026 — subcommand taxonomy, flag vocabulary, config resolution order, auth, pipe discipline, doctor patterns, one-liner install — and audits where `wittgenstein`'s current CLI is on the industry grid and where it is off. Verdict: the shape is mostly right (noun-first subcommands, `--seed`, `--dry-run`, a `doctor`), but the output contract, config precedence, and install story are under-specified; RFC-0002 should adopt a small set of hard conventions (`--json`/NDJSON on stdout, stderr for logs, `flag > env > project file > user file > defaults`, a single `npx @wittgenstein/cli` one-liner) and deliberately diverge from the "LLM-chat CLI" pattern — Wittgenstein is a harness, not a chatbot, and its CLI is first a pipeline tool, second a demo.
 

--- a/docs/research/briefs/E_benchmarks_v2.md
+++ b/docs/research/briefs/E_benchmarks_v2.md
@@ -1,7 +1,7 @@
 # Brief E — Per-modality quality benchmarks (v2)
 
 **Date:** 2026-04-23
-**Author:** research (max.zhuang.yan@gmail.com)
+**Author:** research (@Jah-yee @Moapacha)
 **Status:** Draft v0.1
 **Summary:** Picks the smallest set of real (non-structural) quality metrics per modality that Wittgenstein can actually run locally and reproducibly without breaking the Latency / Price / Quality contract. For v0.2 the shipping target is a **default tier only**; heavier metrics remain a documented v0.3+ reservation, not a CLI promise.
 

--- a/docs/research/briefs/F_site_reconciliation.md
+++ b/docs/research/briefs/F_site_reconciliation.md
@@ -1,7 +1,7 @@
 # Brief F — Site ↔ repo reconciliation
 
 **Date:** 2026-04-23
-**Author:** research (max.zhuang.yan@gmail.com)
+**Author:** research (@Jah-yee @Moapacha)
 **Status:** Draft v0.1 — **reconciliation direction partially superseded 2026-04-25** by the v0.2 alignment + final-audit pass. `THESIS.md`, `AGENTS.md`, and `README.md` now consistently use _"text-first LLMs."_ The site tagline remains the thinner placeholder surface and should be updated by the site rewrite rather than treated as canonical doctrine.
 **Summary:** `https://wittgenstein.wtf` resolves, but the page returns nothing more than the tagline _"Wittgenstein — The modality harness for text-first models."_ There is no architecture section, no showcase, no CLI, no CTA to contradict — which means the public narrative is not drifting from the repo, it is simply absent. The correct move is not reconciliation; it is to stand up a minimal v0.1 site straight out of `docs/THESIS.md` and `docs/showcase.md`, then treat Brief F as dormant until there is actually prose on the page to diff.
 

--- a/docs/research/briefs/G_image_network_clues.md
+++ b/docs/research/briefs/G_image_network_clues.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-04-24
 **Last amended:** 2026-04-25 (stub → draft v0.1; G1/G2/G3 each carry a steelman / red team / kill criteria / verdict)
-**Author:** research (max.zhuang.yan@gmail.com)
+**Author:** research (@Jah-yee @Moapacha)
 **Status:** 🟡 Draft v0.1 — G1 has a concrete pick; G2 has a v0.2 path and a v0.3 escalation; G3 has a release-train recommendation
 **Feeds from:** `docs/v02-alignment-review.md` §2.5, Brief A (VQ/VLM lineage), Brief B (compression vs world models), `docs/exec-plans/active/codec-v2-port.md` (M1 image port)
 

--- a/docs/research/briefs/H_codec_engineering_prior_art.md
+++ b/docs/research/briefs/H_codec_engineering_prior_art.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-04-26
 **Status:** 🟡 Draft v0.1
-**Author:** engineering (max.zhuang.yan@gmail.com)
+**Author:** engineering (@Jah-yee @Moapacha)
 **Question:** Which production-validated TypeScript projects have a shape analogous to `Codec<Req, Art>.produce(req, ctx) → Art + manifest rows`, and what concrete engineering practices should we transfer into M1A of the codec-v2 port before the first port lands?
 **Feeds into:** `docs/agent-guides/image-port.md`, RFC-0001 addendum (2026-04-26), `docs/exec-plans/active/codec-v2-port.md` §M1.
 

--- a/docs/rfcs/0001-codec-protocol-v2.md
+++ b/docs/rfcs/0001-codec-protocol-v2.md
@@ -1,7 +1,7 @@
 # RFC-0001 — Codec Protocol v2
 
 **Date:** 2026-04-25
-**Author:** engineering (max.zhuang.yan@gmail.com)
+**Author:** engineering (@Jah-yee @Moapacha)
 **Status:** 🟢 Accepted
 **Feeds from:** Brief A (VQ / VLM lineage audit, 2026-04-23), Brief B (Compression vs. World Models — Ilya↔LeCun verdict: Position iii Layered + iv Agnostic contract), Brief C (Unproven horizon hypotheses H1 / H4 / H7), v0.2 action plan code-smell inventory.
 **Ratified by:** ADR-0008

--- a/docs/rfcs/0002-cli-ergonomics.md
+++ b/docs/rfcs/0002-cli-ergonomics.md
@@ -1,7 +1,7 @@
 # RFC-0002 — CLI ergonomics
 
 **Date:** 2026-04-25
-**Author:** engineering (max.zhuang.yan@gmail.com)
+**Author:** engineering (@Jah-yee @Moapacha)
 **Status:** 🟢 Accepted
 **Feeds from:** Brief D (`docs/research/briefs/D_cli_and_sdk_conventions.md`)
 **Ratified by:** ADR-0009

--- a/docs/rfcs/0003-naming-pass.md
+++ b/docs/rfcs/0003-naming-pass.md
@@ -1,7 +1,7 @@
 # RFC-0003 — Naming pass
 
 **Date:** 2026-04-25
-**Author:** engineering (max.zhuang.yan@gmail.com)
+**Author:** engineering (@Jah-yee @Moapacha)
 **Status:** ⛔ **Superseded by RFC-0005 (2026-04-24)** per `docs/v02-alignment-review.md` §2.2. Kept as a historical record of the naming-pass reasoning; the four proposed names (Loom / Transducer / Score / Handoff) are **not** adopted. See RFC-0005 for the actual locked vocabulary (Codec / IR / Spec / Adapter / Decoder), which matches the original PPT and the existing `AGENTS.md` §Architectural vocabulary.
 **Feeds from:** RFC-0001 (Codec Protocol v2), Brief B (agnostic IR)
 **Ratified by:** — (superseded before ratification; ADR-0010 also superseded by ADR-0011)
@@ -86,7 +86,7 @@ The renames are concrete and, because the code hasn't landed yet, mostly cost-fr
 
 // Now:
 type Handoff =
-  | { kind: "Text";   tokens: TokenStream }
+  | { kind: "Text"; tokens: TokenStream }
   | { kind: "Latent"; tensor: LatentTensor }
   | { kind: "Hybrid"; tokens: TokenStream; tensor: LatentTensor };
 ```
@@ -95,13 +95,13 @@ The `Transducer` name lives at the conceptual layer; in code, the Adapter and De
 
 **Doc-level.** `docs/architecture.md` gains a "Conceptual name" column on the L1–L5 table:
 
-| Layer | Implementation name | Conceptual name |
-|-------|---------------------|-----------------|
-| L1    | Harness             | Harness         |
-| L2    | Codec               | Codec           |
+| Layer | Implementation name | Conceptual name        |
+| ----- | ------------------- | ---------------------- |
+| L1    | Harness             | Harness                |
+| L2    | Codec               | Codec                  |
 | L3    | Decoder             | Transducer (pair half) |
 | L4    | Adapter             | Transducer (pair half) |
-| L5    | Packaging           | Packaging       |
+| L5    | Packaging           | Packaging              |
 
 L3 and L4 are jointly referred to as the **Transducer** when the pair is the object of discussion.
 
@@ -124,7 +124,7 @@ Phased, but the phases are short — this is a docs-only change until P6.
 
 **"'Loom' is whimsical; industry prefers boring names like Gateway, Bridge, Router."** Those names are colonized. Every one of them lives in dozens of namespaces already — search any of them and you get noise, not signal. Distinctiveness is a feature here: "Loom" is grep-unique, the weaving metaphor matches the harness framing, and it reads as a proper-noun concept rather than a generic piece of plumbing. Boring names are a luxury for architectures that already own their vocabulary.
 
-**"'Transducer' already means something specific in Clojure and in signal processing; users will be confused."** The signal-processing meaning *is* our meaning — text signal in, artifact signal out. Clojure's transducers are a different community with a different context; in a Wittgenstein code review or design doc, the meaning resolves from context without ambiguity. If this does cause confusion, the glossary handles it in one sentence.
+**"'Transducer' already means something specific in Clojure and in signal processing; users will be confused."** The signal-processing meaning _is_ our meaning — text signal in, artifact signal out. Clojure's transducers are a different community with a different context; in a Wittgenstein code review or design doc, the meaning resolves from context without ambiguity. If this does cause confusion, the glossary handles it in one sentence.
 
 ## Kill criteria
 

--- a/docs/rfcs/0004-site-reconciliation.md
+++ b/docs/rfcs/0004-site-reconciliation.md
@@ -1,7 +1,7 @@
 # RFC-0004 — Site reconciliation actions
 
 **Date:** 2026-04-25
-**Author:** engineering (max.zhuang.yan@gmail.com)
+**Author:** engineering (@Jah-yee @Moapacha)
 **Status:** 🟡 Draft v0.1
 **Feeds from:** Brief F
 **Ratified by:** — (no ADR; site-ops RFC, revertible)

--- a/docs/rfcs/0005-naming-lock-v2.md
+++ b/docs/rfcs/0005-naming-lock-v2.md
@@ -1,7 +1,7 @@
 # RFC-0005 — Naming lock v2 (supersedes RFC-0003)
 
 **Date:** 2026-04-24
-**Author:** engineering (max.zhuang.yan@gmail.com)
+**Author:** engineering (@Jah-yee @Moapacha)
 **Status:** 🟢 Locked
 **Feeds from:** `docs/v02-alignment-review.md` §2.2, RFC-0001 (Codec Protocol v2), Brief B (agnostic IR), `AGENTS.md` §Architectural vocabulary, original PPT (`docs/references/01_Build_Book.md`)
 **Supersedes:** RFC-0003 (Loom / Transducer / Score / Handoff — rejected as over-engineered)
@@ -13,13 +13,13 @@
 
 ## Context
 
-RFC-0003 invented four replacement names (Loom, Transducer, Score, Handoff) for slots the codebase had been referring to as *harness*, *codec*, *spec*, and *IR*. The alignment review on 2026-04-24 (`docs/v02-alignment-review.md` §2.2) compared the RFC-0003 vocabulary against:
+RFC-0003 invented four replacement names (Loom, Transducer, Score, Handoff) for slots the codebase had been referring to as _harness_, _codec_, _spec_, and _IR_. The alignment review on 2026-04-24 (`docs/v02-alignment-review.md` §2.2) compared the RFC-0003 vocabulary against:
 
-- the original hackathon PPT (`docs/references/01_Build_Book.md` slides 8–14) — uses *harness*, *codec*, *adapter*, *decoder*, *Scene Spec JSON*, *Modality IR*
-- `AGENTS.md` §Architectural vocabulary — uses *Harness / Codec / IR / Decoder / Adapter / Packaging*
+- the original hackathon PPT (`docs/references/01_Build_Book.md` slides 8–14) — uses _harness_, _codec_, _adapter_, _decoder_, _Scene Spec JSON_, _Modality IR_
+- `AGENTS.md` §Architectural vocabulary — uses _Harness / Codec / IR / Decoder / Adapter / Packaging_
 - every package directory — `packages/core/runtime` (harness), `packages/codec-*` (codec)
 
-The RFC-0003 names did not exist anywhere in the codebase or the original pitch. They were an unforced rename. A senior reader coming into the repo would correctly ask *"why did you invent four new words for four things that already had names?"*
+The RFC-0003 names did not exist anywhere in the codebase or the original pitch. They were an unforced rename. A senior reader coming into the repo would correctly ask _"why did you invent four new words for four things that already had names?"_
 
 The answer is we should not have. Lock the existing vocabulary.
 
@@ -27,15 +27,15 @@ The answer is we should not have. Lock the existing vocabulary.
 
 The v0.2 architecture vocabulary, locked:
 
-| Slot | Locked name | Source |
-|---|---|---|
-| L1 runtime — routing, retry, seed, budget, telemetry | **Harness** | AGENTS.md, PPT slide 9 |
-| L2 middleware — the per-modality module that owns the produce primitive | **Codec** | AGENTS.md, PPT slide 10, all `packages/codec-*` |
-| L2 typed input — the structured description the LLM writes | **Spec** (concrete: `SceneSpec`, `AudioSpec`, `SensorSpec`) | PPT slide 11 ("Scene Spec JSON") |
-| L2 intermediate — the sum type `Text \| Latent \| Hybrid` out of Brief B | **IR** | AGENTS.md, Brief B verdict |
-| L3 renderer — IR-to-bytes, frozen-decoder preferred | **Decoder** | ADR-0005, AGENTS.md |
-| L4 optional bridge — small learned translator shipped beside a codec | **Adapter** | AGENTS.md |
-| L5 distribution — CLI, install, schemas, agent primers | **Packaging** | AGENTS.md |
+| Slot                                                                     | Locked name                                                 | Source                                          |
+| ------------------------------------------------------------------------ | ----------------------------------------------------------- | ----------------------------------------------- |
+| L1 runtime — routing, retry, seed, budget, telemetry                     | **Harness**                                                 | AGENTS.md, PPT slide 9                          |
+| L2 middleware — the per-modality module that owns the produce primitive  | **Codec**                                                   | AGENTS.md, PPT slide 10, all `packages/codec-*` |
+| L2 typed input — the structured description the LLM writes               | **Spec** (concrete: `SceneSpec`, `AudioSpec`, `SensorSpec`) | PPT slide 11 ("Scene Spec JSON")                |
+| L2 intermediate — the sum type `Text \| Latent \| Hybrid` out of Brief B | **IR**                                                      | AGENTS.md, Brief B verdict                      |
+| L3 renderer — IR-to-bytes, frozen-decoder preferred                      | **Decoder**                                                 | ADR-0005, AGENTS.md                             |
+| L4 optional bridge — small learned translator shipped beside a codec     | **Adapter**                                                 | AGENTS.md                                       |
+| L5 distribution — CLI, install, schemas, agent primers                   | **Packaging**                                               | AGENTS.md                                       |
 
 Rejected RFC-0003 renames and why:
 
@@ -53,17 +53,17 @@ No code-surface change from this RFC alone — the vocabulary lock is documentat
 - `packages/*` directory names already matching (`codec-image`, `codec-audio`, etc.)
 - no package or file named `loom-*`, `transducer-*`, `score-*`, or `handoff-*`
 
-The one doc-layer change: `THESIS.md §Open` currently lists "Naming of the middleware layer (informal 'Parasoid' is not binding)" as open — this can now move to *resolved: the middleware layer is `Codec`*.
+The one doc-layer change: `THESIS.md §Open` currently lists "Naming of the middleware layer (informal 'Parasoid' is not binding)" as open — this can now move to _resolved: the middleware layer is `Codec`_.
 
 ## Migration
 
 - **M1 (this RFC's merge):** alignment PR edits the five docs that still reference the RFC-0003 names — RFC-0003 (superseded banner, done), ADR-0010 (superseded banner, this PR), SYNTHESIS_v0.2.md §12, `docs/adrs/README.md` line 16, and the tracks.md mention if any.
-- **M2 (follow-up, small PR):** `THESIS.md §Open` strike the naming bullet. `docs/inheritance-audit.md` move N-3 from *revise* to *resolved*.
+- **M2 (follow-up, small PR):** `THESIS.md §Open` strike the naming bullet. `docs/inheritance-audit.md` move N-3 from _revise_ to _resolved_.
 - **M3 (no code PR needed):** no rename work in `packages/*` because we never renamed anything — we reverted a rename that had not yet shipped in code.
 
 ## Red team
 
-- **"You just admitted the naming pass produced nothing. That's a process failure."** Partially. The naming pass *did* produce a finding — that the existing names survived pressure-testing. That is a legitimate verdict, but it should have been reached in one paragraph of the alignment review, not a full RFC + ADR pair. The process failure is that RFC-0003 shipped without checking AGENTS.md and the PPT first. RFC-0005 corrects that.
+- **"You just admitted the naming pass produced nothing. That's a process failure."** Partially. The naming pass _did_ produce a finding — that the existing names survived pressure-testing. That is a legitimate verdict, but it should have been reached in one paragraph of the alignment review, not a full RFC + ADR pair. The process failure is that RFC-0003 shipped without checking AGENTS.md and the PPT first. RFC-0005 corrects that.
 - **"`Codec` is overloaded — MP3, H.264, etc."** Yes, and that overload is useful. A reader who sees `codec-image` understands the shape — structured-input-to-bytes — without reading docs. The overload cost is less than the "what is a Transducer?" cost.
 - **"What about future modalities that don't fit the Codec metaphor?"** If that happens, add a sibling slot (e.g., `Sensor`, `Synth`) rather than renaming Codec. Metaphor-fit is per-slot, not global.
 

--- a/docs/team-split.md
+++ b/docs/team-split.md
@@ -2,19 +2,19 @@
 
 ## Ownership
 
-| Path | Owner |
-| --- | --- |
-| `packages/core/src/runtime/` | core maintainers |
-| `packages/core/src/codecs/image.ts` | image-team |
-| `packages/core/src/codecs/audio.ts` | audio-team |
-| `packages/core/src/llm/` | core maintainers |
-| `packages/schemas/` | core maintainers |
-| `packages/sandbox/` | core maintainers |
-| `packages/codec-image/` | image-team |
-| `packages/codec-audio/` | audio-team |
-| `packages/codec-video/` | video-team |
-| `packages/codec-sensor/` | sensor-team |
-| `apps/site/` | `@max` |
+| Path                                | Owner                |
+| ----------------------------------- | -------------------- |
+| `packages/core/src/runtime/`        | core maintainers     |
+| `packages/core/src/codecs/image.ts` | image-team           |
+| `packages/core/src/codecs/audio.ts` | audio-team           |
+| `packages/core/src/llm/`            | core maintainers     |
+| `packages/schemas/`                 | core maintainers     |
+| `packages/sandbox/`                 | core maintainers     |
+| `packages/codec-image/`             | image-team           |
+| `packages/codec-audio/`             | audio-team           |
+| `packages/codec-video/`             | video-team           |
+| `packages/codec-sensor/`            | sensor-team          |
+| `apps/site/`                        | `@Jah-yee @Moapacha` |
 
 ## Day 1 Handshake
 

--- a/docs/v02-alignment-review.md
+++ b/docs/v02-alignment-review.md
@@ -1,7 +1,7 @@
 # v0.2 Alignment Review — self-audit against original intent
 
 **Date:** 2026-04-25
-**Author:** review (max.zhuang.yan@gmail.com)
+**Author:** review (@Jah-yee @Moapacha)
 **Status:** Decisions merged into this PR
 **Scope:** P1–P5 of the v0.2 restructuring vs. the original hackathon-era PPT deck and repeated product statements.
 
@@ -17,9 +17,9 @@ The bulk of the doc stack does what it was commissioned to do. In particular:
 
 - **Compression ↔ world-models position (Brief B, ADR-0006).** Matches the deck's Ilya
   quote ("a good enough LLM is a system approximating Kolmogorov-optimal compression")
-  and its "Text LLM 已经在参数里压缩了大量图像的结构信息" frame. The *Layered* position
-  + *Agnostic* engineering contract (only `Text` inhabited today) is the right posture.
-  Keep.
+  and its "Text LLM 已经在参数里压缩了大量图像的结构信息" frame. The _Layered_ position
+  - _Agnostic_ engineering contract (only `Text` inhabited today) is the right posture.
+    Keep.
 - **VQ / LFQ lineage audit (Brief A, feeds ADR-0008).** Matches the timeline slide
   (Wittgenstein 1921 → van den Oord 2017 → Brown/Sutskever 2020 → Rombach/Esser 2021–22
   → Ge/Zhao/Shan 2023–24 → Wittgenstein 2026). The "VQ decoder → LFQ-family discrete-token
@@ -44,14 +44,14 @@ Six drift points. Each has a named decision and a named output.
 
 ### 2.1. "text-first models" vs "text-first LLMs"
 
-**Drift.** P1's THESIS.md locked *"the modality harness for text-first models."* The PPT
-deck, `AGENTS.md`, and the root `README.md:5` all say *"text-first LLMs."* The user's
-follow-up message also says *"Text-First LLMs."* Inside THESIS.md itself the two forms
+**Drift.** P1's THESIS.md locked _"the modality harness for text-first models."_ The PPT
+deck, `AGENTS.md`, and the root `README.md:5` all say _"text-first LLMs."_ The user's
+follow-up message also says _"Text-First LLMs."_ Inside THESIS.md itself the two forms
 co-exist (§Master says "models", §Extension says "text-only LLMs"). Brief F caught a
 README↔THESIS mismatch and chose "models" as canonical — that choice was the drift, not
 the fix.
 
-**Decision.** Revert to *"text-first LLMs"* everywhere. The PPT is the source of truth;
+**Decision.** Revert to _"text-first LLMs"_ everywhere. The PPT is the source of truth;
 "LLMs" is the word the user actually uses; and LLMs is already the word `AGENTS.md`
 sends first-contact agents home with.
 
@@ -62,7 +62,7 @@ and any stray "text-first models" occurrence. Root README stays on "LLMs" (alrea
 
 **Drift.** RFC-0003 / ADR-0010 introduced four new names: **Loom** (middleware layer),
 **Transducer** (Adapter+Decoder pair), **Score** (Build Artifact primitive), **Handoff**
-(IR sum type). The architecture slide uses exactly *one* word for the middleware
+(IR sum type). The architecture slide uses exactly _one_ word for the middleware
 layer — **Codec** — and one word for the middle artifact — **Scene Spec JSON** (or per
 modality: "audio plan", "algorithm spec"). The intermediate type is literally labelled
 **Modality IR**.
@@ -74,22 +74,22 @@ replaces the existing "Spec" vocabulary with a musical metaphor that doesn't tra
 to sensor / audio. "Handoff" replaces "IR" — a word compiler people already understand
 — with a business metaphor.
 
-The user's bar, restated: *"像 Senior 研究员、工程师或 Hacker 做出来的东西"* (should look
+The user's bar, restated: _"像 Senior 研究员、工程师或 Hacker 做出来的东西"_ (should look
 like a senior researcher / engineer / hacker made this). Four creative-writing names in
 place of industry-standard ones fails that bar.
 
 **Decision.** Supersede RFC-0003 with RFC-0005 (v0.2 naming revision) and paired
 ADR-0011. Retire Loom, Transducer, Score, Handoff. Lock the PPT-native vocabulary:
 
-| What | Name | Source |
-|---|---|---|
-| L1 runtime + dispatch | **Harness** | already canonical |
-| L2 middleware layer | **Codec** | PPT architecture slide, AGENTS.md §Thesis |
-| L3 byte producer | **Decoder** | PPT strict-image-path slide |
-| L4 optional learned bridge | **Adapter** | PPT strict-image-path slide |
-| L5 packaging / CLI surface | **Packaging** | AGENTS.md §Thesis |
-| middle structured artifact | **Spec** | PPT: "Scene Spec JSON", "audio plan", "algorithm spec" |
-| IR sum type | **IR** (`IR = Text \| Latent \| Hybrid`) | PPT: "Modality IR" |
+| What                       | Name                                     | Source                                                 |
+| -------------------------- | ---------------------------------------- | ------------------------------------------------------ |
+| L1 runtime + dispatch      | **Harness**                              | already canonical                                      |
+| L2 middleware layer        | **Codec**                                | PPT architecture slide, AGENTS.md §Thesis              |
+| L3 byte producer           | **Decoder**                              | PPT strict-image-path slide                            |
+| L4 optional learned bridge | **Adapter**                              | PPT strict-image-path slide                            |
+| L5 packaging / CLI surface | **Packaging**                            | AGENTS.md §Thesis                                      |
+| middle structured artifact | **Spec**                                 | PPT: "Scene Spec JSON", "audio plan", "algorithm spec" |
+| IR sum type                | **IR** (`IR = Text \| Latent \| Hybrid`) | PPT: "Modality IR"                                     |
 
 No new invented words. Future readers (human or agent) read the PPT, AGENTS.md, or any
 paper in the VQ lineage and can map to our code directly.
@@ -99,8 +99,8 @@ ratifies. RFC-0003 status flips to ⚫ Superseded. ADR-0010 amended with superse
 
 ### 2.3. Two-round LLM pipeline was over-specified as default
 
-**Drift.** RFC-0001 § Interface recommended *two* LLM rounds (round 1 free-form expansion,
-round 2 schema-constrained JSON) as the default. The strict-image-path slide shows *one*
+**Drift.** RFC-0001 § Interface recommended _two_ LLM rounds (round 1 free-form expansion,
+round 2 schema-constrained JSON) as the default. The strict-image-path slide shows _one_
 call producing Scene Spec JSON directly. Two rounds doubles price and latency for a
 quality claim we haven't measured on Wittgenstein's own prompts; the XGrammar/Outlines
 evidence is strong but is not the same thing as "our prompts need this."
@@ -120,8 +120,8 @@ Two-round stays as an opt-in documented in RFC-0001 §Appendix.
 
 **Drift.** `docs/exec-plans/active/codec-v2-port.md` phased the codec-v2 port as
 M1 sensor → M2 audio → M3 image. The argument was "cheapest first" (sensor is a trivial
-three-function dispatch). But the user's explicit priority is *"我们要先实现的是 LLM to
-Image 这条管线"* — image first. The product story, the showcase images, the strict image
+three-function dispatch). But the user's explicit priority is _"我们要先实现的是 LLM to
+Image 这条管线"_ — image first. The product story, the showcase images, the strict image
 path that makes the repo distinctive all live on the image codec. Shipping sensor v2
 first delivers zero demoable progress against the LLM→Image goal.
 
@@ -142,8 +142,8 @@ one, and we'd discover the hole when we hit image.
 **Drift.** The user wants a research doc on (a) what network to build for the image
 codec's learned adapter, (b) training strategy, (c) data sources, (d) GPT-4o image-gen
 prior art including partial-redraw, (e) package form (npx, MCP, Claude skill, curl). None
-of P1–P5 captured this. Brief A audited the *decoder* family (VQGAN, LFQ, etc.); no brief
-surveyed the *adapter* training story or the end-user packaging story.
+of P1–P5 captured this. Brief A audited the _decoder_ family (VQGAN, LFQ, etc.); no brief
+surveyed the _adapter_ training story or the end-user packaging story.
 
 **Decision.** Open **Brief G — Image Network Clues** as a starter/clues document, not a
 full four-station brief yet. Its purpose is to capture the threads the user named so the
@@ -155,7 +155,7 @@ Scope for the clues doc:
 - GPT-4o image generation: what is publicly documented about its tokenizer, its
   adapter-or-lack-thereof, its partial-redraw / inpainting mechanism;
 - The open-weights candidates from Brief A (LlamaGen, MAGVIT-v2, Emu3, TA-TiTok, SEED-LLaMA)
-  reread for *what we would train against*, not just *what we would decode with*;
+  reread for _what we would train against_, not just _what we would decode with_;
 - Post-training cost frame (LoRA / adapter-size sweet spot for scene-spec → latent);
 - Data source options (LAION subsets, SAM masks for spatial grounding, synthetic
   scene-spec data generated from our own pipeline for bootstrapping);
@@ -182,7 +182,7 @@ Cross-reference from RFC-0002.
 
 ## 3. Where the bar was already right (confirming, not changing)
 
-The user said *"合理把控东西的边界，不要被我的话吓到"* (reasonably control scope; don't
+The user said _"合理把控东西的边界，不要被我的话吓到"_ (reasonably control scope; don't
 be frightened by the ask). These items look like drift-candidates but are actually fine:
 
 - **Five layers (L1–L5)** — matches the architecture slide. Keep.
@@ -200,15 +200,15 @@ The user asked for agent-friendly to be the #1 priority, not user-friendly. Curr
 state:
 
 - ✅ `AGENTS.md` at the repo root, loaded early, contains the thesis + L1–L5 + repo map
-  + read order. Good.
+  - read order. Good.
 - ✅ All doc layers are grep-able (THESIS / briefs / RFCs / ADRs / exec-plans have
   headings designed for agent retrieval).
 - ✅ Structured errors, schemas at every boundary, manifest-per-run. Agents get
   traceable failures.
 - ⚠️ Agent read order in `AGENTS.md` doesn't mention `docs/tracks.md` (P5 new),
   `docs/rfcs/`, or `docs/adrs/` beyond implication. Fix: extend the read order.
-- ⚠️ `CONTRIBUTING.md` currently frames architectural proposals as *"update both code
-  and an ADR"* — the P5 update clarified this as brief → RFC → ADR → code, which is
+- ⚠️ `CONTRIBUTING.md` currently frames architectural proposals as _"update both code
+  and an ADR"_ — the P5 update clarified this as brief → RFC → ADR → code, which is
   the agent-friendly chain. Already queued (CONTRIBUTING was updated in P5 but reverted
   on main; P5 PR #36 carries the fix). No new action here.
 
@@ -217,23 +217,23 @@ state:
 
 ## 5. Packaging form — recorded, not decided
 
-The user explicitly said the npx / MCP / skill / curl external packaging is *"目前也不
-急"* (not urgent). Captured in Brief G §Package form so it isn't forgotten when the next
+The user explicitly said the npx / MCP / skill / curl external packaging is _"目前也不
+急"_ (not urgent). Captured in Brief G §Package form so it isn't forgotten when the next
 round comes back to it. No decision this round.
 
 ## 6. Summary of decisions
 
-| # | Drift | Decision | New / changed artifact |
-|---|---|---|---|
-| 2.1 | "text-first models" vs "LLMs" | Revert to **LLMs** | THESIS.md, SYNTHESIS_v0.2.md, inheritance-audit.md edits |
-| 2.2 | Naming over-engineered | Retire Loom/Transducer/Score/Handoff; lock **Codec / Decoder / Adapter / Spec / IR** | RFC-0005 supersedes RFC-0003; ADR-0011 ratifies; RFC-0003 → ⚫ |
-| 2.3 | Two-round LLM default | **One round** default; two rounds opt-in | RFC-0001 §Interface + ADR-0008 §Decision amended |
-| 2.4 | Exec plan ordered wrong | **Image first**, then audio, sensor, cleanup | codec-v2-port.md phase table rewritten |
-| 2.5 | Image-network research not captured | Open **Brief G** as starter/clues | docs/research/briefs/G_image_network_clues.md |
-| 2.6 | Lark CLI not cited | Add lark citation + cross-refs | Brief D + RFC-0002 amended |
-| 4 | Agent read-order incomplete | Extend AGENTS.md §Read Order | AGENTS.md edit |
+| #   | Drift                               | Decision                                                                             | New / changed artifact                                         |
+| --- | ----------------------------------- | ------------------------------------------------------------------------------------ | -------------------------------------------------------------- |
+| 2.1 | "text-first models" vs "LLMs"       | Revert to **LLMs**                                                                   | THESIS.md, SYNTHESIS_v0.2.md, inheritance-audit.md edits       |
+| 2.2 | Naming over-engineered              | Retire Loom/Transducer/Score/Handoff; lock **Codec / Decoder / Adapter / Spec / IR** | RFC-0005 supersedes RFC-0003; ADR-0011 ratifies; RFC-0003 → ⚫ |
+| 2.3 | Two-round LLM default               | **One round** default; two rounds opt-in                                             | RFC-0001 §Interface + ADR-0008 §Decision amended               |
+| 2.4 | Exec plan ordered wrong             | **Image first**, then audio, sensor, cleanup                                         | codec-v2-port.md phase table rewritten                         |
+| 2.5 | Image-network research not captured | Open **Brief G** as starter/clues                                                    | docs/research/briefs/G_image_network_clues.md                  |
+| 2.6 | Lark CLI not cited                  | Add lark citation + cross-refs                                                       | Brief D + RFC-0002 amended                                     |
+| 4   | Agent read-order incomplete         | Extend AGENTS.md §Read Order                                                         | AGENTS.md edit                                                 |
 
-## 7. What this review explicitly does *not* touch
+## 7. What this review explicitly does _not_ touch
 
 - The master statement ("the modality harness for text-first LLMs") and the L1–L5
   architecture stay locked.

--- a/docs/v02-final-audit.md
+++ b/docs/v02-final-audit.md
@@ -1,7 +1,7 @@
 # v0.2 Final Audit — pre-lock review
 
 **Date:** 2026-04-25  
-**Author:** engineering + review (max.zhuang.yan@gmail.com)  
+**Author:** engineering + review (@Jah-yee @Moapacha)
 **Feeds from:** `docs/v02-alignment-review.md`, `docs/THESIS.md`, `docs/inheritance-audit.md`, Briefs A–G, RFCs 0001–0005, ADRs 0006–0011, the P2b–P5 branch train (`docs/p2b-research-briefs` → `docs/p5b-alignment-review`)  
 **Status:** 🟢 Pre-lock doctrine audit for the v0.2 milestone
 


### PR DESCRIPTION
## Summary

This PR updates stale maintainer / author attribution references after the current maintainer handoff. It replaces old `max` / `max.zhuang.yan@gmail.com` references with the current GitHub maintainer pair `@Jah-yee @Moapacha` across governance, RFC, research brief, and review/audit docs.

## Scope

- Updates Code of Conduct reporting guidance to point at the current maintainer pair, without referencing a missing CODEOWNERS file.
- Updates ADR / engineering-discipline maintainer-pair language for independent doctrine ratification.
- Updates historical research brief, RFC, and v0.2 audit author attribution fields.
- Normalizes Markdown formatting in files touched by this attribution pass via Prettier.

## Process notes

- This is intentionally split out from #457 so M1B decoder audit delivery stays reviewable on its own.
- This PR is documentation / governance hygiene only; it does not change runtime code, schemas, package behavior, or M1B gate evidence.
- Because it touches doctrine-adjacent governance surfaces, please wait for CodeRabbit and maintainer review before merge.

## Validation

```bash
git diff --check
pnpm exec prettier --check CODE_OF_CONDUCT.md docs/adrs/0013-independent-ratification-for-doctrine-prs.md docs/engineering-discipline.md docs/research/briefs/A_vq_vlm_lineage_audit.md docs/research/briefs/C_unproven_horizon.md docs/research/briefs/D_cli_and_sdk_conventions.md docs/research/briefs/E_benchmarks_v2.md docs/research/briefs/F_site_reconciliation.md docs/research/briefs/G_image_network_clues.md docs/research/briefs/H_codec_engineering_prior_art.md docs/rfcs/0001-codec-protocol-v2.md docs/rfcs/0002-cli-ergonomics.md docs/rfcs/0003-naming-pass.md docs/rfcs/0004-site-reconciliation.md docs/rfcs/0005-naming-lock-v2.md docs/team-split.md docs/v02-alignment-review.md docs/v02-final-audit.md
```

Both checks passed locally.
