### PR TITLE
docs: add closeout documentation pack

### DIFF
--- a/00-README.md
+++ b/00-README.md
@@ -1,0 +1,61 @@
+# Wittgenstein closeout documentation pack
+
+Date: 2026-05-28  
+Scope: GitHub-only static closeout documentation pack for `p-to-q/wittgenstein`.
+
+## Conservative summary
+
+Wittgenstein now has a stronger text-first modality harness, a clearer manifest/receipt discipline, active M1B image audit-delivery work, and a video path that has moved from pure stub into structured HTML plus opt-in repo-owned MP4 rendering. The correct closeout language is still conservative:
+
+> M1B image depth is not complete until decoder delivery, weight provenance, VSC emission, tokenizer/adapter evidence, and end-to-end artifact receipts are all validated.
+
+## Files in this pack
+
+1. `00-document-decision-ledger.md` — why each document should exist, what it may claim, and what remains uncertain.
+2. `docs/history/image-route-evolution.md` — route history from early procedural PNG to VSC and frozen decoder.
+3. `docs/acceptance/m1b-image.md` — M1B acceptance gates.
+4. `docs/release/m1b-closeout-ledger.md` — PR/issue map for #457/#491/#492/#493/#455/#402/#507.
+5. `docs/research/2026-05-28-m1b-ml-review-checklist.md` — ML review checklist beyond singular-value intuition.
+6. `docs/research/2026-05-28-vsc-emission-validation.md` — VSC emission validation plan.
+7. `docs/evals/image-quality-ladder.md` — layered quality/eval ladder.
+8. `docs/research/seed-length-sweep-report.md` — pre-registered seed-length sweep template.
+9. `docs/model-cards/llamagen-frozen-vq-v0.md` — candidate model card skeleton.
+10. `docs/model-cards/witt-vqgan-tokenizer.md` — future own-trained tokenizer card template.
+11. `docs/failure-receipts/m1b-image.md` — M1B failure receipt taxonomy.
+12. `docs/acceptance/m4-video-renderer.md` — structured video renderer acceptance checklist.
+13. `docs/research/prior-work-map.md` — research map across controller/codec/tokens/renderer/reproducibility.
+14. `docs/research/bibliography.md` — curated bibliography.
+15. `docs/release/distribution-guide.md` — PR split and distribution instructions.
+16. `docs/release/closeout-pr-template.md` — copyable PR body.
+17. `SOURCES.md` — source anchors.
+
+## Recommended PR split
+
+Do not merge this as one giant PR unless maintainers ask for a bulk docs drop.
+
+- PR 1: history + M1B acceptance + closeout ledger + ML/VSC checklists.
+- PR 2: image eval ladder + seed sweep template + failure receipts.
+- PR 3: candidate model-card templates.
+- PR 4: M4 video acceptance.
+- PR 5: prior-work map and bibliography.
+
+## Non-goals
+
+This pack does not claim M1B is complete, does not ship trained weights, does not claim a trained tokenizer exists, and does not describe video as a neural text-to-video model.
+
+## Source anchors
+
+This draft pack was written from a GitHub-only static review on 2026-05-28. Recheck referenced issues/PRs before merge.
+
+- Repository / README: https://github.com/p-to-q/wittgenstein
+- README.md: https://github.com/p-to-q/wittgenstein/blob/main/README.md
+- CHANGELOG.md: https://github.com/p-to-q/wittgenstein/blob/main/CHANGELOG.md
+- docs/implementation-status.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/implementation-status.md
+- docs/exec-plans/active/codec-v2-port.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/exec-plans/active/codec-v2-port.md
+- Issue #507: https://github.com/p-to-q/wittgenstein/issues/507
+- Issue #402: https://github.com/p-to-q/wittgenstein/issues/402
+- PR #457: https://github.com/p-to-q/wittgenstein/pull/457
+- PR #491: https://github.com/p-to-q/wittgenstein/pull/491
+- PR #492: https://github.com/p-to-q/wittgenstein/pull/492
+- PR #493: https://github.com/p-to-q/wittgenstein/pull/493
+- PR #455: https://github.com/p-to-q/wittgenstein/pull/455

--- a/00-document-decision-ledger.md
+++ b/00-document-decision-ledger.md
@@ -1,0 +1,66 @@
+# Document decision ledger
+
+Date: 2026-05-28
+
+## Why write these documents now
+
+The repo has reached an inflection point: public docs describe `v0.3.0-alpha.3`, current status says image/audio/sensor/video HTML produce artifacts, video MP4 is opt-in local render, and M1B is still the image blocker. Open PRs focus on M1B audit surfaces, Gate C/D receipts, decoder provenance, tokenizer scaffolding, and research handoff. Issue #507 explicitly asks for closeout, review gates, and prerelease criteria. That makes documentation useful now, but only if it controls claims.
+
+## Decision table
+
+| Document | Should write? | Reason | Main uncertainty | Merge posture |
+|---|---:|---|---|---|
+| `docs/history/image-route-evolution.md` | Yes | Prevents reviewers from mistaking early procedural PNG for final image doctrine, and explains why VSC became primary. | Exact historical dates may need commit archaeology. | Good first PR. |
+| `docs/acceptance/m1b-image.md` | Yes | M1B needs explicit acceptance gates before release language gets ahead of evidence. | Gate thresholds still need owner decisions. | Good first PR. |
+| `docs/release/m1b-closeout-ledger.md` | Yes | #457/#491/#492/#493/#455/#402/#507 need one map. | Live PR status may change. | Good first PR after recheck. |
+| `docs/research/2026-05-28-m1b-ml-review-checklist.md` | Yes | ML review must cover VSC, decoder, tokenizer, adapter, and E2E receipts, not only singular values. | Metrics/thresholds need ML owner. | Good first PR. |
+| `docs/research/2026-05-28-vsc-emission-validation.md` | Yes | Decoder feasibility is meaningless if the LLM cannot emit valid/stable VSC. | Prompt/model matrix not fixed. | Good first PR. |
+| `docs/evals/image-quality-ladder.md` | Yes | Avoids one-number validation and separates contract, decoder, tokenizer, adapter, E2E. | Requires ML owner thresholds. | PR 2. |
+| `docs/research/seed-length-sweep-report.md` | Yes, as template | Seed length determines VSC information budget. | No experiment results yet. | Template only. |
+| `docs/model-cards/llamagen-frozen-vq-v0.md` | Yes, as candidate card | #491/#492 make the LlamaGen/VQGAN candidate important enough to card. | License/fetch/runtime claims must be verified. | PR 3; candidate only. |
+| `docs/model-cards/witt-vqgan-tokenizer.md` | Yes, as future template | #493 suggests own-trained tokenizer scaffold; card should exist before claims appear. | No trained tokenizer yet. | PR 3; template only. |
+| `docs/failure-receipts/m1b-image.md` | Yes | Failure receipts are the no-silent-fallback enforcement surface. | Exact error names may change. | PR 2. |
+| `docs/acceptance/m4-video-renderer.md` | Yes | Video status changed; MP4 local renderer needs acceptance criteria separate from neural video. | Latest local validation should be rerun. | Separate PR. |
+| `docs/research/prior-work-map.md` | Yes | Prior work must be framed as controller/codec/runtime/reproducibility, not generic multimodal generation. | Bibliography can expand. | Research PR. |
+| `docs/research/bibliography.md` | Yes | Helps reviewer alignment. | Formal citations may need polishing. | Research PR. |
+| `docs/release/distribution-guide.md` | Yes | Pack is too large to distribute blindly. | Maintainer preference may differ. | Keep in pack or PR. |
+| `docs/release/closeout-pr-template.md` | Yes | Prevents overclaiming in PR language. | Live status may change. | Ready. |
+
+## Documents not to write yet
+
+- `docs/release/m1b-complete.md` — M1B is not complete.
+- `docs/evals/final-image-benchmark.md` — no final E2E benchmark exists in this pack.
+- `docs/model-cards/witt-vqgan-tokenizer-final.md` — no released tokenizer.
+- `docs/marketing/image-generation.md` — wrong tone; this is an audit-delivery closeout.
+- `docs/release/video-generation-complete.md` — current video is structured render, not neural video generation.
+
+## Safe claims
+
+- The repo has a text-first modality harness with schema/code contracts and manifest receipts.
+- Image emits PNG today, but the real M1B neural/frozen-decoder path remains pending.
+- M1B work is active across audit surface, Gate C/D receipt, bridge provenance, tokenizer scaffold, and handoff PRs.
+- Video HTML ships; MP4 is opt-in local rendering requiring local dependencies.
+
+## Unsafe claims
+
+- M1B is complete.
+- Trained tokenizer ships.
+- Gate C/D doc-only receipt is enough to call the product path complete.
+- Video is a neural text-to-video generator.
+
+## Source anchors
+
+This draft pack was written from a GitHub-only static review on 2026-05-28. Recheck referenced issues/PRs before merge.
+
+- Repository / README: https://github.com/p-to-q/wittgenstein
+- README.md: https://github.com/p-to-q/wittgenstein/blob/main/README.md
+- CHANGELOG.md: https://github.com/p-to-q/wittgenstein/blob/main/CHANGELOG.md
+- docs/implementation-status.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/implementation-status.md
+- docs/exec-plans/active/codec-v2-port.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/exec-plans/active/codec-v2-port.md
+- Issue #507: https://github.com/p-to-q/wittgenstein/issues/507
+- Issue #402: https://github.com/p-to-q/wittgenstein/issues/402
+- PR #457: https://github.com/p-to-q/wittgenstein/pull/457
+- PR #491: https://github.com/p-to-q/wittgenstein/pull/491
+- PR #492: https://github.com/p-to-q/wittgenstein/pull/492
+- PR #493: https://github.com/p-to-q/wittgenstein/pull/493
+- PR #455: https://github.com/p-to-q/wittgenstein/pull/455

--- a/SOURCES.md
+++ b/SOURCES.md
@@ -1,0 +1,18 @@
+# Sources
+
+## Source anchors
+
+This draft pack was written from a GitHub-only static review on 2026-05-28. Recheck referenced issues/PRs before merge.
+
+- Repository / README: https://github.com/p-to-q/wittgenstein
+- README.md: https://github.com/p-to-q/wittgenstein/blob/main/README.md
+- CHANGELOG.md: https://github.com/p-to-q/wittgenstein/blob/main/CHANGELOG.md
+- docs/implementation-status.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/implementation-status.md
+- docs/exec-plans/active/codec-v2-port.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/exec-plans/active/codec-v2-port.md
+- Issue #507: https://github.com/p-to-q/wittgenstein/issues/507
+- Issue #402: https://github.com/p-to-q/wittgenstein/issues/402
+- PR #457: https://github.com/p-to-q/wittgenstein/pull/457
+- PR #491: https://github.com/p-to-q/wittgenstein/pull/491
+- PR #492: https://github.com/p-to-q/wittgenstein/pull/492
+- PR #493: https://github.com/p-to-q/wittgenstein/pull/493
+- PR #455: https://github.com/p-to-q/wittgenstein/pull/455

--- a/docs/acceptance/m1b-image.md
+++ b/docs/acceptance/m1b-image.md
@@ -1,0 +1,168 @@
+# M1B image acceptance criteria
+
+Status: draft acceptance checklist  
+Last reviewed: 2026-05-28
+
+## Purpose
+
+Define what must be true before the repository can claim M1B image depth is complete.
+
+Current safe release language:
+
+> M1B audit delivery surface.
+
+Unsafe release language:
+
+> M1B completed.
+
+## Gate 0 — doctrine and scope
+
+Required:
+
+- one canonical image route;
+- Visual Seed Code is primary;
+- Semantic IR is support/conditioning/inspection;
+- no cloud render API;
+- no diffusion default;
+- no SVG/canvas/procedural path satisfying the real decoder tier;
+- no silent fallback.
+
+## Gate 1 — bridge manifest and provenance
+
+Required fields:
+
+- bridge family;
+- source repository and commit/revision;
+- weights filename and sha256;
+- codebook filename and sha256 if separate;
+- runtime artifact and sha256 if applicable;
+- code license;
+- weights license;
+- runtime tier;
+- determinism class;
+- supported input shape;
+- known non-goals.
+
+Acceptance:
+
+- schema typed;
+- manifest validates;
+- invalid manifest fails;
+- heavy weights are excluded from npm package;
+- manifest can be compared with lab receipts.
+
+## Gate 2 — lazy weight delivery
+
+Required:
+
+- package does not bundle model weights;
+- loader checks cache by sha256;
+- cache miss fetches from approved source;
+- bytes are sha256-verified before cache promotion;
+- hash mismatch never enters cache;
+- research-only weights are refused unless explicitly allowed;
+- missing runtime returns structured error;
+- fetch failures are structured;
+- no silent fallback.
+
+Required tests:
+
+- cache hit;
+- cache miss;
+- sha mismatch;
+- license refused;
+- runtime unavailable;
+- fetch failed;
+- corrupted cache;
+- tarball weight exclusion.
+
+## Gate 3 — VSC emission validation
+
+Required metrics:
+
+- JSON parse success;
+- schema-valid VSC rate;
+- repair rate;
+- seed length distribution;
+- token entropy/usage;
+- paraphrase stability;
+- semantic/VSC agreement;
+- invalid-output receipts.
+
+M1B cannot be complete if the LLM-facing contract is unstable.
+
+## Gate 4 — tokenizer / decoder reconstruction
+
+Required metrics:
+
+- rFID or FID;
+- LPIPS;
+- SSIM / PSNR;
+- codebook usage;
+- codebook perplexity;
+- collapse rate;
+- decode latency;
+- memory footprint;
+- dataset/license/split.
+
+Candidate decoder evidence and own-trained tokenizer evidence must be separated.
+
+## Gate 5 — adapter / seed expander
+
+Required baselines:
+
+- deterministic replication;
+- trivial seed expander;
+- semantic-only fallback;
+- learned adapter;
+- optionally masked iterative adapter.
+
+Pass condition:
+
+- learned path beats pre-registered baseline, or negative result is documented and claim is narrowed.
+
+## Gate 6 — end-to-end artifact receipt
+
+A valid M1B run manifest must include:
+
+- prompt;
+- model/provider/version;
+- raw output;
+- parsed VSC;
+- semantic support if used;
+- adapter identity;
+- decoder identity;
+- weights/codebook/runtime hashes;
+- determinism class;
+- seed;
+- artifact sha256;
+- failure receipt if failed.
+
+## Gate 7 — ML owner review
+
+ML owner must review:
+
+- tokenizer choice;
+- dataset/license;
+- reconstruction metrics;
+- adapter architecture;
+- seed-length sweep;
+- quality ladder;
+- release-note wording.
+
+## Source anchors
+
+This draft pack was written from a GitHub-only static review on 2026-05-28. Recheck referenced issues/PRs before merge.
+
+- Repository / README: https://github.com/p-to-q/wittgenstein
+- README.md: https://github.com/p-to-q/wittgenstein/blob/main/README.md
+- CHANGELOG.md: https://github.com/p-to-q/wittgenstein/blob/main/CHANGELOG.md
+- docs/implementation-status.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/implementation-status.md
+- docs/exec-plans/active/codec-v2-port.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/exec-plans/active/codec-v2-port.md
+- Issue #507: https://github.com/p-to-q/wittgenstein/issues/507
+- Issue #402: https://github.com/p-to-q/wittgenstein/issues/402
+- PR #457: https://github.com/p-to-q/wittgenstein/pull/457
+- PR #491: https://github.com/p-to-q/wittgenstein/pull/491
+- PR #492: https://github.com/p-to-q/wittgenstein/pull/492
+- PR #493: https://github.com/p-to-q/wittgenstein/pull/493
+- PR #455: https://github.com/p-to-q/wittgenstein/pull/455

--- a/docs/acceptance/m4-video-renderer.md
+++ b/docs/acceptance/m4-video-renderer.md
@@ -1,0 +1,106 @@
+# M4 video renderer acceptance criteria
+
+Status: draft checklist  
+Last reviewed: 2026-05-28
+
+## Purpose
+
+Accept the structured video renderer without confusing it with neural text-to-video generation.
+
+Current safe doctrine:
+
+> LLM → structured video composition → HyperFrames-shaped local HTML render → optional repo-owned MP4 encode → artifact + `videoRender` receipt.
+
+## Safe claim
+
+Video HTML output ships, and MP4 is an opt-in local renderer path requiring Chrome/Chromium and FFmpeg.
+
+## Unsafe claim
+
+Wittgenstein ships a neural text-to-video model.
+
+## Gates
+
+### Gate 0 — composition schema
+
+- `VideoComposition` validates;
+- LLM cannot emit arbitrary renderer code;
+- unsupported fields fail;
+- HTML remains default unless MP4 is enabled.
+
+### Gate 1 — HTML renderer
+
+- self-contained HTML;
+- deterministic structure;
+- no external CDN;
+- manifest records output kind.
+
+### Gate 2 — MP4 opt-in
+
+- MP4 path is opt-in;
+- Chrome/Chromium and FFmpeg required only for MP4;
+- missing deps produce structured errors;
+- HTML path works without MP4 deps.
+
+### Gate 3 — backend selection
+
+- default MP4 backend is repo-owned/internal;
+- upstream CLI backend is explicit experiment/parity mode;
+- backend and versions recorded.
+
+### Gate 4 — `videoRender` receipt
+
+Record:
+
+- backend;
+- backend version;
+- output kind;
+- fps;
+- quality;
+- dimensions;
+- frame count;
+- duration;
+- tool versions;
+- determinism class;
+- artifact sha256.
+
+### Gate 5 — determinism
+
+- same composition gives same HTML structure;
+- MP4 double-render validation exists for pinned environment;
+- if bytes differ, structural diff is recorded;
+- determinism class is honest.
+
+### Gate 6 — failure behavior
+
+Structured failures:
+
+- schema invalid;
+- backend unavailable;
+- Chrome unavailable;
+- FFmpeg unavailable;
+- render timeout;
+- missing receipt.
+
+No hidden MP4-to-HTML fallback unless manifest says so.
+
+## Downstream metrics
+
+Heavy neural-video metrics such as FVD-like or Video-Bench-style scores are downstream. They should not block structured-render acceptance, but they are required before any neural-video-quality claim.
+
+## Source anchors
+
+This draft pack was written from a GitHub-only static review on 2026-05-28. Recheck referenced issues/PRs before merge.
+
+- Repository / README: https://github.com/p-to-q/wittgenstein
+- README.md: https://github.com/p-to-q/wittgenstein/blob/main/README.md
+- CHANGELOG.md: https://github.com/p-to-q/wittgenstein/blob/main/CHANGELOG.md
+- docs/implementation-status.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/implementation-status.md
+- docs/exec-plans/active/codec-v2-port.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/exec-plans/active/codec-v2-port.md
+- Issue #507: https://github.com/p-to-q/wittgenstein/issues/507
+- Issue #402: https://github.com/p-to-q/wittgenstein/issues/402
+- PR #457: https://github.com/p-to-q/wittgenstein/pull/457
+- PR #491: https://github.com/p-to-q/wittgenstein/pull/491
+- PR #492: https://github.com/p-to-q/wittgenstein/pull/492
+- PR #493: https://github.com/p-to-q/wittgenstein/pull/493
+- PR #455: https://github.com/p-to-q/wittgenstein/pull/455

--- a/docs/evals/image-quality-ladder.md
+++ b/docs/evals/image-quality-ladder.md
@@ -1,0 +1,62 @@
+# Image quality ladder
+
+Status: draft evaluation design  
+Last reviewed: 2026-05-28
+
+## Purpose
+
+M1B must not be validated by a single metric. The correct evaluation is layered.
+
+## Ladder
+
+| Level | Object | Question |
+|---|---|---|
+| L0 | Schema/contract | Does it parse and validate? |
+| L1 | VSC emission | Can the LLM emit stable VSC? |
+| L2 | Decoder candidate | Can the frozen decoder run with pinned provenance? |
+| L3 | Tokenizer reconstruction | Does tokenizer preserve visual information? |
+| L4 | Adapter | Does learned adapter beat baseline? |
+| L5 | End-to-end artifact | Does prompt → VSC → adapter → decoder produce traceable artifact? |
+| L6 | Human/reviewer | Are outputs usable and failures honest? |
+
+## Suggested quality tiers
+
+| Tier | Meaning |
+|---|---|
+| `quality.placeholder` | procedural/dry-run placeholder; not M1B |
+| `quality.contract` | schema/manifest path validated |
+| `quality.candidate` | candidate decoder evidence exists |
+| `quality.bridge` | real decoder bridge loads pinned weights |
+| `quality.adapter` | adapter path runs with metrics |
+| `quality.full` | end-to-end M1B artifact with manifest and validation |
+
+## Metrics by level
+
+L0: parse success, schema success, repair count.  
+L1: seed entropy, token usage, paraphrase stability, invalid-output receipts.  
+L2: source/weights/codebook hashes, determinism class, ONNX/runtime latency.  
+L3: rFID/FID, LPIPS, SSIM, PSNR, codebook perplexity, collapse rate.  
+L4: baseline delta, invalid latent rate, latency, determinism.  
+L5: artifact sha256, replay/structural validation, manifest completeness.  
+L6: blinded side-by-side review, success/failure gallery.
+
+## Rule
+
+Do not use L2 candidate receipts as L5 end-to-end claims.
+
+## Source anchors
+
+This draft pack was written from a GitHub-only static review on 2026-05-28. Recheck referenced issues/PRs before merge.
+
+- Repository / README: https://github.com/p-to-q/wittgenstein
+- README.md: https://github.com/p-to-q/wittgenstein/blob/main/README.md
+- CHANGELOG.md: https://github.com/p-to-q/wittgenstein/blob/main/CHANGELOG.md
+- docs/implementation-status.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/implementation-status.md
+- docs/exec-plans/active/codec-v2-port.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/exec-plans/active/codec-v2-port.md
+- Issue #507: https://github.com/p-to-q/wittgenstein/issues/507
+- Issue #402: https://github.com/p-to-q/wittgenstein/issues/402
+- PR #457: https://github.com/p-to-q/wittgenstein/pull/457
+- PR #491: https://github.com/p-to-q/wittgenstein/pull/491
+- PR #492: https://github.com/p-to-q/wittgenstein/pull/492
+- PR #493: https://github.com/p-to-q/wittgenstein/pull/493
+- PR #455: https://github.com/p-to-q/wittgenstein/pull/455

--- a/docs/failure-receipts/m1b-image.md
+++ b/docs/failure-receipts/m1b-image.md
@@ -1,0 +1,97 @@
+# M1B image failure receipts
+
+Status: draft taxonomy  
+Last reviewed: 2026-05-28
+
+## Purpose
+
+Failures should become durable receipts, not silent fallback or hidden retry.
+
+## Required questions
+
+Every failure receipt should answer:
+
+- What was requested?
+- Which tier was requested?
+- Which component failed?
+- Was fallback allowed?
+- What error happened?
+- Which source/weights/runtime were involved?
+- Was an artifact written?
+- Was a manifest written?
+
+## Failure classes
+
+### VSC emission failure
+
+Examples: invalid JSON, schema-invalid VSC, unsupported seed shape, token out of range, Semantic IR/VSC disagreement.
+
+### Decoder manifest failure
+
+Examples: missing weights sha, invalid license, unsupported runtime tier, missing codebook hash.
+
+### Weight delivery failure
+
+Examples: fetch failed, sha mismatch, corrupted cache, research-only weights refused, offline cache miss.
+
+### Runtime unavailable
+
+Examples: `onnxruntime-node` missing, unsupported platform, incompatible runtime.
+
+### Adapter failure
+
+Examples: shape mismatch, invalid latent, token collapse, learned adapter cannot beat baseline.
+
+### Decoder execution failure
+
+Examples: ONNX inference error, invalid latent range, timeout, memory failure, NaN output.
+
+### Silent fallback attempt
+
+Most important class. Examples:
+
+- real decoder tier requested but placeholder PNG produced;
+- bad weights fall back to dry-run;
+- missing runtime silently routes to procedural renderer.
+
+Acceptance: silent fallback attempts should fail tests unless fallback is explicitly allowed and recorded in the manifest.
+
+### Lab-only overclaim
+
+Examples:
+
+- cluster-only metric described as local-proven;
+- doc-only receipt described as product code;
+- DDP smoke described as trained model;
+- "M1B complete" after candidate audit only.
+
+## Suggested receipt fields
+
+```json
+{
+  "kind": "weight_delivery_failure",
+  "requestedTier": "real-decoder",
+  "bridgeFamily": "llamagen",
+  "errorCode": "WEIGHTS_SHA256_MISMATCH",
+  "fallbackAllowed": false,
+  "fallbackUsed": false,
+  "manifestPath": "artifacts/runs/<run-id>/manifest.json"
+}
+```
+
+## Source anchors
+
+This draft pack was written from a GitHub-only static review on 2026-05-28. Recheck referenced issues/PRs before merge.
+
+- Repository / README: https://github.com/p-to-q/wittgenstein
+- README.md: https://github.com/p-to-q/wittgenstein/blob/main/README.md
+- CHANGELOG.md: https://github.com/p-to-q/wittgenstein/blob/main/CHANGELOG.md
+- docs/implementation-status.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/implementation-status.md
+- docs/exec-plans/active/codec-v2-port.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/exec-plans/active/codec-v2-port.md
+- Issue #507: https://github.com/p-to-q/wittgenstein/issues/507
+- Issue #402: https://github.com/p-to-q/wittgenstein/issues/402
+- PR #457: https://github.com/p-to-q/wittgenstein/pull/457
+- PR #491: https://github.com/p-to-q/wittgenstein/pull/491
+- PR #492: https://github.com/p-to-q/wittgenstein/pull/492
+- PR #493: https://github.com/p-to-q/wittgenstein/pull/493
+- PR #455: https://github.com/p-to-q/wittgenstein/pull/455

--- a/docs/history/image-route-evolution.md
+++ b/docs/history/image-route-evolution.md
@@ -1,0 +1,110 @@
+# Image route evolution
+
+Status: draft history / claim-control document  
+Last reviewed: 2026-05-28
+
+## Purpose
+
+This document explains how the image route evolved and why the current direction should be described as:
+
+> text-first LLM → Visual Seed Code → adapter / seed expander → frozen VQ decoder → PNG + manifest receipt
+
+It prevents three common errors:
+
+1. treating the early procedural PNG path as the final image thesis;
+2. treating Semantic IR as the primary decoder-facing object;
+3. treating M1B candidate audits as completed M1B delivery.
+
+## Phase 0 — artifact proof
+
+The early image route proved that the harness could emit real PNG files. That was valuable because the project is about artifact generation, not just model text. But this was not proof of a neural image path.
+
+Safe wording:
+
+> Early image output proved artifact emission.
+
+Unsafe wording:
+
+> The project already had a finished image generator.
+
+## Phase 1 — semantic / scene structure
+
+Semantic or scene-style representations made the image plan inspectable: objects, relations, style, and composition. That remains useful because pure seed codes can be opaque.
+
+Correct role of Semantic IR:
+
+- concept activation;
+- user inspection;
+- optional conditioning;
+- diagnosis and failure explanation.
+
+Incorrect role:
+
+- final image research object;
+- substitute for decoder-facing visual code;
+- evidence that a frozen VQ decoder can already run.
+
+## Phase 2 — Visual Seed Code becomes primary
+
+The doctrine now treats Visual Seed Code as the primary decoder-facing object. VSC is the structured visual code that the LLM emits or conditions, and the adapter/decoder path consumes.
+
+Why this matters:
+
+- the LLM has a concrete contract;
+- image capability remains outside the base model;
+- multiple decoder families can fit behind the same seam;
+- manifests can record the actual code/decoder/weights path.
+
+## Phase 3 — candidate audit before delivery
+
+The current LlamaGen/VQGAN-class discussion is a candidate audit and bridge-provenance line. That evidence can make a decoder candidate credible, but it does not by itself ship a user-facing M1B path.
+
+Candidate audit can prove:
+
+- provenance;
+- license shape;
+- weight hashability;
+- determinism/ONNX feasibility under stated conditions.
+
+Candidate audit cannot prove:
+
+- lazy weight delivery works;
+- end-user install works;
+- VSC emission is stable;
+- adapter quality is sufficient;
+- end-to-end artifact receipts exist.
+
+## Phase 4 — M1B acceptance
+
+M1B should be described as complete only when:
+
+- bridge manifest exists and validates;
+- weights/codebook/runtime are hash-pinned and delivered through tier-aware fetch/cache;
+- license refusal, runtime unavailable, fetch failure, and hash mismatch are structured errors;
+- real decoder tier never silently falls back to procedural PNG;
+- VSC emission validation passes;
+- tokenizer/adapter evidence exists;
+- end-to-end artifact manifests include VSC, bridge identity, hashes, determinism class, and artifact sha256.
+
+## Summary
+
+The correct historical story is neither "just a procedural demo" nor "image is solved." It is:
+
+> Wittgenstein moved from artifact proof to structured semantic support, then to Visual Seed Code doctrine, and now to M1B audit/delivery gates. The final image-depth claim remains pending until the bridge, weights, VSC, adapter/tokenizer, and E2E receipts clear.
+
+## Source anchors
+
+This draft pack was written from a GitHub-only static review on 2026-05-28. Recheck referenced issues/PRs before merge.
+
+- Repository / README: https://github.com/p-to-q/wittgenstein
+- README.md: https://github.com/p-to-q/wittgenstein/blob/main/README.md
+- CHANGELOG.md: https://github.com/p-to-q/wittgenstein/blob/main/CHANGELOG.md
+- docs/implementation-status.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/implementation-status.md
+- docs/exec-plans/active/codec-v2-port.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/exec-plans/active/codec-v2-port.md
+- Issue #507: https://github.com/p-to-q/wittgenstein/issues/507
+- Issue #402: https://github.com/p-to-q/wittgenstein/issues/402
+- PR #457: https://github.com/p-to-q/wittgenstein/pull/457
+- PR #491: https://github.com/p-to-q/wittgenstein/pull/491
+- PR #492: https://github.com/p-to-q/wittgenstein/pull/492
+- PR #493: https://github.com/p-to-q/wittgenstein/pull/493
+- PR #455: https://github.com/p-to-q/wittgenstein/pull/455

--- a/docs/model-cards/llamagen-frozen-vq-v0.md
+++ b/docs/model-cards/llamagen-frozen-vq-v0.md
@@ -1,0 +1,83 @@
+# Model card: LlamaGen / VQGAN-class frozen decoder candidate
+
+Status: candidate template; not a final release card  
+Last reviewed: 2026-05-28
+
+## Warning
+
+This card is a skeleton for a candidate bridge. It must not be treated as a final model card until manifests, hashes, license, runtime, and receipts are verified.
+
+## Candidate identity
+
+| Field | Value |
+|---|---|
+| Candidate name | LlamaGen / VQGAN-class frozen decoder candidate |
+| Intended role | Frozen VQ decoder baseline for M1B |
+| Bridge family | `llamagen` |
+| Source repository | TBD |
+| Source commit | TBD |
+| Weights filename | TBD |
+| Weights sha256 | TBD |
+| Codebook filename | TBD |
+| Codebook sha256 | TBD |
+| Runtime artifact | TBD |
+| Runtime artifact sha256 | TBD |
+| Runtime tier | TBD |
+| Determinism class | TBD |
+| License — code | TBD |
+| License — weights | TBD |
+| Redistribution allowed | TBD |
+
+## Intended use
+
+Approved after verification:
+
+- candidate decoder bridge;
+- audit receipt baseline;
+- adapter baseline;
+- comparison point for own-trained tokenizer.
+
+Not approved:
+
+- marketing claim that M1B is complete;
+- npm-bundled model weights;
+- hidden fallback path;
+- unlicensed redistribution.
+
+## Required before release
+
+- source commit pinned;
+- weights/codebook/runtime hashes pinned;
+- license terms recorded;
+- lazy fetch/cache/sha behavior tested;
+- runtime loads;
+- failure modes tested;
+- artifact manifest emitted;
+- no silent fallback.
+
+## Expected structured failures
+
+- `WEIGHTS_FETCH_FAILED`
+- `WEIGHTS_SHA256_MISMATCH`
+- `WEIGHTS_LICENSE_REFUSED`
+- `RUNTIME_UNAVAILABLE`
+- `DECODER_MANIFEST_INVALID`
+- `DECODER_INPUT_SHAPE_INVALID`
+- `DECODER_BRIDGE_NOT_IMPLEMENTED` until implementation lands
+
+## Source anchors
+
+This draft pack was written from a GitHub-only static review on 2026-05-28. Recheck referenced issues/PRs before merge.
+
+- Repository / README: https://github.com/p-to-q/wittgenstein
+- README.md: https://github.com/p-to-q/wittgenstein/blob/main/README.md
+- CHANGELOG.md: https://github.com/p-to-q/wittgenstein/blob/main/CHANGELOG.md
+- docs/implementation-status.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/implementation-status.md
+- docs/exec-plans/active/codec-v2-port.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/exec-plans/active/codec-v2-port.md
+- Issue #507: https://github.com/p-to-q/wittgenstein/issues/507
+- Issue #402: https://github.com/p-to-q/wittgenstein/issues/402
+- PR #457: https://github.com/p-to-q/wittgenstein/pull/457
+- PR #491: https://github.com/p-to-q/wittgenstein/pull/491
+- PR #492: https://github.com/p-to-q/wittgenstein/pull/492
+- PR #493: https://github.com/p-to-q/wittgenstein/pull/493
+- PR #455: https://github.com/p-to-q/wittgenstein/pull/455

--- a/docs/model-cards/witt-vqgan-tokenizer.md
+++ b/docs/model-cards/witt-vqgan-tokenizer.md
@@ -1,0 +1,86 @@
+# Model card: Wittgenstein VQGAN-class tokenizer
+
+Status: future template; no trained model claimed  
+Last reviewed: 2026-05-28
+
+## Warning
+
+This document is a template. It is not evidence that an own-trained tokenizer exists.
+
+## Model identity
+
+| Field | Value |
+|---|---|
+| Model name | Wittgenstein VQGAN-class tokenizer |
+| Version | TBD |
+| Training status | Not trained / not released |
+| Intended role | M1B tokenizer / decoder component |
+| Checkpoint path | TBD |
+| Checkpoint sha256 | TBD |
+| Codebook size | TBD |
+| Grid shape | TBD |
+| Image resolution | TBD |
+| License | TBD |
+| Runtime tier | TBD |
+
+## Dataset requirements
+
+Before any training claim:
+
+- dataset name/version;
+- license;
+- split;
+- preprocessing;
+- sample count;
+- known exclusions;
+- data manifest sha256.
+
+## Training requirements
+
+Record:
+
+- training script;
+- git SHA;
+- hardware;
+- environment;
+- optimizer;
+- batch size;
+- epochs/steps;
+- seed;
+- DDP config;
+- checkpoint manifest.
+
+## Metrics
+
+Required:
+
+- rFID/FID or accepted reconstruction metric;
+- LPIPS;
+- SSIM/PSNR;
+- codebook usage;
+- perplexity;
+- dead-code rate;
+- collapse rate;
+- latency;
+- memory.
+
+## Release criteria
+
+This becomes a candidate only when checkpoint, hashes, data manifest, metrics, license review, and ML-owner sign-off exist. It becomes canonical only when adapter and end-to-end artifact receipts pass.
+
+## Source anchors
+
+This draft pack was written from a GitHub-only static review on 2026-05-28. Recheck referenced issues/PRs before merge.
+
+- Repository / README: https://github.com/p-to-q/wittgenstein
+- README.md: https://github.com/p-to-q/wittgenstein/blob/main/README.md
+- CHANGELOG.md: https://github.com/p-to-q/wittgenstein/blob/main/CHANGELOG.md
+- docs/implementation-status.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/implementation-status.md
+- docs/exec-plans/active/codec-v2-port.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/exec-plans/active/codec-v2-port.md
+- Issue #507: https://github.com/p-to-q/wittgenstein/issues/507
+- Issue #402: https://github.com/p-to-q/wittgenstein/issues/402
+- PR #457: https://github.com/p-to-q/wittgenstein/pull/457
+- PR #491: https://github.com/p-to-q/wittgenstein/pull/491
+- PR #492: https://github.com/p-to-q/wittgenstein/pull/492
+- PR #493: https://github.com/p-to-q/wittgenstein/pull/493
+- PR #455: https://github.com/p-to-q/wittgenstein/pull/455

--- a/docs/release/closeout-pr-template.md
+++ b/docs/release/closeout-pr-template.md
@@ -1,0 +1,44 @@
+# PR template: M1B closeout docs
+
+## Summary
+
+This PR adds documentation-only claim-control surfaces for M1B image closeout. It does not claim M1B is complete, does not ship trained weights, and does not change runtime behavior.
+
+## Files
+
+- [ ] `docs/history/image-route-evolution.md`
+- [ ] `docs/acceptance/m1b-image.md`
+- [ ] `docs/release/m1b-closeout-ledger.md`
+- [ ] `docs/research/2026-05-28-m1b-ml-review-checklist.md`
+- [ ] `docs/research/2026-05-28-vsc-emission-validation.md`
+
+## Why
+
+The repo has reached an M1B audit-delivery closeout point. The open stack contains audit surfaces, candidate receipts, bridge provenance, training scaffold, and research handoff, but not a completed image-depth path.
+
+## Non-goals
+
+- No M1B completion claim.
+- No trained tokenizer release.
+- No trained weights.
+- No new decoder implementation.
+- No new benchmark result.
+- No marketing language.
+
+## Rechecked before opening
+
+- [ ] README current status.
+- [ ] `docs/implementation-status.md` current status.
+- [ ] `CHANGELOG.md` Unreleased section.
+- [ ] #507 status.
+- [ ] #402 status.
+- [ ] #457/#491/#492/#493/#455 status.
+- [ ] Open PR count and labels.
+
+## Reviewer focus
+
+- [ ] Wording avoids overclaiming.
+- [ ] Local contract checks are separated from lab empirical evidence.
+- [ ] No-silent-fallback doctrine is preserved.
+- [ ] Model cards / seed sweep are marked as templates.
+- [ ] ML-specialist review is required for training/tokenizer claims.

--- a/docs/release/distribution-guide.md
+++ b/docs/release/distribution-guide.md
@@ -1,0 +1,121 @@
+# Distribution guide
+
+Status: draft  
+Last reviewed: 2026-05-28
+
+## Goal
+
+Distribute the closeout docs without making one enormous review burden or overstating M1B.
+
+## PR sequence
+
+### PR 1 — claim-control core
+
+Files:
+
+- `docs/history/image-route-evolution.md`
+- `docs/acceptance/m1b-image.md`
+- `docs/release/m1b-closeout-ledger.md`
+- `docs/research/2026-05-28-m1b-ml-review-checklist.md`
+- `docs/research/2026-05-28-vsc-emission-validation.md`
+
+Title:
+
+```text
+docs(m1b): add image route history and acceptance closeout ledger
+```
+
+### PR 2 — eval and failure receipts
+
+Files:
+
+- `docs/evals/image-quality-ladder.md`
+- `docs/research/seed-length-sweep-report.md`
+- `docs/failure-receipts/m1b-image.md`
+
+Title:
+
+```text
+docs(m1b): add image eval ladder and failure receipt templates
+```
+
+### PR 3 — model cards
+
+Files:
+
+- `docs/model-cards/llamagen-frozen-vq-v0.md`
+- `docs/model-cards/witt-vqgan-tokenizer.md`
+
+Title:
+
+```text
+docs(model-cards): add M1B decoder and tokenizer card templates
+```
+
+### PR 4 — video acceptance
+
+File:
+
+- `docs/acceptance/m4-video-renderer.md`
+
+Title:
+
+```text
+docs(video): add M4 structured renderer acceptance criteria
+```
+
+### PR 5 — prior work
+
+Files:
+
+- `docs/research/prior-work-map.md`
+- `docs/research/bibliography.md`
+
+Title:
+
+```text
+docs(research): add prior-work map for codec/controller artifact routes
+```
+
+## Before opening PRs
+
+Recheck:
+
+- README status;
+- CHANGELOG Unreleased;
+- implementation-status;
+- #507;
+- #402;
+- #457/#491/#492/#493/#455;
+- open PR count.
+
+## Language
+
+Say:
+
+> This is a documentation-only closeout PR that adds claim-control surfaces for M1B. It does not claim M1B is complete and does not ship trained weights.
+
+Do not say:
+
+- M1B complete;
+- image generation ships;
+- trained tokenizer;
+- full video generation;
+- SVD proves the model.
+
+## Source anchors
+
+This draft pack was written from a GitHub-only static review on 2026-05-28. Recheck referenced issues/PRs before merge.
+
+- Repository / README: https://github.com/p-to-q/wittgenstein
+- README.md: https://github.com/p-to-q/wittgenstein/blob/main/README.md
+- CHANGELOG.md: https://github.com/p-to-q/wittgenstein/blob/main/CHANGELOG.md
+- docs/implementation-status.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/implementation-status.md
+- docs/exec-plans/active/codec-v2-port.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/exec-plans/active/codec-v2-port.md
+- Issue #507: https://github.com/p-to-q/wittgenstein/issues/507
+- Issue #402: https://github.com/p-to-q/wittgenstein/issues/402
+- PR #457: https://github.com/p-to-q/wittgenstein/pull/457
+- PR #491: https://github.com/p-to-q/wittgenstein/pull/491
+- PR #492: https://github.com/p-to-q/wittgenstein/pull/492
+- PR #493: https://github.com/p-to-q/wittgenstein/pull/493
+- PR #455: https://github.com/p-to-q/wittgenstein/pull/455

--- a/docs/release/m1b-closeout-ledger.md
+++ b/docs/release/m1b-closeout-ledger.md
@@ -1,0 +1,148 @@
+# M1B closeout ledger
+
+Status: draft release-readiness ledger  
+Last reviewed: 2026-05-28
+
+## Purpose
+
+Map the active M1B stack and prevent overclaiming.
+
+## Current stack
+
+- #507 — umbrella issue for M1B audit-delivery closeout and prerelease criteria.
+- #457 — M1B decoder audit delivery surface.
+- #491 — VQGAN-class Gate C/D receipt.
+- #492 — LlamaGen decoder bridge manifest + provenance.
+- #493 — tokenizer scaffold with manifest spine and smoke-validated DDP loop.
+- #455 — research handoff and experiment hooks.
+- #402 — canonical lazy weight fetch + sha256 delivery gate.
+
+## #457 — audit delivery surface
+
+Proves:
+
+- audit surface is visible;
+- fixtures/preflight/review pack can exist;
+- local/lab boundaries can be documented.
+
+Does not prove:
+
+- real weights load;
+- VSC emission works;
+- image quality is acceptable;
+- training decisions are resolved.
+
+Review focus:
+
+- schema/manifest correctness;
+- structured failure behavior;
+- no hidden fallback.
+
+## #491 — Gate C/D receipt
+
+Proves:
+
+- a VQGAN-class candidate may have determinism and ONNX/CPU feasibility evidence under stated conditions.
+
+Does not prove:
+
+- product bridge implementation;
+- user install success;
+- final M1B quality;
+- own-trained tokenizer quality.
+
+Review focus:
+
+- narrow "unblocked" wording to exact gates;
+- preserve environment, scripts, hashes, hardware, and thresholds;
+- do not turn doc-only evidence into product claim.
+
+## #492 — bridge manifest / provenance
+
+Proves:
+
+- candidate metadata can be pinned.
+
+Does not prove:
+
+- lazy fetch works;
+- license refusal is implemented;
+- runtime availability is tested;
+- real artifacts are emitted.
+
+Review focus:
+
+- align with #402;
+- avoid redistribution overclaim;
+- validate manifest contract.
+
+## #493 — tokenizer scaffold
+
+Proves:
+
+- training code layout and manifest spine may exist;
+- DDP smoke can be exercised.
+
+Does not prove:
+
+- tokenizer is trained;
+- reconstruction quality;
+- dataset/license acceptance;
+- releaseable weights.
+
+Review focus:
+
+- ML-specialist review;
+- static checks;
+- dataset/license framing;
+- do not call smoke validation training success.
+
+## #455 — research handoff
+
+Proves:
+
+- research context and hooks exist.
+
+Does not prove:
+
+- route is chosen;
+- metrics pass.
+
+Review focus:
+
+- preserve useful context;
+- slice if too large;
+- keep owner instructions visible.
+
+## #402 — delivery gate
+
+This remains mandatory for a real decoder delivery story. Acceptance requires typed manifest schema, lazy fetch/cache, sha verification, license refusal, runtime errors, tests, npm weight exclusion, and no silent fallback.
+
+## Prerelease criteria
+
+A small prerelease is reasonable only if:
+
+- #457 is merged or accepted as audit surface;
+- #491/#492 claims are narrowed;
+- #493 is fixed or deferred;
+- #455 is preserved/sliced/deferred intentionally;
+- ML-owner review is visible;
+- #402 is implemented or explicitly called pending;
+- release notes say "audit delivery" and not "M1B complete."
+
+## Source anchors
+
+This draft pack was written from a GitHub-only static review on 2026-05-28. Recheck referenced issues/PRs before merge.
+
+- Repository / README: https://github.com/p-to-q/wittgenstein
+- README.md: https://github.com/p-to-q/wittgenstein/blob/main/README.md
+- CHANGELOG.md: https://github.com/p-to-q/wittgenstein/blob/main/CHANGELOG.md
+- docs/implementation-status.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/implementation-status.md
+- docs/exec-plans/active/codec-v2-port.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/exec-plans/active/codec-v2-port.md
+- Issue #507: https://github.com/p-to-q/wittgenstein/issues/507
+- Issue #402: https://github.com/p-to-q/wittgenstein/issues/402
+- PR #457: https://github.com/p-to-q/wittgenstein/pull/457
+- PR #491: https://github.com/p-to-q/wittgenstein/pull/491
+- PR #492: https://github.com/p-to-q/wittgenstein/pull/492
+- PR #493: https://github.com/p-to-q/wittgenstein/pull/493
+- PR #455: https://github.com/p-to-q/wittgenstein/pull/455

--- a/docs/research/2026-05-28-m1b-ml-review-checklist.md
+++ b/docs/research/2026-05-28-m1b-ml-review-checklist.md
@@ -1,0 +1,105 @@
+# M1B ML review checklist
+
+Status: draft  
+Date: 2026-05-28
+
+## Purpose
+
+ML review must not stop at singular values, SVD, or low-rank intuition. Those can be useful diagnostics, but M1B validation requires evidence across the full interface.
+
+## Checklist
+
+### 1. Visual Seed Code emission
+
+- [ ] fixed prompt set;
+- [ ] provider/model/temperature/seed recorded;
+- [ ] schema-valid rate measured;
+- [ ] repair rate measured;
+- [ ] invalid-output taxonomy written;
+- [ ] token entropy and usage measured;
+- [ ] paraphrase stability measured;
+- [ ] failures write receipts.
+
+Reject: hand-picked prompts, hidden repair loops, or prose claims without schema stats.
+
+### 2. Decoder candidate
+
+- [ ] source commit pinned;
+- [ ] weights sha256 pinned;
+- [ ] codebook sha256 pinned;
+- [ ] runtime artifact sha256 pinned where applicable;
+- [ ] license recorded;
+- [ ] runtime tier recorded;
+- [ ] determinism class recorded;
+- [ ] CPU/GPU environment recorded.
+
+Reject: unpinned local paths or unclear redistribution rights.
+
+### 3. Tokenizer reconstruction
+
+- [ ] dataset license and split recorded;
+- [ ] preprocessing recorded;
+- [ ] rFID/FID or owner-approved metric recorded;
+- [ ] LPIPS/SSIM/PSNR considered;
+- [ ] codebook usage/perplexity recorded;
+- [ ] collapse rate recorded;
+- [ ] latency/memory recorded.
+
+Reject: "loss went down" without reconstruction and codebook metrics.
+
+### 4. Seed-length / capacity sweep
+
+- [ ] S=4/16/64/256 or project-approved grid tested;
+- [ ] 1D and/or 2D shape compared;
+- [ ] VSC-only vs Semantic IR-conditioned compared;
+- [ ] adapter sensitivity measured;
+- [ ] minimum useful seed budget identified.
+
+Reject: adapter training before information budget is understood.
+
+### 5. Adapter / seed expander
+
+- [ ] deterministic baseline;
+- [ ] semantic-only baseline;
+- [ ] learned adapter;
+- [ ] invalid latent rate;
+- [ ] quality delta over baseline;
+- [ ] latency;
+- [ ] determinism class.
+
+Reject: no baseline comparison.
+
+### 6. End-to-end artifact
+
+- [ ] run manifest includes prompt, raw output, VSC, adapter, decoder, hashes, determinism class, artifact sha;
+- [ ] failure cases write receipts;
+- [ ] real-decoder tier cannot fall back silently;
+- [ ] replay or structural validation exists.
+
+Reject: "PNG exists" without manifest-backed trace.
+
+## Final ML-owner questions
+
+1. Which candidate is accepted, rejected, or conditionally accepted?
+2. Which metrics are decisive?
+3. Which thresholds are required?
+4. Which claims remain lab-only?
+5. Which PRs can merge without implying model success?
+6. Which release-note phrases are forbidden?
+
+## Source anchors
+
+This draft pack was written from a GitHub-only static review on 2026-05-28. Recheck referenced issues/PRs before merge.
+
+- Repository / README: https://github.com/p-to-q/wittgenstein
+- README.md: https://github.com/p-to-q/wittgenstein/blob/main/README.md
+- CHANGELOG.md: https://github.com/p-to-q/wittgenstein/blob/main/CHANGELOG.md
+- docs/implementation-status.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/implementation-status.md
+- docs/exec-plans/active/codec-v2-port.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/exec-plans/active/codec-v2-port.md
+- Issue #507: https://github.com/p-to-q/wittgenstein/issues/507
+- Issue #402: https://github.com/p-to-q/wittgenstein/issues/402
+- PR #457: https://github.com/p-to-q/wittgenstein/pull/457
+- PR #491: https://github.com/p-to-q/wittgenstein/pull/491
+- PR #492: https://github.com/p-to-q/wittgenstein/pull/492
+- PR #493: https://github.com/p-to-q/wittgenstein/pull/493
+- PR #455: https://github.com/p-to-q/wittgenstein/pull/455

--- a/docs/research/2026-05-28-vsc-emission-validation.md
+++ b/docs/research/2026-05-28-vsc-emission-validation.md
@@ -1,0 +1,85 @@
+# Visual Seed Code emission validation
+
+Status: draft validation plan  
+Date: 2026-05-28
+
+## Purpose
+
+Validate whether a text-first LLM can reliably emit Visual Seed Code. A decoder can be feasible and still not deliver M1B if the LLM-facing contract is unstable.
+
+## Prompt families
+
+1. Simple object: cube, tree, lighthouse.
+2. Spatial composition: left/right/foreground/background.
+3. Style and lighting: fog, neon, vector icon.
+4. Counting and attributes: five birds, two triangles, grid of windows.
+5. Abstract prompts: uncertainty, memory, compression.
+6. Adversarial prompts: raw JS/Python renderer request, cloud API request, contradictory prompt.
+
+## Metrics
+
+- JSON parse success;
+- schema-valid VSC rate;
+- repair rate;
+- refusal rate;
+- seed length distribution;
+- token entropy;
+- token uniqueness;
+- paraphrase edit distance;
+- grid shape stability;
+- semantic/VSC agreement;
+- adapter acceptance;
+- hidden fallback rate.
+
+## Required artifacts
+
+For each run:
+
+- raw prompt;
+- raw model output;
+- parsed VSC;
+- parser diagnostics;
+- repair diagnostics;
+- adapter acceptance result;
+- failure receipt if applicable.
+
+Suggested directory:
+
+```text
+artifacts/validation/vsc-emission/<date>/<model>/<prompt-family>/
+```
+
+## Placeholder thresholds
+
+These are not policy until maintainer-approved:
+
+- schema-valid rate >= 95% on non-adversarial prompts;
+- repair rate <= 10%;
+- hidden fallback rate = 0%;
+- invalid-output receipt rate = 100%;
+- paraphrase shape stability >= 90%.
+
+## Pass/fail
+
+Pass: VSC is valid, stable, information-rich, adapter-consumable, and failures are visible.
+
+Conditional pass: emission is valid but weak; release wording must say quality is pending.
+
+Fail: invalid rate high, repair hides failures, token collapse, prompt-insensitive VSC, or procedural fallback satisfies real-decoder tier.
+
+## Source anchors
+
+This draft pack was written from a GitHub-only static review on 2026-05-28. Recheck referenced issues/PRs before merge.
+
+- Repository / README: https://github.com/p-to-q/wittgenstein
+- README.md: https://github.com/p-to-q/wittgenstein/blob/main/README.md
+- CHANGELOG.md: https://github.com/p-to-q/wittgenstein/blob/main/CHANGELOG.md
+- docs/implementation-status.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/implementation-status.md
+- docs/exec-plans/active/codec-v2-port.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/exec-plans/active/codec-v2-port.md
+- Issue #507: https://github.com/p-to-q/wittgenstein/issues/507
+- Issue #402: https://github.com/p-to-q/wittgenstein/issues/402
+- PR #457: https://github.com/p-to-q/wittgenstein/pull/457
+- PR #491: https://github.com/p-to-q/wittgenstein/pull/491
+- PR #492: https://github.com/p-to-q/wittgenstein/pull/492
+- PR #493: https://github.com/p-to-q/wittgenstein/pull/493
+- PR #455: https://github.com/p-to-q/wittgenstein/pull/455

--- a/docs/research/bibliography.md
+++ b/docs/research/bibliography.md
@@ -1,0 +1,47 @@
+# Bibliography
+
+Status: curated reading list  
+Last reviewed: 2026-05-28
+
+## Load-bearing papers
+
+- VQ-VAE — Neural Discrete Representation Learning: https://arxiv.org/abs/1711.00937
+- VQGAN / Taming Transformers: https://arxiv.org/abs/2012.09841
+- DALL·E — Zero-Shot Text-to-Image Generation: https://arxiv.org/abs/2102.12092
+- MaskGIT: https://arxiv.org/abs/2202.04200
+- Muse: https://proceedings.mlr.press/v202/chang23b.html
+- LlamaGen: https://arxiv.org/abs/2406.06525
+- SEED / SEED-LLaMA: https://proceedings.iclr.cc/paper_files/paper/2024/file/97011c648eda678424f9292dadeae72e-Paper-Conference.pdf
+- Chameleon: https://arxiv.org/abs/2405.09818
+- Transfusion: https://arxiv.org/abs/2408.11039
+
+## Video comparison papers
+
+- MAGVIT: https://arxiv.org/abs/2212.05199
+- Phenaki: https://arxiv.org/abs/2210.02399
+- VideoPoet: https://proceedings.mlr.press/v235/kondratyuk24a.html
+- Make-A-Video: https://arxiv.org/abs/2209.14792
+
+## LLM-as-controller / tool-use
+
+- PAL: https://arxiv.org/abs/2211.10435
+- Toolformer: https://arxiv.org/abs/2302.04761
+- ReAct: https://arxiv.org/abs/2210.03629
+- VisProg: https://arxiv.org/abs/2211.11559
+
+## Audio codec / token priors
+
+- SoundStream: https://arxiv.org/abs/2107.03312
+- EnCodec: https://arxiv.org/abs/2210.13438
+- AudioLM: https://arxiv.org/abs/2209.03143
+- MusicGen: https://openreview.net/forum?id=jtiQ26sCJi
+
+## Reproducibility / documentation
+
+- Model Cards: https://arxiv.org/abs/1810.03993
+- Datasheets for Datasets: https://arxiv.org/abs/1803.09010
+- ML Reproducibility Checklist: https://jmlr.org/papers/v22/20-303.html
+
+## Suggested reading order
+
+VQ-VAE → VQGAN → DALL·E → MaskGIT → Muse → LlamaGen → SEED → Chameleon → Transfusion → PAL/Toolformer/ReAct/VisProg → MAGVIT/Phenaki/VideoPoet → Model Cards/Datasheets/Reproducibility.

--- a/docs/research/prior-work-map.md
+++ b/docs/research/prior-work-map.md
@@ -1,0 +1,75 @@
+# Prior work map for Wittgenstein
+
+Status: draft research map  
+Last reviewed: 2026-05-28
+
+## Thesis
+
+Wittgenstein should not be framed as only a multimodal generation project. It sits at the intersection of:
+
+- LLM-as-controller;
+- typed codec protocols;
+- discrete visual/audio tokens;
+- frozen decoders;
+- masked visual modeling;
+- structured video rendering;
+- artifact reproducibility.
+
+## A. LLM as controller / tool user
+
+Relevant works: ReAct, Toolformer, PAL, VisProg.
+
+Why it matters: Wittgenstein's LLM emits structured plans/code contracts; external codecs/renderers execute.
+
+## B. Codec protocol and typed interfaces
+
+Relevant ideas: schema-first outputs, parser boundaries, renderer-owned artifacts, manifests.
+
+Why it matters: Codec v2 is the central engineering object and prevents modality-specific prompt hacks.
+
+## C. Discrete visual tokens
+
+Relevant works: VQ-VAE, VQGAN, DALL·E, LlamaGen, SEED, TokenFlow.
+
+Why it matters: M1B depends on visual code/token interfaces and frozen decoder seams.
+
+## D. Masked visual modeling
+
+Relevant works: MaskGIT, Muse, MaskBit-like routes.
+
+Why it matters: A masked iterative adapter may be more plausible than left-to-right visual token generation.
+
+## E. Frozen decoder / adapter split
+
+Relevant comparisons: LlamaGen, SEED, Chameleon, Transfusion.
+
+Why it matters: Wittgenstein's claim is not that the base LLM becomes multimodal, but that a text-first model can plan through a typed interface into frozen/learned modality machinery.
+
+## F. Structured video rendering
+
+Relevant lines: programmatic rendering, Remotion/Motion Canvas-style systems, HyperFrames-shaped HTML/MP4 rendering, MAGVIT/Phenaki/VideoPoet as neural-video comparisons.
+
+Why it matters: current M4 is structured rendering, not neural video generation.
+
+## G. Reproducibility
+
+Relevant works: Model Cards, Datasheets for Datasets, ML Reproducibility Checklist.
+
+Why it matters: manifest, hash, replay, doctor, and failure receipts are the repo's differentiator.
+
+## Source anchors
+
+This draft pack was written from a GitHub-only static review on 2026-05-28. Recheck referenced issues/PRs before merge.
+
+- Repository / README: https://github.com/p-to-q/wittgenstein
+- README.md: https://github.com/p-to-q/wittgenstein/blob/main/README.md
+- CHANGELOG.md: https://github.com/p-to-q/wittgenstein/blob/main/CHANGELOG.md
+- docs/implementation-status.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/implementation-status.md
+- docs/exec-plans/active/codec-v2-port.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/exec-plans/active/codec-v2-port.md
+- Issue #507: https://github.com/p-to-q/wittgenstein/issues/507
+- Issue #402: https://github.com/p-to-q/wittgenstein/issues/402
+- PR #457: https://github.com/p-to-q/wittgenstein/pull/457
+- PR #491: https://github.com/p-to-q/wittgenstein/pull/491
+- PR #492: https://github.com/p-to-q/wittgenstein/pull/492
+- PR #493: https://github.com/p-to-q/wittgenstein/pull/493
+- PR #455: https://github.com/p-to-q/wittgenstein/pull/455

--- a/docs/research/seed-length-sweep-report.md
+++ b/docs/research/seed-length-sweep-report.md
@@ -1,0 +1,59 @@
+# Seed-length sweep report
+
+Status: template / pre-registration  
+Last reviewed: 2026-05-28
+
+## Research question
+
+What Visual Seed Code length and shape allow a text-first LLM plus adapter to produce decoder-compatible latents that beat deterministic baselines?
+
+## Experimental grid
+
+| Axis | Values |
+|---|---|
+| Seed length | 4, 16, 64, 256, decoder-grid |
+| Shape | 1D sequence, 2D grid |
+| Prompt family | object, spatial, style, count, abstract, adversarial |
+| Emission mode | dry-run, LLM, LLM+repair |
+| Conditioning | VSC-only, Semantic IR + VSC |
+| Adapter | deterministic baseline, learned baseline, masked iterative if available |
+| Decoder | placeholder, candidate frozen decoder, own-trained decoder if available |
+
+## Metrics
+
+Emission: valid rate, repair rate, token entropy, prefix stability.  
+Adapter: invalid latent rate, loss, baseline delta, latency.  
+Artifact: quality tier, reconstruction/generation metric, artifact sha, structural determinism.
+
+## Results
+
+Do not fill with invented numbers.
+
+| Seed length | Shape | Valid rate | Repair rate | Adapter delta | Quality tier | Notes |
+|---:|---|---:|---:|---:|---|---|
+| 4 | 1D | TBD | TBD | TBD | TBD | TBD |
+| 16 | 1D | TBD | TBD | TBD | TBD | TBD |
+| 64 | 1D | TBD | TBD | TBD | TBD | TBD |
+| 256 | 1D | TBD | TBD | TBD | TBD | TBD |
+| decoder grid | 2D | TBD | TBD | TBD | TBD | TBD |
+
+## Negative result policy
+
+A failed sweep is useful. Document failures if seed codes collapse, invalid rate is high, adapter cannot beat baseline, decoder is too slow, or licensing/runtime constraints block release.
+
+## Source anchors
+
+This draft pack was written from a GitHub-only static review on 2026-05-28. Recheck referenced issues/PRs before merge.
+
+- Repository / README: https://github.com/p-to-q/wittgenstein
+- README.md: https://github.com/p-to-q/wittgenstein/blob/main/README.md
+- CHANGELOG.md: https://github.com/p-to-q/wittgenstein/blob/main/CHANGELOG.md
+- docs/implementation-status.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/implementation-status.md
+- docs/exec-plans/active/codec-v2-port.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/exec-plans/active/codec-v2-port.md
+- Issue #507: https://github.com/p-to-q/wittgenstein/issues/507
+- Issue #402: https://github.com/p-to-q/wittgenstein/issues/402
+- PR #457: https://github.com/p-to-q/wittgenstein/pull/457
+- PR #491: https://github.com/p-to-q/wittgenstein/pull/491
+- PR #492: https://github.com/p-to-q/wittgenstein/pull/492
+- PR #493: https://github.com/p-to-q/wittgenstein/pull/493
+- PR #455: https://github.com/p-to-q/wittgenstein/pull/455

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,25 @@
+{
+  "created": "2026-05-28",
+  "package": "wittgenstein_closeout_docs_2026-05-28",
+  "file_count": 18,
+  "files": [
+    "00-README.md",
+    "00-document-decision-ledger.md",
+    "SOURCES.md",
+    "docs/acceptance/m1b-image.md",
+    "docs/acceptance/m4-video-renderer.md",
+    "docs/evals/image-quality-ladder.md",
+    "docs/failure-receipts/m1b-image.md",
+    "docs/history/image-route-evolution.md",
+    "docs/model-cards/llamagen-frozen-vq-v0.md",
+    "docs/model-cards/witt-vqgan-tokenizer.md",
+    "docs/release/closeout-pr-template.md",
+    "docs/release/distribution-guide.md",
+    "docs/release/m1b-closeout-ledger.md",
+    "docs/research/2026-05-28-m1b-ml-review-checklist.md",
+    "docs/research/2026-05-28-vsc-emission-validation.md",
+    "docs/research/bibliography.md",
+    "docs/research/prior-work-map.md",
+    "docs/research/seed-length-sweep-report.md"
+  ]
+}


### PR DESCRIPTION
## Summary
- add the 2026-05-28 closeout documentation pack into the repo
- place the docs under the proposed `docs/` structure with top-level pack metadata files
- keep the PR limited to the closeout docs drop only

## Testing
- not run (docs-only change)
