### PR TITLE
docs(research): land M1B research notes + radar Gate E (salvaged from #455)

### DIFF
--- a/docs/research/2026-05-22-cola-dlm-implications.md
+++ b/docs/research/2026-05-22-cola-dlm-implications.md
@@ -1,0 +1,174 @@
+---
+date: 2026-05-22
+status: research note (literature survey + architectural implications)
+labels: [research-derived, m1b-image, adapter, continuous-latent, block-causal]
+tracks: [#283, #70, #67]
+cross-refs: [Brief B (Ilya-LeCun), Brief C H9 (patch-grid), ADR-0005, ADR-0018]
+---
+
+# Cola-DLM: Implications for Wittgenstein
+
+> **Status:** research note. Not doctrine, not active execution guidance.
+> Surveys ByteDance Seed's Cola-DLM (Continuous Latent Diffusion Language Model, arXiv:2605.06548, May 2026) and extracts specific architectural ideas portable to Wittgenstein's Visual Seed Code + frozen VQ decoder pipeline.
+
+## Why this note exists
+
+A maintainer identified Cola-DLM as relevant to two open questions:
+
+1. Whether its intermediate representation is superior to Wittgenstein's current IR design
+2. Whether its continuous-latent + block-causal approach offers techniques borrowable within the frozen-decoder doctrine
+
+This note answers both questions with specific architectural details and numbers from the paper and released code.
+
+---
+
+## Cola-DLM: Architecture Summary
+
+Cola-DLM replaces autoregressive next-token prediction with a three-stage hierarchy:
+
+```
+Text VAE encoder (q_phi)
+  → continuous latent sequence (z_0 in R^(L x d), d=16)
+    → Block-causal DiT prior (p_psi) via Flow Matching
+      → VAE decoder (p_theta) → discrete tokens
+```
+
+**Joint factorization:** `p(x, z_0) = p_theta(x | z_0) * p_psi(z_0)`
+
+### Key Components
+
+| Component        | Architecture                                                        | Params    | Details                                     |
+| ---------------- | ------------------------------------------------------------------- | --------- | ------------------------------------------- |
+| Text VAE encoder | 4 transformer blocks, causal, dim=1536, 12 heads, GQA, SwiGLU, RoPE | ~250M     | Diagonal Gaussian posterior (mean + logvar) |
+| Text VAE decoder | 4 transformer blocks, block-causal, same dims                       | ~250M     | Autoregressive within blocks                |
+| DiT prior        | 24 layers, 16 heads, dim=2048, SwiGLU, RoPE                         | ~1.8B     | Flow Matching, not diffusion                |
+| **Total**        |                                                                     | **~2.3B** |                                             |
+
+### Block-Causal Mechanism
+
+- **Block size:** 4 latent positions per block (released checkpoint; paper ablates {1, 16, 64, 128}, finds 16 optimal)
+- **Attention pattern:** Bidirectional within each block, causal across blocks
+- **Visible set for block b:** `V_b = {sg(z_0^(<b)), z_t^(b)}` where `sg()` = stop-gradient on historical clean blocks
+- **Token generation:** After DiT denoises one block of continuous latents, VAE decoder produces logits over vocabulary for `block_size` token positions at once
+
+### Flow Matching (not classical diffusion)
+
+- **Loss:** `L_FM = sum_b E_{t,z_0,z_1} [||v_psi(z_t^(b), t; z_0^(<b)) - u_t^(b)||^2]`
+- **Noise schedule:** Logit-normal with loc=1.0 (optimal per ablation)
+- **ODE integration:** Euler-style, T=1000.0
+- **Inference steps:** 16 default (8-10 recover most quality)
+- **CFG scale:** 7.0 default (best range 3-7)
+
+### Training Recipe
+
+- Two-stage: Stage 1 = VAE only; Stage 2 = joint VAE + DiT
+- **Critical finding:** Joint DiT with full LR on VAE is best. Fixed VAE saturates early. "All scratch" collapses latent geometry.
+- VAE masking loss (BERT-style) prevents encoder semantic collapse
+- Sequence length: 512 tokens
+- Scaling curves evaluated up to ~2000 EFLOPs
+
+### Key Ablation Findings
+
+1. **VAE co-training:** Joint with LR x1.0 >> Fixed VAE >> All-scratch (collapses)
+2. **Block size:** 16 > 1 (fully causal) > 64/128 on benchmarks
+3. **First-block conditioning:** "Clean repaint" dominates (24.6 avg) vs partial/padding (8.4-16.7)
+4. **Latent compression p=2:** Competitive on aligned boundaries, **fails on misaligned prompts** due to "semantic shifted latents at patch boundary"
+5. **Reconstruction under perturbation:** Stays near-perfect at t=0 (~0.96 at t=100, ~0.92 at t=250)
+
+---
+
+## Implications for Wittgenstein
+
+### What is directly portable (no doctrine conflict)
+
+#### 1. Block-causal adapter design
+
+**Idea:** Wittgenstein's L4 adapter (seed expander) could use block-causal attention over VQ token blocks instead of fully autoregressive or fully independent generation.
+
+**Concrete proposal:** If using TiTok-32 (32 VQ tokens for 256x256), generate in blocks of 4-8 tokens. Within each block, bidirectional attention allows tokens to co-inform. Across blocks, causal attention maintains left-to-right coherence.
+
+**Why this helps:** The LLM's seed code provides the "prompt" for the first block. Each subsequent block conditions on all previous blocks' resolved VQ indices. This is structurally identical to Cola-DLM's block-causal DiT but operates in discrete VQ space, preserving determinism.
+
+**Compatibility:** Does not violate ADR-0005 (decoder ≠ generator) because the adapter is a learned bridge, not a generator. The frozen decoder still receives discrete VQ indices and reconstructs deterministically.
+
+#### 2. Clean-repaint conditioning for seed expansion
+
+**Idea:** When the LLM provides a partial seed code (e.g., 8 tokens out of 32 needed), treat those as "clean" positions pinned to their known VQ indices. Predict/denoise only the unknown positions.
+
+**Source:** Cola-DLM's "clean repaint" strategy for first-block conditioning (ablation shows massive advantage: 24.6 avg vs 8.4-16.7 for alternatives).
+
+**Concrete proposal:** In the seed expander, known seed positions retain their values throughout all expansion steps. Unknown positions are predicted conditioned on the known ones. This is equivalent to masked token prediction (MaskGIT-style) with a fixed mask.
+
+**Why this helps directly on concern (a):** The user's stability concern about first 5-15 tokens is exactly this — if those tokens are good, this mechanism guarantees they're preserved and the rest is filled in coherently around them.
+
+#### 3. Block-wise quality: U-shaped pattern awareness
+
+**Finding from DLCM (arXiv:2512.24617):** Token prediction quality is best at concept boundaries (first and last tokens of a block) and slightly worse at mid-block positions.
+
+**Implication for seed code:** If the LLM emits 8 "seed" tokens, they should correspond to block boundaries (first token of each block of 4), not arbitrary positions. This maximizes the signal-to-noise ratio of the seed.
+
+### What requires adaptation (partially compatible)
+
+#### 4. Continuous-latent planning with discrete quantization boundary
+
+**Idea:** Use a continuous latent space for high-level visual planning (layout, composition, palette), then discretize to VQ indices at the adapter boundary.
+
+**Why it's tempting:** Cola-DLM shows continuous latents are better for global semantic organization. Wittgenstein's Semantic IR already serves this role but is currently unstructured text.
+
+**Adaptation needed:** Train a small "semantic encoder" that maps Semantic IR fields to a continuous embedding, then a "quantization head" that projects from continuous embedding to VQ codebook logits. This keeps the upstream planning in continuous space (better for interpolation, composition) while the downstream decoder receives discrete indices (deterministic).
+
+**Compatibility:** Fits within L4 adapter scope. Does not violate ADR-0005 because the decoder still receives discrete codes. The continuous space is internal to the adapter, not exposed to the decoder.
+
+**Risk:** Training complexity increases. Cola-DLM found that joint VAE training requires careful co-training strategy (LR scheduling, masking loss). A simpler MLP adapter may suffice for v0.3.
+
+### What is incompatible (do not adopt)
+
+#### 5. Full continuous-latent generation path
+
+**Why not:** Cola-DLM's core path generates in continuous R^16 space and only discretizes to tokens at the final step. This requires a continuous decoder (the VAE decoder), not a frozen VQ decoder. Adopting this would:
+
+- Violate ADR-0005 (decoder ≠ generator — the VAE decoder is generative)
+- Break manifest spine bit-exact / structural-parity reproducibility (Flow Matching ODE introduces floating-point sensitivity)
+- Require full model retraining (~2.3B params), violating ADR-0007 (Path C rejected)
+
+#### 6. Latent sequence compression (patch_size > 1)
+
+**Why not:** Cola-DLM's ablation showed patch_size=2 (2x sequence compression) fails on misaligned prompt boundaries. Their released checkpoint uses patch_size=1 (no compression). For Wittgenstein, this means: do NOT try to compress the VQ token sequence further via latent pooling. Keep 1:1 mapping between adapter output positions and decoder input positions.
+
+---
+
+## Comparison to Wittgenstein's Current Architecture
+
+| Dimension             | Wittgenstein (current)                        | Cola-DLM                            | Borrowable?                      |
+| --------------------- | --------------------------------------------- | ----------------------------------- | -------------------------------- |
+| Intermediate repr     | Discrete VQ tokens                            | Continuous latent R^16              | No (violates ADR-0005)           |
+| Generation            | LLM autoregressive → adapter → VQ             | DiT Flow Matching in latent space   | Partially (block-causal pattern) |
+| Determinism           | Structural guarantee (same seed → same bytes) | Not guaranteed (ODE floating-point) | No                               |
+| Multi-modal alignment | Per-modality codec isolation                  | Continuous space natural alignment  | See §4 adaptation                |
+| Token granularity     | Per-token                                     | Per-block (block_size=4-16)         | Yes (block-causal adapter)       |
+| Conditioning          | Full seed code or semantic IR                 | Clean-repaint pinning               | Yes (seed expansion)             |
+
+---
+
+## Recommended Next Steps
+
+1. **[Actionable]** Design block-causal attention mask for the L4 adapter's seed expander (MaskGIT-style, 8 steps, block_size=4 for TiTok-32). File as sub-issue of #70.
+2. **[Actionable]** Implement clean-repaint conditioning in the seed expander interface: known seed positions pinned, unknown positions predicted. Extends `SeedExpander` ABI.
+3. **[Research]** Prototype continuous-to-discrete adapter head: Semantic IR embedding → continuous plan → VQ logits. Evaluate whether the extra complexity buys measurable quality over direct MLP.
+4. **[Watch]** Cola-DLM weights are Apache-2.0 on HuggingFace. If they release a vision-language variant, reassess compatibility.
+
+---
+
+## Citations
+
+- Guo, H. et al. (2026). "Cola-DLM: Continuous Latent Diffusion Language Model." arXiv:2605.06548. Code: github.com/ByteDance-Seed/Cola-DLM. License: Apache-2.0.
+- DLCM / Dynamic Large Concept Models: Qu, X. et al. (2025). arXiv:2512.24617. (Variable-length concept compression; block boundary quality pattern.)
+- Yu, Q. et al. (2024). "An Image is Worth 32 Tokens for Reconstruction and Generation." ICLR 2024. arXiv:2406.07550. (TiTok 32-token baseline for seed code target length.)
+- Sun, P. et al. (2024). "Autoregressive Model Beats Diffusion: Llama for Scalable Image Generation." arXiv:2406.06525. (LlamaGen; M1B canonical decoder candidate.)
+
+## Boundaries
+
+- Does NOT modify code or schema.
+- Does NOT alter doctrine surfaces (ADR-0005, ADR-0018, README, architecture.md).
+- Does NOT pick a tokenizer family — defers to #283 radar.
+- Does NOT propose new operating-doc text.

--- a/docs/research/2026-05-22-cot-inspired-improvements.md
+++ b/docs/research/2026-05-22-cot-inspired-improvements.md
@@ -1,0 +1,220 @@
+---
+date: 2026-05-22
+status: research note (improvement proposals)
+labels: [research-derived, m1b-image, adapter, cot, reasoning, improvement]
+tracks: [#70, #207, #67, #66]
+cross-refs: [ADR-0018, Brief C H9/H10, reserve-paths.md RP-001, 2026-05-22-cola-dlm-implications.md]
+---
+
+# CoT-Inspired Improvements for Image Generation
+
+> **Status:** research note. Not doctrine, not active execution guidance.
+> Connects chain-of-thought / thinking-model ideas to Wittgenstein's image pipeline.
+> Identifies what's already tracked, what's new, and proposes concrete next steps.
+
+## Why this note exists
+
+A maintainer observed that chain-of-thought (CoT) reasoning — where LLMs "think step by step" before answering — may improve Visual Seed Code quality. The intuition: if the LLM reasons through the visual structure before committing to VQ tokens, the tokens should be more stable, more semantically grounded, and more consistent across runs.
+
+This note connects that intuition to three existing tracked items and two new proposals.
+
+---
+
+## What's already tracked
+
+### 1. Two-pass compile (ADR-0018, lane B)
+
+**What it is:** Pass 1 emits Semantic IR only; Pass 2 emits seed code conditioned on that IR.
+
+**How it's CoT:** The first pass is the "thinking" step — the LLM articulates its visual plan in structured text. The second pass is the "answering" step — committing to specific VQ tokens.
+
+**Status:** Ratified as legal lane in ADR-0018. Not implemented (expand phase is no-op in `pipeline/expand.ts`). Tracked as acceptance case in `2026-05-07-vsc-acceptance-cases.md` lane B.
+
+**What's missing:** No implementation, no empirical comparison between one-shot and two-pass quality.
+
+### 2. H10: Long-code clarity (Brief C, lines 113-122)
+
+**What it is:** FIBO-style long-form caption expansion (hundreds to thousands of words) before image generation. The LLM emits 5% of its context window as a detailed "render program."
+
+**How it's CoT:** Extensive "thinking" in natural language before committing to structured output.
+
+**Supporting research:**
+
+- FIBO (Nov 2025, arXiv:2511.06876): Structured long-form captions improve text-to-image alignment
+- TIPO (arXiv:2411.08127): Tag-based prompt optimization
+- Progress by Pieces (Nov 2025, arXiv:2511.21185): Incremental composition
+- Anthropic Extended Thinking: Built-in CoT in frontier models
+
+**Status:** Confidence 0.3 in Brief C. Verdict: "Cheapest hypothesis to run; add optional `--expand` flag." Reserve path RP-001 specifies activation criteria.
+
+**What's missing:** No A/B test data. No `--expand` flag implementation.
+
+### 3. H9: Patch-grid / next-scale IR (Brief C, lines 102-111)
+
+**What it is:** VAR-style coarse-to-fine prediction where each "scale" is a CoT-like refinement step.
+
+**How it's CoT:** Instead of emitting all tokens at once, emit coarse layout first (4x4 = 16 tokens), then refine to medium (8x8 = 64), then fine (16x16 = 256). Each scale conditions on all previous scales.
+
+**Supporting research:**
+
+- VAR (NeurIPS 2024 Best Paper, arXiv:2404.02905): Next-scale prediction beats next-token for images
+- FlexTok (ICML 2025, arXiv:2502.13967): Elastic prefixes with any prefix valid
+
+**Status:** Confidence 0.3 in Brief C. Gated on open-weights LFQ decoder. Tracker: #67.
+
+**What's missing:** No open-weights LFQ decoder yet. No implementation.
+
+---
+
+## What's new (not yet tracked)
+
+### 4. Structured visual reasoning before seed code emission
+
+**Proposal:** Before emitting `seedCode.tokens`, have the LLM produce an explicit "visual reasoning" block within the Semantic IR. This is not the two-pass compile (which requires two LLM calls); it's a single-call CoT where the model reasons in the same output.
+
+**Concrete schema addition:**
+
+```json
+{
+  "semantic": {
+    "intent": "Coastal cliffs at sunset",
+    "reasoning": {
+      "spatialPlan": "Horizon at upper third. Cliffs left-center. Ocean fills right and bottom. Sky dominates upper area.",
+      "colorPlan": "Warm oranges and pinks in sky, transitioning to deep blue at horizon. Dark gray-brown cliffs. Dark blue-green ocean.",
+      "depthPlan": "Foreground: cliff edge with texture. Midground: ocean surface. Background: sky gradient.",
+      "tokenStrategy": "First 8 tokens: sky/horizon/cliff gross layout. Tokens 9-20: ocean and cliff detail. Tokens 21-32: texture and lighting."
+    }
+  },
+  "seedCode": { "tokens": [...] }
+}
+```
+
+**Why this helps:**
+
+1. Forces the LLM to commit to a spatial and color plan before choosing VQ tokens
+2. The `tokenStrategy` field makes the LLM reason about which tokens carry which information — this is essentially the model doing its own "importance ordering"
+3. The adapter can use the reasoning fields as additional conditioning (convert to CLIP embeddings)
+4. The reasoning is inspectable — if the image fails, we can diagnose whether the failure was in reasoning or in token selection
+
+**Difference from two-pass compile:** Single LLM call, not two. The "reasoning" block is generated autoregressively before the `seedCode` block within the same output. This is exactly how CoT works in text: the model generates its reasoning, then generates its answer, conditioned on that reasoning.
+
+**Cost:** ~50-100 extra tokens of LLM output. No extra LLM call. No new infrastructure.
+
+**Risk:** The LLM may ignore the reasoning block when generating tokens (the reasoning may not actually condition the seed code selection). Empirical test needed.
+
+### 5. Block-causal CoT in the adapter (from Cola-DLM)
+
+**Proposal:** The L4 adapter uses block-causal generation where each block's prediction is conditioned on all previous blocks' resolved tokens PLUS a "planning" representation.
+
+**Concrete mechanism:**
+
+1. Semantic IR → CLIP embedding → "plan vector" (512-dim)
+2. Divide 32 target VQ tokens into 4 blocks of 8
+3. For block 1: condition on plan vector → predict 8 tokens (bidirectional within block)
+4. For block 2: condition on plan vector + block 1's resolved tokens → predict 8 tokens
+5. Repeat for blocks 3, 4
+
+**How this is CoT:** The plan vector is the "thought"; each block prediction is a "step" that builds on previous steps.
+
+**Source:** Cola-DLM's block-causal DiT (see `2026-05-22-cola-dlm-implications.md` §1).
+
+**Advantage over fully autoregressive:** Within each block, tokens can attend to each other bidirectionally. This means token 5 in a block is informed by token 8 in the same block, not just tokens 1-4. This reduces the serial dependency length from 32 to 4.
+
+**Cost:** Requires a trained block-causal prediction model in the adapter. Fits within L4 scope. Medium complexity.
+
+---
+
+## Interaction matrix: existing + new proposals
+
+Brief C (lines 111-122) already identifies the natural shape as a 2-axis matrix:
+
+|              | JSON IR (current)                  | Patch-grid IR (H9)             |
+| ------------ | ---------------------------------- | ------------------------------ |
+| **1 round**  | one-shot VSC (current default)     | one-shot VAR-style multi-scale |
+| **2 rounds** | two-pass compile (ADR-0018 lane B) | two-pass + coarse-to-fine      |
+
+Adding the CoT proposals:
+
+|                                     | JSON IR                  | JSON IR + reasoning        | Patch-grid IR             |
+| ----------------------------------- | ------------------------ | -------------------------- | ------------------------- |
+| **1 round, autoregressive adapter** | Current default          | New proposal #4            | H9 future                 |
+| **1 round, block-causal adapter**   | With Cola-DLM adapter    | #4 + #5 combined           | H9 + Cola-DLM             |
+| **2 rounds**                        | Two-pass compile         | Two-pass + reasoning       | Two-pass + coarse-to-fine |
+| **2 rounds + expand**               | H10 long-code + two-pass | H10 + reasoning + two-pass | Full pipeline             |
+
+The **recommended immediate path** is #4 (structured visual reasoning in single-call) because it:
+
+- Has zero infrastructure cost (just a schema/preamble change)
+- Is compatible with all future adapter architectures
+- Provides immediate empirical signal on whether CoT helps image planning
+- Does not require tokenizer family selection or adapter training
+
+---
+
+## Proposed actions
+
+### Immediate (zero-cost)
+
+1. **Preamble experiment:** Modify the VSC skill preamble to include a `reasoning` block template. Test with frontier LLMs. Measure:
+   - Whether the LLM produces coherent spatial/color/depth plans
+   - Whether the seed code tokens change when reasoning is included vs excluded
+   - Whether image quality (perceptual, via human inspection) improves
+
+2. **`--expand` flag stub:** Add a CLI flag that triggers two-pass compile. Even without a trained adapter, the two-pass flow exercises the harness path and validates the schema.
+
+### Short-term (after tokenizer selection)
+
+3. **Prefix degradation with/without CoT:** Compare TiTok-32 rFID when seed codes come from:
+   - Direct one-shot emission (no reasoning)
+   - CoT reasoning + emission (proposal #4)
+   - Two-pass compile (lane B)
+     Measure whether CoT reduces variance in seed code quality.
+
+### Medium-term (after adapter training)
+
+4. **Block-causal adapter (proposal #5):** Implement as a SeedExpander variant. Train on (plan-vector, ground-truth-VQ) pairs. Compare against:
+   - Fully autoregressive adapter
+   - MaskGIT-style parallel adapter
+   - Placeholder expander (baseline)
+
+---
+
+## Connection to the two core concerns
+
+### Concern (a): Seed code stability
+
+CoT directly helps here. If the LLM reasons about spatial layout and token strategy before committing to VQ tokens, the tokens should be:
+
+- More consistent across runs (the reasoning constrains the output)
+- More importance-ordered (the model explicitly plans "first 8 tokens = gross layout")
+- More robust to temperature variation (the reasoning anchors the distribution)
+
+### Concern (b): IR reliability
+
+CoT provides an additional information channel. Even if the seed code tokens are noisy, the `reasoning` block carries structured visual information that the adapter can use as conditioning. This is a **belt-and-suspenders** approach: the IR carries information through both structured text (reasoning) and discrete tokens (seed code).
+
+---
+
+## What NOT to do
+
+1. **Do NOT add CoT as a mandatory pipeline step.** Keep it optional (`--expand` flag, or schema field). One-shot VSC must remain the fast default path.
+2. **Do NOT train a separate "reasoning model."** Use the same LLM — CoT is a prompting strategy, not a model change.
+3. **Do NOT block M1B on CoT results.** CoT is an improvement hypothesis, not a prerequisite. M1B should ship with one-shot VSC as default; CoT experiments inform the post-M1B optimization phase.
+
+## Cross-references
+
+- `docs/research/briefs/C_unproven_horizon.md` — H9 (patch-grid), H10 (long-code)
+- `docs/reserve-paths.md` — RP-001 (two-round interaction)
+- `docs/adrs/0018-hybrid-image-code-and-visual-seed-token.md` — Two-pass compile lane
+- `docs/research/2026-05-22-cola-dlm-implications.md` — Block-causal adapter source
+- `docs/research/2026-05-22-seed-code-stability-analysis.md` — Stability concern
+- `docs/research/2026-05-22-ir-reliability-validation.md` — IR reliability concern
+- `docs/research/visual-seed-code-skill-playbook.md` — Current preamble design
+
+## Boundaries
+
+- This note started as a proposal. A follow-up #454 implementation may modify the
+  image schema / preamble to add optional `semantic.reasoning`; that code change
+  should be reviewed as an experiment hook, not doctrine.
+- Does NOT alter doctrine surfaces.
+- Does NOT require new infrastructure for the immediate proposals.

--- a/docs/research/2026-05-22-ir-reliability-validation.md
+++ b/docs/research/2026-05-22-ir-reliability-validation.md
@@ -1,0 +1,226 @@
+---
+date: 2026-05-22
+status: research note (concern analysis + validation plan)
+labels: [research-derived, m1b-image, ir-design, validation, concern]
+tracks: [#283, #70, #207, #258]
+cross-refs: [ADR-0018, ADR-0006, vsc-as-compression-prior.md, hybrid-image-code.md]
+severity: high — existential for the harness thesis
+---
+
+# IR Reliability: Can the Intermediate Representation Carry Real Visual Information?
+
+> **Status:** research note addressing a maintainer-raised concern.
+> The concern: Wittgenstein's IR (Semantic IR + Visual Seed Code) is a _harness-level_ construct, not a _model-level_ representation. It may not be able to carry enough real visual information for the frozen decoder to produce meaningful images. This note assesses the risk, identifies what "enough information" means for each IR layer, and proposes a concrete validation plan.
+
+## The concern, stated precisely
+
+Wittgenstein defines two IR layers for image (per ADR-0018):
+
+1. **Semantic IR** — structured JSON describing intent, subject, composition, lighting, style, constraints. Emitted by the LLM. Human-readable, inspectable.
+2. **Visual Seed Code** — a short sequence of discrete tokens (target: 32-128). Emitted by the LLM. Decoder-facing, opaque to humans.
+
+The concern has two parts:
+
+**(a) Semantic IR may be "empty calories":** The LLM can produce beautifully structured JSON describing a scene, but the adapter may not be able to extract actionable visual information from text fields like `"mood": "warm golden"` or `"depthPlan": "foreground subject, blurred background"`. These are human-readable descriptions, not machine-actionable features.
+
+**(b) Visual Seed Code may not carry real decoder information:** The LLM emits VQ token IDs, but those IDs may not correspond to what the decoder actually needs. The LLM has never seen the VQ codebook; it's guessing token IDs based on text-domain priors.
+
+If both (a) and (b) fail, the IR is a conduit for format compliance, not information.
+
+---
+
+## Analysis
+
+### Part (a): Semantic IR information capacity
+
+**Current state:** The `ImageSceneSpec` schema defines rich semantic fields, but they are **largely unused** in the pipeline. The adapter's MLP feature engineering hashes the entire spec to a 128-dim float vector (SHA256 → byte-to-float mapping). This is a **lossy, semantically meaningless** encoding — it treats the spec as an opaque blob, not as structured semantic input.
+
+**What would make Semantic IR reliable:**
+
+1. **Structured embeddings:** Instead of hashing, use a pretrained text encoder (CLIP, SigLIP) to embed semantic fields into a vector space where "warm golden lighting" is meaningfully close to "sunset" and far from "fluorescent office." This is standard in text-to-image pipelines.
+
+2. **Field-level conditioning:** Route specific fields to specific adapter components. Composition fields → spatial layout predictor. Style fields → palette predictor. Subject fields → object presence predictor. This is what Stable Diffusion's CLIP conditioning does (text embedding conditions the U-Net at multiple scales).
+
+3. **Validation metric:** Semantic IR is reliable if and only if: changing a semantic field (e.g., "lighting.mood" from "warm" to "cold") produces a measurable change in the output image that aligns with the semantic change. If changing "warm" to "cold" produces no visible difference, the field is not carrying information.
+
+**Assessment:** Semantic IR is currently **format-compliant but information-empty** in the pipeline. The fix is well-understood (use pretrained embeddings, not hashing) and is standard practice in the text-to-image literature. This is an adapter engineering problem, not a fundamental limitation.
+
+### Part (b): Visual Seed Code information capacity
+
+This is the harder question. Three scenarios:
+
+#### Scenario B1: LLM emits valid VQ token IDs (encoder-matching distribution)
+
+**If** the LLM can be trained or prompted to emit token IDs whose distribution matches what a published VQ encoder would produce for similar images, then the seed code carries real decoder information.
+
+**Evidence for:** DALL-E 1 (Ramesh et al., 2021) demonstrated that a 12B autoregressive transformer can learn to predict VQ tokens from text conditioning. LlamaGen (Sun et al., 2024) showed this with a standard LLaMA architecture at 2.18 FID. SEED tokenizer (Ge et al., 2023) trained codebooks to be semantically aligned with language.
+
+**Evidence against:** These models were **trained** on paired (text, image-token) data. Wittgenstein's thesis is that a **frozen** text LLM can emit valid tokens via prompting alone (or with a small adapter), without paired training data.
+
+**Testable prediction (from `vsc-as-compression-prior.md` prediction 1):** Compare the distribution of tokens emitted by a frozen LLM (prompted with VSC preamble) against the distribution produced by a published encoder on similar images. If the distributions are unrelated, the frozen-LLM-as-prior bet is broken.
+
+#### Scenario B2: LLM emits semantically meaningful but decoder-misaligned tokens
+
+**If** the LLM's token choices carry semantic structure (e.g., similar prompts → similar token sequences) but don't align with any published decoder's codebook, then a **trained adapter** can bridge the gap.
+
+This is the **most likely scenario** and is what Wittgenstein's L4 adapter is designed for. The adapter learns the projection from "LLM's semantic token space" to "decoder's VQ codebook space." This is a low-dimensional problem (per `vq-tokens-as-interface.md` §4).
+
+**What makes this reliable:** The adapter's training data must include paired (LLM-emitted-tokens, encoder-derived-ground-truth-tokens) samples. The adapter learns the mapping; the decoder handles reconstruction.
+
+**Risk:** If the LLM's token distribution has no structure (effectively random), the adapter has nothing to learn from. The mapping becomes a lookup table, not a generalizable function.
+
+#### Scenario B3: LLM emits essentially random token IDs
+
+**If** the frozen LLM has no useful prior over visual token distributions — the IDs are arbitrary numbers unrelated to visual content — then the Visual Seed Code is informationless.
+
+**In this scenario:** The VSC-as-compression-prior thesis fails. The recovery path is:
+
+- Fall back to Semantic IR as the sole information carrier
+- Use a strong adapter (not just MLP, but a full text-to-token model like the SEED tokenizer's projection head) to convert semantic text → VQ tokens
+- The LLM's "seed code" becomes a random seed for the adapter, not meaningful input
+
+**This is not catastrophic** — it means the LLM contributes through semantic planning, not through direct visual coding. The architecture still works; the thesis is just weaker.
+
+---
+
+## What makes the IR "solid" — concrete criteria
+
+### Criterion 1: Semantic IR must change the output
+
+**Test:** Generate images with identical seed codes but different Semantic IR fields. Measure LPIPS (perceptual distance) between outputs.
+
+- If LPIPS ≈ 0 (same image regardless of Semantic IR): IR is not carrying information.
+- If LPIPS > 0.1 and changes align with semantic field changes: IR is carrying information.
+
+**Requires:** A trained adapter that actually uses Semantic IR (not the current SHA256-hash feature engineering).
+
+### Criterion 2: Seed code must correlate with image content
+
+**Test:** For a fixed prompt, collect N seed codes from different LLM runs (temperature > 0). For each seed code, run through encoder → decoder to get the "ground truth" image. Measure:
+
+- Mutual information between seed code token distribution and image content features (CLIP embedding)
+- If MI ≈ 0: seed code is noise
+- If MI > 0: seed code carries image information
+
+**Requires:** A published encoder for the chosen tokenizer family + the LLM emission corpus.
+
+### Criterion 3: Adapter must generalize
+
+**Test:** Train adapter on 80% of (prompt, seed-code, ground-truth-VQ) triples. Evaluate on held-out 20%.
+
+- If held-out rFID is within 2x of training rFID: adapter generalizes, IR pipeline is reliable.
+- If held-out rFID is >>2x: adapter is memorizing, not learning a generalizable mapping.
+
+**Requires:** Adapter training infrastructure (research program Track 1).
+
+### Criterion 4: End-to-end prompt fidelity
+
+**Test:** Generate 1000 images from diverse text prompts. Measure CLIPScore (text-image alignment) and compare against:
+
+- Baseline 1: Random VQ tokens → decoder (lower bound)
+- Baseline 2: Published encoder → decoder (upper bound, oracle)
+- Wittgenstein pipeline: LLM → seed code → adapter → decoder
+
+- If Wittgenstein CLIPScore ≈ random baseline: IR is not carrying information end-to-end.
+- If Wittgenstein CLIPScore is between baselines and closer to oracle: IR is working.
+
+**Requires:** Full pipeline with trained adapter + frozen decoder (M1B).
+
+---
+
+## Validation timeline
+
+| Phase              | What                                                                                                     | When                                   | Blocks on                                          |
+| ------------------ | -------------------------------------------------------------------------------------------------------- | -------------------------------------- | -------------------------------------------------- |
+| **Phase 0** (now)  | LLM emission distribution analysis: prompt LLM 100x, collect seed codes, measure entropy and structure   | Immediate                              | Nothing — uses current preamble + any frontier LLM |
+| **Phase 0b** (now) | Semantic IR field sensitivity: with placeholder adapter, vary one field at a time, measure output change | Immediate                              | Nothing — uses current code                        |
+| **Phase 1** (M1B)  | Criterion 2: Seed code ↔ image content mutual information                                                | After tokenizer family selected (#283) | Tokenizer selection                                |
+| **Phase 2** (M1B)  | Criteria 1, 3, 4: Full adapter training + held-out eval + CLIPScore                                      | After adapter training infrastructure  | Research program Track 1                           |
+
+### Phase 0 actions (can execute now)
+
+**Action 0a: LLM emission entropy test**
+
+Prompt a frontier LLM with the VSC preamble for 10 different image prompts, 10 runs each at temperature=0.3. For each prompt:
+
+1. Collect the `seedCode.tokens` arrays (10 arrays per prompt)
+2. Compute per-position token entropy across runs (H = -sum p log p)
+3. Compute inter-run Hamming distance
+
+**Expected results and what they mean:**
+
+- High entropy at all positions → LLM is guessing randomly → Scenario B3 (bad)
+- Low entropy at early positions, high at late → LLM has structure in early tokens → Scenario B2 (workable)
+- Low entropy everywhere → LLM has strong prior → Scenario B1 (ideal)
+
+**Action 0b: Semantic IR field sensitivity**
+
+Using the current placeholder adapter:
+
+1. Fix all fields except one (e.g., `lighting.mood`)
+2. Generate images with `mood = "warm golden"` vs `mood = "cold fluorescent"`
+3. Compare output PNGs pixel-by-pixel
+
+**Expected result:** With current SHA256-hash feature engineering, the outputs WILL differ (different hash → different seed → different image). But the difference will be random, not semantically meaningful. This establishes the **baseline** against which a trained adapter can be measured.
+
+---
+
+## The deeper question: is a harness-level IR fundamentally limited?
+
+The maintainer's concern touches a deeper issue: Wittgenstein defines IR as a **harness construct** (L2 layer), not a **model construct** (inside the LLM). This means:
+
+- The IR schema is designed by humans, not learned from data
+- The IR's information capacity is bounded by the schema fields and the LLM's ability to fill them meaningfully
+- The IR cannot represent visual information that the schema doesn't have fields for
+
+**Contrast with end-to-end models:** In DALL-E 3 or Stable Diffusion 3, the "IR" is a continuous embedding vector learned end-to-end. It can represent arbitrary visual information because it's not constrained by a human-designed schema.
+
+**Defense of the harness approach:**
+
+1. The schema is not the bottleneck — the **VQ codebook** is. A 4096-entry codebook with 32 tokens gives 4096^32 ≈ 10^115 possible images. The schema adds structured conditioning on top of this already-vast space.
+
+2. The adapter can learn to extract information from schema fields that humans didn't explicitly design for. A CLIP embedding of `"stormy ocean at midnight with lightning"` carries visual information even though no schema field says "lightning position" or "wave height."
+
+3. The harness approach is **inspectable** — you can read the IR and understand what the LLM planned. End-to-end embeddings are opaque. This inspectability is a product feature (per THESIS.md), not a compromise.
+
+**Honest limitation:** If the desired visual output requires information that is not expressible in text (e.g., the exact spatial frequency content of a texture), the harness IR cannot carry it. The adapter must hallucinate this from its training distribution. This is also true of text-to-image models — they hallucinate texture details from training data, not from the prompt.
+
+---
+
+## Verdict
+
+**The concern is legitimate but not fatal.**
+
+- **Semantic IR** is currently format-compliant but information-empty in the pipeline. The fix (pretrained text embeddings) is well-understood and standard. Estimated effort: adapter architecture change, not doctrine change.
+
+- **Visual Seed Code** reliability is an empirical question with three possible outcomes (B1/B2/B3). The most likely outcome (B2: semantically structured but decoder-misaligned) is exactly what the L4 adapter is designed to handle.
+
+- **The harness-level IR is not fundamentally limited** — it can carry as much information as the VQ codebook can represent, conditioned on text that a frontier LLM can produce.
+
+**What would change the verdict:**
+
+- Phase 0a shows Scenario B3 (random LLM emission) → VSC thesis weakened, pivot to semantic-only + strong adapter
+- Phase 2 shows Criterion 4 failure (CLIPScore ≈ random baseline) → IR pipeline not carrying information end-to-end
+
+**Recommended actions:**
+
+1. Execute Phase 0a and 0b immediately (no dependencies)
+2. Add "prefix degradation curve" and "emission distribution analysis" to the M1B prep checklist
+3. Upgrade adapter feature engineering from SHA256-hash to CLIP/SigLIP embedding (tracked as adapter architecture decision)
+4. File issue for Semantic IR field-sensitivity baseline measurement
+
+## Cross-references
+
+- `docs/research/2026-05-08-vsc-as-compression-prior.md` — Predictions 1-4 (this note operationalizes them)
+- `docs/research/2026-05-22-seed-code-stability-analysis.md` — Companion note on token-level stability
+- `docs/research/2026-05-22-cola-dlm-implications.md` — Cola-DLM's continuous latent as comparison point
+- `docs/research/hybrid-image-code.md` — Hybrid architecture original design
+- `docs/adrs/0006-layered-epistemology.md` — IR = Text | Latent | Hybrid sum type
+- `docs/adrs/0018-hybrid-image-code-and-visual-seed-token.md` — VSC first-class ratification
+- `docs/research/briefs/B_compression_vs_world_models.md` — Kill criterion 2 (compositional ceiling)
+
+## Boundaries
+
+- Does NOT modify code or schema.
+- Does NOT alter doctrine surfaces.
+- Does NOT claim the IR is or isn't reliable — proposes how to find out.

--- a/docs/research/2026-05-22-research-and-training-handoff.md
+++ b/docs/research/2026-05-22-research-and-training-handoff.md
@@ -1,0 +1,617 @@
+---
+date: 2026-05-22
+status: maintainer / researcher handoff note
+labels: [research-derived, m1b-image, training, reproducibility, handoff, concern]
+tracks: [#70, #259, #393, #394, #396, #397, #398, #399, #400, #435, #441, #451, #452, #453, #454]
+cross-refs:
+  [
+    ADR-0018,
+    docs/research/2026-05-08-vsc-as-compression-prior.md,
+    docs/research/2026-05-13-wittgenstein-research-program.md,
+    docs/research/2026-05-16-training-stack-re-audit.md,
+  ]
+---
+
+# Research and Training Handoff: What We Are Actually Trying to Prove
+
+> **Status:** handoff note, not doctrine. This is a letter to future
+> researcher / maintainer passes. It tries to say the quiet part clearly:
+> what we are afraid of, what would count as evidence, what prior notes
+> already exist, and where outside researchers should challenge us.
+
+## The ask
+
+We need more than a tidy summary of the current branch. We need a real research
+handoff.
+
+Wittgenstein is trying to make a strong claim:
+
+> A text-first LLM can plan multimodal artifacts through structured code-bearing
+> contracts; for image, Visual Seed Code can become the decoder-facing layer
+> between text planning and frozen pixel reconstruction.
+
+That sounds elegant. It may also be wrong.
+
+The job for researchers is not to protect the elegance. The job is to find out
+whether the claim survives pressure.
+
+If it survives, Wittgenstein has a research story. If it fails, we need to know
+early enough to pivot without spending GPU months training the wrong adapter or
+building a beautiful manifest around an empty signal.
+
+## The current anxiety
+
+There are two separate worries, and they should not be blurred together.
+
+### Worry 1: Visual Seed Code may be format compliance, not information
+
+The LLM can emit JSON. That is not the question.
+
+The question is whether `seedCode.tokens` carry real visual information:
+
+- Do runs for the same prompt have stable early tokens?
+- Are nearby prompts mapped to nearby token distributions?
+- Are first tokens more layout-bearing than later tokens?
+- Does a partial prefix degrade gracefully?
+- Does the token distribution resemble any real encoder distribution?
+
+If the answer is no, then direct VSC emission is not a prior over compressed
+visual programs. It is a random-number field inside valid JSON.
+
+That does not kill the whole architecture, but it weakens the thesis. The pivot
+would be: `Semantic IR + learned text/vision embedding adapter -> VQ logits`,
+with `seedCode` demoted to an optional hint or stochastic seed.
+
+### Worry 2: Training code may become expensive amateur infrastructure
+
+M1B cannot be treated like a normal feature branch. Tokenizer / adapter /
+decoder training can burn real compute and produce misleading confidence if the
+data, checkpoint, eval, and publishing surfaces are weak.
+
+The training stack must be good enough that a researcher would trust the
+experiment and an engineer would trust the artifact:
+
+- dataset snapshots are pinned;
+- checkpoint bytes are hashed;
+- eval preprocessing is fixed;
+- framework versions and commands are recorded;
+- failed runs still leave receipts;
+- model cards and weight manifests say what was actually trained;
+- reusable upstream code is evaluated before we write our own.
+
+The manifest is not only accountability after the fact. It is how training code
+stays professional while it is being written.
+
+## Prior research chain we should not forget
+
+Do not read only the 2026-05-22 notes. The real chain is longer:
+
+- `docs/research/briefs/B_compression_vs_world_models.md` — compression /
+  world-model pressure.
+- `docs/research/briefs/C_unproven_horizon.md` — H9 patch-grid and H10
+  long-code lanes.
+- `docs/research/vq-tokens-as-interface.md` — older VQ-token interface
+  framing.
+- `docs/research/hybrid-image-code.md` — hybrid image code predecessor.
+- `docs/research/2026-05-07-vsc-acceptance-cases.md` — lanes that define what
+  success could look like.
+- `docs/research/2026-05-08-vsc-as-compression-prior.md` — theoretical anchor:
+  LLM as prior, decoder as decompressor.
+- `docs/research/2026-05-08-image-tokenizer-decoder-radar.md` and
+  `2026-05-08-vsc-eval-matrix-cells.md` — tokenizer / decoder family map.
+- `docs/research/2026-05-13-m1b-prep-research.md` — Phase 0 floor, still useful
+  when compute is constrained.
+- `docs/research/2026-05-13-wittgenstein-research-program.md` — compute-rich
+  three-track plan.
+- `docs/research/2026-05-16-training-stack-re-audit.md` — training stack
+  re-audit and receipt-first warning.
+- `docs/research/2026-05-22-*` — new stability / Cola-DLM / SVD / CoT / IR
+  reliability concerns.
+
+The next researcher should stitch these together, not overwrite them.
+
+## Latest outside signals that should change our research questions
+
+Several recent tokenizer lines make the old "VQGAN-class grid first" default
+feel less obviously optimal for Visual Seed Code.
+
+- **FlexTok** projects images into ordered, variable-length 1D token sequences.
+  The key claim for us is not only quality; it is that 1 to 256 tokens can form
+  a hierarchy where shorter prefixes still reconstruct plausible images. That
+  is close to the VSC prefix thesis.
+- **Spectral Image Tokenizer** tokenizes the image spectrum with a
+  coarse-to-fine ordering and explicitly supports partial decoding. This is
+  almost exactly the kind of token order that VSC wants.
+- **SEED-Voken / Open-MAGVIT2** keeps improving open tokenizer quality, but its
+  LFQ / bit-factorized structure may change the adapter surface.
+- **MaskBit** argues for embedding-free bit tokens and masked bit modeling. The
+  relevance is not "copy MaskBit"; it is whether bit-token neighborhoods are
+  more robust than integer codebook IDs for LLM-side emission errors.
+- **BAR / masked bit modeling** suggests another direction: if large
+  vocabularies are awkward, predict bits or groups of bits through progressive
+  unmasking instead of predicting one huge token ID.
+
+These are not automatically compatible with Wittgenstein. Some use decoders or
+training regimes that may violate the canonical path unless frozen and treated
+carefully. But they do change what "best candidate" means. A tokenizer that is
+slightly worse on full reconstruction but much better under prefix truncation
+may be more valuable for VSC than a better raster-grid tokenizer.
+
+## Research questions that need answers
+
+### RQ1 — Is direct frozen-LLM VSC emission meaningful?
+
+Run Phase 0a:
+
+- prompt a frontier LLM with the current VSC preamble;
+- collect multiple runs per prompt at controlled temperature;
+- measure token entropy, Hamming distance, early-token stability, parse
+  failures, and reasoning compliance.
+
+Expected outcomes:
+
+- Low early-token entropy: promising; the LLM may have a useful visual prior.
+- High entropy everywhere: direct VSC is probably not meaningful.
+- Stable JSON but unstable tokens: schema compliance is solved, research is not.
+
+### RQ2 — Does reasoning reduce token variance?
+
+Compare:
+
+- one-shot VSC without `semantic.reasoning`;
+- one-shot VSC with structured reasoning;
+- two-pass compile where Semantic IR is emitted first.
+
+Measure whether reasoning changes token stability, parse success, and eventual
+adapter output. If reasoning is only pretty prose, we should stop treating it as
+a research lever.
+
+### RQ3 — Which tokenizer ordering fits VSC?
+
+Do not choose only by full rFID. Add prefix tests:
+
+- full tokens;
+- 50% prefix;
+- 25% prefix;
+- 12.5% prefix;
+- random subset control.
+
+The important comparison is prefix vs random subset. If prefix behaves like
+random deletion, the tokenizer is not ordered in the way VSC needs.
+
+### RQ4 — What is the null baseline for the adapter?
+
+Before training a learned adapter, run deterministic unfolding:
+
+- seed length S in `{4, 16, 64, 256}`;
+- fixed mapping from seed positions to token grid;
+- same eval set and metrics as learned adapter.
+
+The learned adapter must beat this baseline. If it does not, the training story
+is adding complexity without information gain.
+
+### RQ5 — Does Semantic IR carry usable information?
+
+The current placeholder path hashes semantic fields. That makes outputs differ,
+but not semantically.
+
+We need a real test:
+
+- same seed code, varied semantic fields;
+- adapter with CLIP / SigLIP / other text-vision embedding conditioning;
+- output deltas aligned with field changes.
+
+If "warm golden" and "cold fluorescent" only change arbitrary pixels, Semantic
+IR is not doing its job.
+
+## Training engineering questions that need answers before real compute
+
+### TQ1 — Which upstream code can we reuse?
+
+For each candidate family, answer:
+
+- license for code and weights;
+- whether the training loop is reusable or only reference material;
+- whether checkpoints are SHA-pinnable;
+- whether eval scripts are clean enough to trust;
+- whether preprocessing is pinned;
+- whether model cards / release artifacts are reproducible.
+
+Candidates to compare include at least:
+
+- LlamaGen;
+- SEED-Voken / Open-MAGVIT2;
+- MaskBit;
+- TiTok / FlexTok-adjacent implementations;
+- VAR / multi-scale VQ;
+- clean-fid or other metric references.
+
+If we write our own training code, it should be because reuse failed a clear
+criterion, not because we did not look.
+
+### TQ2 — What is the minimum professional training stack?
+
+The current recommendation is plain PyTorch as the base contract, with optional
+launcher / scale tools:
+
+- PyTorch loop owns the manifest writes.
+- `torchrun` / DDP first.
+- FSDP2 when model size needs sharding.
+- Lightning Fabric only if it preserves explicit loops.
+- Accelerate only if it helps device launch or checkpoint loading without
+  hiding receipts.
+- DeepSpeed only as escalation for very large LLM-head distillation.
+
+This needs maintainer challenge. If another stack is better, say why in terms
+of receipts, eval, reproducibility, and reuse.
+
+### TQ3 — What must every training run emit?
+
+At minimum:
+
+- `run_id`;
+- git SHA;
+- command and args;
+- seed;
+- framework versions;
+- hardware fingerprint;
+- dataset refs with URI / DVC hash / sample count;
+- checkpoint path + sha256;
+- tokenizer / decoder family + weights sha256;
+- metric snapshots;
+- eval set refs;
+- model-card metadata;
+- notes / known limitations.
+
+This is the floor, not the final system.
+
+### TQ4 — How do we avoid false eval wins?
+
+Metric code must be pinned:
+
+- exact resize / crop;
+- color space;
+- feature extractor version;
+- sample count;
+- prompt set;
+- random seed;
+- real-vs-generated pairing.
+
+Any FID / rFID / CLIPScore without preprocessing receipts should be treated as
+illustrative, not publishable.
+
+## Proposed near-term work packages
+
+## Research leads to split out
+
+This section is deliberately a lead board, not a verdict. The next researchers
+should take these as starting points, expand the citation set, inspect code /
+weights / licenses, and report back with sharper recommendations.
+
+### Lead A — Ordered / variable-length tokenizers
+
+Core question:
+
+> If Visual Seed Code is a prefix, which tokenizer families make prefixes
+> meaningful?
+
+Starting points:
+
+- FlexTok: variable-length ordered 1D token sequences.
+- Spectral Image Tokenizer: DWT / spectrum tokens with coarse-to-fine partial
+  decoding.
+- TiTok / TA-TiTok / One-D-Piece-style 1D tokenizers.
+- VAR / multi-scale VQVAE as a coarse-to-fine bridge even if not used directly.
+
+What to collect:
+
+- prefix reconstruction curves;
+- whether public weights exist;
+- license for code and weights;
+- whether token order is learned, spectral, multi-scale, or arbitrary;
+- whether a short prefix preserves global layout;
+- whether decoding a prefix is supported by the reference code or only claimed
+  in paper figures.
+
+Why it matters:
+
+If prefix degradation is the central VSC gate, then a tokenizer with slightly
+worse full rFID but graceful prefix behavior may be better than a stronger
+full-grid VQGAN tokenizer.
+
+### Lead B — Bit-token and large-vocabulary alternatives
+
+Core question:
+
+> Are integer codebook IDs the wrong target for a frozen text LLM?
+
+Starting points:
+
+- MaskBit: embedding-free bit tokens.
+- BAR / masked bit autoregressive modeling.
+- Open-MAGVIT2 / LFQ bit-factorized tokens.
+
+What to collect:
+
+- whether bit tokens are easier for an LLM to emit consistently than 14-bit /
+  18-bit integer IDs;
+- whether bit flips degrade locally or catastrophically;
+- whether masked bit prediction can be used as the seed expander;
+- whether the reference repos expose tokenizer-only encode/decode cleanly;
+- whether weights are canonical-path eligible or research-only.
+
+Why it matters:
+
+The VSC failure mode may be "LLMs cannot choose codebook IDs," not "LLMs cannot
+plan images." Bit tokens could turn one huge categorical prediction into many
+smaller binary decisions.
+
+### Lead C — Text-aware / semantic-conditioned tokenizers
+
+Core question:
+
+> Should the tokenizer itself know about text, or should text stay only in the
+> adapter?
+
+Starting points:
+
+- TA-TiTok / text-aware 1D tokenizer work.
+- SEED-family language-aligned tokenizer work.
+- VLM bridge literature: BLIP-2, LLaVA, Q-Former-like adapters.
+- CLIP / SigLIP conditioning as a baseline semantic channel.
+
+What to collect:
+
+- whether text-aware tokenizers improve token stability for similar prompts;
+- whether they violate the frozen-decoder posture;
+- whether the tokenizer / decoder can still be frozen at inference;
+- whether Semantic IR fields map cleanly into their conditioning interface;
+- whether this makes `semantic.reasoning` useful or redundant.
+
+Why it matters:
+
+If direct VSC tokens are decoder-misaligned, the next best architecture may be
+`Semantic IR + text-aware adapter -> decoder tokens`, not raw prompt-emitted
+token IDs.
+
+### Lead D — Tokenizer scale and reconstruction frontier
+
+Core question:
+
+> How much tokenizer quality do we actually need before the adapter question is
+> meaningful?
+
+Starting points:
+
+- GigaTok / scaled visual tokenizers.
+- SoftVQ-VAE / continuous 1D tokenizer lines.
+- Open-MAGVIT2 / VQGAN+ / modern VQGAN improvements.
+- LlamaGen tokenizer as the reproducible older baseline.
+
+What to collect:
+
+- rFID / LPIPS / PSNR / SSIM on ImageNet;
+- parameter count and inference cost;
+- encode/decode API cleanliness;
+- training recipe reproducibility;
+- whether reconstruction quality remains stable under prefix / downsampled
+  seed conditions.
+
+Why it matters:
+
+If tokenizer reconstruction is weak, adapter experiments are polluted. But if
+the best tokenizer is too heavy or license-blocked, it cannot be canonical.
+
+### Lead E — Adapter families and null baselines
+
+Core question:
+
+> What is the simplest adapter that beats deterministic unfolding?
+
+Starting points:
+
+- deterministic replicate / tile mosaic / PixelShuffle as null baselines;
+- MaskGIT-style parallel unmasking;
+- block-causal clean-repaint from Cola-DLM;
+- coarse-to-fine next-scale prediction from VAR-like models;
+- CLIP/SigLIP-conditioned MLP or transformer adapters.
+
+What to collect:
+
+- compute cost;
+- deterministic inference path;
+- ability to pin known seed positions;
+- eval against seed lengths `{4, 16, 64, 256}`;
+- whether it consumes Semantic IR as text embedding, structured fields, or both.
+
+Why it matters:
+
+The adapter is where the thesis becomes an engineering object. If a learned
+adapter cannot beat a deterministic baseline, we should not spend on larger
+heads.
+
+### Lead F — Training infrastructure exemplars
+
+Core question:
+
+> What training-code practices should Wittgenstein copy before writing large
+> model scripts?
+
+Starting points:
+
+- LlamaGen training scripts and eval recipe.
+- Open-MAGVIT2 / SEED-Voken training surfaces.
+- MaskBit / BAR reproducibility surfaces.
+- PyTorch FSDP2 examples.
+- Lightning Fabric launcher examples.
+- Hugging Face Accelerate for launch / checkpoint-loading cases.
+- DVC / DataLad-style data snapshotting.
+- clean-fid and other metric implementations with pinned preprocessing.
+
+What to collect:
+
+- config system;
+- launch command shape;
+- distributed strategy;
+- data snapshot contract;
+- checkpoint format;
+- metric wrapper;
+- model-card / release convention;
+- how failures are logged;
+- whether code can be reused, copied with attribution, or only studied.
+
+Why it matters:
+
+Training manifest work is not just traceability. It is the difference between a
+professional research stack and an expensive pile of scripts.
+
+### Lead G — Cheap thesis killers
+
+Core question:
+
+> What is the cheapest experiment that would force us to pivot?
+
+Candidates:
+
+- Phase 0a: high token entropy at all positions across prompts.
+- Prefix vs random-subset degradation: prefix behaves no better than random.
+- Semantic field sensitivity: semantic changes produce only arbitrary output
+  changes.
+- Adapter null baseline: learned adapter fails to beat deterministic unfold.
+- Encoder-distribution comparison: LLM-emitted tokens are far outside the
+  natural encoder token distribution.
+
+What to collect:
+
+- exact experiment;
+- expected cost;
+- pass / fail threshold;
+- what pivot follows if it fails.
+
+Why it matters:
+
+The research program should invite falsification. If no cheap experiment can
+hurt the thesis, the thesis is not yet operational.
+
+### WP1 — Research map and falsification plan
+
+Owner shape: researcher / maintainer pair.
+
+Output:
+
+- one note that stitches old and new research together;
+- a table mapping each hypothesis to evidence, missing experiment, and kill
+  criterion;
+- a candidate tokenizer table that includes prefix degradation, not only rFID.
+
+Do not modify doctrine in this work package.
+
+### WP2 — Phase 0 experiment hooks
+
+Owner shape: implementation + researcher review.
+
+Output:
+
+- Phase 0a emission entropy script;
+- Phase 0b semantic field sensitivity test;
+- clean-repaint SeedExpander ABI;
+- optional `semantic.reasoning` schema / preamble hook;
+- prefix degradation criterion in radar docs.
+
+This is the bridge from research prose to measurable signals.
+
+### WP3 — Training engineering benchmark
+
+Owner shape: infra engineer + researcher.
+
+Output:
+
+- comparison against upstream repos / frameworks;
+- reuse vs rewrite decision table;
+- manifest schema draft;
+- eval wrapper plan;
+- dataset snapshot contract.
+
+This is not a training script yet.
+
+### WP4 — Training manifest smoke
+
+Owner shape: infra implementation.
+
+Output:
+
+- CPU-only synthetic checkpoint smoke;
+- training manifest helper;
+- tests;
+- clear statement that this is a receipt floor, not a training platform.
+
+This should be small and mergeable.
+
+## My local answer / current best guess
+
+My current belief:
+
+1. Direct frozen-LLM emission of integer VQ IDs is the riskiest part of the
+   thesis. It might work weakly, but we should expect B2 rather than B1:
+   semantically structured but decoder-misaligned tokens.
+2. Importance-ordered tokenizers are more aligned with Wittgenstein than
+   raster-grid VQGAN tokenizers. FlexTok / Spectral / TiTok-style 1D or
+   coarse-to-fine ordering should be promoted in the audit criteria.
+3. The adapter probably has to become a real learned bridge that consumes both
+   seed code and semantic embeddings. A pure SHA/hash or deterministic mosaic is
+   only a seam test.
+4. The training stack is the project-risk center. Bad training infra can waste
+   more time and money than a wrong research note. The first serious training
+   artifact must be a manifest-backed smoke, not a large model run.
+5. If Phase 0a shows high entropy everywhere, we should not panic silently. We
+   should pivot explicitly: Semantic IR becomes the main information carrier,
+   and VSC becomes either an adapter-generated code or a learned head output,
+   not raw prompt-emitted IDs.
+
+This is not a conclusion. It is my current prior, written so other maintainers
+can argue with it.
+
+## What we need from other maintainers / researchers
+
+Please challenge any of the following:
+
+- Is "LLM emits visual code" a meaningful research surface, or are we merely
+  rebuilding a text-conditioned tokenizer with extra ceremony?
+- Which recent tokenizer family should become the next serious audit target?
+- Is prefix degradation the right gate, or should we use a different
+  information-ordering test?
+- Which upstream training repo should we reuse before writing our own loops?
+- What would make a training manifest publishable enough for a paper appendix?
+- What is the cheapest experiment that could kill the VSC thesis?
+- What is the strongest pivot that preserves the harness thesis if direct VSC
+  fails?
+
+The project will be healthier if these questions are answered by multiple
+passes, not by one author.
+
+## References
+
+Local:
+
+- `docs/research/2026-05-08-vsc-as-compression-prior.md`
+- `docs/research/2026-05-13-wittgenstein-research-program.md`
+- `docs/research/2026-05-16-training-stack-re-audit.md`
+- `docs/research/2026-05-22-seed-code-stability-analysis.md`
+- `docs/research/2026-05-22-ir-reliability-validation.md`
+- `docs/research/2026-05-22-cot-inspired-improvements.md`
+- `docs/research/2026-05-22-cola-dlm-implications.md`
+- `docs/research/2026-05-22-svd-low-rank-and-vq-tokens.md`
+
+External:
+
+- FlexTok — <https://arxiv.org/abs/2502.13967>
+- Spectral Image Tokenizer — <https://research.google/pubs/spectral-image-tokenizer/>
+- SEED-Voken / Open-MAGVIT2 — <https://github.com/TencentARC/SEED-Voken>
+- MaskBit — <https://github.com/markweberdev/maskbit>
+- BAR masked bit modeling — <https://github.com/amazon-far/BAR>
+- GigaTok — <https://github.com/SilentView/GigaTok>
+- TA-TiTok — <https://arxiv.org/abs/2501.07730>
+- SoftVQ-VAE — <https://openaccess.thecvf.com/content/CVPR2025/html/Chen_SoftVQ-VAE_Efficient_1-Dimensional_Continuous_Tokenizer_CVPR_2025_paper.html>
+- PyTorch FSDP2 — <https://docs.pytorch.org/docs/main/distributed.fsdp.fully_shard.html>
+- DVC remote storage — <https://dvc.org/doc/user-guide/data-management/remote-storage>
+- Hugging Face model cards — <https://huggingface.co/docs/hub/en/model-cards>

--- a/docs/research/2026-05-22-seed-code-stability-analysis.md
+++ b/docs/research/2026-05-22-seed-code-stability-analysis.md
@@ -1,0 +1,203 @@
+---
+date: 2026-05-22
+status: research note (concern analysis + mitigation proposals)
+labels: [research-derived, m1b-image, adapter, stability, concern]
+tracks: [#283, #70, #207, #334]
+cross-refs: [ADR-0018, vsc-as-compression-prior.md, 2026-05-22-cola-dlm-implications.md]
+severity: high — load-bearing on the VSC thesis
+---
+
+# Seed Code Stability: First-Token Sensitivity Analysis
+
+> **Status:** research note addressing a maintainer-raised concern.
+> The concern: if the LLM's first 5-15 seed code tokens are unstable or inconsistent across runs, the entire Visual Seed Code architecture may fail to produce reliable images. This note analyzes the failure modes, connects to published research, and proposes concrete mitigations.
+
+## The concern, stated precisely
+
+Wittgenstein's image path asks a frozen text LLM to emit Visual Seed Code — a short sequence of discrete tokens (target: 32-128 tokens for TiTok/VQGAN-class). The seed expander / adapter then maps these to a full decoder-native token grid, and a frozen decoder reconstructs pixels.
+
+**The stability question:** Given the same text prompt and the same system preamble, will the LLM emit the same (or semantically equivalent) seed code tokens?
+
+This decomposes into three sub-questions:
+
+1. **Token-level consistency:** Does the same prompt → same VQ token IDs? (Requires temperature=0 or fixed seed.)
+2. **Semantic consistency:** Do different token IDs from the same prompt produce perceptually similar images? (Requires the VQ codebook to have smooth neighborhoods.)
+3. **Prefix sensitivity:** If the first k tokens are correct but the rest diverge, does the image degrade gracefully or catastrophically?
+
+### Why this matters
+
+If the answer to all three is "no" — the LLM emits different tokens each time, the tokens don't have smooth neighborhoods, and small prefix errors cascade — then the VSC thesis is broken. The LLM is not a useful "prior over compressed visual programs" (see `vsc-as-compression-prior.md` prediction 1); it's a random number generator dressed in JSON.
+
+---
+
+## Analysis of each sub-question
+
+### Sub-question 1: Token-level consistency
+
+**Current state:** Text LLMs are deterministic at temperature=0 given identical input. Wittgenstein's manifest spine already pins the seed and full LLM I/O. So at temperature=0, the same prompt + same model + same system preamble → identical output tokens.
+
+**But:** Temperature=0 is not always desirable. For creative image generation, users want variation. At temperature > 0, the LLM will emit different token sequences for the same prompt.
+
+**Mitigation already in architecture:** The manifest records the exact LLM output, so any run is reproducible. The question shifts to: are the different outputs from temperature > 0 all "good" outputs?
+
+**Assessment:** Token-level consistency is **solved** at temperature=0 by construction. At temperature > 0, consistency is a property of the LLM's learned distribution over seed codes, which is an empirical question (see prediction 1 in `vsc-as-compression-prior.md`).
+
+### Sub-question 2: Semantic consistency (VQ codebook smoothness)
+
+**The worry:** Two nearby VQ codebook entries might decode to wildly different visual features. If the LLM picks codebook entry 42 instead of 41, does the image change slightly or catastrophically?
+
+**Published evidence:**
+
+- **VQGAN codebooks** are trained with perceptual + adversarial loss, which encourages smooth codebook neighborhoods (nearby entries encode similar visual features). Esser et al. (2021) show this implicitly through interpolation experiments.
+- **TiTok** uses a 4096-entry codebook with 16 channels. The proxy-code training (Stage 1) further regularizes the codebook because it trains against an existing VQGAN's distribution, not raw pixels.
+- **FSQ (Finite Scalar Quantization)** has the strongest smoothness guarantee: each dimension is independently quantized to integer levels, so adjacent codes differ by exactly 1 on one dimension. This makes the codebook a regular grid with predictable neighborhoods.
+- **VQ-VAE commitment loss** (van den Oord 2017) pulls encoder outputs toward codebook entries, implicitly regularizing the codebook to be smooth (unused entries collapse, active entries spread to cover the data manifold).
+
+**Assessment:** Modern VQ codebooks are **moderately smooth** — adjacent entries usually encode similar features. However, the codebook is not a continuous manifold; there can be "gaps" where small index changes cause large visual changes. FSQ has the best smoothness guarantee.
+
+**Implication for tokenizer selection:** FSQ-based decoders (Open-MAGVIT2) or TiTok (proxy-code trained) are preferred over raw VQGAN for seed code stability. This is an additional selection criterion for #283.
+
+### Sub-question 3: Prefix sensitivity (the core concern)
+
+**The worry:** In autoregressive generation, errors in early tokens compound. If token 3 is wrong, tokens 4-32 condition on a wrong context and diverge. By token 32, the image may be completely unrelated to the prompt.
+
+**This is the most serious of the three sub-questions.**
+
+**Published evidence on error compounding:**
+
+1. **LeCun's critique (Brief B, lines 38-43):** "Errors compound exponentially" in autoregressive models. LeCun argues this is a fundamental limitation of left-to-right generation.
+
+2. **Cola-DLM's block-causal solution:** By generating in blocks with bidirectional attention within blocks, Cola-DLM limits error propagation to block boundaries. Errors within one block cannot propagate backwards within the block.
+
+3. **MaskGIT (Chang et al., 2022):** Non-autoregressive iterative decoding. All tokens are predicted simultaneously, then the least-confident tokens are re-masked and re-predicted. This breaks the sequential dependency entirely. TiTok uses MaskGIT as its generation method (8 steps, arccos schedule).
+
+4. **VAR (next-scale prediction):** Errors at coarse scales propagate to fine scales, but fine-scale errors do not propagate to coarse scales. The hierarchy provides natural error containment.
+
+5. **FlexTok elastic prefixes:** Any prefix length produces a valid reconstruction. This means the first k tokens are a self-contained representation, not dependent on tokens k+1...N. Error in token k+1 does not affect the meaning of tokens 1...k.
+
+**Assessment:** Prefix sensitivity is a real risk for **autoregressive** seed code generation but is **mitigable** through architectural choices in the seed expander.
+
+---
+
+## Proposed mitigations (ranked by implementation cost)
+
+### Mitigation 1: MaskGIT-style parallel seed expansion (RECOMMENDED)
+
+**Instead of** expanding seed code autoregressively (token 1 → token 2 → ... → token 32), **use** masked iterative prediction:
+
+1. Start with all positions masked except the seed positions (known from LLM output)
+2. Predict all masked positions in parallel (one forward pass)
+3. Keep the most-confident predictions, re-mask the rest
+4. Repeat for 8 steps (per TiTok's optimal setting)
+
+**Why this solves the concern:** No sequential dependency. Errors in one position do not cascade to others. Each iteration refines all positions simultaneously.
+
+**Cost:** Requires a trained masked prediction model (~86M params for TiTok-B). Fits within L4 adapter scope.
+
+**Compatibility:** Fully compatible with ADR-0005 (the masked predictor is a trained adapter, not a generator; the frozen decoder is still deterministic). Fully compatible with ADR-0018 (seed code positions are the "known" mask).
+
+### Mitigation 2: Clean-repaint conditioning (FROM COLA-DLM)
+
+**When** the LLM emits a partial seed (k < 32 tokens), **pin** those k positions to their known VQ indices throughout all expansion steps. Only predict the remaining 32-k positions.
+
+**Why this helps:** The known seed tokens cannot be corrupted by the expansion process. They act as structural anchors that constrain the predicted tokens.
+
+**Cost:** Minimal — extends the SeedExpander interface with a binary mask parameter. The expansion model must support conditioning on known positions (standard in MaskGIT and diffusion models).
+
+**Compatibility:** Already anticipated by the `SeedExpander` ABI in `adapters/seed-expander.ts`.
+
+### Mitigation 3: Importance-ordered tokenizer selection
+
+**Select** a tokenizer family where early tokens in the sequence carry more structural information than later tokens (VAR, FlexTok, TiTok-1D).
+
+**Why this helps:** Even if later tokens are noisy or wrong, the first tokens already specify the gross structure. The image degrades gracefully rather than catastrophically.
+
+**Cost:** Zero implementation cost — this is a tokenizer selection criterion for #283. Adds a column to the radar audit.
+
+**How to test:** For each candidate tokenizer, measure rFID as a function of prefix length:
+
+- rFID(32 tokens) — full quality
+- rFID(16 tokens, rest zero-filled) — half quality
+- rFID(8 tokens, rest zero-filled) — quarter quality
+- rFID(4 tokens, rest zero-filled) — minimal quality
+
+A "good" tokenizer for Wittgenstein shows smooth rFID degradation. A "bad" one shows a cliff (e.g., rFID jumps from 5 to 50 between 16 and 8 tokens).
+
+### Mitigation 4: Two-pass compile (ALREADY IN ADR-0018)
+
+**Pass 1:** LLM emits Semantic IR only (no VQ tokens). This is a structured text description of the scene — robust to formatting errors, inspectable, debuggable.
+
+**Pass 2:** Given the validated Semantic IR, emit seed code. The LLM now has a clear "spec" to work from, reducing the chance of emitting nonsensical VQ tokens.
+
+**Why this helps on stability:** The first pass produces stable text (LLMs are good at text). The second pass conditions on that stable text, reducing variance in the VQ token output.
+
+**Cost:** 2x LLM inference cost. Already ratified as legal by ADR-0018. Currently not implemented (expand phase is a no-op in `pipeline/expand.ts`).
+
+### Mitigation 5: Adapter robustness training (longer-term)
+
+**Train** the L4 adapter with deliberate input corruption:
+
+- Drop random seed tokens (simulate partial emission)
+- Swap random tokens to adjacent codebook entries (simulate LLM errors)
+- Truncate the seed to various prefix lengths
+
+The adapter learns to produce reasonable outputs even when the input seed is imperfect.
+
+**Cost:** Requires adapter training infrastructure (tracked in research program). Medium-term.
+
+---
+
+## Empirical validation plan
+
+### Phase 0: Can do now (no trained models needed)
+
+1. **Placeholder expander degradation test:** Feed the placeholder seed expander seeds of length 32, 16, 8, 4, 2. Compare the output latent grids. Do they show structured differences or random noise?
+   - If structured: the SeedExpander ABI at least doesn't destroy information.
+   - If random: the placeholder is too simplistic to evaluate degradation (expected).
+
+2. **LLM emission consistency test:** Prompt a frontier LLM (GPT-5, Claude) 10 times with the same image prompt + VSC preamble at temperature=0.3. Collect the emitted seed code tokens. Measure:
+   - Token-level agreement rate across runs
+   - Hamming distance between runs
+   - Whether disagreements cluster in early or late positions
+
+### Phase 1: After M1B decoder lands
+
+3. **Prefix truncation rFID curve:** For the chosen tokenizer (likely TiTok or LlamaGen), measure reconstruction quality as seed code is progressively truncated. This is the definitive test of whether partial seed codes produce graceful degradation.
+
+4. **Cross-run perceptual similarity:** Generate images from 10 different seed codes for the same prompt. Measure LPIPS (learned perceptual similarity) between all pairs. If perceptual similarity is high despite token-level differences, the system is semantically stable even without token-level consistency.
+
+---
+
+## Connection to the SVD framing
+
+The SVD note (`2026-05-22-svd-low-rank-and-vq-tokens.md`) frames seed code as a discrete low-rank approximation. The stability concern maps to: **is the "rank-k approximation" (first k seed tokens) a robust representation, or is it fragile to perturbation?**
+
+SVD rank-k approximation is provably optimal and robust (Eckart-Young theorem). VQ tokenization has no such guarantee. The mitigations above are engineering strategies to approximate SVD's robustness properties in the discrete VQ setting.
+
+## Verdict
+
+**The concern is legitimate and load-bearing.** If first-token stability fails empirically, the VSC thesis has a serious problem.
+
+**But:** Multiple mitigation strategies exist, and the most effective ones (MaskGIT-style parallel expansion, importance-ordered tokenizer selection, clean-repaint conditioning) are architecturally compatible with the locked doctrine. The concern motivates specific tokenizer selection criteria and adapter design choices, not a doctrine change.
+
+**Recommended priority:**
+
+1. Add "prefix degradation curve" as a mandatory radar criterion for #283
+2. Implement clean-repaint conditioning in the seed expander ABI
+3. Select an importance-ordered tokenizer (FlexTok > TiTok > VAR > VQGAN)
+4. Design the M1B adapter as MaskGIT-style parallel predictor, not autoregressive
+
+## Cross-references
+
+- `docs/research/2026-05-08-vsc-as-compression-prior.md` — Predictions 1-4 (testable consequences)
+- `docs/research/2026-05-22-cola-dlm-implications.md` — Clean-repaint and block-causal sources
+- `docs/research/2026-05-22-svd-low-rank-and-vq-tokens.md` — Mathematical framing
+- `docs/research/2026-05-07-vsc-acceptance-cases.md` — Acceptance test matrix
+- `docs/research/briefs/C_unproven_horizon.md` — H9 (patch-grid / VAR) and H10 (long-code)
+- `docs/adrs/0018-hybrid-image-code-and-visual-seed-token.md` — Two-pass compile lane
+
+## Boundaries
+
+- Does NOT modify code or schema.
+- Does NOT change the locked doctrine.
+- Does NOT pick a tokenizer family — proposes selection criteria.

--- a/docs/research/2026-05-22-svd-low-rank-and-vq-tokens.md
+++ b/docs/research/2026-05-22-svd-low-rank-and-vq-tokens.md
@@ -1,0 +1,163 @@
+---
+date: 2026-05-22
+status: research note (theoretical connection)
+labels: [research-derived, m1b-image, theoretical-anchor, compression]
+tracks: [#283, #70]
+cross-refs: [vsc-as-compression-prior.md, vq-tokens-as-interface.md, Brief B (compression)]
+---
+
+# SVD / Low-Rank Approximation and the VQ Token Architecture
+
+> **Status:** research note. Not doctrine, not active execution guidance.
+> Connects classical matrix decomposition (SVD) to Wittgenstein's discrete VQ token architecture. Frames why "few tokens carry most visual structure" is not a hope but a mathematical expectation, and identifies where the analogy breaks.
+
+## Why this note exists
+
+A maintainer observed that SVD image compression demonstrates a powerful principle: a 1000x1000 pixel image (1M numbers) can be perceptually reconstructed from ~50 singular values and their corresponding vectors. The question: does this insight help Wittgenstein's Visual Seed Code pipeline, and can it inform graceful degradation when seed codes are partial or noisy?
+
+## The SVD principle, precisely stated
+
+Any m x n matrix A admits a decomposition A = U _ Sigma _ V^T where:
+
+- U (m x m) contains left singular vectors (output-direction patterns)
+- Sigma (m x n) is diagonal with non-negative singular values sigma_1 >= sigma_2 >= ... >= 0
+- V^T (n x n) contains right singular vectors (input-direction patterns)
+
+The **rank-k approximation** `A_k = U_k * Sigma_k * V_k^T` (keeping only the top k singular values) is the **best** rank-k approximation of A in both Frobenius and spectral norms (Eckart-Young-Mirsky theorem, 1936).
+
+For natural images:
+
+- k=5: ~1% of singular values → color blocks, gross layout
+- k=15: face contours and major shadows identifiable
+- k=50: perceptually close to original for most low-frequency content
+- Storage: k(m + n + 1) numbers instead of m\*n. At k=50, 1000x1000: 100,050 vs 1,000,000 (10x compression)
+
+The singular value spectrum of natural images decays **rapidly** — typically exponentially or as a power law. This is not accidental; it reflects the low intrinsic dimensionality of natural visual scenes.
+
+## The VQ token architecture as discrete low-rank approximation
+
+Wittgenstein's image pipeline:
+
+```
+Image (m x n pixels) → VQ encoder → K discrete tokens → VQ decoder → Reconstructed image
+```
+
+This is structurally analogous to SVD truncation:
+
+| SVD                                     | VQ Tokenization                                                      |
+| --------------------------------------- | -------------------------------------------------------------------- |
+| Continuous singular values sigma_i      | Discrete codebook entries c_i                                        |
+| Rank-k approximation (keep top k)       | K-token representation (keep K codes)                                |
+| U, V capture directional patterns       | Encoder/decoder capture spatial patterns                             |
+| Reconstruction: `U_k * Sigma_k * V_k^T` | Reconstruction: Decoder(c_1, ..., c_K)                               |
+| Optimal in Frobenius norm               | Optimal in training loss (reconstruction + perceptual + adversarial) |
+
+**Key parallel:** Both exploit the fact that natural images have low intrinsic dimensionality. The information is not uniformly distributed across pixels; it concentrates in a small number of structural patterns.
+
+### TiTok as the extreme case
+
+TiTok (Yu et al., ICLR 2024) demonstrates this concentration empirically:
+
+| Token count | rFID (TiTok-L)       | Analogy                          |
+| ----------- | -------------------- | -------------------------------- |
+| 16          | 13.0                 | ~SVD rank-5: gross layout only   |
+| 32          | 2.21                 | ~SVD rank-50: perceptually close |
+| 64          | 1.70                 | ~SVD rank-100: high quality      |
+| 128         | 1.71                 | Diminishing returns              |
+| 256         | 2.5 (VQGAN baseline) | Full 2D grid, not better         |
+
+The pattern is identical to SVD: a sharp quality elbow at low token counts, then diminishing returns. 32 tokens capture the vast majority of visual structure for a 256x256 image.
+
+## Where the analogy holds
+
+### 1. Partial seed codes are like truncated SVD
+
+If the LLM emits only 8 out of 32 needed seed tokens, this is analogous to keeping only 8 singular values. The analogy predicts:
+
+- **Gross layout should be recoverable.** The first few tokens (like the first few singular values) carry the most structural information.
+- **Fine details will be lost.** Textures, small objects, edges — these live in the "tail" tokens.
+- **Graceful degradation is expected.** Quality should degrade smoothly as tokens are removed, not cliff.
+
+This directly informs the adapter's **partial-input robustness** requirement: the seed expander should produce a reasonable (blurry but structured) image from partial seed codes, not garbage.
+
+### 2. Token ordering matters
+
+In SVD, singular values are ordered by magnitude — the first captures the most variance. In VQ tokenization:
+
+- **VAR (next-scale prediction):** Tokens are explicitly ordered coarse-to-fine. Early tokens = low-resolution layout. Later tokens = high-frequency detail. This is the closest VQ analog to SVD ordering.
+- **TiTok (1D sequence):** Tokens are learned to be ordered by the encoder's attention mechanism. Not explicitly coarse-to-fine, but the transformer learns to allocate early positions to more global features.
+- **VQGAN (2D grid):** Tokens are spatially ordered, not importance-ordered. This is like shuffling the singular values — no natural truncation point.
+
+**Implication for Wittgenstein:** VAR-style or TiTok-style 1D ordering is strongly preferred over 2D grid ordering, because it enables meaningful partial seed codes (prefix = low-rank approximation).
+
+### 3. "Seed code as compression prior" is SVD-aligned
+
+The VSC-as-compression-prior note (2026-05-08) frames the LLM as a "prior over compressed visual programs." SVD provides the mathematical backing: if images are low-rank, then specifying the top-k components (= seed code) plus a decoder that can reconstruct from them (= frozen VQ decoder) is a theoretically sound compression scheme.
+
+## Where the analogy breaks
+
+### 1. SVD is linear; VQ is nonlinear
+
+SVD decomposes into linear subspaces. VQ codebooks encode nonlinear manifold structure. A single VQ token can represent a complex texture pattern that would require many SVD components. This means VQ is potentially **more efficient** than SVD for natural images — 32 VQ tokens may capture structure that would require 200+ SVD components.
+
+### 2. SVD has a unique optimal truncation; VQ does not
+
+The Eckart-Young theorem guarantees SVD rank-k is optimal. VQ codebook quality depends on training data, codebook size, and training objective. There is no guarantee that any particular VQ tokenizer is "optimal" in the SVD sense.
+
+### 3. SVD components are orthogonal; VQ tokens are not
+
+SVD singular vectors are orthogonal by construction — each captures independent variance. VQ tokens from a learned codebook may be correlated. This means removing one VQ token might not reduce information by the same predictable amount as removing one SVD component.
+
+### 4. SVD decomposition is unique; VQ encoding is not
+
+For a given image, SVD produces one decomposition. Different VQ encoders (VQGAN, TiTok, MAGVIT) produce different token sequences for the same image. The "right" tokenization depends on the downstream decoder.
+
+## Practical consequences for Wittgenstein
+
+### 1. Do NOT introduce SVD into the pipeline
+
+SVD itself is not useful here. The VQ token architecture already achieves the same goal (compact representation of visual structure) with better efficiency for natural images. Adding SVD would be redundant complexity.
+
+### 2. DO design the adapter for graceful degradation
+
+The SVD analogy predicts that partial seed codes should produce blurry-but-structured images, not noise. The adapter (seed expander) should be tested with:
+
+- Full seed (32 tokens) → best quality
+- Half seed (16 tokens) → reduced quality, recognizable structure
+- Quarter seed (8 tokens) → gross layout visible
+- Minimal seed (4 tokens) → scene-type identifiable
+
+If the quality curve does NOT follow this graceful pattern, it indicates the tokenizer's ordering is pathological and should trigger a tokenizer-family reassessment.
+
+### 3. DO prefer importance-ordered tokenizers
+
+Tokenizers that produce importance-ordered token sequences (VAR, FlexTok, potentially TiTok) are strictly better for the Visual Seed Code use case than spatial-grid tokenizers (VQGAN). The SVD analogy makes this preference theoretically grounded: you want the "first k tokens" to be the "top k singular values," not random spatial patches.
+
+**FlexTok (ICML 2025, arXiv:2502.13967)** is particularly relevant: it explicitly trains for elastic prefixes where any prefix length produces a valid (lower-fidelity) reconstruction. This is SVD-like ordering by design.
+
+### 4. DO use this framing for the "fast preview" use case
+
+The maintainer's original insight — "use SVD-like mechanism for fast preview even when seed code is partial" — maps directly to: **if the tokenizer is importance-ordered, the first N tokens of any seed code are already a fast preview.** No additional mechanism needed. The frozen decoder applied to the first N tokens (with remaining positions filled by the adapter's best guess) IS the fast preview.
+
+## Cross-references
+
+- `docs/research/2026-05-08-vsc-as-compression-prior.md` — VSC as compression prior framing (complementary)
+- `docs/research/vq-tokens-as-interface.md` — VQ tokens as LLM-decoder interface
+- `docs/research/briefs/B_compression_vs_world_models.md` — Compression-as-intelligence (Sutskever/Hutter)
+- `docs/research/briefs/C_unproven_horizon.md` — H9 (patch-grid IR) tracks VAR/FlexTok ordering
+- `docs/research/2026-05-13-audits-fsq-openmagvit2-titok-maskbit.md` — TiTok audit
+- `docs/research/hybrid-image-code.md` — FlexTok elastic prefix discussion
+
+## Citations
+
+- Eckart, C. and Young, G. (1936). "The approximation of one matrix by another of lower rank." Psychometrika 1(3):211-218.
+- Yu, Q. et al. (2024). "An Image is Worth 32 Tokens for Reconstruction and Generation." ICLR 2024. arXiv:2406.07550.
+- Tian, K. et al. (2024). "Visual Autoregressive Modeling: Scalable Image Generation via Next-Scale Prediction." NeurIPS 2024 Best Paper. arXiv:2404.02905.
+- Ren, T. et al. (2025). "FlexTok: Resampling Images into 1D Token Sequences of Flexible Length." ICML 2025. arXiv:2502.13967.
+
+## Boundaries
+
+- Does NOT modify code or schema.
+- Does NOT propose SVD as a pipeline component.
+- Does NOT pick a tokenizer family.
+- Does NOT alter doctrine surfaces.


### PR DESCRIPTION
## Summary

Docs-only slice salvaged from **#455** (which can't merge as-is — stale base 39 commits behind, a dead `manifest.py` that conflicts with the merged #493 spine, and a `schema.ts` contract change needing independent codec review). These 7 doc changes are **additive, leak-clean, and apply cleanly on current `main`**.

### New research notes (`docs/research/2026-05-22-*`)
- `cola-dlm-implications.md`
- `cot-inspired-improvements.md`
- `ir-reliability-validation.md`
- `research-and-training-handoff.md`
- `seed-code-stability-analysis.md`
- `svd-low-rank-and-vq-tokens.md`

### Modified
- `2026-05-08-radar-audit-plan.md` — adds the optional soft **Gate E** (prefix-degradation curve) after the four hard gates. Verified byte-identical to #455's version; applies clean (merge-base unchanged on main).

## What is intentionally NOT here

The **code** parts of #455 stay on #455 for proper handling:
- `schema.ts` `semantic.reasoning` block — a NEW image-codec contract surface; per ADR-0013 / engineering-discipline it needs an independent codec/core review pass + a check against RFC-0007, which shouldn't be self-ratified in a salvage PR.
- `seed-expander` clean-repaint hooks + tests — interdependent with the above; belong with the codec review.
- `research/training/_shared/manifest.py` — **dead**: it re-introduces a competing `TrainingManifest` contract (107 lines) incompatible with the 258-line spine already merged via #493. Must be dropped/reconciled, not landed.

## Verification

- Leak scan (`node1048|qiyuan|nfsdata|172.16.|thunlp|aTrust|wxu`) on all 7 files: **clean**.
- `docs/research/` is not a doctrine-bearing path (ADR-0013), so no ratification gate.
- All 6 new notes carry kill-criteria / hypothesis framing consistent with the brief→RFC→ADR flow.

## Test plan

- [ ] One maintainer review (docs-only)
- [ ] #455 remains open for its code slice (rebase + codec review + manifest reconcile)

Refs #455