### PR TITLE
feat(codec-image): pin LlamaGen decoder bridge manifest + provenance README

### DIFF
--- a/packages/codec-image/src/decoders/llamagen/README.md
+++ b/packages/codec-image/src/decoders/llamagen/README.md
@@ -1,0 +1,85 @@
+# LlamaGen frozen decoder bridge
+
+`packages/codec-image/src/decoders/llamagen/` holds the build-time
+artifacts for the LlamaGen-class image decoder bridge. The bridge code
+lives in [`../llamagen.ts`](../llamagen.ts) (the loader) and reuses the
+shared [`../weights.ts`](../weights.ts) cache + sha256 resolver and the
+[`../runtime.ts`](../runtime.ts) ONNX-runtime probe.
+
+## Files
+
+- [`manifest.json`](./manifest.json) — `DecoderWeightsManifest`-shaped
+  pin record: `family`, `repoId`, `revision`, `weightsFilename`,
+  `weightsSha256`, `license`. Parsed by `DecoderWeightsManifestSchema`
+  in `../weights.ts`.
+
+## Provenance
+
+- **Upstream source repo** — `FoundationVision/LlamaGen` ([github](https://github.com/FoundationVision/LlamaGen),
+  Apache-2.0). The `repoId` + `revision` in the manifest point at the
+  audited snapshot (`81e41139…`) of the VQ tokenizer source code.
+- **Upstream weights** — `vq_ds16_c2i.pt` (~287 MB FP32, ~72M
+  parameters, K=16384, embed dim D=8, downsample factor p=16).
+  Upstream SHA-256: `109aa8afb2cf3761eec23cdc8644154cb498f5ab7eef2a35264d25e5e0499f7d`.
+- **Shipped weights file** — `llamagen_vq_ds16_decoder.onnx` (~163 MB,
+  opset 17). This is the upstream tokenizer's **decoder half** exported
+  via `torch.onnx.export` per the audit script
+  `m1b-work/scripts/gate_d_onnx_export.py`. Encoder is intentionally
+  not in the shipped file — the bridge contract is `decode(codes) →
+  raster`; encoders are offline tooling for adapter training only.
+- **Audit provenance** — Gates A+B in
+  [`docs/research/2026-05-13-audit-vqgan-class.md`](../../../../../docs/research/2026-05-13-audit-vqgan-class.md);
+  Gates C+D in
+  [`docs/research/2026-05-27-audit-vqgan-class-gates-cd.md`](../../../../../docs/research/2026-05-27-audit-vqgan-class-gates-cd.md).
+
+## Capabilities the bridge advertises
+
+| Field | Value | Source |
+|---|---|---|
+| `family` | `"llamagen"` | manifest |
+| `decoderId` | `"llamagen-frozen-vq-v0"` | locked constant in `../llamagen.ts` |
+| `supportedShapes` | `[{ shape: "2D", tokenGrid: [16, 16], outputPixels: [256, 256] }]` | Gate D `latent_grid` + `image_size` |
+| `codebook` | `"vq_ds16_c2i"` | upstream tokenizer artifact name |
+| `codebookVersion` | `"FoundationVision/LlamaGen@81e41139"` | manifest `repoId@revision` shortening |
+| `determinismClass` | `"structural-parity"` | Gate C verdict (ADR-0015 cross-platform precedent) |
+| `runtimeTier` | `"node-onnx-cpu"` | canonical M-phase tier per `docs/hard-constraints.md` |
+| `codeLicense` | `"MIT"` | manifest |
+| `weightsLicense` | `"permissive"` | manifest |
+
+## ONNX hosting — pending
+
+The shipped `.onnx` is a derivative artifact (we exported it from the
+upstream `.pt`; the upstream repo does not publish ONNX). For the
+bridge to fetch on cache-miss, the ONNX needs a stable, SHA-pinnable
+URL.
+
+Until that URL is decided (tracked by [#402](https://github.com/p-to-q/wittgenstein/issues/402) —
+decoder-delivery; [#435](https://github.com/p-to-q/wittgenstein/issues/435) —
+model-owner review hub), the bridge runs in **cache-only mode**:
+`loadLlamagenDecoderBridge()` does NOT supply a fetcher to
+`resolveDecoderWeights()`. A cache miss surfaces as
+`WEIGHTS_NOT_INSTALLED` with `installHint: "wittgenstein install image"`
+(the install CLI itself is tracked by [#403](https://github.com/p-to-q/wittgenstein/issues/403)).
+
+Once the URL lands, wiring a fetcher is a small follow-up: pass a
+`fetcher: async (asset, manifest) => fetch(url).then(r =>
+new Uint8Array(await r.arrayBuffer()))` into the resolver — the
+SHA-pinning + atomic-write logic already in `weights.ts` does the rest.
+
+## Phase relationship
+
+Per [`2026-05-13-wittgenstein-research-program.md`](../../../../../docs/research/2026-05-13-wittgenstein-research-program.md):
+
+- **LlamaGen is the M1B Phase 0 floor** — ships first, validates the
+  full bridge → adapter → decoder → PNG pipeline end-to-end with a
+  permissive baseline.
+- **`wittgenstein-native` is Phase 1 canonical** — our own-trained
+  VQGAN-class tokenizer on ImageNet+CC12M, K=16384, embed dim D=32,
+  rFID target ≤ 2.0 on ImageNet val. Training tracked at
+  [#396](https://github.com/p-to-q/wittgenstein/issues/396);
+  scaffold at `research/training/tokenizer/`.
+
+The LlamaGen bridge advertises its own `decoderId` so manifest
+receipts can be filtered per family. Replacing the canonical lane with
+`wittgenstein-native` later is a separate bridge package; this one
+stays as the audited floor.

--- a/packages/codec-image/src/decoders/llamagen/manifest.json
+++ b/packages/codec-image/src/decoders/llamagen/manifest.json
@@ -1,0 +1,11 @@
+{
+  "family": "llamagen",
+  "repoId": "FoundationVision/LlamaGen",
+  "revision": "81e41139272c038412e4fe8f1c52a51ebbf95b8b",
+  "weightsFilename": "llamagen_vq_ds16_decoder.onnx",
+  "weightsSha256": "fd6800b3df8193968656e3e6b01ab48bd8899ebede829dfd1166da5f5b9f9389",
+  "license": {
+    "code": "MIT",
+    "weights": "permissive"
+  }
+}

--- a/packages/codec-image/test/llamagen-manifest.test.ts
+++ b/packages/codec-image/test/llamagen-manifest.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Guardrail for the checked-in LlamaGen decoder bridge manifest
+ * (`src/decoders/llamagen/manifest.json`, added in PR #492).
+ *
+ * The manifest is a `DecoderWeightsManifest`-shaped pin record consumed at
+ * runtime by `resolveDecoderWeights()` in `../weights.ts`. It is plain JSON
+ * with no compile-time check, so without this test a silent edit — a
+ * malformed SHA, a dropped field, a license downgrade — would only surface
+ * when a user actually tried to load the bridge.
+ *
+ * This pins three things:
+ *   1. The committed JSON parses against `DecoderWeightsManifestSchema`.
+ *   2. The SHA-256 + license fields match the values the audit receipt
+ *      (`docs/research/2026-05-27-audit-vqgan-class-gates-cd.md`) and the
+ *      sibling README declare, so the manifest cannot drift away from its
+ *      provenance unnoticed.
+ *   3. The shape stays in lockstep with the schema (e.g. a future required
+ *      field forces a manifest update, not a silent skip).
+ *
+ * Source: #507 open decision — "Should #492 receive the local guardrail
+ * test patch before merge?" → yes.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { DecoderWeightsManifestSchema } from "../src/decoders/weights.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const manifestPath = resolve(here, "../src/decoders/llamagen/manifest.json");
+
+describe("llamagen decoder bridge manifest (#492 guardrail)", () => {
+  const raw = readFileSync(manifestPath, "utf8");
+
+  it("is valid JSON", () => {
+    expect(() => JSON.parse(raw)).not.toThrow();
+  });
+
+  it("conforms to DecoderWeightsManifestSchema", () => {
+    const parsed = DecoderWeightsManifestSchema.safeParse(JSON.parse(raw));
+    if (!parsed.success) {
+      throw new Error(
+        `llamagen/manifest.json failed schema validation:\n${parsed.error.issues
+          .map((issue) => `  ${issue.path.join(".")}: ${issue.message}`)
+          .join("\n")}`,
+      );
+    }
+    expect(parsed.success).toBe(true);
+  });
+
+  it("pins the audited provenance values (SHA / license / revision)", () => {
+    const manifest = DecoderWeightsManifestSchema.parse(JSON.parse(raw));
+    // These exact values come from the Gate D ONNX export receipt
+    // (docs/research/2026-05-27-audit-vqgan-class-gates-cd.md). Changing
+    // the shipped artifact requires updating both the audit doc and this
+    // pin in the same PR — a silent SHA swap fails here.
+    expect(manifest.family).toBe("llamagen");
+    expect(manifest.repoId).toBe("FoundationVision/LlamaGen");
+    expect(manifest.revision).toBe("81e41139272c038412e4fe8f1c52a51ebbf95b8b");
+    expect(manifest.weightsFilename).toBe("llamagen_vq_ds16_decoder.onnx");
+    expect(manifest.weightsSha256).toBe(
+      "fd6800b3df8193968656e3e6b01ab48bd8899ebede829dfd1166da5f5b9f9389",
+    );
+    expect(manifest.license.code).toBe("MIT");
+    expect(manifest.license.weights).toBe("permissive");
+  });
+
+  it("declares a sha256 in the canonical 64-hex-char form", () => {
+    const manifest = DecoderWeightsManifestSchema.parse(JSON.parse(raw));
+    expect(manifest.weightsSha256).toMatch(/^[a-f0-9]{64}$/);
+  });
+});


### PR DESCRIPTION
## Summary

First half of the M1B canonical-path wiring for the LlamaGen frozen-VQ decoder bridge. Lands the build-time artifacts the loader needs:

- **`packages/codec-image/src/decoders/llamagen/manifest.json`** — pinned ONNX SHA-256 `fd6800b3...` + MIT-permissive license tier. Conforms to `DecoderWeightsManifestSchema` in `weights.ts`.
- **`packages/codec-image/src/decoders/llamagen/README.md`** — provenance (upstream `ce98ec41`, weights revision `81e41139`), advertised capabilities, and the open ONNX-hosting decision tracked at #402 / #435.

Pairs with the empirical Gates C+D audit landing in #491 (the manifest's `weightsSha256` references the ONNX export receipt in that audit).

## What this advertises

| Capability field | Value | Source |
|---|---|---|
| `family` | `\"llamagen\"` | manifest |
| `decoderId` | `\"llamagen-frozen-vq-v0\"` | locked constant in `decoders/llamagen.ts` |
| `supportedShapes` | `[{ shape: \"2D\", tokenGrid: [16, 16], outputPixels: [256, 256] }]` | Gate D pinned |
| `codebook` | `\"vq_ds16_c2i\"` | upstream artifact name |
| `codebookVersion` | `\"FoundationVision/LlamaGen@81e41139\"` | manifest `repoId@revision` |
| `determinismClass` | `\"structural-parity\"` | Gate C verdict (ADR-0015 precedent) |
| `runtimeTier` | `\"node-onnx-cpu\"` | canonical M-phase tier per `docs/hard-constraints.md` |
| `codeLicense` | `\"MIT\"` | manifest |
| `weightsLicense` | `\"permissive\"` | manifest |

## What this PR does NOT do (intentionally deferred)

- **Does NOT implement `loadLlamagenDecoderBridge`** in `packages/codec-image/src/decoders/llamagen.ts` — that becomes a contract-fill once the ONNX hosting URL is decided (#402 / #435). The stub continues to throw `LLAMAGEN_BRIDGE_NOT_IMPLEMENTED` with structured details until then. Rationale: code-fill needs (a) a stable fetchable URL for the ONNX, and (b) extracting `encodeRgbaAsPng` from `pipeline/decoder.ts` into a shared module — both better in their own PRs.
- **Does NOT add a fetcher to `weights.ts`** — the existing `resolveDecoderWeights()` cache-or-fetch path already supports injectable fetchers (line 39-45); wiring one in needs the hosting URL first.

## Test plan

- [ ] `pnpm typecheck` green (additive only — no TypeScript imports affected)
- [ ] `pnpm test` green (no test depends on the manifest at import time)
- [ ] CodeRabbit / reviewdog clean
- [ ] (manual) manifest parses cleanly against `DecoderWeightsManifestSchema` — verified mentally; SHA regex `^[a-f0-9]{64}$` ✅, all required fields present, license enum value `\"permissive\"` valid
- [ ] Confirms 1 of 3 PR series for the Gates C+D audit landing:
  1. #491 (audit doc, doc-only)
  2. **this PR** (bridge manifest, additive)
  3. (next) training scaffold for Phase 1 own-trained tokenizer

Refs #283, #329, #334, #335