### PR TITLE
chore(quality): #367 error-path coverage (sensor+asciipng) + #464 puppeteer-core optional peer

### DIFF
--- a/packages/codec-asciipng/test/codec.test.ts
+++ b/packages/codec-asciipng/test/codec.test.ts
@@ -7,6 +7,33 @@ describe("@wittgenstein/codec-asciipng", () => {
     expect(asciipngCodec.modality).toBe("asciipng");
   });
 
+  it("returns ASCIIPNG_SCHEMA_PARSE_FAILED for invalid JSON (#367 error-path coverage)", () => {
+    const result = asciipngCodec.parse("definitely-not-json");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("ASCIIPNG_SCHEMA_PARSE_FAILED");
+    expect(result.error.cause).toBeInstanceOf(SyntaxError);
+  });
+
+  it("returns ASCIIPNG_SCHEMA_INVALID with zod issues for out-of-range columns", () => {
+    // columns has min: 8, max: 120 — passing 5000 should fail validation.
+    const result = asciipngCodec.parse(JSON.stringify({ columns: 5000 }));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("ASCIIPNG_SCHEMA_INVALID");
+    const issues = (result.error.details as { issues: ReadonlyArray<{ path: ReadonlyArray<string | number> }> })
+      .issues;
+    expect(issues.some((issue) => issue.path.includes("columns"))).toBe(true);
+  });
+
+  it("returns ASCIIPNG_SCHEMA_INVALID for malformed fg color tuple", () => {
+    // fg expects [r, g, b] integers in [0, 255]; passing a wrong shape fails.
+    const result = asciipngCodec.parse(JSON.stringify({ fg: ["red"] }));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("ASCIIPNG_SCHEMA_INVALID");
+  });
+
   it("post-processes Minimax-style text into a fixed-size grid IR", () => {
     const raw = "```\n##\n..##\n```";
     const ir = minimaxTextToAsciiIr(raw, 6, 3, 4);

--- a/packages/codec-sensor/test/codec.test.ts
+++ b/packages/codec-sensor/test/codec.test.ts
@@ -349,6 +349,83 @@ describe("sensor patchGrammar operator", () => {
   });
 });
 
+/**
+ * Structured error-path coverage (#367 — sparse error-path coverage audit
+ * finding). Verifies that `parse()` returns the typed `SENSOR_SCHEMA_*` codes
+ * for the obvious boundary failures rather than throwing, returning silently
+ * `{ ok: true }`, or losing the structured shape.
+ */
+describe("@wittgenstein/codec-sensor structured error paths", () => {
+  it("returns SENSOR_SCHEMA_PARSE_FAILED for invalid JSON", () => {
+    const result = sensorCodec.parse("not-json {");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("SENSOR_SCHEMA_PARSE_FAILED");
+    expect(result.error.message).toBe("Sensor signal spec was not valid JSON.");
+    expect(result.error.cause).toBeInstanceOf(SyntaxError);
+  });
+
+  it("returns SENSOR_SCHEMA_INVALID with zod issues for unknown signal type", () => {
+    const result = sensorCodec.parse(
+      JSON.stringify({
+        signal: "not-a-real-signal-kind",
+        sampleRateHz: 100,
+        durationSec: 1,
+      }),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("SENSOR_SCHEMA_INVALID");
+    const issues = (result.error.details as { issues: ReadonlyArray<{ path: ReadonlyArray<string | number> }> })
+      .issues;
+    expect(issues.length).toBeGreaterThan(0);
+    expect(issues.some((issue) => issue.path.includes("signal"))).toBe(true);
+  });
+
+  it("returns SENSOR_SCHEMA_INVALID for affineNormalize range violation (#247)", () => {
+    const result = sensorCodec.parse(
+      JSON.stringify({
+        signal: "gyro",
+        sampleRateHz: 50,
+        durationSec: 1,
+        operators: [
+          {
+            type: "patchGrammar",
+            patchLengthSec: 1,
+            patches: [
+              {
+                operators: [{ type: "oscillator", frequencyHz: 1, amplitude: 1, phaseRad: 0 }],
+                // Inverted range — schema requires min < max strictly.
+                affineNormalize: { minOutput: 1, maxOutput: 0 },
+              },
+            ],
+          },
+        ],
+      }),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("SENSOR_SCHEMA_INVALID");
+  });
+
+  it("returns SENSOR_SCHEMA_INVALID for unknown operator type (discriminated-union miss)", () => {
+    const result = sensorCodec.parse(
+      JSON.stringify({
+        signal: "gyro",
+        sampleRateHz: 20,
+        durationSec: 1,
+        operators: [{ type: "totally-fictional-operator", amplitude: 1 }],
+      }),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("SENSOR_SCHEMA_INVALID");
+    const issues = (result.error.details as { issues: ReadonlyArray<{ path: ReadonlyArray<string | number> }> })
+      .issues;
+    expect(issues.some((issue) => issue.path.includes("operators"))).toBe(true);
+  });
+});
+
 async function renderToCsv(spec: SensorSignalSpec, seed: number): Promise<Buffer> {
   const dir = await mkdtemp(join(tmpdir(), "witt-sensor-pg-"));
   await sensorCodec.render(spec, {

--- a/packages/codec-video/package.json
+++ b/packages/codec-video/package.json
@@ -18,7 +18,14 @@
   "dependencies": {
     "@wittgenstein/process-runner": "workspace:*",
     "@wittgenstein/schemas": "workspace:*",
-    "puppeteer-core": "^24.31.0",
     "zod": "^3.23.8"
+  },
+  "peerDependencies": {
+    "puppeteer-core": "^24.31.0"
+  },
+  "peerDependenciesMeta": {
+    "puppeteer-core": {
+      "optional": true
+    }
   }
 }

--- a/packages/codec-video/src/mp4-renderer-runtime.ts
+++ b/packages/codec-video/src/mp4-renderer-runtime.ts
@@ -1,0 +1,109 @@
+// Runtime-tier dynamic loading for the video MP4 renderer's puppeteer-core peer.
+//
+// Per the delivery doctrine and #464 follow-up to PR #456, `puppeteer-core` is
+// only needed when the codec emits MP4 output (`WITTGENSTEIN_HYPERFRAMES_RENDER=1`
+// + `.mp4` extension). The HTML-only path — which is the codec's default — does
+// not load it. Mirrors the `ensureOnnxRuntime()` pattern in
+// `@wittgenstein/codec-image/src/decoders/runtime.ts`.
+//
+// The contract:
+//   - `renderHtmlToMp4()` calls `ensurePuppeteerCore()` BEFORE launching a browser.
+//   - On success: returns the imported module structurally typed for the
+//     calls this codec actually makes.
+//   - On failure: throws `WittgensteinPuppeteerUnavailableError` with structured
+//     details (code `MP4_RENDERER_PUPPETEER_UNAVAILABLE`) pointing the user at
+//     the install hint, instead of leaking Node's `ERR_MODULE_NOT_FOUND`.
+//   - The helper compiles cleanly even when `puppeteer-core` is not installed
+//     on disk, because all types are local and the import is hidden behind a
+//     dynamic-import-from-variable shape.
+import { z } from "zod";
+
+/**
+ * Minimal structural surface this codec needs from `puppeteer-core`. Extending
+ * this means the renderer can use a new symbol; the codec still compiles
+ * without the peer because the types are local.
+ */
+export interface PuppeteerCore {
+  readonly launch: (options: PuppeteerLaunchOptions) => Promise<PuppeteerBrowser>;
+}
+
+export interface PuppeteerLaunchOptions {
+  readonly executablePath: string;
+  readonly headless: boolean;
+  readonly args?: ReadonlyArray<string>;
+}
+
+export interface PuppeteerBrowser {
+  newPage(): Promise<PuppeteerPage>;
+  version(): Promise<string>;
+  close(): Promise<void>;
+}
+
+export interface PuppeteerPage {
+  setViewport(viewport: { width: number; height: number; deviceScaleFactor?: number }): Promise<void>;
+  goto(url: string, options?: { waitUntil?: string }): Promise<unknown>;
+  $(selector: string): Promise<PuppeteerElementHandle | null>;
+}
+
+export interface PuppeteerElementHandle {
+  screenshot(options: { path: string; omitBackground?: boolean }): Promise<unknown>;
+}
+
+export interface PuppeteerUnavailableDetails {
+  readonly runtime: "puppeteer-core";
+  readonly tier: "video";
+  readonly installHint: string;
+  readonly cause: string;
+  readonly tracker: string;
+}
+
+export const PuppeteerUnavailableDetailsSchema = z.object({
+  runtime: z.literal("puppeteer-core"),
+  tier: z.literal("video"),
+  installHint: z.string().min(1),
+  cause: z.string(),
+  tracker: z.string().url(),
+}) satisfies z.ZodType<PuppeteerUnavailableDetails>;
+
+export class WittgensteinPuppeteerUnavailableError extends Error {
+  readonly code = "MP4_RENDERER_PUPPETEER_UNAVAILABLE";
+  readonly details: PuppeteerUnavailableDetails;
+
+  constructor(message: string, details: PuppeteerUnavailableDetails) {
+    super(message);
+    this.name = "WittgensteinError";
+    this.details = PuppeteerUnavailableDetailsSchema.parse(details);
+  }
+}
+
+/**
+ * Load `puppeteer-core` and return its module. Throws a structured
+ * `MP4_RENDERER_PUPPETEER_UNAVAILABLE` if the peer isn't installed.
+ *
+ * The dynamic-import-from-variable shape (`new Function('return import(...)')`)
+ * keeps the TypeScript compiler from resolving the module at type level — the
+ * package compiles whether or not `puppeteer-core` is on the disk.
+ */
+export async function ensurePuppeteerCore(): Promise<PuppeteerCore> {
+  const moduleId = "puppeteer-core";
+  try {
+    const dynamicImport = new Function("id", "return import(id)") as (
+      id: string,
+    ) => Promise<PuppeteerCore>;
+    return await dynamicImport(moduleId);
+  } catch (error) {
+    const cause = error instanceof Error ? error.message : String(error);
+    throw new WittgensteinPuppeteerUnavailableError(
+      "Video MP4 renderer requires `puppeteer-core`. Install it with " +
+        "`pnpm add puppeteer-core` (or `npm install puppeteer-core`) and retry, " +
+        "or unset `WITTGENSTEIN_HYPERFRAMES_RENDER` to emit HTML only.",
+      {
+        runtime: "puppeteer-core",
+        tier: "video",
+        installHint: "pnpm add puppeteer-core",
+        cause,
+        tracker: "https://github.com/p-to-q/wittgenstein/issues/464",
+      },
+    );
+  }
+}

--- a/packages/codec-video/src/mp4-renderer.ts
+++ b/packages/codec-video/src/mp4-renderer.ts
@@ -5,6 +5,7 @@ import { pathToFileURL } from "node:url";
 import { runProcess } from "@wittgenstein/process-runner";
 import type { VideoRenderManifest } from "@wittgenstein/schemas";
 import { STAGE_HEIGHT, STAGE_WIDTH } from "./compositions/shared.js";
+import { ensurePuppeteerCore } from "./mp4-renderer-runtime.js";
 
 export interface InternalMp4RenderParams {
   htmlPath: string;
@@ -78,7 +79,7 @@ async function captureFrames(params: InternalMp4RenderParams & {
   frameDir: string;
   frameCount: number;
 }): Promise<string> {
-  const puppeteer = await import("puppeteer-core");
+  const puppeteer = await ensurePuppeteerCore();
   const executablePath = resolveChromeExecutable();
   const browser = await puppeteer.launch({
     executablePath,


### PR DESCRIPTION
Two related quality slices from the 2026-05-26 maintainer review session.

## Slice 1 — #367 first slice: error-path coverage for codec-sensor + codec-asciipng

Closes the two worst-covered codecs from the [#367](https://github.com/p-to-q/wittgenstein/issues/367) sparse-error-path audit finding.

| Codec | Before | After | Added |
|---|---|---|---|
| `codec-sensor` | 18 tests | 22 tests | 4 |
| `codec-asciipng` | 5 tests | 8 tests | 3 |

### codec-sensor tests added

- `SENSOR_SCHEMA_PARSE_FAILED` returned for invalid JSON, with `cause` as `SyntaxError`.
- `SENSOR_SCHEMA_INVALID` returned with zod `issues[].path` for unknown signal kind.
- `SENSOR_SCHEMA_INVALID` returned for `affineNormalize.minOutput >= maxOutput` (pins #247).
- `SENSOR_SCHEMA_INVALID` returned for unknown operator type — verifies the discriminated-union miss case.

### codec-asciipng tests added

- `ASCIIPNG_SCHEMA_PARSE_FAILED` returned for invalid JSON.
- `ASCIIPNG_SCHEMA_INVALID` returned for `columns: 5000` (above max-120).
- `ASCIIPNG_SCHEMA_INVALID` returned for malformed `fg` tuple shape.

Other codecs (image: 17 error-code refs, audio: 18, svg: 3 dedicated tests) already have meaningful coverage per the audit; not in scope for this slice.

## Slice 2 — Closes #464: puppeteer-core optional peer (#456 follow-up)

PR [#456](https://github.com/p-to-q/wittgenstein/pull/456) added `puppeteer-core` to `@wittgenstein/codec-video` as a hard `dependencies` entry. The codec only actually needs it on the opt-in MP4 path (`WITTGENSTEIN_HYPERFRAMES_RENDER=1` + `.mp4` extension); the default HTML path never loads it.

This refactor mirrors the `onnxruntime-node` pattern from `@wittgenstein/codec-image`:

- `packages/codec-video/package.json` — moves `puppeteer-core` from `dependencies` → `peerDependencies` + `peerDependenciesMeta.optional: true`. HTML-only consumers no longer pay the install cost.
- `packages/codec-video/src/mp4-renderer-runtime.ts` (new, 109 lines) — adds `ensurePuppeteerCore()` analogous to `ensureOnnxRuntime()`: dynamic-import-from-variable shape, minimal local `PuppeteerCore` interface, structured `WittgensteinPuppeteerUnavailableError` (\`code: \"MP4_RENDERER_PUPPETEER_UNAVAILABLE\"\`) with actionable install hint.
- `packages/codec-video/src/mp4-renderer.ts` — replaces bare `await import(\"puppeteer-core\")` with `await ensurePuppeteerCore()`. Behavior unchanged when peer is present; structured error when absent.

## Verification

```
pnpm install --frozen-lockfile                                                # green; lockfile unchanged
pnpm --filter @wittgenstein/codec-sensor test                                 # 22/22 pass
pnpm --filter @wittgenstein/codec-asciipng test                               # 8/8 pass
pnpm --filter @wittgenstein/codec-video typecheck                             # green
pnpm --filter @wittgenstein/codec-video test                                  # 14/14 pass
pnpm --filter @wittgenstein/codec-video lint                                  # green
pnpm lint:deps                                                                 # codec boundaries green for 6 packages
pnpm lint:publish-surface                                                      # no-research-imports + tarball check green
```

## R/E/H

- **R**: error-path tests pin behavior at the schema boundary; puppeteer migration follows the established #404/#409 peer pattern. Both reduce ad-hoc surface area.
- **E**: tests assert structured error codes (not just \`result.ok === false\`), so future renames or silent-fallback drift fails CI. Puppeteer dynamic-import-from-variable trick keeps the codec compiling without the peer on disk.
- **H**: small, surgical. Two commits, one logical \"quality sweep\" from the audit. Reviewable in one pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)