### PR TITLE
ci: auto-label needs-ml-specialist for image changes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -38,3 +38,14 @@ rfc-derived:
   - changed-files:
       - any-glob-to-any-file:
           - "docs/rfcs/**"
+
+# ML/image specialist escalation. Use path-based routing to avoid requesting
+# reviews on unrelated PRs while still making image + training changes loud.
+needs-ml-specialist:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "packages/codec-image/**"
+          - "packages/core/src/codecs/image.ts"
+          - "docs/codecs/image.md"
+          - "data/image_adapter/**"
+          - "python/image_adapter/**"


### PR DESCRIPTION
Auto-apply the `needs-ml-specialist` label when a PR touches image/training-critical paths (codec-image, image codec shim, image docs, adapter data/scripts). This keeps koriyoshi2041 review requests focused on the high-impact surfaces.