### PR TITLE
fix(ci): publish-tarball guard — fix bench→benchmarks miss + cover python/ + polyglot-mini/

### DIFF
--- a/scripts/check-npm-publish-tarball.mjs
+++ b/scripts/check-npm-publish-tarball.mjs
@@ -54,11 +54,27 @@ process.once("uncaughtException", (error) => {
   throw error;
 });
 
-/** Per-file patterns that MUST NOT appear in any published tarball. */
+/**
+ * Per-file patterns that MUST NOT appear in any published tarball.
+ *
+ * Covers the dev / research / training surfaces that the Apache-2.0 TS
+ * packages must never bundle, plus heavy model-weight extensions. The
+ * directory list mirrors the delivery doctrine
+ * (`docs/research/2026-05-13-delivery-and-componentization.md`): a user
+ * running `npm install @wittgenstein/cli` pulls runtime code only, never
+ * training/research Python, benchmark harnesses, examples, or weights.
+ */
 const FORBIDDEN_PATTERNS = [
   /^research\//,
-  /^bench\//,
+  // NOTE: the dir is `benchmarks/`, not `bench/` — the old `^bench\/`
+  // pattern silently never matched. Fixed to the real directory name.
+  /^benchmarks\//,
   /^examples\//,
+  // Python training / research surfaces. `python/` is the image-adapter
+  // trainer (added 2026-05 via the M1B adapter work); `polyglot-mini/` is
+  // the Python rapid-prototype surface. Neither ships in the TS tarball.
+  /^python\//,
+  /^polyglot-mini\//,
   /\.pt$/,
   /\.ckpt$/,
   /\.safetensors$/,
@@ -311,7 +327,7 @@ async function main() {
 
   if (leaks.length === 0) {
     process.stdout.write(
-      `✓ ${packages.length} publishable package(s) clean — no research/, bench/, examples/, large binaries.\n`,
+      `✓ ${packages.length} publishable package(s) clean — no research/, benchmarks/, examples/, python/, polyglot-mini/, weights, or large binaries.\n`,
     );
     process.exit(0);
   }


### PR DESCRIPTION
## Summary

Cross-section drift caught after this week's rapid M1B merges. Two gaps in the npm-publish-surface guard (`scripts/check-npm-publish-tarball.mjs`):

### 1. `/^bench\//` never matched its target

The directory is `benchmarks/`, not `bench/`. The regex required `bench` immediately followed by `/`, so `benchmarks/harness.ts` slipped through silently. The guard's own comment says it must block "research/, bench/, examples/" — the intent was clearly `benchmarks/`.

- old `/^bench\//` vs `benchmarks/harness.ts` → false (the bug)
- new `/^benchmarks\//` → true

### 2. `python/` and `polyglot-mini/` were uncovered

`python/image_adapter/` is the image-adapter trainer that landed via the M1B adapter work (#512 / #515) — a new top-level Python training surface, outside the `research/training/` home the delivery doctrine documents. Neither it nor `polyglot-mini/` was in the forbidden list.

## Why it matters

The only publishable package today (`@wittgenstein/cli`) has an explicit `files: [bin, dist, README.md]` allowlist, so nothing leaks right now. This guard exists so a future packaging change can't quietly regress — and a denylist with a silently-dead pattern (`bench`) reads as covered when it isn't.

## Verification

- node sanity check: research/ benchmarks/ python/ polyglot-mini/ examples/ + weight extensions all BLOCK; dist/ bin/ pass
- `pnpm lint:npm-publish-tarball` green (cli tarball unchanged)
- `pnpm format:check` clean

Surfaced by the post-merge cross-section sweep over the M1B closeout (#507).

🤖 Generated with [Claude Code](https://claude.com/claude-code)