### PR TITLE
docs: tighten truth-surface wording

### DIFF
--- a/docs/benchmark-standards.md
+++ b/docs/benchmark-standards.md
@@ -190,8 +190,12 @@ consistency, and motion fidelity. More interpretable than FVD alone.
 
 ### Current status
 
-Video codec is a typed stub. No local proxy is defined until the MP4 renderer lands.
-This section will be the first place upgraded once that branch merges.
+Video codec ships deterministic HTML composition output, plus an opt-in local MP4 renderer
+when `WITTGENSTEIN_HYPERFRAMES_RENDER=1` is set (the renderer depends on Chrome/Chromium +
+ffmpeg being available on the host).
+
+This section is still intentionally light: video benchmarks that assume a neural generator
+(FVD, Video-Bench) are not meaningful for the current composition-first surface.
 
 ---
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -130,9 +130,10 @@ python3 -m polyglot.cli sensor "treadmill walk, 3-axis accelerometer" --out /tmp
 
 ## What ran
 
-Every command above produces a real file. No mocks, no placeholders, no "I'll implement this
-later." If a command fails, it fails loudly with a structured error and a manifest recording
-the failure.
+Every command above produces a real file artifact (written to disk) and a run manifest. Some
+modalities may emit deterministic placeholder outputs on purpose (and mark `quality.partial`)
+until their frozen decoder bridges land — this is how the scaffold stays runnable without
+claiming capabilities it does not yet ship.
 
 For the full status of what's a real renderer vs what's a typed stub, see
 [`implementation-status.md`](implementation-status.md).

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -9,7 +9,7 @@ The scaffold does not need a real sandbox today, but the repo reserves a stable 
 ## Stability Promise
 
 - `execProgram()` is the public seam.
-- The current implementation throws `NotImplementedError`-style behavior on purpose.
+- The current implementation throws a `NotImplementedError`-style failure on purpose.
 - Future versions may swap the backend implementation without changing the call shape.
 
 Reserved boundary for untrusted-code execution.


### PR DESCRIPTION
Tighten a few repo truth-surface statements to match current shipped behavior.

- docs/benchmark-standards.md: video is no longer a typed stub; it ships HTML + opt-in local MP4 renderer.
- docs/quickstart.md: avoid implying no placeholders exist; call out intentional placeholder outputs + quality.partial.
- packages/sandbox/README.md: avoid backtick quoting that breaks some shells.