### PR TITLE
docs: point contributor links at canonical repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ valid as wiring a new codec. This page tells you where to start and what we look
 # clone your fork (see branch workflow below)
 git clone git@github.com:<you>/wittgenstein.git
 cd wittgenstein
-git remote add upstream https://github.com/Moapacha/wittgenstein.git
+git remote add upstream https://github.com/p-to-q/wittgenstein.git
 
 # TypeScript side
 nvm use            # installs Node 20.19 if you use nvm

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -8,11 +8,11 @@ get answered.
 
 | You want to... | Go here |
 |---|---|
-| Report a bug (crash, wrong output, broken command) | [Open an issue → Bug report](https://github.com/Moapacha/wittgenstein/issues/new?template=bug.md) |
-| Suggest a feature or new modality | [Open an issue → Feature request](https://github.com/Moapacha/wittgenstein/issues/new?template=feature.md) |
-| Ask "how do I...", "why does X..." | [Open an issue → Question](https://github.com/Moapacha/wittgenstein/issues/new?template=question.md) |
-| Give feedback on an experimental part (⚠️) | [Open an issue → Experimental feedback](https://github.com/Moapacha/wittgenstein/issues/new?template=experimental-feedback.md) |
-| Report a security vulnerability | Private advisory via [the "Report a vulnerability" button](https://github.com/Moapacha/wittgenstein/security/advisories/new) — **do not open a public issue** |
+| Report a bug (crash, wrong output, broken command) | [Open an issue → Bug report](https://github.com/p-to-q/wittgenstein/issues/new?template=bug.md) |
+| Suggest a feature or new modality | [Open an issue → Feature request](https://github.com/p-to-q/wittgenstein/issues/new?template=feature.md) |
+| Ask "how do I...", "why does X..." | [Open an issue → Question](https://github.com/p-to-q/wittgenstein/issues/new?template=question.md) |
+| Give feedback on an experimental part (⚠️) | [Open an issue → Experimental feedback](https://github.com/p-to-q/wittgenstein/issues/new?template=experimental-feedback.md) |
+| Report a security vulnerability | Private advisory via [the "Report a vulnerability" button](https://github.com/p-to-q/wittgenstein/security/advisories/new) — **do not open a public issue** |
 | Propose an architectural change | Draft a PR that updates both the code and an ADR under `docs/adrs/` |
 
 ## Before you open an issue
@@ -48,6 +48,6 @@ If you want the fastest path to a resolved issue:
 
 ## Community
 
-- Project repo: <https://github.com/Moapacha/wittgenstein>
+- Project repo: <https://github.com/p-to-q/wittgenstein>
 - Discussions: we haven't enabled GitHub Discussions yet; issues are the primary channel
   until volume warrants a separate space.


### PR DESCRIPTION
Governance/doc hygiene: update contributor-facing links that still pointed to a fork.

- CONTRIBUTING.md: upstream remote now uses https://github.com/p-to-q/wittgenstein.git
- SUPPORT.md: issue/security links + repo link now use https://github.com/p-to-q/wittgenstein