### PR TITLE
chore: add .rgignore for huge local datasets

### DIFF
--- a/.rgignore
+++ b/.rgignore
@@ -1,0 +1,7 @@
+# ripgrep ignore file.
+#
+# Purpose: keep repo-wide scans usable by default. The paths below contain large
+# downloaded training datasets that are intentionally gitignored but may still
+# exist in local checkouts.
+
+polyglot-mini/train/coco/*.json


### PR DESCRIPTION
Repo hygiene: add a root `.rgignore` so ripgrep scans don’t get swamped by large, gitignored local training datasets (e.g. polyglot-mini/train/coco/*.json).