### PR TITLE
docs: truth-surface capability matrix + security sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,20 @@ See [`docs/implementation-status.md`](docs/implementation-status.md) for compone
 Summary: sensor, audio, polyglot-mini image fallback, and the Python image code-as-painter
 path all ship today; the TS neural image codec has real scene + adapter + placeholder
 latents and is waiting on a frozen VQ decoder bridge; video ships HTML composition output
-by default with an opt-in local MP4 renderer.
+by default with an opt-in local MP4 renderer. This is **composition-first rendering**,
+not neural text-to-video generation.
+
+### Current capability matrix
+
+This is the shortest “what can I actually get out today?” view. For deeper component-by-component detail, keep using `docs/implementation-status.md`.
+
+| Modality | Default artifact | Opt-in artifact | Notes |
+| --- | --- | --- | --- |
+| Image (TS) | PNG (placeholder-class) | PNG (reference decode when weights present) | Scene + seed/semantic receipts ship; frozen decoder bridge not yet wired for LlamaGen/SEED |
+| Image (polyglot-mini) | PNG | — | Research-grade code-as-painter and MLP fallback painter ship |
+| Audio (TS) | WAV | — | Speech + soundscape + music ship |
+| Sensor (TS) | JSON / HTML / PNG | — | Loupe dashboard ships |
+| Video (TS) | HyperFrames-shaped HTML | MP4 (local) | MP4 requires local Chrome/Chromium + FFmpeg and enabling `WITTGENSTEIN_HYPERFRAMES_RENDER=1` |
 
 **What's next.** Doctrine is locked; the active workstream is the Codec Protocol v2 port
 across all modalities, sequenced in [`docs/exec-plans/active/codec-v2-port.md`](docs/exec-plans/active/codec-v2-port.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -87,5 +87,11 @@ Older tags are not patched; upgrade to `main` or the latest release for fixes.
 ## Dependencies
 
 The repo ships with a pinned `pnpm-lock.yaml`. CI installs with `--frozen-lockfile` to
-prevent silent upgrades. Dependency audits are advisory today; a CI step will land in a
-future phase (see `docs/roadmap.md`).
+prevent silent upgrades.
+
+Dependency review is enforced on pull requests via GitHub's Dependency Review Action:
+
+- blocks new **HIGH / CRITICAL** advisories introduced by the PR
+- blocks new **GPL-3.0 / AGPL-3.0** dependencies (Apache-2.0 incompatible)
+
+See `.github/workflows/ci.yml` (`Dependency review (PR)`).


### PR DESCRIPTION
Truth-surface cleanup (high leverage / low risk):

- README: clarify video is composition-first (HTML default, MP4 opt-in), not neural text-to-video.
- README: add a concise "Current capability matrix" to reduce claim drift.
- SECURITY.md: update dependency-audit section to match CI reality (dependency review gate is enforced on PRs).

No runtime behavior changes.