### PR TITLE
chore(audit): cross-section sweep — post-alpha.3 truth surface + dependabot engine floor + workspace hygiene

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,15 @@
 #     `ignore` entry — explicit opt-in beats weekly opt-out.
 #   - polyglot-mini is research-grade Python; security patches only, monthly cadence.
 #
+# Engine floor:
+#   The root `package.json` pins `engines.node: ">=20.19.0"`. Major bumps that
+#   require Node >=22 (e.g. undici 8.x) must wait for an explicit baseline
+#   move — they belong in the `ignore` list below until then.
+#
 # When to revisit:
 #   - After M1 (image) lands → consider unfreezing typescript major.
 #   - After M5b (benchmarks) → consider unfreezing zod, react/next majors.
+#   - When the Node engine floor moves to 22+ → revisit the undici major ignore.
 #   - Any time a CVE lands → security updates bypass `ignore` automatically.
 
 version: 2
@@ -96,6 +102,10 @@ updates:
       - dependency-name: "tailwindcss"
         update-types: ["version-update:semver-major"]
       - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
+      # undici 8.x requires Node >=22.19; the repo engine floor is Node 20.19.
+      # See #450 (closed) — unfreeze once the Node baseline moves.
+      - dependency-name: "undici"
         update-types: ["version-update:semver-major"]
 
   # ---------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ Image, audio, sensor, and video HTML produce real artifacts today; video MP4 is 
 
 The image codec's split between **Visual Seed Code** (primary, decoder-facing) and **`Semantic IR`** (support: concept activation, user inspection, optional conditioning) is a doctrine correction ratified by [ADR-0018](docs/adrs/0018-hybrid-image-code-and-visual-seed-token.md). `Semantic IR` is important support — pure seed output can be opaque, brittle, or hard to diagnose — but it is not the main image research object.
 
-> **🧪 Project status — early-stage, doctrine-locked, post-alpha.2 M1B follow-through.**
-> Wittgenstein is an early prerelease (`v0.3.0-alpha.2` cut is already out) with a working Python
+> **🧪 Project status — early-stage, doctrine-locked, post-alpha.3 M1B follow-through.**
+> Wittgenstein is an early prerelease (`v0.3.0-alpha.3` cut is already out) with a working Python
 > surface, a production-shaped TypeScript harness, and a few intentionally
 > unfinished surfaces clearly flagged with ⚠️ or 🔴 in
 > [`docs/implementation-status.md`](docs/implementation-status.md). The v0.2

--- a/docs/exec-plans/active/v0.3-roadmap.md
+++ b/docs/exec-plans/active/v0.3-roadmap.md
@@ -1,8 +1,8 @@
 # v0.3 Roadmap — index
 
 **Date opened:** 2026-05-04
-**Last refreshed:** 2026-05-16
-**Status:** 🟡 Active as a maintainer-facing truth surface. v0.3 gates are closed; the repo is now in post-alpha.2 M1B owner-review and delivery follow-through, not generic prerelease triage.
+**Last refreshed:** 2026-05-26
+**Status:** 🟡 Active as a maintainer-facing truth surface. v0.3 gates are closed; the repo is now in post-alpha.3 M1B owner-review and delivery follow-through, not generic prerelease triage.
 **Engineering source of truth:** [`codec-v2-port.md`](codec-v2-port.md) — that file owns the M-phase contract, current blocker, and rollback criteria. This page is the maintainer-facing index.
 
 ---

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -10,7 +10,7 @@
 > - `docs/agent-guides/`
 > - `docs/archive-policy.md` if a row here starts to drift into historical-only status
 >
-> Last updated: 2026-05-07. "Ships" = produces real output today. "Stub" = typed interface,
+> Last updated: 2026-05-26. "Ships" = produces real output today. "Stub" = typed interface,
 > throws `NotImplementedError`, waiting for a renderer. "Partial" = some routes work.
 
 ---
@@ -37,8 +37,9 @@ Everything below runs with `python3 -m polyglot.cli <cmd>`.
 
 ## @wittgenstein/\* TypeScript packages
 
-The TS monorepo is the **production harness layer** (L1–L5). Core, schemas, CLI, and sensor/audio
-codecs are wired. Image and video codecs are typed stubs — intentional until training is complete.
+The TS monorepo is the **production harness layer** (L1–L5). Core, schemas, CLI, sensor, audio, and
+video HTML codecs ship; image codec is ⚠️ Partial pending M1B trained projector, and the video MP4
+encode path is an opt-in repo-owned renderer (Chrome/Chromium + FFmpeg).
 
 ### @wittgenstein/schemas
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,7 @@ packages:
   - "packages/*"
   - "apps/*"
   - "!apps/wittgenstein-kimi"
+  # apps/_vercel-kimi-out/ is gitignored build output from the Kimi deck.
+  # Excluded from the workspace too so locally generated artifacts can't
+  # trip `pnpm install --frozen-lockfile` for maintainers who built it.
+  - "!apps/_vercel-kimi-out"


### PR DESCRIPTION
## Summary

Cross-section audit findings from the 2026-05-26 maintainer review session. None are functional changes; they close drift between authoritative surfaces, the dependabot policy, and the local workspace.

## Findings + fixes

### Status drift (post-alpha.3 wording)

- `README.md` Project-status block said `post-alpha.2 M1B follow-through` and `v0.3.0-alpha.2 cut is already out`. alpha.3 was cut on 2026-05-13 via [#411](https://github.com/p-to-q/wittgenstein/pull/411). Updated.
- `docs/exec-plans/active/v0.3-roadmap.md` same alpha.2→alpha.3 fix; `Last refreshed` bumped to 2026-05-26.
- `docs/implementation-status.md` `Last updated` bumped from 2026-05-07 → 2026-05-26. TS-monorepo preamble rewritten — the line `Image and video codecs are typed stubs — intentional until training is complete` is now stale because video HTML codec ships and the video MP4 path is the new opt-in repo-owned renderer that landed in [#456](https://github.com/p-to-q/wittgenstein/pull/456).

### Dependabot engine floor

- `.github/dependabot.yml`: document the Node 20.19 engine floor and the trigger to revisit it. Add `undici` major to the ignore list — [#450](https://github.com/p-to-q/wittgenstein/pull/450) (closed) hit the Node 22 requirement; this prevents weekly re-opens. Mirrors the existing `typescript`/`react`/`next` deferred-major pattern.

### Workspace hygiene

- `pnpm-workspace.yaml`: exclude `apps/_vercel-kimi-out` (gitignored Kimi deck build output). Without this, maintainers who built the deck locally trip `pnpm install --frozen-lockfile` because the workspace glob picks up the generated `package.json`. Mirrors the existing `apps/wittgenstein-kimi` exclusion.

## What this PR does NOT touch (filed separately or already known)

- **[#460](https://github.com/p-to-q/wittgenstein/issues/460) Vercel authorization failure** — separate, needs Vercel UI access; not fixable from code.
- **\`apps/presentation/\`** — tracked but currently unwired (only `index.html` + `vercel.json` + `package.json`). Not in README or AGENTS. Will be a separate triage issue (retire / document).
- **\`apps/site copy/\`** — local-only on the maintainer's disk, not tracked.
- **ML/training surfaces** — handed off to model-training specialist (separate review track).

## Verification

```
pnpm install --frozen-lockfile           # clean; scope drops from 16 to 15 workspace projects
pnpm -r typecheck                         # green
pnpm -r test                              # green (all codec / core / cli / schemas)
pnpm -r --filter '!@wittgenstein/site' lint  # green for all packages/*
pnpm lint:deps                            # codec boundary check green for 6 codec packages
```

\`apps/site lint\` flags pre-existing errors in generated `.next/types/` on the maintainer's local clone (not caused by this PR; not visible in CI which doesn't have the local build output).

## Researcher / Engineer / Hacker notes

- **R**: this PR is the receipt that the cross-section is now honest after #456 + the maintainer-truth refresh in #437 — the implementation surface (codec-video HTML/MP4) and the doctrine surface (README + exec-plan + implementation-status) now agree.
- **E**: workspace glob brittleness is a real foot-gun for maintainers who run the demo deck. Fix mirrors the existing exclusion pattern (no new mechanism).
- **H**: the dependabot ignore for undici closes one weekly-PR noise source until the Node baseline moves. Drops the PR-review tax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)