### PR TITLE
docs: fix issue contact links and CODEOWNERS note

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: false
 contact_links:
   - name: Security vulnerability
-    url: https://github.com/Moapacha/wittgenstein/security/advisories/new
+    url: https://github.com/p-to-q/wittgenstein/security/advisories/new
     about: Report a security issue privately (do not open a public issue)
   - name: Support & FAQ
-    url: https://github.com/Moapacha/wittgenstein/blob/main/SUPPORT.md
+    url: https://github.com/p-to-q/wittgenstein/blob/main/SUPPORT.md
     about: Where to ask what, what to expect, and how to file an effective issue
   - name: Implementation status (what ships vs stub)
-    url: https://github.com/Moapacha/wittgenstein/blob/main/docs/implementation-status.md
+    url: https://github.com/p-to-q/wittgenstein/blob/main/docs/implementation-status.md
     about: Before filing a bug, confirm the component isn't a known stub

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -104,7 +104,12 @@ and failure modes.
 
 ### Step 8. Register in CODEOWNERS
 
-Add the codec path to `.github/CODEOWNERS` with the owning team.
+Add the codec path to `.github/CODEOWNERS` with its owning reviewer(s).
+
+Notes:
+
+- The repo currently routes by GitHub usernames (and a small maintainer roster), not org teams.
+- If you want team-based routing, provision the team in the GitHub org first, then add it to CODEOWNERS in a dedicated commit.
 
 ---
 


### PR DESCRIPTION
Small repo polish:

- Fix `.github/ISSUE_TEMPLATE/config.yml` contact links to point at the canonical repo (p-to-q/wittgenstein) instead of a fork.
- Clarify `docs/extending.md` Step 8 wording: CODEOWNERS uses reviewers/users (teams only if provisioned).