### PR TITLE
docs: split closeout PR2 eval and failure surfaces

### DIFF
--- a/docs/evals/image-quality-ladder.md
+++ b/docs/evals/image-quality-ladder.md
@@ -1,0 +1,62 @@
+# Image quality ladder
+
+Status: draft evaluation design  
+Last reviewed: 2026-05-28
+
+## Purpose
+
+M1B must not be validated by a single metric. The correct evaluation is layered.
+
+## Ladder
+
+| Level | Object | Question |
+|---|---|---|
+| L0 | Schema/contract | Does it parse and validate? |
+| L1 | VSC emission | Can the LLM emit stable VSC? |
+| L2 | Decoder candidate | Can the frozen decoder run with pinned provenance? |
+| L3 | Tokenizer reconstruction | Does tokenizer preserve visual information? |
+| L4 | Adapter | Does learned adapter beat baseline? |
+| L5 | End-to-end artifact | Does prompt → VSC → adapter → decoder produce traceable artifact? |
+| L6 | Human/reviewer | Are outputs usable and failures honest? |
+
+## Suggested quality tiers
+
+| Tier | Meaning |
+|---|---|
+| `quality.placeholder` | procedural/dry-run placeholder; not M1B |
+| `quality.contract` | schema/manifest path validated |
+| `quality.candidate` | candidate decoder evidence exists |
+| `quality.bridge` | real decoder bridge loads pinned weights |
+| `quality.adapter` | adapter path runs with metrics |
+| `quality.full` | end-to-end M1B artifact with manifest and validation |
+
+## Metrics by level
+
+L0: parse success, schema success, repair count.  
+L1: seed entropy, token usage, paraphrase stability, invalid-output receipts.  
+L2: source/weights/codebook hashes, determinism class, ONNX/runtime latency.  
+L3: rFID/FID, LPIPS, SSIM, PSNR, codebook perplexity, collapse rate.  
+L4: baseline delta, invalid latent rate, latency, determinism.  
+L5: artifact sha256, replay/structural validation, manifest completeness.  
+L6: blinded side-by-side review, success/failure gallery.
+
+## Rule
+
+Do not use L2 candidate receipts as L5 end-to-end claims.
+
+## Source anchors
+
+This draft pack was written from a GitHub-only static review on 2026-05-28. Recheck referenced issues/PRs before merge.
+
+- Repository / README: https://github.com/p-to-q/wittgenstein
+- README.md: https://github.com/p-to-q/wittgenstein/blob/main/README.md
+- CHANGELOG.md: https://github.com/p-to-q/wittgenstein/blob/main/CHANGELOG.md
+- docs/implementation-status.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/implementation-status.md
+- docs/exec-plans/active/codec-v2-port.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/exec-plans/active/codec-v2-port.md
+- Issue #507: https://github.com/p-to-q/wittgenstein/issues/507
+- Issue #402: https://github.com/p-to-q/wittgenstein/issues/402
+- PR #457: https://github.com/p-to-q/wittgenstein/pull/457
+- PR #491: https://github.com/p-to-q/wittgenstein/pull/491
+- PR #492: https://github.com/p-to-q/wittgenstein/pull/492
+- PR #493: https://github.com/p-to-q/wittgenstein/pull/493
+- PR #455: https://github.com/p-to-q/wittgenstein/pull/455

--- a/docs/failure-receipts/m1b-image.md
+++ b/docs/failure-receipts/m1b-image.md
@@ -1,0 +1,97 @@
+# M1B image failure receipts
+
+Status: draft taxonomy  
+Last reviewed: 2026-05-28
+
+## Purpose
+
+Failures should become durable receipts, not silent fallback or hidden retry.
+
+## Required questions
+
+Every failure receipt should answer:
+
+- What was requested?
+- Which tier was requested?
+- Which component failed?
+- Was fallback allowed?
+- What error happened?
+- Which source/weights/runtime were involved?
+- Was an artifact written?
+- Was a manifest written?
+
+## Failure classes
+
+### VSC emission failure
+
+Examples: invalid JSON, schema-invalid VSC, unsupported seed shape, token out of range, Semantic IR/VSC disagreement.
+
+### Decoder manifest failure
+
+Examples: missing weights sha, invalid license, unsupported runtime tier, missing codebook hash.
+
+### Weight delivery failure
+
+Examples: fetch failed, sha mismatch, corrupted cache, research-only weights refused, offline cache miss.
+
+### Runtime unavailable
+
+Examples: `onnxruntime-node` missing, unsupported platform, incompatible runtime.
+
+### Adapter failure
+
+Examples: shape mismatch, invalid latent, token collapse, learned adapter cannot beat baseline.
+
+### Decoder execution failure
+
+Examples: ONNX inference error, invalid latent range, timeout, memory failure, NaN output.
+
+### Silent fallback attempt
+
+Most important class. Examples:
+
+- real decoder tier requested but placeholder PNG produced;
+- bad weights fall back to dry-run;
+- missing runtime silently routes to procedural renderer.
+
+Acceptance: silent fallback attempts should fail tests unless fallback is explicitly allowed and recorded in the manifest.
+
+### Lab-only overclaim
+
+Examples:
+
+- cluster-only metric described as local-proven;
+- doc-only receipt described as product code;
+- DDP smoke described as trained model;
+- "M1B complete" after candidate audit only.
+
+## Suggested receipt fields
+
+```json
+{
+  "kind": "weight_delivery_failure",
+  "requestedTier": "real-decoder",
+  "bridgeFamily": "llamagen",
+  "errorCode": "WEIGHTS_SHA256_MISMATCH",
+  "fallbackAllowed": false,
+  "fallbackUsed": false,
+  "manifestPath": "artifacts/runs/<run-id>/manifest.json"
+}
+```
+
+## Source anchors
+
+This draft pack was written from a GitHub-only static review on 2026-05-28. Recheck referenced issues/PRs before merge.
+
+- Repository / README: https://github.com/p-to-q/wittgenstein
+- README.md: https://github.com/p-to-q/wittgenstein/blob/main/README.md
+- CHANGELOG.md: https://github.com/p-to-q/wittgenstein/blob/main/CHANGELOG.md
+- docs/implementation-status.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/implementation-status.md
+- docs/exec-plans/active/codec-v2-port.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/exec-plans/active/codec-v2-port.md
+- Issue #507: https://github.com/p-to-q/wittgenstein/issues/507
+- Issue #402: https://github.com/p-to-q/wittgenstein/issues/402
+- PR #457: https://github.com/p-to-q/wittgenstein/pull/457
+- PR #491: https://github.com/p-to-q/wittgenstein/pull/491
+- PR #492: https://github.com/p-to-q/wittgenstein/pull/492
+- PR #493: https://github.com/p-to-q/wittgenstein/pull/493
+- PR #455: https://github.com/p-to-q/wittgenstein/pull/455

--- a/docs/research/seed-length-sweep-report.md
+++ b/docs/research/seed-length-sweep-report.md
@@ -1,0 +1,59 @@
+# Seed-length sweep report
+
+Status: template / pre-registration  
+Last reviewed: 2026-05-28
+
+## Research question
+
+What Visual Seed Code length and shape allow a text-first LLM plus adapter to produce decoder-compatible latents that beat deterministic baselines?
+
+## Experimental grid
+
+| Axis | Values |
+|---|---|
+| Seed length | 4, 16, 64, 256, decoder-grid |
+| Shape | 1D sequence, 2D grid |
+| Prompt family | object, spatial, style, count, abstract, adversarial |
+| Emission mode | dry-run, LLM, LLM+repair |
+| Conditioning | VSC-only, Semantic IR + VSC |
+| Adapter | deterministic baseline, learned baseline, masked iterative if available |
+| Decoder | placeholder, candidate frozen decoder, own-trained decoder if available |
+
+## Metrics
+
+Emission: valid rate, repair rate, token entropy, prefix stability.  
+Adapter: invalid latent rate, loss, baseline delta, latency.  
+Artifact: quality tier, reconstruction/generation metric, artifact sha, structural determinism.
+
+## Results
+
+Do not fill with invented numbers.
+
+| Seed length | Shape | Valid rate | Repair rate | Adapter delta | Quality tier | Notes |
+|---:|---|---:|---:|---:|---|---|
+| 4 | 1D | TBD | TBD | TBD | TBD | TBD |
+| 16 | 1D | TBD | TBD | TBD | TBD | TBD |
+| 64 | 1D | TBD | TBD | TBD | TBD | TBD |
+| 256 | 1D | TBD | TBD | TBD | TBD | TBD |
+| decoder grid | 2D | TBD | TBD | TBD | TBD | TBD |
+
+## Negative result policy
+
+A failed sweep is useful. Document failures if seed codes collapse, invalid rate is high, adapter cannot beat baseline, decoder is too slow, or licensing/runtime constraints block release.
+
+## Source anchors
+
+This draft pack was written from a GitHub-only static review on 2026-05-28. Recheck referenced issues/PRs before merge.
+
+- Repository / README: https://github.com/p-to-q/wittgenstein
+- README.md: https://github.com/p-to-q/wittgenstein/blob/main/README.md
+- CHANGELOG.md: https://github.com/p-to-q/wittgenstein/blob/main/CHANGELOG.md
+- docs/implementation-status.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/implementation-status.md
+- docs/exec-plans/active/codec-v2-port.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/exec-plans/active/codec-v2-port.md
+- Issue #507: https://github.com/p-to-q/wittgenstein/issues/507
+- Issue #402: https://github.com/p-to-q/wittgenstein/issues/402
+- PR #457: https://github.com/p-to-q/wittgenstein/pull/457
+- PR #491: https://github.com/p-to-q/wittgenstein/pull/491
+- PR #492: https://github.com/p-to-q/wittgenstein/pull/492
+- PR #493: https://github.com/p-to-q/wittgenstein/pull/493
+- PR #455: https://github.com/p-to-q/wittgenstein/pull/455


### PR DESCRIPTION
## Summary
- split PR 2 out of the larger closeout documentation pack from #516
- isolate the image eval ladder, seed-length sweep template, and M1B failure receipt taxonomy
- keep this slice focused on empirical/research-adjacent review surfaces without implying implementation completion

## Included in this slice
- `docs/evals/image-quality-ladder.md`
- `docs/research/seed-length-sweep-report.md`
- `docs/failure-receipts/m1b-image.md`

## Review routing
- engineering-maintainer review for structure/claim control
- ML-owner glance recommended for thresholds/metric framing

## Validation
- `pnpm format:check`
