### PR TITLE
hygiene: fix pnpm workspace drift and doctor command

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -19,8 +19,8 @@ get answered.
 
 Two minutes here save us both an hour later:
 
-1. **Run `pnpm doctor`** (TypeScript surface) or `python3 -m polyglot.cli --help`
-   (Python surface) — confirms the toolchain loads at all.
+1. **Run `pnpm --filter @wittgenstein/cli exec wittgenstein doctor`** (TypeScript surface) or
+   `python3 -m polyglot.cli --help` (Python surface) — confirms the toolchain loads at all.
 2. **Search existing issues**, including closed ones. Early-stage projects repeat their own
    mistakes fast.
 3. **If a command failed**, attach the manifest from `artifacts/runs/<id>/manifest.json` —

--- a/docs/technical-details-script.md
+++ b/docs/technical-details-script.md
@@ -14,7 +14,7 @@ Reference: `README.md`
 
 ### 1.1 Monorepo and toolchain
 
-- Package manager: `pnpm` workspace (`workspaces: ["packages/*", "apps/*"]`)
+- Package manager: `pnpm` workspace (`pnpm-workspace.yaml`)
 - Runtime baseline: Node `>=20.19.0`
 - Language: TypeScript + zod contracts
 - Root scripts:

--- a/package.json
+++ b/package.json
@@ -9,11 +9,6 @@
     "pnpm": ">=9.0.0"
   },
   "packageManager": "pnpm@9.12.0",
-  "workspaces": [
-    "packages/*",
-    "apps/*",
-    "!apps/wittgenstein-kimi"
-  ],
   "scripts": {
     "build": "pnpm -r build",
     "typecheck": "pnpm -r typecheck",


### PR DESCRIPTION
Repo-wide small footgun cleanup:

- Remove unsupported `workspaces` field from `package.json` (pnpm uses `pnpm-workspace.yaml`), eliminating a persistent pnpm warning.
- Update `docs/technical-details-script.md` to reference `pnpm-workspace.yaml`.
- Fix `SUPPORT.md` instruction from `pnpm doctor` to `pnpm --filter @wittgenstein/cli exec wittgenstein doctor`.