### PR TITLE
governance: clarify ML specialist routing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,9 @@
 #
 # Maintainer pair (per ADR-0013): @Jah-yee + @Moapacha.
 # ML specialist reviewer: @koriyoshi2041 (a.k.a. Parafee).
+# Intentionally NOT in the global fallback (`*`) to keep review requests high-signal:
+# the maintainer pair still sees every PR; the specialist is routed only for image /
+# training critical surfaces (and via `needs-ml-specialist` escalation).
 #
 # Per-modality team handles (@wittgenstein-image / -audio / -video / -sensor /
 # -core) were previously listed alongside the maintainer pair as aspirational

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -120,6 +120,11 @@ Color: `#d93f0b` (red-orange).
 
 Escalation label for **image + training + ML-sensitive** changes. When present on a PR, the repo will automatically request review from the ML specialist reviewer (`koriyoshi2041`).
 
+**Relationship to queue labels:**
+
+- `stage/m1-image` and `milestone/m1b-image-depth` are roadmap/queue metadata; they do **not** automatically request review.
+- `needs-ml-specialist` is the explicit escalation switch: apply it when you want specialist review (or let the path labeler apply it for image/training critical files).
+
 **Intended scope (high-signal only):**
 
 - `packages/codec-image/**` (image codec + adapter/decoder seams)


### PR DESCRIPTION
Clarify two small governance points:

- `.github/CODEOWNERS` explains why the ML specialist is not in the global fallback (`*`).
- `docs/labels.md` explains that `needs-ml-specialist` is the escalation switch, while `stage/m1-image` / `milestone/m1b-image-depth` are queue metadata.

No routing behavior changes; just makes the loop easier to reason about.