### PR TITLE
docs(research): redact internal cluster identifiers from M1B audit + tokenizer scaffold

### DIFF
--- a/docs/research/2026-05-27-audit-vqgan-class-gates-cd.md
+++ b/docs/research/2026-05-27-audit-vqgan-class-gates-cd.md
@@ -33,8 +33,8 @@ empirical determinism (Gate C) and Node/ONNX/CPU feasibility (Gate D).
 
 This note delivers the empirical verdicts. Both audits use the same
 pinned weights file and the same upstream commit of the LlamaGen source
-for reproducibility, and both run on the same machine (qiyuan
-`node1048`, 8× A800-SXM4-80GB) for cross-device (CPU vs CUDA) parity
+for reproducibility, and both run on the same machine (a single
+8× A800-SXM4-80GB node) for cross-device (CPU vs CUDA) parity
 characterization.
 
 ## Pinned artifacts
@@ -93,8 +93,8 @@ Three sub-tests, repeated 3× per machine (n_runs=3):
 
 | Machine | Device | T1 (encode parity) | T2 (decode parity) | T3 (round-trip exact) | T3 drift | Per-decode latency (median, warm) |
 |---|---|---|---|---|---|---|
-| node1048 | cuda (A800-80G, cudnn 8500) | ✅ all 3 runs equal | ✅ all 3 runs equal | ❌ drift | 30 / 256 tokens (11.72%) | encode 9.6 ms · decode 13.0 ms |
-| node1048 | cpu (x86_64, glibc 2.35) | ✅ all 3 runs equal | ✅ all 3 runs equal | ❌ drift | 31 / 256 tokens (12.11%) | encode 4.04 s · decode 5.19 s |
+| A800 node | cuda (A800-80G, cudnn 8500) | ✅ all 3 runs equal | ✅ all 3 runs equal | ❌ drift | 30 / 256 tokens (11.72%) | encode 9.6 ms · decode 13.0 ms |
+| A800 node | cpu (x86_64, glibc 2.35) | ✅ all 3 runs equal | ✅ all 3 runs equal | ❌ drift | 31 / 256 tokens (12.11%) | encode 4.04 s · decode 5.19 s |
 
 **Within-device determinism**: byte-identical across all 3 runs on both
 devices, for both encode (token grid) and decode (PNG SHA-256).
@@ -247,10 +247,10 @@ that own-trained weights will plug into.
   ADR-0015 / #374 precedent and not a Gate C failure.
 - Does NOT upgrade `taming-transformers` upstream weights from PARTIAL
   — that work, if ever needed, is a separate wiring-slice follow-up.
-- Does NOT measure a second machine. node1048 was the only host audited
-  in this pass; a sibling node audit (172.16.1.35-40 on the same
-  cluster) would cross-confirm the `structural-parity` declaration but
-  is not a release blocker.
+- Does NOT measure a second machine. A single A800 node was the only
+  host audited in this pass; a sibling-node audit on the same cluster
+  would cross-confirm the `structural-parity` declaration but is not a
+  release blocker.
 - Does NOT touch the GPU ONNX runtime tier — Gate D measures
   `CPUExecutionProvider` only, which is the canonical M-phase
   `node-onnx-cpu` target. A `node-onnx-gpu` audit is its own follow-up
@@ -267,8 +267,8 @@ that own-trained weights will plug into.
 | Gate C script | `m1b-work/scripts/gate_c_roundtrip.py` SHA-256 `a333000f11b9ebcc6a692112f7f46197075ba82a276f21bdf06b4cde5c8abd98` |
 | Gate D script | `m1b-work/scripts/gate_d_onnx_export.py` SHA-256 `393ddb8728808e528f77765c0003e8c911e746efea15788d9aa9b17272e1cae6` |
 | Run driver | `m1b-work/scripts/run_audits.sh` SHA-256 `d3570957d476d9bdbd5773b2afb8589634bdb1591a3a6376c9d3dcffe620ce2b` |
-| Receipts | `m1b-work/receipts/gate_c_cuda_node1048_20260527T092649Z.json`, `gate_c_cpu_*.json`, `gate_d_*.json` |
-| Hardware (primary) | qiyuan node1048, 8× A800-SXM4-80GB, NVIDIA CUDA 11.7 cudnn 8500 |
+| Receipts | `m1b-work/receipts/gate_c_cuda_20260527T092649Z.json`, `gate_c_cpu_*.json`, `gate_d_*.json` |
+| Hardware (primary) | 8× A800-SXM4-80GB node, NVIDIA CUDA 11.7 cudnn 8500 |
 | Software | linear conda env: torch 2.0.1+cu117, onnx 1.21.0 (opset_max 26), onnxruntime 1.23.2, PIL 11.3.0, numpy 1.23.5, Python 3.10.18 |
 | OS | Linux 5.15.0-60-generic x86_64 glibc 2.35 |
 

--- a/research/training/tokenizer/README.md
+++ b/research/training/tokenizer/README.md
@@ -6,8 +6,8 @@ trained on ImageNet + CC12M, per
 
 ## Status
 
-Scaffold and DDP training loop **shipped and smoke-validated on
-qiyuan node1048 (A800-SXM4-80GB ×2, NCCL 2.18.5, CUDA 12.8, torch
+Scaffold and DDP training loop **shipped and smoke-validated on a
+2× A800-SXM4-80GB node (NCCL 2.18.5, CUDA 12.8, torch
 2.9.1)**. Real-data launch is gated on dataset prep
 ([#400](https://github.com/p-to-q/wittgenstein/issues/400) DVC remote)
 and the training-stack re-audit close
@@ -92,16 +92,16 @@ must be true:
 
 ## Phase 1.1 launch (real)
 
-Once dataset prep lands, launch on qiyuan as:
+Once dataset prep lands, launch on an 8×-GPU node as:
 
 ```bash
-cd /nfsdata/wxu/wittgenstein/witt-repo
+cd "$WITT_REPO"
 
 # 8× A800-80GB single-node DDP — effective batch 1024 at bs=128/GPU
 torchrun --nproc-per-node 8 --master-port 29500 \
     -m research.training.tokenizer.train \
-    --train-data-root /nfsdata/wxu/datasets/imagenet/train \
-    --out-root /nfsdata/wxu/wittgenstein/runs \
+    --train-data-root "$DATA_ROOT/imagenet/train" \
+    --out-root "$OUT_ROOT/runs" \
     --max-steps 200000 \
     --batch-size-per-gpu 128 \
     --codebook-embed-dim 32 \

--- a/research/training/tokenizer/config.py
+++ b/research/training/tokenizer/config.py
@@ -4,8 +4,8 @@ Pulls hyperparameters into a single dataclass that's snapshotted into the
 training manifest (so every checkpoint records exactly what config produced
 it). Override via CLI flags in train.py.
 
-Defaults follow research-program note §1.1 with adjustments for the
-qiyuan cluster (8× A800-80GB) — see `batch_size` doc below.
+Defaults follow research-program note §1.1 with adjustments for an
+8× A800-80GB node — see `batch_size` doc below.
 """
 
 from __future__ import annotations
@@ -45,7 +45,7 @@ class TrainConfig:
 
     # Batch size:
     #   - LlamaGen recipe: 128 per-GPU at 256² on A100-80G is comfortable.
-    #   - 8× A800-80GB on qiyuan node1048 → effective 1024 with DDP, no grad
+    #   - 8× A800-80GB single node → effective 1024 with DDP, no grad
     #     accumulation. Matches the research-program §1.1 target.
     batch_size_per_gpu: int = 128
 

--- a/research/training/tokenizer/train.py
+++ b/research/training/tokenizer/train.py
@@ -9,11 +9,11 @@ Design choices per #441 (training-stack re-audit):
     training manifest via _shared/manifest.py.
   - FSDP2 deferred — a 72M-param VQGAN fits comfortably on a single A800.
 
-Launch (single-node multi-GPU on qiyuan):
-    cd /nfsdata/wxu/wittgenstein/witt-repo
+Launch (single-node multi-GPU):
+    cd "$WITT_REPO"
     torchrun --nproc-per-node 8 -m research.training.tokenizer.train \\
-        --train-data-root /nfsdata/wxu/datasets/imagenet/train \\
-        --out-root /nfsdata/wxu/wittgenstein/runs
+        --train-data-root "$DATA_ROOT/imagenet/train" \\
+        --out-root "$OUT_ROOT/runs"
 
 Smoke (1 GPU, synthetic data, no actual deps installed beyond torch):
     python -m research.training.tokenizer.smoke_test


### PR DESCRIPTION
## Summary

Removes internal cluster-topology references that landed via the M1B audit (#491) and tokenizer scaffold (#493). **No secrets, API keys, IPs-with-credentials, or SSH keys were ever committed** — but the internal hostname, cluster name, NFS mount path + username are needless internal-topology exposure on a public repo with zero value to external readers.

## What changed (4 files, behavior-preserving)

| Was | Now |
|---|---|
| `qiyuan` / `node1048` | `8× A800-SXM4-80GB node` / `A800 node` |
| `172.16.1.35-40` (RFC-1918 private IP) | "the same cluster" (prose) |
| `/nfsdata/wxu/...` absolute paths | `$WITT_REPO` / `$DATA_ROOT` / `$OUT_ROOT` env-var placeholders |
| receipt filenames `..._node1048_...` | timestamp kept, host segment dropped |

Files:
- `docs/research/2026-05-27-audit-vqgan-class-gates-cd.md`
- `research/training/tokenizer/README.md`
- `research/training/tokenizer/{config,train}.py`

## What is deliberately KEPT

The **A800-80GB / CUDA 11.7 / cuDNN 8500 / torch 2.x** facts stay — they are the load-bearing reproducibility context for the `structural-parity` verdict (cross-device float drift depends on the exact accelerator + cuDNN). Only machine/cluster/path *identifiers* are removed, not the hardware characterization.

## Verification

- `git grep -nE "node1048|qiyuan|nfsdata|172\.16\.|thunlp|aTrust|wxu"` → **0 matches** on this branch.
- `config.py` and `train.py` still parse (`python -m ast`).
- Launch commands now use env-var placeholders a contributor sets locally.

## Caveat

git **history** still contains the original strings (commits from #491/#493). Removing those requires a history rewrite, which is out of scope and disruptive for a public repo; this PR cleans the HEAD/working surface so fresh clones and readers don't see internal topology.

## Test plan

- [ ] Docs/scaffold-only; `Verify (Node + Python)` unaffected (no TS, research/ not in build graph)
- [ ] Confirm `git grep` for the identifier set returns empty on merge
- [ ] One maintainer review (docs-only)