### PR TITLE
docs: split closeout PR3 model card templates

### DIFF
--- a/docs/model-cards/llamagen-frozen-vq-v0.md
+++ b/docs/model-cards/llamagen-frozen-vq-v0.md
@@ -1,0 +1,83 @@
+# Model card: LlamaGen / VQGAN-class frozen decoder candidate
+
+Status: candidate template; not a final release card  
+Last reviewed: 2026-05-28
+
+## Warning
+
+This card is a skeleton for a candidate bridge. It must not be treated as a final model card until manifests, hashes, license, runtime, and receipts are verified. Cross-check any eventual populated fields against the accepted Gate C/D receipt and the pinned bridge manifest rather than creating a third conflicting provenance source.
+
+## Candidate identity
+
+| Field | Value |
+|---|---|
+| Candidate name | LlamaGen / VQGAN-class frozen decoder candidate |
+| Intended role | Frozen VQ decoder baseline for M1B |
+| Bridge family | `llamagen` |
+| Source repository | TBD |
+| Source commit | TBD |
+| Weights filename | TBD |
+| Weights sha256 | TBD |
+| Codebook filename | TBD |
+| Codebook sha256 | TBD |
+| Runtime artifact | TBD |
+| Runtime artifact sha256 | TBD |
+| Runtime tier | TBD |
+| Determinism class | TBD |
+| License — code | TBD |
+| License — weights | TBD |
+| Redistribution allowed | TBD |
+
+## Intended use
+
+Approved after verification:
+
+- candidate decoder bridge;
+- audit receipt baseline;
+- adapter baseline;
+- comparison point for own-trained tokenizer.
+
+Not approved:
+
+- marketing claim that M1B is complete;
+- npm-bundled model weights;
+- hidden fallback path;
+- unlicensed redistribution.
+
+## Required before release
+
+- source commit pinned;
+- weights/codebook/runtime hashes pinned;
+- license terms recorded;
+- lazy fetch/cache/sha behavior tested;
+- runtime loads;
+- failure modes tested;
+- artifact manifest emitted;
+- no silent fallback.
+
+## Expected structured failures
+
+- `WEIGHTS_FETCH_FAILED`
+- `WEIGHTS_SHA256_MISMATCH`
+- `WEIGHTS_LICENSE_REFUSED`
+- `RUNTIME_UNAVAILABLE`
+- `DECODER_MANIFEST_INVALID`
+- `DECODER_INPUT_SHAPE_INVALID`
+- `DECODER_BRIDGE_NOT_IMPLEMENTED` until implementation lands
+
+## Source anchors
+
+This draft pack was written from a GitHub-only static review on 2026-05-28. Recheck referenced issues/PRs before merge.
+
+- Repository / README: https://github.com/p-to-q/wittgenstein
+- README.md: https://github.com/p-to-q/wittgenstein/blob/main/README.md
+- CHANGELOG.md: https://github.com/p-to-q/wittgenstein/blob/main/CHANGELOG.md
+- docs/implementation-status.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/implementation-status.md
+- docs/exec-plans/active/codec-v2-port.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/exec-plans/active/codec-v2-port.md
+- Issue #507: https://github.com/p-to-q/wittgenstein/issues/507
+- Issue #402: https://github.com/p-to-q/wittgenstein/issues/402
+- PR #457: https://github.com/p-to-q/wittgenstein/pull/457
+- PR #491: https://github.com/p-to-q/wittgenstein/pull/491
+- PR #492: https://github.com/p-to-q/wittgenstein/pull/492
+- PR #493: https://github.com/p-to-q/wittgenstein/pull/493
+- PR #455: https://github.com/p-to-q/wittgenstein/pull/455

--- a/docs/model-cards/witt-vqgan-tokenizer.md
+++ b/docs/model-cards/witt-vqgan-tokenizer.md
@@ -1,0 +1,86 @@
+# Model card: Wittgenstein VQGAN-class tokenizer
+
+Status: future template; no trained model claimed  
+Last reviewed: 2026-05-28
+
+## Warning
+
+This document is a template. It is not evidence that an own-trained tokenizer exists, nor that any reconstruction metrics, dataset license decisions, or releaseable weights have been accepted.
+
+## Model identity
+
+| Field | Value |
+|---|---|
+| Model name | Wittgenstein VQGAN-class tokenizer |
+| Version | TBD |
+| Training status | Not trained / not released |
+| Intended role | M1B tokenizer / decoder component |
+| Checkpoint path | TBD |
+| Checkpoint sha256 | TBD |
+| Codebook size | TBD |
+| Grid shape | TBD |
+| Image resolution | TBD |
+| License | TBD |
+| Runtime tier | TBD |
+
+## Dataset requirements
+
+Before any training claim:
+
+- dataset name/version;
+- license;
+- split;
+- preprocessing;
+- sample count;
+- known exclusions;
+- data manifest sha256.
+
+## Training requirements
+
+Record:
+
+- training script;
+- git SHA;
+- hardware;
+- environment;
+- optimizer;
+- batch size;
+- epochs/steps;
+- seed;
+- DDP config;
+- checkpoint manifest.
+
+## Metrics
+
+Required:
+
+- rFID/FID or accepted reconstruction metric;
+- LPIPS;
+- SSIM/PSNR;
+- codebook usage;
+- perplexity;
+- dead-code rate;
+- collapse rate;
+- latency;
+- memory.
+
+## Release criteria
+
+This becomes a candidate only when checkpoint, hashes, data manifest, metrics, license review, and ML-owner sign-off exist. It becomes canonical only when adapter and end-to-end artifact receipts pass.
+
+## Source anchors
+
+This draft pack was written from a GitHub-only static review on 2026-05-28. Recheck referenced issues/PRs before merge.
+
+- Repository / README: https://github.com/p-to-q/wittgenstein
+- README.md: https://github.com/p-to-q/wittgenstein/blob/main/README.md
+- CHANGELOG.md: https://github.com/p-to-q/wittgenstein/blob/main/CHANGELOG.md
+- docs/implementation-status.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/implementation-status.md
+- docs/exec-plans/active/codec-v2-port.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/exec-plans/active/codec-v2-port.md
+- Issue #507: https://github.com/p-to-q/wittgenstein/issues/507
+- Issue #402: https://github.com/p-to-q/wittgenstein/issues/402
+- PR #457: https://github.com/p-to-q/wittgenstein/pull/457
+- PR #491: https://github.com/p-to-q/wittgenstein/pull/491
+- PR #492: https://github.com/p-to-q/wittgenstein/pull/492
+- PR #493: https://github.com/p-to-q/wittgenstein/pull/493
+- PR #455: https://github.com/p-to-q/wittgenstein/pull/455


### PR DESCRIPTION
## Summary
- split PR 3 out of the larger closeout documentation pack from #516
- isolate the candidate model-card templates for the frozen decoder candidate and the future tokenizer
- narrow the template wording so these docs cannot be read as accepted provenance or release claims

## Included in this slice
- `docs/model-cards/llamagen-frozen-vq-v0.md`
- `docs/model-cards/witt-vqgan-tokenizer.md`

## Review routing
- **needs ML specialist**
- engineering review can confirm placement and claim control
- model-owner review is required for provenance, metrics, dataset/license, and release wording

## Validation
- `pnpm format:check`
