### PR TITLE
refactor: centralize hardcoded GitHub issue URLs as TRACKERS/CLOSED_TRACKERS constants (closes #487 item 2)

### DIFF
--- a/packages/cli/src/tiers.ts
+++ b/packages/cli/src/tiers.ts
@@ -1,3 +1,5 @@
+import { TRACKERS } from "@wittgenstein/schemas";
+
 export type InstallTierId = "image" | "image-gpu";
 
 export interface RuntimeTierStatus {
@@ -18,7 +20,7 @@ export interface InstallTierPlan {
   blockedBy: "decoder-manifest";
 }
 
-const IMAGE_INSTALL_TRACKER = "https://github.com/p-to-q/wittgenstein/issues/403";
+const IMAGE_INSTALL_TRACKER = TRACKERS.installTierCli;
 
 export function runtimeTierReadiness(): Record<
   "tier0" | "tier1" | "tier2" | "tier3",

--- a/packages/codec-image/src/decoders/llamagen.ts
+++ b/packages/codec-image/src/decoders/llamagen.ts
@@ -14,6 +14,7 @@
  *   - Bridge contract: `./types.ts`
  *   - Replay verifier for the wired path: `wittgenstein replay` (#384)
  */
+import { TRACKERS } from "@wittgenstein/schemas";
 import type { ImageDecoderBridge, LoadDecoderBridgeOptions } from "./types.js";
 
 /**
@@ -59,9 +60,9 @@ function createBridgeNotImplementedError(): Error & { code: string; details: obj
       family: "llamagen",
       decoderId: LLAMAGEN_DECODER_ID,
       blockers: {
-        gateC: "https://github.com/p-to-q/wittgenstein/issues/334",
-        gateD: "https://github.com/p-to-q/wittgenstein/issues/335",
-        umbrella: "https://github.com/p-to-q/wittgenstein/issues/283",
+        gateC: TRACKERS.m1bGateCDeterminism,
+        gateD: TRACKERS.m1bGateDOnnxCpu,
+        umbrella: TRACKERS.m1bImageDecoderUmbrella,
       },
     },
   });

--- a/packages/codec-image/src/decoders/runtime.ts
+++ b/packages/codec-image/src/decoders/runtime.ts
@@ -24,6 +24,7 @@
 //     bridges actually use, not against `onnxruntime-node`'s full types,
 //     so the package can compile cleanly without the peer installed.
 import { z } from "zod";
+import { CLOSED_TRACKERS } from "@wittgenstein/schemas";
 
 /**
  * The minimal structural surface a bridge needs from `onnxruntime-node`.
@@ -90,7 +91,7 @@ export async function ensureOnnxRuntime(): Promise<OnnxRuntime> {
         tier: "image",
         installHint: "wittgenstein install image",
         cause,
-        tracker: "https://github.com/p-to-q/wittgenstein/issues/404",
+        tracker: CLOSED_TRACKERS.onnxRuntimeOptionalPeer,
       },
     );
   }

--- a/packages/codec-image/src/decoders/seed.ts
+++ b/packages/codec-image/src/decoders/seed.ts
@@ -11,6 +11,7 @@
  *   - Audit (P3-5): `docs/research/2026-05-13-audits-fsq-openmagvit2-titok-maskbit.md`
  *   - Bridge contract: `./types.ts`
  */
+import { TRACKERS } from "@wittgenstein/schemas";
 import type { ImageDecoderBridge, LoadDecoderBridgeOptions } from "./types.js";
 
 export const SEED_DECODER_ID = "seed-frozen-vq-v0" as const;
@@ -32,8 +33,8 @@ function createBridgeNotImplementedError(): Error & { code: string; details: obj
       family: "seed",
       decoderId: SEED_DECODER_ID,
       blockers: {
-        audit: "https://github.com/p-to-q/wittgenstein/issues/331",
-        umbrella: "https://github.com/p-to-q/wittgenstein/issues/283",
+        audit: TRACKERS.m1bOpenMagvit2Audit,
+        umbrella: TRACKERS.m1bImageDecoderUmbrella,
       },
     },
   });

--- a/packages/codec-image/src/decoders/weights.ts
+++ b/packages/codec-image/src/decoders/weights.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { z } from "zod";
+import { CLOSED_TRACKERS, TRACKERS } from "@wittgenstein/schemas";
 import type { LoadDecoderBridgeOptions } from "./types.js";
 
 export const DecoderWeightsManifestSchema = z
@@ -67,7 +68,7 @@ export class ResearchWeightsRequiresOptInError extends Error {
       repoId: manifest.repoId,
       weightsRestriction: manifest.license.weights,
       adr: "docs/adrs/0020-code-weights-license-divergence-policy.md",
-      tracker: "https://github.com/p-to-q/wittgenstein/issues/376",
+      tracker: CLOSED_TRACKERS.adr0020Implementation,
     };
   }
 }
@@ -90,7 +91,7 @@ export class DecoderWeightsNotInstalledError extends Error {
       weightsSha256: manifest.weightsSha256,
       cachePath,
       installHint: "wittgenstein install image",
-      tracker: "https://github.com/p-to-q/wittgenstein/issues/402",
+      tracker: TRACKERS.decoderDeliveryDecision,
     };
   }
 }
@@ -110,7 +111,7 @@ export class DecoderWeightsSha256MismatchError extends Error {
       filename: asset.filename,
       expectedSha256: asset.sha256,
       actualSha256,
-      tracker: "https://github.com/p-to-q/wittgenstein/issues/402",
+      tracker: TRACKERS.decoderDeliveryDecision,
     };
   }
 }
@@ -129,7 +130,7 @@ export class DecoderWeightsFetchFailedError extends Error {
       revision: manifest.revision,
       assetKind: asset.kind,
       filename: asset.filename,
-      tracker: "https://github.com/p-to-q/wittgenstein/issues/402",
+      tracker: TRACKERS.decoderDeliveryDecision,
     };
   }
 }

--- a/packages/codec-video/src/mp4-renderer-runtime.ts
+++ b/packages/codec-video/src/mp4-renderer-runtime.ts
@@ -17,6 +17,7 @@
 //     on disk, because all types are local and the import is hidden behind a
 //     dynamic-import-from-variable shape.
 import { z } from "zod";
+import { CLOSED_TRACKERS } from "@wittgenstein/schemas";
 
 /**
  * Minimal structural surface this codec needs from `puppeteer-core`. Extending
@@ -40,7 +41,11 @@ export interface PuppeteerBrowser {
 }
 
 export interface PuppeteerPage {
-  setViewport(viewport: { width: number; height: number; deviceScaleFactor?: number }): Promise<void>;
+  setViewport(viewport: {
+    width: number;
+    height: number;
+    deviceScaleFactor?: number;
+  }): Promise<void>;
   goto(url: string, options?: { waitUntil?: string }): Promise<unknown>;
   $(selector: string): Promise<PuppeteerElementHandle | null>;
 }
@@ -102,7 +107,7 @@ export async function ensurePuppeteerCore(): Promise<PuppeteerCore> {
         tier: "video",
         installHint: "pnpm add puppeteer-core",
         cause,
-        tracker: "https://github.com/p-to-q/wittgenstein/issues/464",
+        tracker: CLOSED_TRACKERS.puppeteerCoreOptionalPeer,
       },
     );
   }

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -2,5 +2,6 @@ export * from "./codec.js";
 export * from "./config.js";
 export * from "./modality.js";
 export * from "./manifest.js";
+export * from "./trackers.js";
 export * as codecV2 from "./codec/v2/index.js";
 export * as llm from "./llm/index.js";

--- a/packages/schemas/src/trackers.ts
+++ b/packages/schemas/src/trackers.ts
@@ -1,0 +1,68 @@
+// Named tracker-URL constants for receipt fields, error details, and doctor
+// surface output. Centralized here so:
+//
+//   1. The repo can move orgs (it has — see #83 `org-rename-p-to-q`) without
+//      a fan-out string-literal hunt across packages.
+//   2. Future maintainers reading a stale receipt know what the link *means*
+//      from the constant name, not from clicking through to discover the
+//      issue's intent.
+//   3. New runtime call sites importing one of these constants accept the
+//      canonical URL shape (no typos, no missing slashes, no protocol
+//      variants).
+//
+// Convention:
+//
+//   - Active blockers / pending-work trackers go in `TRACKERS`.
+//   - Closed-but-referenced trackers (kept in code as provenance for a
+//     decision the runtime still enforces) go in `CLOSED_TRACKERS` with a
+//     comment naming the closing PR or successor issue.
+//
+// Names describe *intent*, not issue number. A future renumber or org move
+// touches one line per tracker.
+//
+// Surfaced + landed by the 2026-05-27 pre-training audit follow-up
+// (#487 item 2).
+
+const REPO_ISSUES = "https://github.com/p-to-q/wittgenstein/issues" as const;
+
+function issueUrl(n: number): string {
+  return `${REPO_ISSUES}/${n}`;
+}
+
+/**
+ * Active trackers — pending work, open issues. Runtime emits these in
+ * `details.tracker`, `details.umbrella`, etc. so an operator hitting a
+ * structured error can click through to the right discussion.
+ */
+export const TRACKERS = {
+  /** M1B umbrella — image trained projector blocker. */
+  m1bImageDecoderUmbrella: issueUrl(283),
+  /** VQGAN-class Gate C (deterministic encode/decode round-trip). */
+  m1bGateCDeterminism: issueUrl(334),
+  /** VQGAN-class Gate D (ONNX export + CPU decode feasibility). */
+  m1bGateDOnnxCpu: issueUrl(335),
+  /** OpenMAGVIT2 per-candidate four-gate audit. */
+  m1bOpenMagvit2Audit: issueUrl(331),
+  /** Decoder-delivery decision: lazy weight fetch + sha256 verify. */
+  decoderDeliveryDecision: issueUrl(402),
+  /** `wittgenstein install <tier>` CLI + doctor tier readiness. */
+  installTierCli: issueUrl(403),
+} as const;
+
+/**
+ * Closed trackers — preserved in code because the runtime references them
+ * as the provenance for a still-live invariant (ADR enforcement, peer-dep
+ * contract). The constant keeps the link working; the comment names the
+ * closing PR or successor so a maintainer can trace the chain.
+ */
+export const CLOSED_TRACKERS = {
+  /** ADR-0020 implementation; closed 2026-05-26 (already shipped). */
+  adr0020Implementation: issueUrl(376),
+  /** Optional/peer-dep declarations for heavy runtimes; closed via #409. */
+  onnxRuntimeOptionalPeer: issueUrl(404),
+  /** puppeteer-core optional peer; closed via #488 (the consolidation PR). */
+  puppeteerCoreOptionalPeer: issueUrl(464),
+} as const;
+
+export type TrackerKey = keyof typeof TRACKERS;
+export type ClosedTrackerKey = keyof typeof CLOSED_TRACKERS;

--- a/packages/schemas/test/trackers.test.ts
+++ b/packages/schemas/test/trackers.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Pins the tracker URL constants exported from `@wittgenstein/schemas`.
+ *
+ * These constants replace ~13 hardcoded `https://github.com/p-to-q/wittgenstein/issues/<N>`
+ * string literals scattered across the cli, codec-image, and codec-video
+ * packages (#487 item 2). Future renumber / org-rename touches one line per
+ * tracker; receipt-format consumers reference the named constant.
+ */
+import { describe, expect, it } from "vitest";
+import { CLOSED_TRACKERS, TRACKERS } from "../src/index.js";
+
+const URL_SHAPE = /^https:\/\/github\.com\/p-to-q\/wittgenstein\/issues\/\d+$/;
+
+describe("@wittgenstein/schemas — trackers (#487 item 2)", () => {
+  it("every active tracker matches the canonical GitHub issue URL shape", () => {
+    for (const [name, url] of Object.entries(TRACKERS)) {
+      expect(url, name).toMatch(URL_SHAPE);
+    }
+  });
+
+  it("every closed tracker matches the canonical GitHub issue URL shape", () => {
+    for (const [name, url] of Object.entries(CLOSED_TRACKERS)) {
+      expect(url, name).toMatch(URL_SHAPE);
+    }
+  });
+
+  it("active and closed tracker namespaces don't overlap", () => {
+    const activeKeys = new Set(Object.keys(TRACKERS));
+    const closedKeys = new Set(Object.keys(CLOSED_TRACKERS));
+    const overlap = [...activeKeys].filter((k) => closedKeys.has(k));
+    expect(overlap).toEqual([]);
+  });
+
+  it("pins the specific URLs that runtime receipts depend on", () => {
+    // These exact values are checked into the public receipt surface; renaming
+    // either key requires updating the receipt consumers. The test pins the
+    // mapping so a typo in `trackers.ts` cannot silently change a receipt.
+    expect(TRACKERS.m1bImageDecoderUmbrella).toBe(
+      "https://github.com/p-to-q/wittgenstein/issues/283",
+    );
+    expect(TRACKERS.m1bGateCDeterminism).toBe("https://github.com/p-to-q/wittgenstein/issues/334");
+    expect(TRACKERS.m1bGateDOnnxCpu).toBe("https://github.com/p-to-q/wittgenstein/issues/335");
+    expect(TRACKERS.decoderDeliveryDecision).toBe(
+      "https://github.com/p-to-q/wittgenstein/issues/402",
+    );
+    expect(TRACKERS.installTierCli).toBe("https://github.com/p-to-q/wittgenstein/issues/403");
+    expect(CLOSED_TRACKERS.adr0020Implementation).toBe(
+      "https://github.com/p-to-q/wittgenstein/issues/376",
+    );
+    expect(CLOSED_TRACKERS.onnxRuntimeOptionalPeer).toBe(
+      "https://github.com/p-to-q/wittgenstein/issues/404",
+    );
+    expect(CLOSED_TRACKERS.puppeteerCoreOptionalPeer).toBe(
+      "https://github.com/p-to-q/wittgenstein/issues/464",
+    );
+  });
+});


### PR DESCRIPTION
Closes the second item of [#487](https://github.com/p-to-q/wittgenstein/issues/487) (local-optima consolidation tracker).

## What was found

13 hardcoded \`https://github.com/p-to-q/wittgenstein/issues/<N>\` string literals across 5 source files in 3 packages. All sat behind receipt fields, structured error details, or runtime tier metadata where future tooling reads the URL programmatically.

Risk: the repo has already moved orgs once ([#83](https://github.com/p-to-q/wittgenstein/pull/83) \`org-rename-p-to-q\`). A second rename, an issue renumber, or even a typo would silently change public receipts without any test catching it.

## What this PR does

- New \`packages/schemas/src/trackers.ts\` exports two const maps:
  - \`TRACKERS\` — open, pending-work trackers (intent-named keys: \`m1bImageDecoderUmbrella\`, \`m1bGateCDeterminism\`, \`m1bGateDOnnxCpu\`, \`m1bOpenMagvit2Audit\`, \`decoderDeliveryDecision\`, \`installTierCli\`).
  - \`CLOSED_TRACKERS\` — closed but referenced for receipt provenance (\`adr0020Implementation\`, \`onnxRuntimeOptionalPeer\`, \`puppeteerCoreOptionalPeer\`); comment names the closing PR or successor.

- 13 hardcoded URL literals replaced with constant references:
  - \`packages/cli/src/tiers.ts\` × 1
  - \`packages/codec-image/src/decoders/weights.ts\` × 4
  - \`packages/codec-image/src/decoders/seed.ts\` × 2
  - \`packages/codec-image/src/decoders/llamagen.ts\` × 3
  - \`packages/codec-image/src/decoders/runtime.ts\` × 1
  - \`packages/codec-video/src/mp4-renderer-runtime.ts\` × 1

- 4 new tests in \`packages/schemas/test/trackers.test.ts\` pin:
  - Every URL matches the canonical GitHub-issue shape.
  - Active and closed namespaces don't overlap.
  - 8 specific intent → URL mappings (so a typo in \`trackers.ts\` can't silently change a receipt).

## Verification

\`\`\`
pnpm install --frozen-lockfile     # symlinks unchanged (already-declared deps)
pnpm -r typecheck                  # green
pnpm -r test                       # 270+ tests (schemas 40→44)
pnpm reviewer-bench                # 8/8 pass
pnpm lint:deps                     # codec boundaries clean
pnpm lint:publish-surface          # tarball clean
pnpm format:check                  # clean
\`\`\`

## Naming convention

Constants are named by **intent** (\`m1bGateCDeterminism\`), not by issue number. A future renumber or org move touches one line per tracker. New consumers should import from \`@wittgenstein/schemas\` rather than re-typing the URL.

## Closed-tracker rationale

Some references point to issues that are already closed (\`adr0020Implementation\` is closed, but the constraint it tracks is still enforced at runtime in \`weights.ts\`). Those go in \`CLOSED_TRACKERS\` with a comment naming the closing PR — the link keeps working for archaeology, but the namespace separation lets future readers know the issue isn't actively maintained.

## R/E/H

- **R**: receipts and structured errors now name the *intent* the link represents, not just an opaque issue number. A reader of a stale receipt knows what the link *means* before clicking.
- **E**: −13 hardcoded literals, +1 single source of truth, +4 tests pinning the values. Future renumber touches one line per tracker.
- **H**: the constants are a typed map; any consumer typo (\`TRACKERS.m1bGate\` vs \`TRACKERS.m1bGateC\`) is caught at compile time.

## Refs

Surfaced + filed as item 2 of [#487](https://github.com/p-to-q/wittgenstein/issues/487). Item 3 (\`spawnSync\` timeout policy unification) remains for separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)