### PR TITLE
docs(site): point Vercel check failures to issue 460

### DIFF
--- a/apps/site/README.md
+++ b/apps/site/README.md
@@ -47,6 +47,8 @@ The monorepo root [`vercel.json`](../../vercel.json) now builds `@wittgenstein/s
 
 This app also includes [`vercel.json`](./vercel.json) for a Vercel project whose root directory is set to `apps/site`. Vercel Git Source is still a manual follow-up step: the production project may still point at the old external repository ([`Jah-yee/wittgenstein-www`](https://github.com/Jah-yee/wittgenstein-www)) until a maintainer switches it.
 
+If PR checks show a failing `Vercel` status context with an authorization URL, track it under Issue #460 (repo ↔ Vercel integration), not as a regression in the PR.
+
 Supported Vercel configurations:
 
 - Root directory: repository root


### PR DESCRIPTION
Small governance tweak: document where to triage failing Vercel status contexts.

- Adds a short pointer in apps/site/README.md to Issue #460 so PR authors don’t treat the check as a code regression.
- Issue #460 itself was also expanded into a concrete checklist (edited in-place).