### PR TITLE
site: restore GitHub mark and brand badge

### DIFF
--- a/apps/site/src/sections/AgenticSystemSection.tsx
+++ b/apps/site/src/sections/AgenticSystemSection.tsx
@@ -37,7 +37,7 @@ export default function AgenticSystemSection() {
               <div className="bg-secondary rounded-lg p-4 mb-4 border border-border">
                 <div className="flex items-start gap-3">
                   <div className="w-6 h-6 rounded-full bg-primary/20 flex items-center justify-center flex-shrink-0 border border-primary/35">
-                    <span className="text-xs font-medium text-primary">W</span>
+                    <span className="text-xs font-serif font-bold text-primary">W</span>
                   </div>
                   <div>
                     <p className="text-sm text-muted-foreground leading-relaxed">

--- a/apps/site/src/sections/HeroSection.tsx
+++ b/apps/site/src/sections/HeroSection.tsx
@@ -1,8 +1,19 @@
-import { GitFork } from "lucide-react";
-
 import { HeroAnimatedTitle } from "@/components/HeroAnimatedTitle";
 
 const GITHUB_REPO_HREF = "https://github.com/p-to-q/wittgenstein";
+
+function GitHubMarkIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      aria-hidden
+      viewBox="0 0 16 16"
+      className={className}
+      fill="currentColor"
+    >
+      <path d="M8 0C3.58 0 0 3.58 0 8a8 8 0 0 0 5.47 7.59c.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.5-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82A7.5 7.5 0 0 1 8 4.84c.68 0 1.37.09 2.01.27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8 8 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
+    </svg>
+  );
+}
 
 export default function HeroSection() {
   return (
@@ -31,7 +42,7 @@ export default function HeroSection() {
           rel="noopener noreferrer"
           className="inline-flex items-center gap-2 rounded-full border border-[#020408] bg-[#020408] px-6 py-3 text-sm font-medium text-[#FAF9F5] shadow-[0_0_0_1px_#020408] transition-colors hover:bg-[#0a0d14]"
         >
-          <GitFork className="h-4 w-4 shrink-0 opacity-90" aria-hidden />
+          <GitHubMarkIcon className="h-4 w-4 shrink-0 opacity-90" />
           GitHub
         </a>
       </div>

--- a/apps/site/src/sections/HumanReadabilitySection.tsx
+++ b/apps/site/src/sections/HumanReadabilitySection.tsx
@@ -50,7 +50,7 @@ export default function HumanReadabilitySection() {
           >
             <span className="text-[hsl(var(--coral))]">User prompt</span>
             {"\n    →  schema preamble + "}
-            <span className="text-[hsl(var(--coral))]">Visual Seed Code (VSC)</span>-bearing image contract
+            <span className="text-[hsl(var(--coral))]">Visual Seed Code (VSC)</span> - bearing image contract
             {"\n          →  "}
             <span className="text-[hsl(var(--coral))]">LLM</span>
             {" (planner)"}


### PR DESCRIPTION
## Summary
- restore the homepage GitHub button from the incorrect fork glyph to a stable GitHub mark
- switch the harness card W badge to the brand serif/bold treatment
- keep the change narrowly scoped to site polish

## Validation
- pnpm --filter @wittgenstein/site build
