### PR TITLE
site: tighten homepage truth surface and pipeline UX

### DIFF
--- a/apps/site/src/components/PipelineGargantua.tsx
+++ b/apps/site/src/components/PipelineGargantua.tsx
@@ -2,8 +2,8 @@ import { useEffect, useRef } from 'react';
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
-/** Original look (550). Perf comes mainly from not rendering off-screen / in background. */
-const RAYMARCH_STEPS = 550;
+/** Slightly trimmed from the original 550 to keep the homepage demo smoother. */
+const RAYMARCH_STEPS = 500;
 
 const vertexShader = `
   varying vec2 vUv;
@@ -67,8 +67,8 @@ const fragmentShader = `
     float angle = atan(p.z, p.x) + u_time * (1.2 / sqrt(r));
     vec3 pRot = vec3(r * 2.0, p.y * 12.0, angle * 18.0);
 
-    float pNoise = pow(noise3D(pRot * 1.8), 16.0) * 120.0;
-    pNoise += pow(noise3D(pRot * 4.0 + u_time * 0.1), 24.0) * 180.0;
+    float pNoise = pow(noise3D(pRot * 1.8), 17.5) * 88.0;
+    pNoise += pow(noise3D(pRot * 4.0 + u_time * 0.1), 27.0) * 128.0;
 
     return pNoise * diskLayer * densityMask;
   }
@@ -166,7 +166,7 @@ const fragmentShader = `
       float particleAmount = getSuspendedParticles(p, r);
       if(particleAmount > 0.0) {
         vec3 pCol = getParticleColor(r, vUv, p);
-        finalCol += pCol * particleAmount * transmittance * 0.0075;
+        finalCol += pCol * particleAmount * transmittance * 0.0061;
       }
       vec3 ship = getShipColor(p, transmittance);
       finalCol += ship;
@@ -197,9 +197,9 @@ const fragmentShader = `
       if (r > 85.0) {
         vec3 starCoord = v * 320.0;
         float starSeed = hash(floor(starCoord.xy + starCoord.z));
-        float stars = pow(noise3D(starCoord), 45.0) * 1.5;
+        float stars = pow(noise3D(starCoord), 52.0) * 1.1;
         float twinkle = mix(0.3, 1.0, sin(u_time * (2.0 + starSeed * 4.0) + starSeed * 10.0) * 0.5 + 0.5);
-        finalCol += transmittance * vec3(stars * 0.8, stars * 0.9, stars * 1.1) * twinkle;
+        finalCol += transmittance * vec3(stars * 0.78, stars * 0.88, stars * 1.02) * twinkle;
         break;
       }
       if (transmittance < 0.01) break;
@@ -220,7 +220,7 @@ function getPixelRatioCap(): number {
   const saveData = (navigator as Navigator & { connection?: { saveData?: boolean } }).connection?.saveData;
   if (saveData || coarse) return Math.min(dpr, 1);
   // Match typical crispness on Retina; cap avoids extreme mobile/webview DPR blow-ups.
-  return Math.min(dpr, 2);
+  return Math.min(dpr, 1.75);
 }
 
 /** Same vertical inset idea as IntersectionObserver rootMargin — keep logic in one place. */
@@ -265,7 +265,9 @@ export default function PipelineGargantua({ className }: PipelineGargantuaProps)
 
     const controls = new OrbitControls(camera, renderer.domElement);
     controls.enableDamping = true;
-    controls.dampingFactor = 0.05;
+    controls.dampingFactor = 0.045;
+    controls.autoRotate = true;
+    controls.autoRotateSpeed = 0.22;
 
     const geometry = new THREE.PlaneGeometry(2, 2);
     const uniforms = {

--- a/apps/site/src/sections/AgenticSystemSection.tsx
+++ b/apps/site/src/sections/AgenticSystemSection.tsx
@@ -9,7 +9,7 @@ const toolChain = [
     name: "codec.registry",
     active: false,
     description:
-      "Dispatches per-modality WittgensteinCodec implementations through one shared contract.",
+      "Dispatches per-modality codecs through one shared `Codec<Req, Art>.produce()` contract.",
   },
   {
     name: "artifacts.replay",
@@ -28,7 +28,7 @@ export default function AgenticSystemSection() {
         <p className="text-muted-foreground text-sm max-w-xl mb-10 leading-relaxed">
           The LLM plans; the harness owns routing, schema injection, validation, and traces.
           Modality codecs sit behind a shared contract surface so new file types can ship without
-          pretending the backbone has become a giant native VLM.
+          pretending the backbone has become a giant native multimodal model.
         </p>
 
         <div className="card-border p-6">

--- a/apps/site/src/sections/AttributionSection.tsx
+++ b/apps/site/src/sections/AttributionSection.tsx
@@ -1,5 +1,14 @@
 const promptTokens = ["Create", "a", "traceable", "PNG", "artifact", "from", "text"];
 const responseTokens = ["semantic", "seedCode", "decoder", "PNG", "manifest"];
+const vscTokens = [
+  "r81",
+  "bw4",
+  "q17·23",
+  "f12",
+  "x41",
+  "n2",
+  "z57m31",
+];
 
 export default function AttributionSection() {
   return (
@@ -49,6 +58,35 @@ export default function AttributionSection() {
                   key={i}
                   className={`px-2 py-1 text-sm rounded-md border shadow-[0_0_0_1px_hsl(var(--ring))] ${
                     ["semantic", "seedCode", "decoder", "manifest"].includes(token)
+                      ? "bg-primary/15 text-foreground border-primary/35"
+                      : "bg-secondary text-secondary-foreground"
+                  }`}
+                >
+                  {token}
+                </span>
+              ))}
+            </div>
+
+            <div className="flex justify-center my-6 text-muted-foreground">
+              <svg
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
+                <path d="M12 5v14M5 12l7 7 7-7" />
+              </svg>
+            </div>
+
+            <div className="text-xs font-mono text-muted-foreground mb-4">visual seed code (vsc)</div>
+            <div className="flex flex-wrap gap-1.5">
+              {vscTokens.map((token, i) => (
+                <span
+                  key={i}
+                  className={`px-2 py-1 text-sm rounded-md border shadow-[0_0_0_1px_hsl(var(--ring))] ${
+                    i < 2 || i === 4 || i === 6
                       ? "bg-primary/15 text-foreground border-primary/35"
                       : "bg-secondary text-secondary-foreground"
                   }`}

--- a/apps/site/src/sections/EvalsSection.tsx
+++ b/apps/site/src/sections/EvalsSection.tsx
@@ -23,9 +23,9 @@ const modalityChecks = [
   },
   {
     name: "Runnable surfaces",
-    subtitle: "image · audio · sensor",
+    subtitle: "image · audio · sensor · video html",
     description:
-      "Lightweight smoke checks track the currently runnable local paths while video catches up.",
+      "Lightweight smoke checks track the currently runnable local paths, while heavier video MP4 and benchmark surfaces stay opt-in.",
     metrics: [
       { label: "image editorial", value: 85, tone: "accent" as const },
       { label: "tts launch", value: 85, tone: "accent" as const },
@@ -58,7 +58,8 @@ export default function EvalsSection() {
           Contract-shaped checks for schemas, decoders, and runnable artifact paths. Every real run
           still leaves traces under <span className="font-mono text-xs">artifacts/runs/</span>. The
           percentages below are directional product surfaces, not release receipts; the ground truth
-          still lives in manifests, tests, and docs.
+          still lives in manifests, tests, and docs, and some heavier paths remain machine-local or
+          opt-in by design.
         </p>
 
         <div className="grid md:grid-cols-3 gap-6 mb-10">

--- a/apps/site/src/sections/FactualChecksSection.tsx
+++ b/apps/site/src/sections/FactualChecksSection.tsx
@@ -9,7 +9,7 @@ const codecs = [
   },
   {
     label: "Video",
-    body: "Composition-first IR plus a HyperFrames-shaped render seam. The structure is in place; the fuller MP4 path is still being merged.",
+    body: "Composition-first IR plus a HyperFrames-shaped render seam. HTML output ships today; repo-owned MP4 export is local and opt-in rather than a universal default path.",
   },
   {
     label: "Sensor",
@@ -25,13 +25,14 @@ export default function FactualChecksSection() {
         <h2 className="text-4xl md:text-5xl font-serif mt-2 mb-4 lowercase">codecs</h2>
         <p className="text-muted-foreground text-sm max-w-xl mb-10 leading-relaxed">
           Each modality is an isolated package sharing the{" "}
-          <strong className="text-foreground font-semibold">WittgensteinCodec</strong>-shaped
+          <strong className="text-foreground font-semibold">Codec&lt;Req, Art&gt;</strong>-shaped
           contract through shared schemas, manifests, and runtime conventions.
         </p>
         <p className="text-muted-foreground text-sm max-w-2xl mb-10 leading-relaxed">
           In practice, that means each codec can move at its own speed while still fitting the same
           harness. Image is the strictest and most research-shaped path; audio and sensor already
-          produce useful local outputs; video is waiting for the fuller MP4 path to land.
+          produce useful local outputs; video already ships HTML and can opt into local MP4 export
+          when the machine has the required renderer toolchain.
         </p>
 
         <div className="grid sm:grid-cols-2 gap-4">

--- a/apps/site/src/sections/FooterCTA.tsx
+++ b/apps/site/src/sections/FooterCTA.tsx
@@ -1,3 +1,6 @@
+const LAUNCH_DOC_HREF =
+  "https://github.com/p-to-q/wittgenstein/blob/main/docs/modality-launch-surface.md";
+
 export default function FooterCTA() {
   return (
     <section className="py-20 px-4 border-t border-border bg-secondary" id="footer-cta">
@@ -10,17 +13,20 @@ export default function FooterCTA() {
           >
             Back to overview
           </a>
-          <span
-            className="inline-flex items-center px-5 py-2.5 rounded-md text-sm font-medium bg-card text-secondary-foreground border border-transparent shadow-[0_0_0_1px_hsl(var(--ring))] cursor-default"
-            title="In repository"
+          <a
+            href={LAUNCH_DOC_HREF}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center px-5 py-2.5 rounded-md text-sm font-medium bg-card text-secondary-foreground border border-transparent shadow-[0_0_0_1px_hsl(var(--ring))] hover:bg-background hover:shadow-[0_0_0_1px_hsl(var(--stone))] transition-colors"
+            title="Open the launch surface doc on GitHub"
           >
             docs/modality-launch-surface.md
-          </span>
-          <span
-            className="inline-flex items-center px-5 py-2.5 rounded-md text-sm font-medium bg-card text-secondary-foreground border border-transparent shadow-[0_0_0_1px_hsl(var(--ring))] cursor-default"
-            title="From monorepo root"
-          >
-            pnpm launch:check
+          </a>
+        </div>
+
+        <div className="mb-12">
+          <span className="inline-flex items-center px-5 py-2.5 rounded-md text-sm font-medium bg-card text-secondary-foreground border border-transparent shadow-[0_0_0_1px_hsl(var(--ring))]">
+            <span className="font-mono text-[0.8125rem]">pnpm launch:check</span>
           </span>
         </div>
 

--- a/apps/site/src/sections/FooterCTA.tsx
+++ b/apps/site/src/sections/FooterCTA.tsx
@@ -22,11 +22,8 @@ export default function FooterCTA() {
           >
             docs/modality-launch-surface.md
           </a>
-        </div>
-
-        <div className="mb-12">
           <span className="inline-flex items-center px-5 py-2.5 rounded-md text-sm font-medium bg-card text-secondary-foreground border border-transparent shadow-[0_0_0_1px_hsl(var(--ring))]">
-            <span className="font-mono text-[0.8125rem]">pnpm launch:check</span>
+            pnpm launch:check
           </span>
         </div>
 

--- a/apps/site/src/sections/HeroSection.tsx
+++ b/apps/site/src/sections/HeroSection.tsx
@@ -2,7 +2,7 @@ import { GitFork } from "lucide-react";
 
 import { HeroAnimatedTitle } from "@/components/HeroAnimatedTitle";
 
-const GITHUB_REPO_HREF = "https://github.com/wittgenstein-cli/wittgenstein";
+const GITHUB_REPO_HREF = "https://github.com/p-to-q/wittgenstein";
 
 export default function HeroSection() {
   return (
@@ -12,8 +12,8 @@ export default function HeroSection() {
         A <strong className="text-foreground font-semibold">harness-first modality layer</strong>{" "}
         for text-first LLMs. The model stays a planner; modality contracts, codecs, seed expanders,
         frozen decoders, and deterministic runtimes turn structured outputs into real files such as{" "}
-        <strong className="text-foreground font-semibold">PNG, WAV, HTML, JSON,</strong> and, once
-        the video branch is fully wired back in,{" "}
+        <strong className="text-foreground font-semibold">PNG, WAV, HTML, JSON,</strong> and, on
+        machines with the local video renderer installed,{" "}
         <strong className="text-foreground font-semibold">MP4</strong>.
       </p>
       <p className="text-sm text-muted-foreground max-w-xl mx-auto mb-8 leading-relaxed">

--- a/apps/site/src/sections/HumanReadabilitySection.tsx
+++ b/apps/site/src/sections/HumanReadabilitySection.tsx
@@ -50,7 +50,7 @@ export default function HumanReadabilitySection() {
           >
             <span className="text-[hsl(var(--coral))]">User prompt</span>
             {"\n    →  schema preamble + "}
-            <span className="text-[hsl(var(--coral))]">Visual Seed Code (VSC)-bearing image contract</span>
+            <span className="text-[hsl(var(--coral))]">Visual Seed Code (VSC)</span>-bearing image contract
             {"\n          →  "}
             <span className="text-[hsl(var(--coral))]">LLM</span>
             {" (planner)"}

--- a/apps/site/src/sections/HumanReadabilitySection.tsx
+++ b/apps/site/src/sections/HumanReadabilitySection.tsx
@@ -49,7 +49,8 @@ export default function HumanReadabilitySection() {
             aria-hidden
           >
             <span className="text-[hsl(var(--coral))]">User prompt</span>
-            {"\n    →  schema preamble + image contract"}
+            {"\n    →  schema preamble + "}
+            <span className="text-[hsl(var(--coral))]">Visual Seed Code (VSC)-bearing image contract</span>
             {"\n          →  "}
             <span className="text-[hsl(var(--coral))]">LLM</span>
             {" (planner)"}
@@ -58,10 +59,10 @@ export default function HumanReadabilitySection() {
             {" (zod)"}
             {"\n                      →  "}
             <span className="text-[hsl(var(--coral))]">inspect</span>
-            {" (semantic, optional)"}
+            {" (semantic IR, optional)"}
             {"\n                            →  "}
             <span className="text-[hsl(var(--coral))]">expand</span>
-            {" (seedCode / coarse code)"}
+            {" (Visual Seed Code / coarse VQ hints)"}
             {"\n                                  →  "}
             <span className="text-[hsl(var(--coral))]">adapter</span>
             {" (seed expander)"}
@@ -104,8 +105,8 @@ export default function HumanReadabilitySection() {
             Illustrative only: these bars show relative scaffold depth, not benchmarked release
             scores. Runtime and shared contracts are ahead of some finished renderers. Image already
             centers on Visual Seed Code plus frozen-decoder wiring; sensor expands deterministic
-            operators; audio renders local WAV artifacts; video still waits on the fuller MP4 branch
-            to be merged back into the main flow.
+            operators; audio renders local WAV artifacts; video already ships HTML and can opt into
+            local MP4 export when the required renderer toolchain is present.
           </p>
         </div>
       </div>

--- a/apps/site/src/sections/WeightEditingSection.tsx
+++ b/apps/site/src/sections/WeightEditingSection.tsx
@@ -57,7 +57,7 @@ export default function WeightEditingSection() {
           <p className="text-sm text-muted-foreground mb-6">
             The percentages below are directional packaging signals, not release-gating numbers.
             They show where the shared runtime is already stable and where some modality surfaces
-            are still catching up.
+            still rely on opt-in local toolchains or unfinished closeout work.
           </p>
 
           <div className="grid md:grid-cols-3 gap-8">
@@ -118,7 +118,7 @@ export default function WeightEditingSection() {
               <div className="mt-4 flex items-center gap-2 text-sm">
                 <span className="text-[hsl(var(--muted-green))] font-mono">pnpm ok</span>
                 <span className="text-border">|</span>
-                <span className="text-primary font-mono">benchmark</span>
+                <span className="text-primary font-mono">checks</span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- tighten homepage truth-surface copy around codec/video/VSC status
- refine thesis and pipeline cards to better reflect the locked image path
- tune the Gargantua demo for cleaner motion and more stable homepage performance
- clean up footer CTA targets so every surface points at a real destination

## Validation
- pnpm --filter @wittgenstein/site build
- localhost browser spot-check for hero, thesis, pipeline, and footer CTA

## Notes
- keeps the larger pipeline demo presentation while adding modest runtime protection
- avoids inventing new doctrine; aligns copy to existing repo docs and current local surfaces