### PR TITLE
m1b: add eval_all runner for adapter metrics

### DIFF
--- a/python/image_adapter/README.md
+++ b/python/image_adapter/README.md
@@ -18,6 +18,7 @@ Apple Silicon: PyTorch uses MPS when available.
 | `train.py` | trains MLP (PyTorch), writes `adapter_mlp.json` |
 | `train_numpy.py` | same JSON contract, **pure NumPy + Adam** (no torch) — good for CI / parity with polyglot-style loops |
 | `eval_metrics.py` | token MAE / exact-match rate on a held-out file |
+| `eval_all.py` | one-shot runner: token metrics + spectrum health checks |
 | `spectrum_check.py` | singular-value spectrum + effective-rank health checks for adapter weights (detect rank-collapse) |
 | `build_natural_dataset.py` | optional: generate or download a larger, category-bounded dataset |
 
@@ -49,4 +50,10 @@ Run:
 
 ```bash
 python3 spectrum_check.py --weights /absolute/path/to/adapter_mlp.json
+```
+
+Or run the bundle (token metrics + spectrum) in one command:
+
+```bash
+python3 eval_all.py --weights /absolute/path/to/adapter_mlp.json --data /absolute/path/to/encoded.jsonl
 ```

--- a/python/image_adapter/eval_all.py
+++ b/python/image_adapter/eval_all.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Run a compact eval bundle for the image adapter.
+
+This is meant to be a single command that prints:
+- token metrics (MAE / exact-match) on encoded JSONL
+- spectrum health checks (singular values + effective rank) on weights
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--weights", type=Path, required=True, help="Path to adapter_mlp.json")
+    parser.add_argument("--data", type=Path, required=True, help="Path to encoded.jsonl (train/encoded.jsonl format)")
+    parser.add_argument("--top-k", type=int, default=8, help="How many top singular values/eigs to print")
+    parser.add_argument("--latent-dump", type=Path, default=None, help="Optional .npy file with (N,D) latent/features")
+    args = parser.parse_args()
+
+    try:
+        from eval_metrics import evaluate_token_metrics
+    except ModuleNotFoundError as e:
+        raise SystemExit(
+            "Missing Python dependencies for token-metric evaluation. "
+            "Run `pip install -r requirements.txt` under python/image_adapter/."
+        ) from e
+
+    metrics = evaluate_token_metrics(args.weights, args.data)
+    print(
+        f"token_metrics: samples={metrics['samples']} "
+        f"token_mae={metrics['token_mae']:.4f} "
+        f"token_exact_rate={metrics['token_exact_rate']:.4f}"
+    )
+    print("spectrum_metrics:")
+
+    # Reuse the spectrum_check CLI implementation for consistent formatting.
+    from spectrum_check import main as spectrum_main
+    import sys
+
+    argv = ["spectrum_check.py", "--weights", str(args.weights), "--top-k", str(args.top_k)]
+    if args.latent_dump is not None:
+        argv += ["--latent-dump", str(args.latent_dump)]
+    old_argv = sys.argv
+    try:
+        sys.argv = argv
+        spectrum_main()
+    finally:
+        sys.argv = old_argv
+
+
+if __name__ == "__main__":
+    main()

--- a/python/image_adapter/eval_metrics.py
+++ b/python/image_adapter/eval_metrics.py
@@ -44,18 +44,13 @@ def load_weights(path: Path) -> tuple[MlpAdapter, dict]:
     return m, raw
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--weights", type=Path, required=True)
-    parser.add_argument("--data", type=Path, required=True)
-    args = parser.parse_args()
-
-    model, meta = load_weights(args.weights)
+def evaluate_token_metrics(weights: Path, data: Path) -> dict:
+    model, meta = load_weights(weights)
     codebook_size = int(meta["codebookSize"])
     max_idx = max(0, codebook_size - 1)
 
     rows = []
-    with args.data.open(encoding="utf-8") as f:
+    with data.open(encoding="utf-8") as f:
         for line in f:
             line = line.strip()
             if line:
@@ -81,7 +76,25 @@ def main() -> None:
 
     mae = total_abs / max(1, count)
     acc = total_exact / max(1, count)
-    print(f"samples={len(rows)} token_mae={mae:.4f} token_exact_rate={acc:.4f}")
+    return {
+        "samples": len(rows),
+        "token_mae": float(mae),
+        "token_exact_rate": float(acc),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--weights", type=Path, required=True)
+    parser.add_argument("--data", type=Path, required=True)
+    args = parser.parse_args()
+
+    metrics = evaluate_token_metrics(args.weights, args.data)
+    print(
+        f"samples={metrics['samples']} "
+        f"token_mae={metrics['token_mae']:.4f} "
+        f"token_exact_rate={metrics['token_exact_rate']:.4f}"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds a one-shot runner for the image adapter Python stack:

- `python/image_adapter/eval_all.py`: runs token metrics + spectrum health checks in one command.
- `python/image_adapter/eval_metrics.py`: refactored to expose `evaluate_token_metrics()` for reuse.
- `python/image_adapter/README.md`: documents the new entrypoint.

Related: #511 (spectrum checks) / #435 (owner-review hub)