### PR TITLE
chore(packages): add missing license + repository + homepage + bugs metadata to all package.json

### DIFF
--- a/packages/agent-contact-text/package.json
+++ b/packages/agent-contact-text/package.json
@@ -2,5 +2,15 @@
   "name": "@wittgenstein/agent-contact-text",
   "version": "0.0.0",
   "private": true,
-  "description": "Extended agent-facing primers (00–03) and narrative context for coding agents."
+  "description": "Extended agent-facing primers (00–03) and narrative context for coding agents.",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/p-to-q/wittgenstein.git",
+    "directory": "packages/agent-contact-text"
+  },
+  "homepage": "https://github.com/p-to-q/wittgenstein",
+  "bugs": {
+    "url": "https://github.com/p-to-q/wittgenstein/issues"
+  }
 }

--- a/packages/codec-asciipng/package.json
+++ b/packages/codec-asciipng/package.json
@@ -22,5 +22,15 @@
   },
   "devDependencies": {
     "@types/pngjs": "^6.0.5"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/p-to-q/wittgenstein.git",
+    "directory": "packages/codec-asciipng"
+  },
+  "homepage": "https://github.com/p-to-q/wittgenstein",
+  "bugs": {
+    "url": "https://github.com/p-to-q/wittgenstein/issues"
   }
 }

--- a/packages/codec-audio/package.json
+++ b/packages/codec-audio/package.json
@@ -21,5 +21,15 @@
     "kokoro-js": "1.2.1",
     "undici": "^7.26.0",
     "zod": "^3.23.8"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/p-to-q/wittgenstein.git",
+    "directory": "packages/codec-audio"
+  },
+  "homepage": "https://github.com/p-to-q/wittgenstein",
+  "bugs": {
+    "url": "https://github.com/p-to-q/wittgenstein/issues"
   }
 }

--- a/packages/codec-image/package.json
+++ b/packages/codec-image/package.json
@@ -26,5 +26,15 @@
     "onnxruntime-node": {
       "optional": true
     }
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/p-to-q/wittgenstein.git",
+    "directory": "packages/codec-image"
+  },
+  "homepage": "https://github.com/p-to-q/wittgenstein",
+  "bugs": {
+    "url": "https://github.com/p-to-q/wittgenstein/issues"
   }
 }

--- a/packages/codec-sensor/package.json
+++ b/packages/codec-sensor/package.json
@@ -19,5 +19,15 @@
   "dependencies": {
     "@wittgenstein/schemas": "workspace:*",
     "zod": "^3.23.8"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/p-to-q/wittgenstein.git",
+    "directory": "packages/codec-sensor"
+  },
+  "homepage": "https://github.com/p-to-q/wittgenstein",
+  "bugs": {
+    "url": "https://github.com/p-to-q/wittgenstein/issues"
   }
 }

--- a/packages/codec-svg/package.json
+++ b/packages/codec-svg/package.json
@@ -18,5 +18,15 @@
   "dependencies": {
     "@wittgenstein/schemas": "workspace:*",
     "zod": "^3.23.8"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/p-to-q/wittgenstein.git",
+    "directory": "packages/codec-svg"
+  },
+  "homepage": "https://github.com/p-to-q/wittgenstein",
+  "bugs": {
+    "url": "https://github.com/p-to-q/wittgenstein/issues"
   }
 }

--- a/packages/codec-video/package.json
+++ b/packages/codec-video/package.json
@@ -27,5 +27,15 @@
     "puppeteer-core": {
       "optional": true
     }
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/p-to-q/wittgenstein.git",
+    "directory": "packages/codec-video"
+  },
+  "homepage": "https://github.com/p-to-q/wittgenstein",
+  "bugs": {
+    "url": "https://github.com/p-to-q/wittgenstein/issues"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,5 +24,15 @@
     "@wittgenstein/schemas": "workspace:*",
     "@wittgenstein/sandbox": "workspace:*",
     "zod": "^3.23.8"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/p-to-q/wittgenstein.git",
+    "directory": "packages/core"
+  },
+  "homepage": "https://github.com/p-to-q/wittgenstein",
+  "bugs": {
+    "url": "https://github.com/p-to-q/wittgenstein/issues"
   }
 }

--- a/packages/process-runner/package.json
+++ b/packages/process-runner/package.json
@@ -13,5 +13,15 @@
     "lint": "eslint src test --ext .ts",
     "test": "vitest run",
     "build": "tsc"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/p-to-q/wittgenstein.git",
+    "directory": "packages/process-runner"
+  },
+  "homepage": "https://github.com/p-to-q/wittgenstein",
+  "bugs": {
+    "url": "https://github.com/p-to-q/wittgenstein/issues"
   }
 }

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -5,11 +5,23 @@
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
-  "exports": { ".": "./src/index.ts" },
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "scripts": {
     "typecheck": "tsc -b",
     "lint": "eslint src --ext .ts",
     "test": "vitest run",
     "build": "tsc"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/p-to-q/wittgenstein.git",
+    "directory": "packages/sandbox"
+  },
+  "homepage": "https://github.com/p-to-q/wittgenstein",
+  "bugs": {
+    "url": "https://github.com/p-to-q/wittgenstein/issues"
   }
 }

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -16,5 +16,15 @@
   },
   "dependencies": {
     "zod": "^3.23.8"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/p-to-q/wittgenstein.git",
+    "directory": "packages/schemas"
+  },
+  "homepage": "https://github.com/p-to-q/wittgenstein",
+  "bugs": {
+    "url": "https://github.com/p-to-q/wittgenstein/issues"
   }
 }


### PR DESCRIPTION
## Summary

Cross-section audit finding: only \`@wittgenstein/cli\` declared \`license\` / \`repository\` / \`homepage\` / \`bugs\` in its package.json. All 11 other workspace packages were missing those fields.

They're all marked \`private:true\` so this is not a tarball leak today, but the consistency gap is a real smell:

- Quietly opts every package out of the SPDX license expression (\`Apache-2.0\`) that \`@wittgenstein/cli\` is published with.
- Hides the upstream repo + issues URL from \`pnpm view\`, \`npm pack --dry-run\`, and any future tooling that walks package.json metadata.
- Flipping any package from \`private:true\` to public would quietly publish without a license field — the canonical npm packaging bug.

## What this PR does

For each of the 11 missing packages:

- \`license: \"Apache-2.0\"\` — matches repo \`LICENSE\` + the cli package.
- \`repository: { type, url, directory: packages/<name> }\` — each package points at its own subdirectory, same shape as the cli package.
- \`homepage: \"https://github.com/p-to-q/wittgenstein\"\`.
- \`bugs: { url: \".../issues\" }\`.

Prettier-formatted to keep \`format:check\` green.

## Packages updated

\`agent-contact-text\`, \`codec-asciipng\`, \`codec-audio\`, \`codec-image\`, \`codec-sensor\`, \`codec-svg\`, \`codec-video\`, \`core\`, \`process-runner\`, \`sandbox\`, \`schemas\`.

(\`cli\` already had all four fields.)

## Verification

\`\`\`
pnpm install --frozen-lockfile      # lockfile unchanged
pnpm -r typecheck                   # green
pnpm lint:deps                      # codec boundaries clean
pnpm lint:publish-surface           # nothing leaks
pnpm reviewer-bench                 # 8/8 pass
\`\`\`

## R/E/H

- **R**: future maintainers reading any sub-package can find the repo + license without scanning the root. Metadata-shaped knowledge becomes self-contained per package.
- **E**: pure metadata hygiene; zero behavior change. The cli package already proved this exact shape works under \`npm pack\` + \`npm publish\`.
- **H**: closes the \"oh wait this package leaked without a license field\" foot-gun before it can happen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)