### PR TITLE
governance: needs-ml-specialist review loop

### DIFF
--- a/.github/workflows/review-request-ml-expert.yml
+++ b/.github/workflows/review-request-ml-expert.yml
@@ -2,7 +2,7 @@ name: Request ML specialist review
 
 on:
   pull_request_target:
-    types: [labeled]
+    types: [opened, reopened, ready_for_review, synchronize, labeled]
 
 permissions:
   contents: read
@@ -16,16 +16,34 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            const label = context.payload.label?.name ?? "";
-            if (label !== "needs-ml-specialist") {
-              core.info(`Label "${label}" does not match trigger; skipping.`);
-              return;
-            }
-
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const pull_number = context.payload.pull_request.number;
             const reviewer = "koriyoshi2041";
+
+            const requiredLabel = "needs-ml-specialist";
+            const labelFromEvent = context.payload.label?.name;
+
+            // Fast path: if we're here due to a label event and it isn't our label, skip.
+            if (labelFromEvent && labelFromEvent !== requiredLabel) {
+              core.info(`Label "${labelFromEvent}" does not match trigger; skipping.`);
+              return;
+            }
+
+            // Robust path: actions that apply labels may not always trigger downstream labeled workflows
+            // (depending on token / event restrictions). Re-check current labels on the PR.
+            const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
+              owner,
+              repo,
+              issue_number: pull_number,
+              per_page: 100,
+            });
+
+            const hasRequiredLabel = (currentLabels ?? []).some((l) => l.name === requiredLabel);
+            if (!hasRequiredLabel) {
+              core.info(`PR #${pull_number} does not have "${requiredLabel}" label; skipping.`);
+              return;
+            }
 
             const { data: requested } = await github.rest.pulls.listRequestedReviewers({
               owner,

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -114,6 +114,24 @@ Code restructure with no behaviour change — same inputs produce the same outpu
 
 `refactor` PRs should be reviewable as "is this a true no-op for behaviour?" — if a reviewer cannot answer that question from the diff, the PR is too big.
 
+#### `needs-ml-specialist`
+
+Color: `#0e8a16` (green).
+
+Escalation label for **image + training + ML-sensitive** changes. When present on a PR, the repo will automatically request review from the ML specialist reviewer (`koriyoshi2041`).
+
+**Intended scope (high-signal only):**
+
+- `packages/codec-image/**` (image codec + adapter/decoder seams)
+- `packages/core/src/codecs/image.ts` (image routing shim)
+- `docs/codecs/image.md` (image contract/doctrine surface)
+- `data/image_adapter/**` and `python/image_adapter/**` (adapter training data/scripts)
+
+**Engineering-only (do not use this label):**
+
+- generic infra/CI changes not specific to image or training
+- purely doc/typo changes outside the image codec surface
+
 ### Audience
 
 #### `good first issue`


### PR DESCRIPTION
Small closed loop:

- `.github/CODEOWNERS` stays path-level static routing.
- `.github/labeler.yml` auto-applies `needs-ml-specialist` for image/training-critical paths.
- `.github/workflows/review-request-ml-expert.yml` now re-checks labels on PR events so the review request is robust.
- `docs/labels.md` documents what requires ML-specialist vs engineering-only.

This keeps koriyoshi2041 review load high-signal while ensuring image/training changes never miss specialist review.