### PR TITLE
fix(training): remove duplicate nin allowlist

### DIFF
--- a/typos.toml
+++ b/typos.toml
@@ -40,7 +40,6 @@ PNGs = "PNGs"
 # typos extracts "PN" as a sub-token from "PNGs" and suggests "ON";
 # allowlist the extracted form too.
 PN = "PN"
-nin = "nin"
 FSQ = "FSQ"
 LoRA = "LoRA"
 SafeTensors = "SafeTensors"


### PR DESCRIPTION
## Summary
- drop the duplicate `nin = "nin"` entry from `typos.toml` now that `#517` is in the branch ancestry

## Why
After `#517` merged, the `feat/research-training-tokenizer-scaffold` line still carried a second `nin` entry in the PR merge context, which causes `typos.toml` to fail with a duplicate-key parse error in `#493` CI. This PR is the narrow follow-up to get the parent branch back to a clean static-check state.

## Validation
- static failure root cause confirmed from `#493` failed CI log (`duplicate key` for `nin` in `typos.toml`)
