### PR TITLE
docs: split closeout PR1 acceptance and review surfaces

### DIFF
--- a/docs/acceptance/m1b-image.md
+++ b/docs/acceptance/m1b-image.md
@@ -1,0 +1,168 @@
+# M1B image acceptance criteria
+
+Status: draft acceptance checklist  
+Last reviewed: 2026-05-28
+
+## Purpose
+
+Define what must be true before the repository can claim M1B image depth is complete.
+
+Current safe release language:
+
+> M1B audit delivery surface.
+
+Unsafe release language:
+
+> M1B completed.
+
+## Gate 0 — doctrine and scope
+
+Required:
+
+- one canonical image route;
+- Visual Seed Code is primary;
+- Semantic IR is support/conditioning/inspection;
+- no cloud render API;
+- no diffusion default;
+- no SVG/canvas/procedural path satisfying the real decoder tier;
+- no silent fallback.
+
+## Gate 1 — bridge manifest and provenance
+
+Required fields:
+
+- bridge family;
+- source repository and commit/revision;
+- weights filename and sha256;
+- codebook filename and sha256 if separate;
+- runtime artifact and sha256 if applicable;
+- code license;
+- weights license;
+- runtime tier;
+- determinism class;
+- supported input shape;
+- known non-goals.
+
+Acceptance:
+
+- schema typed;
+- manifest validates;
+- invalid manifest fails;
+- heavy weights are excluded from npm package;
+- manifest can be compared with lab receipts.
+
+## Gate 2 — lazy weight delivery
+
+Required:
+
+- package does not bundle model weights;
+- loader checks cache by sha256;
+- cache miss fetches from approved source;
+- bytes are sha256-verified before cache promotion;
+- hash mismatch never enters cache;
+- research-only weights are refused unless explicitly allowed;
+- missing runtime returns structured error;
+- fetch failures are structured;
+- no silent fallback.
+
+Required tests:
+
+- cache hit;
+- cache miss;
+- sha mismatch;
+- license refused;
+- runtime unavailable;
+- fetch failed;
+- corrupted cache;
+- tarball weight exclusion.
+
+## Gate 3 — VSC emission validation
+
+Required metrics:
+
+- JSON parse success;
+- schema-valid VSC rate;
+- repair rate;
+- seed length distribution;
+- token entropy/usage;
+- paraphrase stability;
+- semantic/VSC agreement;
+- invalid-output receipts.
+
+M1B cannot be complete if the LLM-facing contract is unstable.
+
+## Gate 4 — tokenizer / decoder reconstruction
+
+Required metrics:
+
+- rFID or FID;
+- LPIPS;
+- SSIM / PSNR;
+- codebook usage;
+- codebook perplexity;
+- collapse rate;
+- decode latency;
+- memory footprint;
+- dataset/license/split.
+
+Candidate decoder evidence and own-trained tokenizer evidence must be separated.
+
+## Gate 5 — adapter / seed expander
+
+Required baselines:
+
+- deterministic replication;
+- trivial seed expander;
+- semantic-only fallback;
+- learned adapter;
+- optionally masked iterative adapter.
+
+Pass condition:
+
+- learned path beats pre-registered baseline, or negative result is documented and claim is narrowed.
+
+## Gate 6 — end-to-end artifact receipt
+
+A valid M1B run manifest must include:
+
+- prompt;
+- model/provider/version;
+- raw output;
+- parsed VSC;
+- semantic support if used;
+- adapter identity;
+- decoder identity;
+- weights/codebook/runtime hashes;
+- determinism class;
+- seed;
+- artifact sha256;
+- failure receipt if failed.
+
+## Gate 7 — ML owner review
+
+ML owner must review:
+
+- tokenizer choice;
+- dataset/license;
+- reconstruction metrics;
+- adapter architecture;
+- seed-length sweep;
+- quality ladder;
+- release-note wording.
+
+## Source anchors
+
+This draft pack was written from a GitHub-only static review on 2026-05-28. Recheck referenced issues/PRs before merge.
+
+- Repository / README: https://github.com/p-to-q/wittgenstein
+- README.md: https://github.com/p-to-q/wittgenstein/blob/main/README.md
+- CHANGELOG.md: https://github.com/p-to-q/wittgenstein/blob/main/CHANGELOG.md
+- docs/implementation-status.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/implementation-status.md
+- docs/exec-plans/active/codec-v2-port.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/exec-plans/active/codec-v2-port.md
+- Issue #507: https://github.com/p-to-q/wittgenstein/issues/507
+- Issue #402: https://github.com/p-to-q/wittgenstein/issues/402
+- PR #457: https://github.com/p-to-q/wittgenstein/pull/457
+- PR #491: https://github.com/p-to-q/wittgenstein/pull/491
+- PR #492: https://github.com/p-to-q/wittgenstein/pull/492
+- PR #493: https://github.com/p-to-q/wittgenstein/pull/493
+- PR #455: https://github.com/p-to-q/wittgenstein/pull/455

--- a/docs/history/image-route-evolution.md
+++ b/docs/history/image-route-evolution.md
@@ -1,0 +1,110 @@
+# Image route evolution
+
+Status: draft history / claim-control document  
+Last reviewed: 2026-05-28
+
+## Purpose
+
+This document explains how the image route evolved and why the current direction should be described as:
+
+> text-first LLM → Visual Seed Code → adapter / seed expander → frozen VQ decoder → PNG + manifest receipt
+
+It prevents three common errors:
+
+1. treating the early procedural PNG path as the final image thesis;
+2. treating Semantic IR as the primary decoder-facing object;
+3. treating M1B candidate audits as completed M1B delivery.
+
+## Phase 0 — artifact proof
+
+The early image route proved that the harness could emit real PNG files. That was valuable because the project is about artifact generation, not just model text. But this was not proof of a neural image path.
+
+Safe wording:
+
+> Early image output proved artifact emission.
+
+Unsafe wording:
+
+> The project already had a finished image generator.
+
+## Phase 1 — semantic / scene structure
+
+Semantic or scene-style representations made the image plan inspectable: objects, relations, style, and composition. That remains useful because pure seed codes can be opaque.
+
+Correct role of Semantic IR:
+
+- concept activation;
+- user inspection;
+- optional conditioning;
+- diagnosis and failure explanation.
+
+Incorrect role:
+
+- final image research object;
+- substitute for decoder-facing visual code;
+- evidence that a frozen VQ decoder can already run.
+
+## Phase 2 — Visual Seed Code becomes primary
+
+The doctrine now treats Visual Seed Code as the primary decoder-facing object. VSC is the structured visual code that the LLM emits or conditions, and the adapter/decoder path consumes.
+
+Why this matters:
+
+- the LLM has a concrete contract;
+- image capability remains outside the base model;
+- multiple decoder families can fit behind the same seam;
+- manifests can record the actual code/decoder/weights path.
+
+## Phase 3 — candidate audit before delivery
+
+The current LlamaGen/VQGAN-class discussion is a candidate audit and bridge-provenance line. That evidence can make a decoder candidate credible, but it does not by itself ship a user-facing M1B path.
+
+Candidate audit can prove:
+
+- provenance;
+- license shape;
+- weight hashability;
+- determinism/ONNX feasibility under stated conditions.
+
+Candidate audit cannot prove:
+
+- lazy weight delivery works;
+- end-user install works;
+- VSC emission is stable;
+- adapter quality is sufficient;
+- end-to-end artifact receipts exist.
+
+## Phase 4 — M1B acceptance
+
+M1B should be described as complete only when:
+
+- bridge manifest exists and validates;
+- weights/codebook/runtime are hash-pinned and delivered through tier-aware fetch/cache;
+- license refusal, runtime unavailable, fetch failure, and hash mismatch are structured errors;
+- real decoder tier never silently falls back to procedural PNG;
+- VSC emission validation passes;
+- tokenizer/adapter evidence exists;
+- end-to-end artifact manifests include VSC, bridge identity, hashes, determinism class, and artifact sha256.
+
+## Summary
+
+The correct historical story is neither "just a procedural demo" nor "image is solved." It is:
+
+> Wittgenstein moved from artifact proof to structured semantic support, then to Visual Seed Code doctrine, and now to M1B audit/delivery gates. The final image-depth claim remains pending until the bridge, weights, VSC, adapter/tokenizer, and E2E receipts clear.
+
+## Source anchors
+
+This draft pack was written from a GitHub-only static review on 2026-05-28. Recheck referenced issues/PRs before merge.
+
+- Repository / README: https://github.com/p-to-q/wittgenstein
+- README.md: https://github.com/p-to-q/wittgenstein/blob/main/README.md
+- CHANGELOG.md: https://github.com/p-to-q/wittgenstein/blob/main/CHANGELOG.md
+- docs/implementation-status.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/implementation-status.md
+- docs/exec-plans/active/codec-v2-port.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/exec-plans/active/codec-v2-port.md
+- Issue #507: https://github.com/p-to-q/wittgenstein/issues/507
+- Issue #402: https://github.com/p-to-q/wittgenstein/issues/402
+- PR #457: https://github.com/p-to-q/wittgenstein/pull/457
+- PR #491: https://github.com/p-to-q/wittgenstein/pull/491
+- PR #492: https://github.com/p-to-q/wittgenstein/pull/492
+- PR #493: https://github.com/p-to-q/wittgenstein/pull/493
+- PR #455: https://github.com/p-to-q/wittgenstein/pull/455

--- a/docs/release/m1b-closeout-ledger.md
+++ b/docs/release/m1b-closeout-ledger.md
@@ -1,0 +1,148 @@
+# M1B closeout ledger
+
+Status: draft release-readiness ledger  
+Last reviewed: 2026-05-28
+
+## Purpose
+
+Map the active M1B stack and prevent overclaiming.
+
+## Current stack
+
+- #507 — umbrella issue for M1B audit-delivery closeout and prerelease criteria.
+- #457 — M1B decoder audit delivery surface.
+- #491 — VQGAN-class Gate C/D receipt.
+- #492 — LlamaGen decoder bridge manifest + provenance.
+- #493 — tokenizer scaffold with manifest spine and smoke-validated DDP loop.
+- #455 — research handoff and experiment hooks.
+- #402 — canonical lazy weight fetch + sha256 delivery gate.
+
+## #457 — audit delivery surface
+
+Proves:
+
+- audit surface is visible;
+- fixtures/preflight/review pack can exist;
+- local/lab boundaries can be documented.
+
+Does not prove:
+
+- real weights load;
+- VSC emission works;
+- image quality is acceptable;
+- training decisions are resolved.
+
+Review focus:
+
+- schema/manifest correctness;
+- structured failure behavior;
+- no hidden fallback.
+
+## #491 — Gate C/D receipt
+
+Proves:
+
+- a VQGAN-class candidate may have determinism and ONNX/CPU feasibility evidence under stated conditions.
+
+Does not prove:
+
+- product bridge implementation;
+- user install success;
+- final M1B quality;
+- own-trained tokenizer quality.
+
+Review focus:
+
+- narrow "unblocked" wording to exact gates;
+- preserve environment, scripts, hashes, hardware, and thresholds;
+- do not turn doc-only evidence into product claim.
+
+## #492 — bridge manifest / provenance
+
+Proves:
+
+- candidate metadata can be pinned.
+
+Does not prove:
+
+- lazy fetch works;
+- license refusal is implemented;
+- runtime availability is tested;
+- real artifacts are emitted.
+
+Review focus:
+
+- align with #402;
+- avoid redistribution overclaim;
+- validate manifest contract.
+
+## #493 — tokenizer scaffold
+
+Proves:
+
+- training code layout and manifest spine may exist;
+- DDP smoke can be exercised.
+
+Does not prove:
+
+- tokenizer is trained;
+- reconstruction quality;
+- dataset/license acceptance;
+- releaseable weights.
+
+Review focus:
+
+- ML-specialist review;
+- static checks;
+- dataset/license framing;
+- do not call smoke validation training success.
+
+## #455 — research handoff
+
+Proves:
+
+- research context and hooks exist.
+
+Does not prove:
+
+- route is chosen;
+- metrics pass.
+
+Review focus:
+
+- preserve useful context;
+- slice if too large;
+- keep owner instructions visible.
+
+## #402 — delivery gate
+
+This remains mandatory for a real decoder delivery story. Acceptance requires typed manifest schema, lazy fetch/cache, sha verification, license refusal, runtime errors, tests, npm weight exclusion, and no silent fallback.
+
+## Prerelease criteria
+
+A small prerelease is reasonable only if:
+
+- #457 is merged or accepted as audit surface;
+- #491/#492 claims are narrowed;
+- #493 is fixed or deferred;
+- #455 is preserved/sliced/deferred intentionally;
+- ML-owner review is visible;
+- #402 is implemented or explicitly called pending;
+- release notes say "audit delivery" and not "M1B complete."
+
+## Source anchors
+
+This draft pack was written from a GitHub-only static review on 2026-05-28. Recheck referenced issues/PRs before merge.
+
+- Repository / README: https://github.com/p-to-q/wittgenstein
+- README.md: https://github.com/p-to-q/wittgenstein/blob/main/README.md
+- CHANGELOG.md: https://github.com/p-to-q/wittgenstein/blob/main/CHANGELOG.md
+- docs/implementation-status.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/implementation-status.md
+- docs/exec-plans/active/codec-v2-port.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/exec-plans/active/codec-v2-port.md
+- Issue #507: https://github.com/p-to-q/wittgenstein/issues/507
+- Issue #402: https://github.com/p-to-q/wittgenstein/issues/402
+- PR #457: https://github.com/p-to-q/wittgenstein/pull/457
+- PR #491: https://github.com/p-to-q/wittgenstein/pull/491
+- PR #492: https://github.com/p-to-q/wittgenstein/pull/492
+- PR #493: https://github.com/p-to-q/wittgenstein/pull/493
+- PR #455: https://github.com/p-to-q/wittgenstein/pull/455

--- a/docs/release/m1b-closeout-pack/00-README.md
+++ b/docs/release/m1b-closeout-pack/00-README.md
@@ -11,23 +11,30 @@ Wittgenstein now has a stronger text-first modality harness, a clearer manifest/
 
 ## Files in this pack
 
+### Included in this PR (PR 1)
+
 1. `00-document-decision-ledger.md` — why each document should exist, what it may claim, and what remains uncertain.
 2. `docs/history/image-route-evolution.md` — route history from early procedural PNG to VSC and frozen decoder.
 3. `docs/acceptance/m1b-image.md` — M1B acceptance gates.
 4. `docs/release/m1b-closeout-ledger.md` — PR/issue map for #457/#491/#492/#493/#455/#402/#507.
 5. `docs/research/2026-05-28-m1b-ml-review-checklist.md` — ML review checklist beyond singular-value intuition.
 6. `docs/research/2026-05-28-vsc-emission-validation.md` — VSC emission validation plan.
-7. `docs/evals/image-quality-ladder.md` — layered quality/eval ladder.
-8. `docs/research/seed-length-sweep-report.md` — pre-registered seed-length sweep template.
-9. `docs/model-cards/llamagen-frozen-vq-v0.md` — candidate model card skeleton.
-10. `docs/model-cards/witt-vqgan-tokenizer.md` — future own-trained tokenizer card template.
-11. `docs/failure-receipts/m1b-image.md` — M1B failure receipt taxonomy.
-12. `docs/acceptance/m4-video-renderer.md` — structured video renderer acceptance checklist.
-13. `docs/research/prior-work-map.md` — research map across controller/codec/tokens/renderer/reproducibility.
-14. `docs/research/bibliography.md` — curated bibliography.
-15. `docs/release/distribution-guide.md` — PR split and distribution instructions.
-16. `docs/release/closeout-pr-template.md` — copyable PR body.
-17. `SOURCES.md` — source anchors.
+7. `SOURCES.md` — source anchors.
+
+### Planned follow-up docs (PR 2–5)
+
+These follow-up docs are planned pack slices and are not included in this PR.
+
+8. `docs/evals/image-quality-ladder.md` — layered quality/eval ladder.
+9. `docs/research/seed-length-sweep-report.md` — pre-registered seed-length sweep template.
+10. `docs/model-cards/llamagen-frozen-vq-v0.md` — candidate model card skeleton.
+11. `docs/model-cards/witt-vqgan-tokenizer.md` — future own-trained tokenizer card template.
+12. `docs/failure-receipts/m1b-image.md` — M1B failure receipt taxonomy.
+13. `docs/acceptance/m4-video-renderer.md` — structured video renderer acceptance checklist.
+14. `docs/research/prior-work-map.md` — research map across controller/codec/tokens/renderer/reproducibility.
+15. `docs/research/bibliography.md` — curated bibliography.
+16. `docs/release/distribution-guide.md` — PR split and distribution instructions.
+17. `docs/release/closeout-pr-template.md` — copyable PR body.
 
 ## Recommended PR split
 

--- a/docs/release/m1b-closeout-pack/00-README.md
+++ b/docs/release/m1b-closeout-pack/00-README.md
@@ -1,0 +1,61 @@
+# Wittgenstein closeout documentation pack
+
+Date: 2026-05-28  
+Scope: GitHub-only static closeout documentation pack for `p-to-q/wittgenstein`.
+
+## Conservative summary
+
+Wittgenstein now has a stronger text-first modality harness, a clearer manifest/receipt discipline, active M1B image audit-delivery work, and a video path that has moved from pure stub into structured HTML plus opt-in repo-owned MP4 rendering. The correct closeout language is still conservative:
+
+> M1B image depth is not complete until decoder delivery, weight provenance, VSC emission, tokenizer/adapter evidence, and end-to-end artifact receipts are all validated.
+
+## Files in this pack
+
+1. `00-document-decision-ledger.md` — why each document should exist, what it may claim, and what remains uncertain.
+2. `docs/history/image-route-evolution.md` — route history from early procedural PNG to VSC and frozen decoder.
+3. `docs/acceptance/m1b-image.md` — M1B acceptance gates.
+4. `docs/release/m1b-closeout-ledger.md` — PR/issue map for #457/#491/#492/#493/#455/#402/#507.
+5. `docs/research/2026-05-28-m1b-ml-review-checklist.md` — ML review checklist beyond singular-value intuition.
+6. `docs/research/2026-05-28-vsc-emission-validation.md` — VSC emission validation plan.
+7. `docs/evals/image-quality-ladder.md` — layered quality/eval ladder.
+8. `docs/research/seed-length-sweep-report.md` — pre-registered seed-length sweep template.
+9. `docs/model-cards/llamagen-frozen-vq-v0.md` — candidate model card skeleton.
+10. `docs/model-cards/witt-vqgan-tokenizer.md` — future own-trained tokenizer card template.
+11. `docs/failure-receipts/m1b-image.md` — M1B failure receipt taxonomy.
+12. `docs/acceptance/m4-video-renderer.md` — structured video renderer acceptance checklist.
+13. `docs/research/prior-work-map.md` — research map across controller/codec/tokens/renderer/reproducibility.
+14. `docs/research/bibliography.md` — curated bibliography.
+15. `docs/release/distribution-guide.md` — PR split and distribution instructions.
+16. `docs/release/closeout-pr-template.md` — copyable PR body.
+17. `SOURCES.md` — source anchors.
+
+## Recommended PR split
+
+Do not merge this as one giant PR unless maintainers ask for a bulk docs drop.
+
+- PR 1: history + M1B acceptance + closeout ledger + ML/VSC checklists.
+- PR 2: image eval ladder + seed sweep template + failure receipts.
+- PR 3: candidate model-card templates.
+- PR 4: M4 video acceptance.
+- PR 5: prior-work map and bibliography.
+
+## Non-goals
+
+This pack does not claim M1B is complete, does not ship trained weights, does not claim a trained tokenizer exists, and does not describe video as a neural text-to-video model.
+
+## Source anchors
+
+This draft pack was written from a GitHub-only static review on 2026-05-28. Recheck referenced issues/PRs before merge.
+
+- Repository / README: https://github.com/p-to-q/wittgenstein
+- README.md: https://github.com/p-to-q/wittgenstein/blob/main/README.md
+- CHANGELOG.md: https://github.com/p-to-q/wittgenstein/blob/main/CHANGELOG.md
+- docs/implementation-status.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/implementation-status.md
+- docs/exec-plans/active/codec-v2-port.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/exec-plans/active/codec-v2-port.md
+- Issue #507: https://github.com/p-to-q/wittgenstein/issues/507
+- Issue #402: https://github.com/p-to-q/wittgenstein/issues/402
+- PR #457: https://github.com/p-to-q/wittgenstein/pull/457
+- PR #491: https://github.com/p-to-q/wittgenstein/pull/491
+- PR #492: https://github.com/p-to-q/wittgenstein/pull/492
+- PR #493: https://github.com/p-to-q/wittgenstein/pull/493
+- PR #455: https://github.com/p-to-q/wittgenstein/pull/455

--- a/docs/release/m1b-closeout-pack/00-document-decision-ledger.md
+++ b/docs/release/m1b-closeout-pack/00-document-decision-ledger.md
@@ -1,0 +1,66 @@
+# Document decision ledger
+
+Date: 2026-05-28
+
+## Why write these documents now
+
+The repo has reached an inflection point: public docs describe `v0.3.0-alpha.3`, current status says image/audio/sensor/video HTML produce artifacts, video MP4 is opt-in local render, and M1B is still the image blocker. Open PRs focus on M1B audit surfaces, Gate C/D receipts, decoder provenance, tokenizer scaffolding, and research handoff. Issue #507 explicitly asks for closeout, review gates, and prerelease criteria. That makes documentation useful now, but only if it controls claims.
+
+## Decision table
+
+| Document | Should write? | Reason | Main uncertainty | Merge posture |
+|---|---:|---|---|---|
+| `docs/history/image-route-evolution.md` | Yes | Prevents reviewers from mistaking early procedural PNG for final image doctrine, and explains why VSC became primary. | Exact historical dates may need commit archaeology. | Good first PR. |
+| `docs/acceptance/m1b-image.md` | Yes | M1B needs explicit acceptance gates before release language gets ahead of evidence. | Gate thresholds still need owner decisions. | Good first PR. |
+| `docs/release/m1b-closeout-ledger.md` | Yes | #457/#491/#492/#493/#455/#402/#507 need one map. | Live PR status may change. | Good first PR after recheck. |
+| `docs/research/2026-05-28-m1b-ml-review-checklist.md` | Yes | ML review must cover VSC, decoder, tokenizer, adapter, and E2E receipts, not only singular values. | Metrics/thresholds need ML owner. | Good first PR. |
+| `docs/research/2026-05-28-vsc-emission-validation.md` | Yes | Decoder feasibility is meaningless if the LLM cannot emit valid/stable VSC. | Prompt/model matrix not fixed. | Good first PR. |
+| `docs/evals/image-quality-ladder.md` | Yes | Avoids one-number validation and separates contract, decoder, tokenizer, adapter, E2E. | Requires ML owner thresholds. | PR 2. |
+| `docs/research/seed-length-sweep-report.md` | Yes, as template | Seed length determines VSC information budget. | No experiment results yet. | Template only. |
+| `docs/model-cards/llamagen-frozen-vq-v0.md` | Yes, as candidate card | #491/#492 make the LlamaGen/VQGAN candidate important enough to card. | License/fetch/runtime claims must be verified. | PR 3; candidate only. |
+| `docs/model-cards/witt-vqgan-tokenizer.md` | Yes, as future template | #493 suggests own-trained tokenizer scaffold; card should exist before claims appear. | No trained tokenizer yet. | PR 3; template only. |
+| `docs/failure-receipts/m1b-image.md` | Yes | Failure receipts are the no-silent-fallback enforcement surface. | Exact error names may change. | PR 2. |
+| `docs/acceptance/m4-video-renderer.md` | Yes | Video status changed; MP4 local renderer needs acceptance criteria separate from neural video. | Latest local validation should be rerun. | Separate PR. |
+| `docs/research/prior-work-map.md` | Yes | Prior work must be framed as controller/codec/runtime/reproducibility, not generic multimodal generation. | Bibliography can expand. | Research PR. |
+| `docs/research/bibliography.md` | Yes | Helps reviewer alignment. | Formal citations may need polishing. | Research PR. |
+| `docs/release/distribution-guide.md` | Yes | Pack is too large to distribute blindly. | Maintainer preference may differ. | Keep in pack or PR. |
+| `docs/release/closeout-pr-template.md` | Yes | Prevents overclaiming in PR language. | Live status may change. | Ready. |
+
+## Documents not to write yet
+
+- `docs/release/m1b-complete.md` — M1B is not complete.
+- `docs/evals/final-image-benchmark.md` — no final E2E benchmark exists in this pack.
+- `docs/model-cards/witt-vqgan-tokenizer-final.md` — no released tokenizer.
+- `docs/marketing/image-generation.md` — wrong tone; this is an audit-delivery closeout.
+- `docs/release/video-generation-complete.md` — current video is structured render, not neural video generation.
+
+## Safe claims
+
+- The repo has a text-first modality harness with schema/code contracts and manifest receipts.
+- Image emits PNG today, but the real M1B neural/frozen-decoder path remains pending.
+- M1B work is active across audit surface, Gate C/D receipt, bridge provenance, tokenizer scaffold, and handoff PRs.
+- Video HTML ships; MP4 is opt-in local rendering requiring local dependencies.
+
+## Unsafe claims
+
+- M1B is complete.
+- Trained tokenizer ships.
+- Gate C/D doc-only receipt is enough to call the product path complete.
+- Video is a neural text-to-video generator.
+
+## Source anchors
+
+This draft pack was written from a GitHub-only static review on 2026-05-28. Recheck referenced issues/PRs before merge.
+
+- Repository / README: https://github.com/p-to-q/wittgenstein
+- README.md: https://github.com/p-to-q/wittgenstein/blob/main/README.md
+- CHANGELOG.md: https://github.com/p-to-q/wittgenstein/blob/main/CHANGELOG.md
+- docs/implementation-status.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/implementation-status.md
+- docs/exec-plans/active/codec-v2-port.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/exec-plans/active/codec-v2-port.md
+- Issue #507: https://github.com/p-to-q/wittgenstein/issues/507
+- Issue #402: https://github.com/p-to-q/wittgenstein/issues/402
+- PR #457: https://github.com/p-to-q/wittgenstein/pull/457
+- PR #491: https://github.com/p-to-q/wittgenstein/pull/491
+- PR #492: https://github.com/p-to-q/wittgenstein/pull/492
+- PR #493: https://github.com/p-to-q/wittgenstein/pull/493
+- PR #455: https://github.com/p-to-q/wittgenstein/pull/455

--- a/docs/release/m1b-closeout-pack/SOURCES.md
+++ b/docs/release/m1b-closeout-pack/SOURCES.md
@@ -1,0 +1,18 @@
+# Sources
+
+## Source anchors
+
+This draft pack was written from a GitHub-only static review on 2026-05-28. Recheck referenced issues/PRs before merge.
+
+- Repository / README: https://github.com/p-to-q/wittgenstein
+- README.md: https://github.com/p-to-q/wittgenstein/blob/main/README.md
+- CHANGELOG.md: https://github.com/p-to-q/wittgenstein/blob/main/CHANGELOG.md
+- docs/implementation-status.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/implementation-status.md
+- docs/exec-plans/active/codec-v2-port.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/exec-plans/active/codec-v2-port.md
+- Issue #507: https://github.com/p-to-q/wittgenstein/issues/507
+- Issue #402: https://github.com/p-to-q/wittgenstein/issues/402
+- PR #457: https://github.com/p-to-q/wittgenstein/pull/457
+- PR #491: https://github.com/p-to-q/wittgenstein/pull/491
+- PR #492: https://github.com/p-to-q/wittgenstein/pull/492
+- PR #493: https://github.com/p-to-q/wittgenstein/pull/493
+- PR #455: https://github.com/p-to-q/wittgenstein/pull/455

--- a/docs/research/2026-05-28-m1b-ml-review-checklist.md
+++ b/docs/research/2026-05-28-m1b-ml-review-checklist.md
@@ -1,0 +1,105 @@
+# M1B ML review checklist
+
+Status: draft  
+Date: 2026-05-28
+
+## Purpose
+
+ML review must not stop at singular values, SVD, or low-rank intuition. Those can be useful diagnostics, but M1B validation requires evidence across the full interface.
+
+## Checklist
+
+### 1. Visual Seed Code emission
+
+- [ ] fixed prompt set;
+- [ ] provider/model/temperature/seed recorded;
+- [ ] schema-valid rate measured;
+- [ ] repair rate measured;
+- [ ] invalid-output taxonomy written;
+- [ ] token entropy and usage measured;
+- [ ] paraphrase stability measured;
+- [ ] failures write receipts.
+
+Reject: hand-picked prompts, hidden repair loops, or prose claims without schema stats.
+
+### 2. Decoder candidate
+
+- [ ] source commit pinned;
+- [ ] weights sha256 pinned;
+- [ ] codebook sha256 pinned;
+- [ ] runtime artifact sha256 pinned where applicable;
+- [ ] license recorded;
+- [ ] runtime tier recorded;
+- [ ] determinism class recorded;
+- [ ] CPU/GPU environment recorded.
+
+Reject: unpinned local paths or unclear redistribution rights.
+
+### 3. Tokenizer reconstruction
+
+- [ ] dataset license and split recorded;
+- [ ] preprocessing recorded;
+- [ ] rFID/FID or owner-approved metric recorded;
+- [ ] LPIPS/SSIM/PSNR considered;
+- [ ] codebook usage/perplexity recorded;
+- [ ] collapse rate recorded;
+- [ ] latency/memory recorded.
+
+Reject: "loss went down" without reconstruction and codebook metrics.
+
+### 4. Seed-length / capacity sweep
+
+- [ ] S=4/16/64/256 or project-approved grid tested;
+- [ ] 1D and/or 2D shape compared;
+- [ ] VSC-only vs Semantic IR-conditioned compared;
+- [ ] adapter sensitivity measured;
+- [ ] minimum useful seed budget identified.
+
+Reject: adapter training before information budget is understood.
+
+### 5. Adapter / seed expander
+
+- [ ] deterministic baseline;
+- [ ] semantic-only baseline;
+- [ ] learned adapter;
+- [ ] invalid latent rate;
+- [ ] quality delta over baseline;
+- [ ] latency;
+- [ ] determinism class.
+
+Reject: no baseline comparison.
+
+### 6. End-to-end artifact
+
+- [ ] run manifest includes prompt, raw output, VSC, adapter, decoder, hashes, determinism class, artifact sha;
+- [ ] failure cases write receipts;
+- [ ] real-decoder tier cannot fall back silently;
+- [ ] replay or structural validation exists.
+
+Reject: "PNG exists" without manifest-backed trace.
+
+## Final ML-owner questions
+
+1. Which candidate is accepted, rejected, or conditionally accepted?
+2. Which metrics are decisive?
+3. Which thresholds are required?
+4. Which claims remain lab-only?
+5. Which PRs can merge without implying model success?
+6. Which release-note phrases are forbidden?
+
+## Source anchors
+
+This draft pack was written from a GitHub-only static review on 2026-05-28. Recheck referenced issues/PRs before merge.
+
+- Repository / README: https://github.com/p-to-q/wittgenstein
+- README.md: https://github.com/p-to-q/wittgenstein/blob/main/README.md
+- CHANGELOG.md: https://github.com/p-to-q/wittgenstein/blob/main/CHANGELOG.md
+- docs/implementation-status.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/implementation-status.md
+- docs/exec-plans/active/codec-v2-port.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/exec-plans/active/codec-v2-port.md
+- Issue #507: https://github.com/p-to-q/wittgenstein/issues/507
+- Issue #402: https://github.com/p-to-q/wittgenstein/issues/402
+- PR #457: https://github.com/p-to-q/wittgenstein/pull/457
+- PR #491: https://github.com/p-to-q/wittgenstein/pull/491
+- PR #492: https://github.com/p-to-q/wittgenstein/pull/492
+- PR #493: https://github.com/p-to-q/wittgenstein/pull/493
+- PR #455: https://github.com/p-to-q/wittgenstein/pull/455

--- a/docs/research/2026-05-28-vsc-emission-validation.md
+++ b/docs/research/2026-05-28-vsc-emission-validation.md
@@ -1,0 +1,85 @@
+# Visual Seed Code emission validation
+
+Status: draft validation plan  
+Date: 2026-05-28
+
+## Purpose
+
+Validate whether a text-first LLM can reliably emit Visual Seed Code. A decoder can be feasible and still not deliver M1B if the LLM-facing contract is unstable.
+
+## Prompt families
+
+1. Simple object: cube, tree, lighthouse.
+2. Spatial composition: left/right/foreground/background.
+3. Style and lighting: fog, neon, vector icon.
+4. Counting and attributes: five birds, two triangles, grid of windows.
+5. Abstract prompts: uncertainty, memory, compression.
+6. Adversarial prompts: raw JS/Python renderer request, cloud API request, contradictory prompt.
+
+## Metrics
+
+- JSON parse success;
+- schema-valid VSC rate;
+- repair rate;
+- refusal rate;
+- seed length distribution;
+- token entropy;
+- token uniqueness;
+- paraphrase edit distance;
+- grid shape stability;
+- semantic/VSC agreement;
+- adapter acceptance;
+- hidden fallback rate.
+
+## Required artifacts
+
+For each run:
+
+- raw prompt;
+- raw model output;
+- parsed VSC;
+- parser diagnostics;
+- repair diagnostics;
+- adapter acceptance result;
+- failure receipt if applicable.
+
+Suggested directory:
+
+```text
+artifacts/validation/vsc-emission/<date>/<model>/<prompt-family>/
+```
+
+## Placeholder thresholds
+
+These are not policy until maintainer-approved:
+
+- schema-valid rate >= 95% on non-adversarial prompts;
+- repair rate <= 10%;
+- hidden fallback rate = 0%;
+- invalid-output receipt rate = 100%;
+- paraphrase shape stability >= 90%.
+
+## Pass/fail
+
+Pass: VSC is valid, stable, information-rich, adapter-consumable, and failures are visible.
+
+Conditional pass: emission is valid but weak; release wording must say quality is pending.
+
+Fail: invalid rate high, repair hides failures, token collapse, prompt-insensitive VSC, or procedural fallback satisfies real-decoder tier.
+
+## Source anchors
+
+This draft pack was written from a GitHub-only static review on 2026-05-28. Recheck referenced issues/PRs before merge.
+
+- Repository / README: https://github.com/p-to-q/wittgenstein
+- README.md: https://github.com/p-to-q/wittgenstein/blob/main/README.md
+- CHANGELOG.md: https://github.com/p-to-q/wittgenstein/blob/main/CHANGELOG.md
+- docs/implementation-status.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/implementation-status.md
+- docs/exec-plans/active/codec-v2-port.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/exec-plans/active/codec-v2-port.md
+- Issue #507: https://github.com/p-to-q/wittgenstein/issues/507
+- Issue #402: https://github.com/p-to-q/wittgenstein/issues/402
+- PR #457: https://github.com/p-to-q/wittgenstein/pull/457
+- PR #491: https://github.com/p-to-q/wittgenstein/pull/491
+- PR #492: https://github.com/p-to-q/wittgenstein/pull/492
+- PR #493: https://github.com/p-to-q/wittgenstein/pull/493
+- PR #455: https://github.com/p-to-q/wittgenstein/pull/455


### PR DESCRIPTION
## Summary
- split PR 1 out of the larger closeout documentation pack from #516
- keep the engineering-maintainer slice only: image route history, M1B acceptance, closeout ledger, and ML/VSC review checklists
- relocate pack-internal helper docs out of the repo root into `docs/release/m1b-closeout-pack/`
- omit the generated root `manifest.json` and defer the remaining pack slices to follow-up PRs

## Included in this slice
- `docs/history/image-route-evolution.md`
- `docs/acceptance/m1b-image.md`
- `docs/release/m1b-closeout-ledger.md`
- `docs/research/2026-05-28-m1b-ml-review-checklist.md`
- `docs/research/2026-05-28-vsc-emission-validation.md`
- `docs/release/m1b-closeout-pack/00-README.md`
- `docs/release/m1b-closeout-pack/00-document-decision-ledger.md`
- `docs/release/m1b-closeout-pack/SOURCES.md`

## Follow-up
- PR 2: eval ladder + seed sweep + failure receipts
- PR 3: model cards (needs ML specialist)
- PR 4: M4 video acceptance
- PR 5 if still wanted: prior-work map + bibliography

## Validation
- `pnpm format:check`
