### PR TITLE
chore(pre-training): refresh reviewer-bench pins + wire into CI + fill training subprogram READMEs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,14 @@ jobs:
       - name: Golden tests
         run: pnpm test:golden
 
+      - name: Reviewer bench (Tier-0 deterministic surface)
+        # Verifies the sensor / svg-local / asciipng deterministic routes
+        # plus `wittgenstein replay` still match the pinned SHA-256
+        # receipts in examples/reviewer-bench/expected.json. Catches
+        # silent byte drift across PRs that touch a deterministic codec
+        # without updating its pin. See #471 (post-#426/#389 drift fix).
+        run: pnpm reviewer-bench
+
       - name: Setup Python
         uses: actions/setup-python@v6
         with:

--- a/examples/reviewer-bench/expected.json
+++ b/examples/reviewer-bench/expected.json
@@ -7,7 +7,7 @@
       "route": "sensor",
       "args": ["sensor", "ECG 72 bpm resting", "--dry-run", "--seed", "42"],
       "artifactBasename": "out.html",
-      "sha256": "dbbf8ccae0815fac2801e132224623c4f641082732cdc8938b942abb48e27d14",
+      "sha256": "2684d511d6016207c771d2dee1a2712b0b444adb76442f29d986664df676eb4d",
       "description": "sensor route, ECG dry-run @ seed 42 — HTML artifact byte-stable"
     },
     {
@@ -39,7 +39,7 @@
       "route": "sensor",
       "args": ["sensor", "replay smoke target ECG", "--dry-run", "--seed", "1234"],
       "artifactBasename": "out.html",
-      "sha256": "7fe25f0e0e06d87dc8028e92a867295285e6f44273a921b17d116f7b903ac742",
+      "sha256": "bce0ef868809af08416cceeda9f86454b851a5911a2ed35746b6b8030e30bc04",
       "description": "sensor replay target (different seed to isolate from sensor-ecg row)"
     }
   ]

--- a/research/training/adapter/README.md
+++ b/research/training/adapter/README.md
@@ -1,0 +1,37 @@
+# Adapter training subprogram
+
+Phase-1 deliverable: a learned MaskGIT-style L4 seed-code adapter that
+expands compact Visual Seed Code emissions from the LLM into
+decoder-native latent tokens.
+
+This directory is the dedicated workspace for the adapter training
+program. It will host the training entrypoint, configs, eval scripts, and
+any local helpers that are not shared across subprograms. Shared
+infrastructure (dataset loaders, manifest-spine adapters, eval harness)
+lives in `../_shared/`.
+
+## Status
+
+This directory is currently a Phase-1 placeholder. Actual training code
+lands as part of the M1B specialist track. The skeleton is intentionally
+empty so contributor-machine `pnpm install` and the boundary guards
+(`scripts/check-no-research-imports.mjs`,
+`scripts/check-npm-publish-tarball.mjs`) work against the documented
+shape from day one.
+
+## Owning issues
+
+- [#397](https://github.com/p-to-q/wittgenstein/issues/397) — Train
+  learned MaskGIT-style L4 adapter (seed expander).
+- [#393](https://github.com/p-to-q/wittgenstein/issues/393) —
+  Deterministic-unfolding adapter empirical sweep.
+- [#453](https://github.com/p-to-q/wittgenstein/issues/453) — Block-causal
+  + clean-repaint adapter design (Cola-DLM-inspired).
+- [#454](https://github.com/p-to-q/wittgenstein/issues/454) — CoT-inspired
+  visual reasoning block in the VSC preamble.
+
+## Receipt contract
+
+Every adapter training run emits a Wittgenstein manifest receipt under
+`research/training/_shared/manifests/<run-id>/` per the contract in
+[`docs/contributing/training-setup.md`](../../../docs/contributing/training-setup.md).

--- a/research/training/llm-head/README.md
+++ b/research/training/llm-head/README.md
@@ -1,0 +1,34 @@
+# LLM head training subprogram
+
+Phase-1 deliverable: a Wittgenstein-native image-emitting LLM head
+distilled from a teacher (initially LlamaGen-3B).
+
+This directory is the dedicated workspace for the LLM-head training
+program. It will host the training entrypoint, configs, eval scripts, and
+any local helpers that are not shared across subprograms. Shared
+infrastructure (dataset loaders, manifest-spine adapters, eval harness)
+lives in `../_shared/`.
+
+## Status
+
+This directory is currently a Phase-1 placeholder. Actual training code
+lands as part of the M1B specialist track. The skeleton is intentionally
+empty so contributor-machine `pnpm install` and the boundary guards
+(`scripts/check-no-research-imports.mjs`,
+`scripts/check-npm-publish-tarball.mjs`) work against the documented
+shape from day one.
+
+## Owning issues
+
+- [#398](https://github.com/p-to-q/wittgenstein/issues/398) — Distill
+  Wittgenstein-native image-emitting LLM head from LlamaGen-3B teacher.
+- [#451](https://github.com/p-to-q/wittgenstein/issues/451) — Seed code
+  first-token stability empirical validation plan.
+- [#452](https://github.com/p-to-q/wittgenstein/issues/452) — IR
+  information-carrying capacity empirical validation plan.
+
+## Receipt contract
+
+Every LLM-head training run emits a Wittgenstein manifest receipt under
+`research/training/_shared/manifests/<run-id>/` per the contract in
+[`docs/contributing/training-setup.md`](../../../docs/contributing/training-setup.md).

--- a/research/training/tokenizer/README.md
+++ b/research/training/tokenizer/README.md
@@ -1,0 +1,35 @@
+# Tokenizer training subprogram
+
+Phase-1 deliverable: a Wittgenstein-native VQGAN-class image tokenizer
+trained on ImageNet + CC12M.
+
+This directory is the dedicated workspace for the tokenizer training
+program. It will host the training entrypoint, configs, eval scripts, and
+any local helpers that are not shared across subprograms. Shared
+infrastructure (dataset loaders, manifest-spine adapters, eval harness)
+lives in `../_shared/`.
+
+## Status
+
+This directory is currently a Phase-1 placeholder. Actual training code
+lands as part of the M1B specialist track. The skeleton is intentionally
+empty so contributor-machine `pnpm install` and the boundary guards
+(`scripts/check-no-research-imports.mjs`,
+`scripts/check-npm-publish-tarball.mjs`) work against the documented
+shape from day one.
+
+## Owning issues
+
+- [#396](https://github.com/p-to-q/wittgenstein/issues/396) — Train
+  Wittgenstein-native VQGAN-class image tokenizer on ImageNet + CC12M.
+- [#329](https://github.com/p-to-q/wittgenstein/issues/329)–[#335](https://github.com/p-to-q/wittgenstein/issues/335) — per-candidate four-gate audits that
+  inform tokenizer family selection.
+- [#334](https://github.com/p-to-q/wittgenstein/issues/334) / [#335](https://github.com/p-to-q/wittgenstein/issues/335) — Gate C / D empirical thresholds.
+- [#473](https://github.com/p-to-q/wittgenstein/issues/473) — Gate C/D
+  threshold policy.
+
+## Receipt contract
+
+Every tokenizer training run emits a Wittgenstein manifest receipt under
+`research/training/_shared/manifests/<run-id>/` per the contract in
+[`docs/contributing/training-setup.md`](../../../docs/contributing/training-setup.md).


### PR DESCRIPTION
Pre-training-kickoff sweep. The model-training specialist is about to engage M1B; this PR is the engineering-side hygiene pass that ensures the Tier-0 surface they land against is clean and self-honest.

## Bug found + fixed: \`pnpm reviewer-bench\` was failing on main

Two SHA mismatches:

| Row | Expected (stale) | Observed (current) |
|---|---|---|
| \`sensor-ecg\` | \`dbbf8cca…48e27d14\` | \`2684d511…f676eb4d\` |
| \`sensor-replay\` | \`7fe25f0e…903ac742\` | \`bce0ef86…0e30bc04\` |

**Root cause:** [#426](https://github.com/p-to-q/wittgenstein/pull/426) (ship sensor sidecar receipts and bundled loupe) and [#389](https://github.com/p-to-q/wittgenstein/pull/389) (fix codec-sensor HTML fallback embeds csv basename, not absolute path) intentionally changed sensor HTML output, but the reviewer-bench \`expected.json\` pins were not refreshed in either PR.

Regenerated via \`scripts/reviewer-bench-pin.ts\` (runs each row's CLI twice for determinism; both runs match). After this PR: \`pnpm reviewer-bench\` → **8/8 pass**.

## Why this matters before training

\`pnpm reviewer-bench\` is the **first command** a new contributor (including the ML specialist) types after a clean checkout to verify Wittgenstein's engineering claims at Tier 0. If the bench is broken on \`main\`, the specialist hits a confusing failure on day-one onboarding.

## Regression protection — \`pnpm reviewer-bench\` is now a CI step

Wired into \`Verify (Node + Python)\` so this same drift cannot happen silently again. A PR that intentionally changes a deterministic-by-construction route's output must refresh the pin in the same PR — CI will fail otherwise. (Closes a CI-coverage gap that allowed #426 / #389 to land without a bench refresh.)

## Training scaffold honesty

[\`research/training/README.md\`](https://github.com/p-to-q/wittgenstein/blob/main/research/training/README.md) advertises three subprograms (\`tokenizer/\`, \`adapter/\`, \`llm-head/\`) but those directories were empty. Each now has a focused README that:

- states the Phase-1 deliverable;
- explicitly flags the directory as a skeleton placeholder (so the specialist sees the doctrine, not just an empty dir);
- cross-links the owning M1B issues so PR context is already inline;
- restates the receipt contract from \`docs/contributing/training-setup.md\`.

## Verification

\`\`\`
pnpm install --frozen-lockfile            # clean
pnpm -r typecheck                         # green
pnpm reviewer-bench                       # 8/8 pass (was 6/8 before)
pnpm lint:publish-surface                 # training/ subdirs don't leak
\`\`\`

## R/E/H

- **R**: Tier-0 self-verification command was lying. Specialist would have hit confusion on first command. This is exactly the kind of pre-handoff hygiene that prevents \"is this repo even green?\" overhead.
- **E**: CI now runs the bench every PR — drift is impossible to ship silently. The pin SHAs are deterministic (verified by running twice).
- **H**: Training subprogram READMEs cross-link issues so a specialist opening the directory has the issue stack visible at the door, not buried in the queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)