### PR TITLE
docs: refresh governance pointers

### DIFF
--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -11,6 +11,9 @@ Wittgenstein is designed to be installable and skill-friendly, not just a local 
 
 Maintainers:
 
+- Publish owner(s): `@Jah-yee`, `@Moapacha` (CODEOWNERS maintainer pair)
+- Image/training specialist reviewer: `@koriyoshi2041` (for `needs-ml-specialist` escalations; see `docs/labels.md`)
+
 **Do not run `npm publish` from the repo root** — the root package is `private` and you will get `EPRIVATE`, and npm may try to pack the whole tree.
 
 From the **monorepo root**:

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ Current maintainer pointers:
 - Engineering source of truth: [`exec-plans/active/codec-v2-port.md`](exec-plans/active/codec-v2-port.md)
 - Current M1B owner-review hub: [Issue #435](https://github.com/p-to-q/wittgenstein/issues/435)
 - Current decoder-delivery decision: [Issue #402](https://github.com/p-to-q/wittgenstein/issues/402)
-- Current truth-surface cleanup tracker: [Issue #436](https://github.com/p-to-q/wittgenstein/issues/436)
+- Current governance / re-audit tracker: [Issue #439](https://github.com/p-to-q/wittgenstein/issues/439)
 
 ## Then understand the thesis and governance
 


### PR DESCRIPTION
Small repo hygiene:

- docs/index.md: update truth-surface tracker pointer from closed #436 to active #439.
- docs/distribution.md: replace empty "Maintainers:" stub with a minimal, accurate maintainer pointer list.