### PR TITLE
site: reduce harness badge W size

### DIFF
--- a/apps/site/src/sections/AgenticSystemSection.tsx
+++ b/apps/site/src/sections/AgenticSystemSection.tsx
@@ -37,7 +37,7 @@ export default function AgenticSystemSection() {
               <div className="bg-secondary rounded-lg p-4 mb-4 border border-border">
                 <div className="flex items-start gap-3">
                   <div className="w-6 h-6 rounded-full bg-primary/20 flex items-center justify-center flex-shrink-0 border border-primary/35">
-                    <span className="text-xs font-serif font-bold text-primary">W</span>
+                    <span className="text-[0.625rem] font-serif font-bold text-primary">W</span>
                   </div>
                   <div>
                     <p className="text-sm text-muted-foreground leading-relaxed">


### PR DESCRIPTION
## Summary
- reduce the harness card W badge text size slightly for a cleaner fit inside the circular marker

## Validation
- pnpm --filter @wittgenstein/site build
