### PR TITLE
refactor(process-runner): consolidate spawnVersionCheck helper (closes #487 item 3)

### DIFF
--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,7 +1,6 @@
-import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { loadWittgensteinConfig } from "@wittgenstein/core";
-import { firstOutputLine } from "@wittgenstein/process-runner";
+import { firstOutputLine, spawnVersionCheck } from "@wittgenstein/process-runner";
 import type { Command } from "commander";
 import { resolveExecutionRoot } from "./shared.js";
 import { runtimeTierReadiness } from "../tiers.js";
@@ -14,8 +13,6 @@ interface DoctorCheck {
   path?: string;
   message?: string;
 }
-
-const OPTIONAL_DEPENDENCY_CHECK_TIMEOUT_MS = 1_000;
 
 interface VideoRenderDoctor {
   enabled: boolean;
@@ -83,11 +80,17 @@ function checkVideoRenderDependencies(): VideoRenderDoctor {
     hyperframesNode:
       backend === "npx-cli"
         ? checkNodeForHyperframesCli()
-        : { status: "skipped", message: "Only checked when WITTGENSTEIN_HYPERFRAMES_BACKEND=npx-cli." },
+        : {
+            status: "skipped",
+            message: "Only checked when WITTGENSTEIN_HYPERFRAMES_BACKEND=npx-cli.",
+          },
     hyperframesCli:
       backend === "npx-cli"
         ? checkHyperframesCli()
-        : { status: "skipped", message: "Only checked when WITTGENSTEIN_HYPERFRAMES_BACKEND=npx-cli." },
+        : {
+            status: "skipped",
+            message: "Only checked when WITTGENSTEIN_HYPERFRAMES_BACKEND=npx-cli.",
+          },
     ffmpeg: checkCommandVersion("ffmpeg", ["-version"], "Install FFmpeg for video MP4 rendering."),
     chrome: checkChrome(),
   };
@@ -116,17 +119,14 @@ function readVideoBackend(): "distilled-internal" | "npx-cli" {
 }
 
 function checkHyperframesCli(): DoctorCheck {
-  const result = spawnSync("npx", ["--no-install", "hyperframes", "--version"], {
-    encoding: "utf8",
-    timeout: OPTIONAL_DEPENDENCY_CHECK_TIMEOUT_MS,
+  const result = spawnVersionCheck("npx", ["--no-install", "hyperframes", "--version"], {
     env: {
-      ...process.env,
       HYPERFRAMES_NO_TELEMETRY: process.env.HYPERFRAMES_NO_TELEMETRY ?? "1",
       HYPERFRAMES_NO_UPDATE_CHECK: process.env.HYPERFRAMES_NO_UPDATE_CHECK ?? "1",
     },
   });
 
-  if (result.status === 0) {
+  if (result.ok) {
     return {
       status: "ok",
       version: firstOutputLine(result.stdout, result.stderr),
@@ -141,12 +141,9 @@ function checkHyperframesCli(): DoctorCheck {
 }
 
 function checkCommandVersion(command: string, args: string[], missingMessage: string): DoctorCheck {
-  const result = spawnSync(command, args, {
-    encoding: "utf8",
-    timeout: OPTIONAL_DEPENDENCY_CHECK_TIMEOUT_MS,
-  });
+  const result = spawnVersionCheck(command, args);
 
-  if (result.status === 0) {
+  if (result.ok) {
     return {
       status: "ok",
       version: firstOutputLine(result.stdout, result.stderr),
@@ -191,18 +188,14 @@ function checkChrome(): DoctorCheck {
 
   return {
     status: "missing",
-    message:
-      "Install Chrome/Chromium or set PUPPETEER_EXECUTABLE_PATH for video MP4 rendering.",
+    message: "Install Chrome/Chromium or set PUPPETEER_EXECUTABLE_PATH for video MP4 rendering.",
   };
 }
 
 function checkChromeCandidate(candidate: string): DoctorCheck {
-  const result = spawnSync(candidate, ["--version"], {
-    encoding: "utf8",
-    timeout: OPTIONAL_DEPENDENCY_CHECK_TIMEOUT_MS,
-  });
+  const result = spawnVersionCheck(candidate, ["--version"]);
 
-  if (result.status === 0) {
+  if (result.ok) {
     return {
       status: "ok",
       path: candidate,

--- a/packages/codec-video/src/hyperframes-cli-renderer.ts
+++ b/packages/codec-video/src/hyperframes-cli-renderer.ts
@@ -1,6 +1,5 @@
-import { spawnSync } from "node:child_process";
 import { stat } from "node:fs/promises";
-import { firstOutputLine, runProcess } from "@wittgenstein/process-runner";
+import { firstOutputLine, runProcess, spawnVersionCheck } from "@wittgenstein/process-runner";
 import type { VideoRenderManifest } from "@wittgenstein/schemas";
 import { STAGE_HEIGHT, STAGE_WIDTH } from "./compositions/shared.js";
 import type { InternalMp4RenderParams, InternalMp4RenderResult } from "./mp4-renderer.js";
@@ -60,16 +59,17 @@ export function buildHyperframesCliRenderArgs(params: {
 }
 
 export function readHyperframesCliVersion(): string {
-  const result = spawnSync("npx", ["--no-install", "hyperframes", "--version"], {
-    encoding: "utf8",
-    timeout: 10_000,
+  const result = spawnVersionCheck("npx", ["--no-install", "hyperframes", "--version"], {
+    // npx --no-install on a cold-cache machine can occasionally exceed
+    // the default 1s policy; the receipt path benefits from a longer
+    // ceiling than the doctor probe.
+    timeoutMs: 10_000,
     env: {
-      ...process.env,
       HYPERFRAMES_NO_TELEMETRY: process.env.HYPERFRAMES_NO_TELEMETRY ?? "1",
       HYPERFRAMES_NO_UPDATE_CHECK: process.env.HYPERFRAMES_NO_UPDATE_CHECK ?? "1",
     },
   });
-  if (result.status === 0) {
+  if (result.ok) {
     return firstOutputLine(result.stdout, result.stderr) || "hyperframes";
   }
   return "hyperframes";

--- a/packages/codec-video/src/mp4-renderer.ts
+++ b/packages/codec-video/src/mp4-renderer.ts
@@ -2,7 +2,7 @@ import { statSync } from "node:fs";
 import { mkdir, readdir, stat } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
-import { firstOutputLine, runProcess } from "@wittgenstein/process-runner";
+import { firstOutputLine, runProcess, spawnVersionCheck } from "@wittgenstein/process-runner";
 import type { VideoRenderManifest } from "@wittgenstein/schemas";
 import { STAGE_HEIGHT, STAGE_WIDTH } from "./compositions/shared.js";
 import { ensurePuppeteerCore } from "./mp4-renderer-runtime.js";
@@ -75,10 +75,12 @@ export async function renderHtmlToMp4(
   };
 }
 
-async function captureFrames(params: InternalMp4RenderParams & {
-  frameDir: string;
-  frameCount: number;
-}): Promise<string> {
+async function captureFrames(
+  params: InternalMp4RenderParams & {
+    frameDir: string;
+    frameCount: number;
+  },
+): Promise<string> {
   const puppeteer = await ensurePuppeteerCore();
   const executablePath = resolveChromeExecutable();
   const browser = await puppeteer.launch({
@@ -112,12 +114,14 @@ async function captureFrames(params: InternalMp4RenderParams & {
   }
 }
 
-async function encodeFrames(params: InternalMp4RenderParams & {
-  frameDir: string;
-  frameCount: number;
-}): Promise<string> {
+async function encodeFrames(
+  params: InternalMp4RenderParams & {
+    frameDir: string;
+    frameCount: number;
+  },
+): Promise<string> {
   await mkdir(dirname(params.outputMp4), { recursive: true });
-  const version = await readFfmpegVersion(params.runDir, params.timeoutMs);
+  const version = readFfmpegVersion();
   const args = [
     "-y",
     "-framerate",
@@ -166,20 +170,15 @@ async function encodeFrames(params: InternalMp4RenderParams & {
   return version;
 }
 
-async function readFfmpegVersion(cwd: string, timeoutMs: number): Promise<string> {
-  try {
-    const { spawnSync } = await import("node:child_process");
-    const result = spawnSync("ffmpeg", ["-version"], {
-      cwd,
-      env: process.env,
-      encoding: "utf8",
-      timeout: timeoutMs,
-    });
-    if (result.status === 0) {
-      return firstOutputLine(result.stdout, result.stderr) || "ffmpeg";
-    }
-  } catch {
-    // The encode step below will raise the structured process error.
+function readFfmpegVersion(): string {
+  // `ffmpeg -version` is a synchronous version probe — the encode timeout
+  // (10-minute render budget) is the wrong policy here; use the
+  // process-runner default (1s) which is the right floor for version checks.
+  // On failure, fall back to the literal "ffmpeg" — the encode call below
+  // will surface any real process error via runProcess.
+  const result = spawnVersionCheck("ffmpeg", ["-version"]);
+  if (result.ok) {
+    return firstOutputLine(result.stdout, result.stderr) || "ffmpeg";
   }
   return "ffmpeg";
 }

--- a/packages/process-runner/src/index.ts
+++ b/packages/process-runner/src/index.ts
@@ -3,7 +3,7 @@
 // codec subprocess work can reuse the timeout boundary, bounded output capture,
 // and structured-error extraction without creating codec/core dependency cycles.
 
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 
 export interface ProcessRunnerOptions {
   cwd: string;
@@ -113,5 +113,89 @@ export async function runProcess(
  * When omitted, behaves identically to the older single-arg variant.
  */
 export function firstOutputLine(stdout: string, stderr = ""): string {
-  return (stdout || stderr).split(/\r?\n/).find((line) => line.trim().length > 0)?.trim() ?? "";
+  return (
+    (stdout || stderr)
+      .split(/\r?\n/)
+      .find((line) => line.trim().length > 0)
+      ?.trim() ?? ""
+  );
+}
+
+/**
+ * Standardized timeout policy for `<cmd> --version` probes. Version checks
+ * should be near-instant; anything slower than this is either a misconfigured
+ * tool, a hung subprocess, or the wrong command. The doctor / video-render
+ * call sites previously used 1000ms and 10_000ms inconsistently for the same
+ * probe; this constant pins the policy.
+ *
+ * Source: #487 item 3 (pre-training audit follow-up).
+ */
+export const DEFAULT_VERSION_CHECK_TIMEOUT_MS = 1_000;
+
+export interface SpawnVersionCheckOptions {
+  /**
+   * Override the default 1s timeout. Long-tail tools (`npx --no-install` on
+   * a cold-cache macOS machine) sometimes need more; otherwise leave default.
+   */
+  readonly timeoutMs?: number;
+  /**
+   * Extra env to merge over `process.env`. Pass telemetry-suppression vars
+   * (e.g. `HYPERFRAMES_NO_TELEMETRY: "1"`) without re-typing the whole env
+   * spread at each call site.
+   */
+  readonly env?: NodeJS.ProcessEnv;
+}
+
+export interface SpawnVersionCheckResult {
+  /** True iff the process exited with status 0 within the timeout. */
+  readonly ok: boolean;
+  /** Exit code, or `null` if the process was killed (timeout / signal). */
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+  /** True iff the process was killed by the timeout. */
+  readonly timedOut: boolean;
+}
+
+/**
+ * Synchronous `<cmd> [args...]` probe with a standardized timeout policy.
+ * Designed for the `<binary> --version` shape used by doctor and runtime
+ * peer checks. Behaviour:
+ *
+ *   - Captures stdout + stderr as utf8 strings.
+ *   - Merges `options.env` over `process.env` (so per-call telemetry-off
+ *     toggles compose with the user's env).
+ *   - Times out at `DEFAULT_VERSION_CHECK_TIMEOUT_MS` unless overridden.
+ *   - Returns `{ ok, status, stdout, stderr, timedOut }`. Never throws on
+ *     a missing binary — that's `ok: false` with `status: null`.
+ *
+ * The caller decides what to do with a failure (doctor reports `missing`,
+ * video-render falls back to a default version string). Consolidating the
+ * timeout + result shape here means a future maintainer touching version
+ * probes doesn't have to re-derive "what should I do on timeout?" at each
+ * call site.
+ *
+ * Source: #487 item 3.
+ */
+export function spawnVersionCheck(
+  command: string,
+  args: ReadonlyArray<string>,
+  options: SpawnVersionCheckOptions = {},
+): SpawnVersionCheckResult {
+  const timeout = options.timeoutMs ?? DEFAULT_VERSION_CHECK_TIMEOUT_MS;
+  const env = options.env ? { ...process.env, ...options.env } : process.env;
+  const result = spawnSync(command, [...args], {
+    encoding: "utf8",
+    timeout,
+    env,
+  });
+  // Node sets `signal` when the timeout kills the child.
+  const timedOut = result.signal !== null && result.signal !== undefined;
+  return {
+    ok: result.status === 0,
+    status: result.status,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    timedOut,
+  };
 }

--- a/packages/process-runner/test/process-runner.test.ts
+++ b/packages/process-runner/test/process-runner.test.ts
@@ -5,7 +5,12 @@
  * timeout + bounded-capture + structured-error invariants directly.
  */
 import { describe, expect, it } from "vitest";
-import { firstOutputLine, runProcess } from "../src/index.js";
+import {
+  DEFAULT_VERSION_CHECK_TIMEOUT_MS,
+  firstOutputLine,
+  runProcess,
+  spawnVersionCheck,
+} from "../src/index.js";
 
 const baseOptions = {
   cwd: process.cwd(),
@@ -126,5 +131,51 @@ describe("firstOutputLine (#487 consolidation)", () => {
 
   it("works in single-argument mode (legacy mp4-renderer firstLine call shape)", () => {
     expect(firstOutputLine("ffmpeg version 8.1.1 …\nbuild")).toBe("ffmpeg version 8.1.1 …");
+  });
+});
+
+/**
+ * Coverage for the consolidated `spawnVersionCheck` helper (#487 item 3).
+ * Pins the timeout policy, env merge, missing-binary fallback, and the
+ * `ok` / `status` / `timedOut` triple that callers branch on. Uses `node`
+ * itself as the test command because it's guaranteed to exist wherever
+ * tests run.
+ */
+describe("spawnVersionCheck (#487 item 3)", () => {
+  it("exports the canonical version-check timeout policy", () => {
+    expect(DEFAULT_VERSION_CHECK_TIMEOUT_MS).toBe(1_000);
+  });
+
+  it("returns ok=true with stdout populated for a successful probe", () => {
+    const result = spawnVersionCheck("node", ["--version"]);
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe(0);
+    expect(result.stdout.length).toBeGreaterThan(0);
+    expect(result.timedOut).toBe(false);
+  });
+
+  it("returns ok=false with status=null when the binary is missing", () => {
+    const result = spawnVersionCheck("definitely-not-a-real-binary-xyz", ["--version"]);
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(null);
+    expect(result.timedOut).toBe(false);
+  });
+
+  it("returns ok=false for a non-zero exit", () => {
+    // `node -e "process.exit(7)"` exits 7 without printing version-shaped output.
+    const result = spawnVersionCheck("node", ["-e", "process.exit(7)"]);
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(7);
+    expect(result.timedOut).toBe(false);
+  });
+
+  it("merges options.env over process.env without overwriting unspecified keys", () => {
+    const result = spawnVersionCheck(
+      "node",
+      ["-e", "console.log(process.env.WITTGENSTEIN_TEST_MARKER || 'absent')"],
+      { env: { WITTGENSTEIN_TEST_MARKER: "present" } },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.stdout.trim()).toBe("present");
   });
 });


### PR DESCRIPTION
Closes the third (final) item of [#487](https://github.com/p-to-q/wittgenstein/issues/487).

## Bug found + fixed

Three different files used \`spawnSync(cmd, args, { encoding: \"utf8\", timeout: N })\` for \`--version\`-style probes with three different timeouts:

| Call site | Probe | Timeout |
|---|---|---|
| \`doctor.ts\` × 3 | \`npx hyperframes --version\`, \`ffmpeg -version\`, \`<chrome> --version\` | 1000 ms |
| \`hyperframes-cli-renderer.ts\` | \`npx hyperframes --version\` (same probe as doctor!) | 10_000 ms |
| \`mp4-renderer.ts\` (readFfmpegVersion) | \`ffmpeg -version\` | **\`params.timeoutMs\`** (default \`WITTGENSTEIN_HYPERFRAMES_RENDER_TIMEOUT_MS = 600_000\`) |

That last one is **a real latent bug**: \`readFfmpegVersion\` accepted the *render-budget timeout* (10 minutes by default). If \`ffmpeg -version\` ever hung, the renderer would block for 10 minutes before falling back to the literal string \`\"ffmpeg\"\`. A version probe should be near-instant; the right ceiling is the same 1s policy doctor uses.

## What this PR does

- Exports from \`@wittgenstein/process-runner\`:
  - \`DEFAULT_VERSION_CHECK_TIMEOUT_MS = 1_000\` — pinned policy constant.
  - \`spawnVersionCheck(command, args, opts?)\` — synchronous helper returning \`{ ok, status, stdout, stderr, timedOut }\`. Never throws on missing binary.
  - Types \`SpawnVersionCheckOptions\` + \`SpawnVersionCheckResult\`.
- Refactors all 4 \`spawnSync\` probe call sites:
  - \`doctor.ts\`: \`checkHyperframesCli\`, \`checkCommandVersion\`, \`checkChromeCandidate\` — drops the \`OPTIONAL_DEPENDENCY_CHECK_TIMEOUT_MS\` constant + \`spawnSync\` import.
  - \`hyperframes-cli-renderer.ts\`: \`readHyperframesCliVersion\` — keeps the 10s override via \`opts.timeoutMs\` (npx --no-install can be slow on cold-cache macOS; the receipt path benefits from a longer ceiling).
  - \`mp4-renderer.ts\`: \`readFfmpegVersion\` — uses the default 1s, **fixing the 10-minute hang potential**. Also drops the now-unnecessary \`await import(\"node:child_process\")\` since process-runner imports it once.
- 5 new tests in process-runner pin the helper:
  - Timeout constant value.
  - Successful probe (\`node --version\`).
  - Missing-binary returns \`ok: false, status: null\`.
  - Non-zero exit returns the actual status.
  - \`opts.env\` merges over \`process.env\` correctly.

## Verification

\`\`\`
pnpm -r typecheck                       # green
pnpm --filter process-runner test       # 16/16 pass (was 11)
pnpm --filter codec-video test          # 14/14 pass
pnpm --filter cli test                  # 23/23 pass
pnpm reviewer-bench                     # 8/8 pass
pnpm format:check                       # clean
\`\`\`

## R/E/H

- **R**: a hidden 10-minute-hang ffmpeg version probe gets a tight 1s policy. The probe-vs-render timeout distinction is now in one place; future call sites won't re-derive \"what should I do on timeout?\" wrong.
- **E**: 4 spawnSync call sites → 4 \`spawnVersionCheck\` calls; 1 dynamic import dropped; 1 unused constant dropped. Behaviour at every call site is equivalent except the now-correct ffmpeg-version timeout.
- **H**: tests cover the contract the helper promises — future maintainers can lean on \`{ ok, status, stdout, stderr, timedOut }\` instead of re-reading spawnSync semantics.

## Refs

Closes [#487](https://github.com/p-to-q/wittgenstein/issues/487) (3-of-3 items now landed via [#488](https://github.com/p-to-q/wittgenstein/pull/488), [#489](https://github.com/p-to-q/wittgenstein/pull/489), this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)