### PR TITLE
chore(typos): allowlist `nin` (nin_shortcut VQGAN identifier) — unblocks #493

### DIFF
--- a/typos.toml
+++ b/typos.toml
@@ -43,3 +43,9 @@ PN = "PN"
 FSQ = "FSQ"
 LoRA = "LoRA"
 SafeTensors = "SafeTensors"
+# `nin_shortcut` is the canonical VQGAN / taming-transformers ResnetBlock
+# identifier (network-in-network shortcut conv). typos extracts the `nin`
+# sub-token and suggests inn/min/bin/nine; allowlist it so vendored
+# VQGAN-class tokenizer code (research/training/tokenizer/, M1B Phase 1)
+# passes the spelling gate. See PR #493.
+nin = "nin"


### PR DESCRIPTION
## Summary

The \`Static checks (spelling + workflow + deps)\` job fails on [#493](https://github.com/p-to-q/wittgenstein/pull/493) (tokenizer scaffold) because typos extracts the \`nin\` sub-token from \`nin_shortcut\` and flags it:

\`\`\`
error: `nin` should be `inn`, `min`, `bin`, `nine`
297 │ self.nin_shortcut = nn.Conv2d(in_channels, out_channels, ...)
\`\`\`

\`nin_shortcut\` is the canonical **network-in-network shortcut** conv in the VQGAN / taming-transformers \`ResnetBlock\` — a real identifier in the vendored VQGAN-class tokenizer code, not a typo.

## Why this is on main, not #493's branch

The typos allowlist is **repo-wide tooling config**, not ML content. Putting it on main rather than in the ML PR branch means:

- The fix benefits any future PR touching VQGAN-class vendored code.
- The ML PR ([#493](https://github.com/p-to-q/wittgenstein/pull/493)) doesn't carry a tooling-config change mixed in with its training scaffold.
- \`nin\` does not appear anywhere on main today, so this allowlist is purely forward-looking — once #493 rebases, its static check passes.

Mirrors the existing \`PN = "PN"\` sub-token allowlist precedent already in \`typos.toml\` (extracted from \`PNGs\`).

## Per #507

This resolves one of the umbrella's open decisions:

> Should #493's vendored typo allowlist be pushed into the PR branch by the owner, or proposed as a small follow-up PR?

→ Answer: small follow-up PR to main (this one). Keeps the ML PR clean; the fix is shared config.

Refs [#493](https://github.com/p-to-q/wittgenstein/pull/493), [#507](https://github.com/p-to-q/wittgenstein/issues/507).

🤖 Generated with [Claude Code](https://claude.com/claude-code)