### PR TITLE
feat(codec-image): seed-code clean-repaint + optional visual-reasoning block (salvaged from #455)

### DIFF
--- a/packages/codec-image/src/adapters/seed-expander-tile-mosaic.ts
+++ b/packages/codec-image/src/adapters/seed-expander-tile-mosaic.ts
@@ -4,7 +4,7 @@ import {
   type ImageSceneSpec,
   type ImageVisualSeedCode,
 } from "../schema.js";
-import type { SeedExpander } from "./seed-expander.js";
+import { validateCleanRepaintInputs, type SeedExpander } from "./seed-expander.js";
 
 const PLACEHOLDER_CODEBOOK_SIZE = 8192;
 
@@ -47,13 +47,22 @@ function pickCoarseLayout(tokenCount: number): { coarseW: number; coarseH: numbe
  * `(seedCode, decoder, seed)` triple → byte-identical `ImageLatentCodes`.
  */
 export const tileMosaicSeedExpander: SeedExpander = {
-  expand({ seedCode, decoder, seed }: {
+  expand({
+    seedCode,
+    decoder,
+    seed,
+    knownPositions,
+    knownTokens,
+  }: {
     seedCode: ImageVisualSeedCode;
     decoder: ImageSceneSpec["decoder"];
     seed: number;
+    knownPositions?: readonly boolean[];
+    knownTokens?: readonly number[];
   }): ImageLatentCodes {
     const [width, height] = decoder.latentResolution;
     const totalTokens = width * height;
+    validateCleanRepaintInputs(knownPositions, knownTokens, totalTokens);
     const tokens = new Array<number>(totalTokens);
     const { coarseW, coarseH } = pickCoarseLayout(seedCode.tokens.length);
 
@@ -61,13 +70,19 @@ export const tileMosaicSeedExpander: SeedExpander = {
       // Map target row to coarse-grid row.
       const yc = Math.min(coarseH - 1, Math.floor((y * coarseH) / Math.max(1, height)));
       for (let x = 0; x < width; x += 1) {
+        const targetIndex = y * width + x;
+        // Clean-repaint: if this position is pinned, preserve the known token.
+        const knownToken = knownTokens?.[targetIndex];
+        if (knownPositions?.[targetIndex] && knownToken !== undefined) {
+          tokens[targetIndex] = knownToken;
+          continue;
+        }
         const xc = Math.min(coarseW - 1, Math.floor((x * coarseW) / Math.max(1, width)));
         // Wrap modulo tokens.length so non-square layouts (e.g. 6×6 over 32
         // tokens) still resolve to a valid base.
         const tileIndex = (yc * coarseW + xc) % seedCode.tokens.length;
         const base = seedCode.tokens[tileIndex] ?? 0;
         const localSalt = x * 17 + y * 31 + seed * 1009;
-        const targetIndex = y * width + x;
         tokens[targetIndex] = (base + localSalt) % PLACEHOLDER_CODEBOOK_SIZE;
       }
     }

--- a/packages/codec-image/src/adapters/seed-expander.ts
+++ b/packages/codec-image/src/adapters/seed-expander.ts
@@ -28,6 +28,21 @@ export interface SeedExpansionInput {
   readonly seedCode: ImageVisualSeedCode;
   readonly decoder: ImageSceneSpec["decoder"];
   readonly seed: number;
+  /**
+   * Optional binary mask for clean-repaint conditioning (Cola-DLM-inspired).
+   * When provided, `knownPositions[i] = true` means the token at position `i`
+   * in the target latent grid is already known and must NOT be overwritten by
+   * the expander. The known value is taken from `knownTokens[i]`.
+   *
+   * This enables partial seed expansion: the LLM provides a few anchor tokens,
+   * and the expander fills the remaining positions while preserving the anchors.
+   *
+   * @see docs/research/2026-05-22-cola-dlm-implications.md §2 (clean-repaint)
+   * @see docs/research/2026-05-22-seed-code-stability-analysis.md §Mitigation 2
+   * @see https://github.com/p-to-q/wittgenstein/issues/453
+   */
+  readonly knownPositions?: readonly boolean[];
+  readonly knownTokens?: readonly number[];
 }
 
 export interface SeedExpander {
@@ -35,6 +50,23 @@ export interface SeedExpander {
 }
 
 const PLACEHOLDER_CODEBOOK_SIZE = 8192;
+
+export function validateCleanRepaintInputs(
+  knownPositions: readonly boolean[] | undefined,
+  knownTokens: readonly number[] | undefined,
+  totalTokens: number,
+): void {
+  if (knownPositions && knownPositions.length !== totalTokens) {
+    throw new Error(
+      `knownPositions length ${knownPositions.length} does not match totalTokens ${totalTokens}`,
+    );
+  }
+  if (knownTokens && knownTokens.length !== totalTokens) {
+    throw new Error(
+      `knownTokens length ${knownTokens.length} does not match totalTokens ${totalTokens}`,
+    );
+  }
+}
 
 /**
  * Deterministic, dependency-free SeedExpander used in v0.3 scaffolding.
@@ -51,12 +83,19 @@ const PLACEHOLDER_CODEBOOK_SIZE = 8192;
  * on the visual-seed-code branch firing.
  */
 export const placeholderSeedExpander: SeedExpander = {
-  expand({ seedCode, decoder, seed }) {
+  expand({ seedCode, decoder, seed, knownPositions, knownTokens }) {
     const [width, height] = decoder.latentResolution;
     const totalTokens = width * height;
+    validateCleanRepaintInputs(knownPositions, knownTokens, totalTokens);
     const tokens = new Array<number>(totalTokens);
 
     for (let index = 0; index < totalTokens; index += 1) {
+      // Clean-repaint: if this position is pinned, preserve the known token.
+      const knownToken = knownTokens?.[index];
+      if (knownPositions?.[index] && knownToken !== undefined) {
+        tokens[index] = knownToken;
+        continue;
+      }
       const base = seedCode.tokens[index % seedCode.tokens.length] ?? 0;
       tokens[index] = (base + seed + index * 31) % PLACEHOLDER_CODEBOOK_SIZE;
     }

--- a/packages/codec-image/src/schema.ts
+++ b/packages/codec-image/src/schema.ts
@@ -36,9 +36,28 @@ export const ImageLatentCodesSchema = z
   });
 export type ImageLatentCodes = z.infer<typeof ImageLatentCodesSchema>;
 
+/**
+ * Optional structured visual reasoning block (CoT-inspired).
+ * When present, the LLM articulates spatial, color, depth, and token-allocation
+ * plans before committing to seedCode tokens. The adapter may use these fields
+ * as additional conditioning via text embeddings.
+ *
+ * @see docs/research/2026-05-22-cot-inspired-improvements.md
+ * @see https://github.com/p-to-q/wittgenstein/issues/454
+ */
+const ImageVisualReasoningSchema = z
+  .object({
+    spatialPlan: z.string().optional(),
+    colorPlan: z.string().optional(),
+    depthPlan: z.string().optional(),
+    tokenStrategy: z.string().optional(),
+  })
+  .optional();
+
 const ImageSemanticLayerSchema = z.object({
   intent: z.string().default("placeholder scene"),
   subject: z.string().default("placeholder subject"),
+  reasoning: ImageVisualReasoningSchema,
   composition: z
     .object({
       framing: z.string().default("medium shot"),
@@ -149,6 +168,12 @@ export function imageSchemaPreamble(req: ImageRequest): string {
     "Emit a JSON Visual Seed Code contract for the sole neural image pipeline.",
     "Prefer seedCode as the primary decoder-facing output.",
     "Use Semantic IR to organize concepts, expose the user-facing plan, and optionally condition seed expansion.",
+    "Before emitting seedCode.tokens, populate semantic.reasoning with your visual plan:",
+    "  - spatialPlan: describe the spatial layout (horizon, subject placement, regions).",
+    "  - colorPlan: describe the dominant color scheme and transitions.",
+    "  - depthPlan: describe foreground / midground / background allocation.",
+    "  - tokenStrategy: describe which seed tokens encode which visual regions.",
+    "This reasoning step helps produce more stable and coherent seed tokens.",
     "Optional coarseVq hints may be included when you can provide stable partial VQ structure.",
     "Use providerLatents only when you can emit decoder-native latent tokens directly.",
     "Do not emit SVG, HTML, Canvas commands, or pixel arrays.",

--- a/packages/codec-image/test/codec.test.ts
+++ b/packages/codec-image/test/codec.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import type { RenderCtx } from "@wittgenstein/schemas";
 import { describe, expect, it } from "vitest";
-import { imageCodec } from "../src/index.js";
+import { imageCodec, imageSchemaPreamble } from "../src/index.js";
 import { imageCodeReceipt } from "../src/image-code-receipt.js";
 import { adaptSceneToLatents } from "../src/pipeline/adapter.js";
 import { renderImagePipeline } from "../src/pipeline/index.js";
@@ -95,6 +95,46 @@ describe("@wittgenstein/codec-image", () => {
     expect(parsed.value.subject).toBe("misty pine forest");
     expect(parsed.value.seedCode?.length).toBe(4);
     expect(parsed.value.mode).toBe("one-shot-vsc");
+  });
+
+  it("preserves structured visual reasoning in the semantic layer", () => {
+    const parsed = imageCodec.parse(
+      JSON.stringify({
+        mode: "one-shot-vsc",
+        semantic: {
+          intent: "coastal cliffs at sunset",
+          subject: "cliffs and ocean",
+          reasoning: {
+            spatialPlan: "Horizon on upper third, cliffs left, ocean right.",
+            colorPlan: "Warm orange sky with blue-green water.",
+            depthPlan: "Foreground cliff edge, midground ocean, background sky.",
+            tokenStrategy: "First tokens encode horizon and cliff silhouette.",
+          },
+        },
+        seedCode: {
+          family: "vqvae",
+          mode: "prefix",
+          tokens: [3, 17, 9, 220],
+        },
+      }),
+    );
+
+    expect(parsed.ok).toBe(true);
+    if (parsed.ok) {
+      expect(parsed.value.semantic?.reasoning?.spatialPlan).toContain("Horizon");
+      expect(parsed.value.semantic?.reasoning?.tokenStrategy).toContain("First tokens");
+    }
+  });
+
+  it("asks the LLM to emit semantic.reasoning before seedCode tokens", () => {
+    const preamble = imageSchemaPreamble({
+      modality: "image",
+      prompt: "coastal cliffs at sunset",
+    });
+
+    expect(preamble).toContain("populate semantic.reasoning");
+    expect(preamble).toContain("tokenStrategy");
+    expect(preamble).toContain("Before emitting seedCode.tokens");
   });
 
   it("distinguishes emitted semantic from legacy/effective semantic receipts", () => {

--- a/packages/codec-image/test/phase0-seed-degradation.test.ts
+++ b/packages/codec-image/test/phase0-seed-degradation.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Phase 0b: Seed code degradation test (Semantic IR field sensitivity).
+ *
+ * Tests whether varying semantic fields produces structured differences in
+ * the placeholder adapter output, establishing a baseline for measuring
+ * information-carrying capacity of the IR.
+ *
+ * @see docs/research/2026-05-22-ir-reliability-validation.md §Phase 0b
+ * @see https://github.com/p-to-q/wittgenstein/issues/452
+ */
+import { describe, expect, it } from "vitest";
+import { placeholderSeedExpander } from "../src/adapters/seed-expander.js";
+import {
+  ImageVisualSeedCodeSchema,
+  ImageSceneSpecSchema,
+  type ImageSceneSpec,
+} from "../src/schema.js";
+
+/** Build a minimal ImageSceneSpec with overrides. */
+function makeSpec(overrides: Partial<ImageSceneSpec> = {}): ImageSceneSpec {
+  return ImageSceneSpecSchema.parse({
+    mode: "one-shot-vsc",
+    intent: "test scene",
+    subject: "test subject",
+    ...overrides,
+  });
+}
+
+describe("Phase 0b — Semantic IR field sensitivity (placeholder baseline)", () => {
+  const seedCode = ImageVisualSeedCodeSchema.parse({
+    family: "vqvae",
+    mode: "prefix",
+    tokens: [42, 17, 88, 201, 15, 33, 77, 100],
+  });
+
+  it("different intent fields produce different adapter outputs", () => {
+    const specA = makeSpec({ intent: "stormy ocean at midnight" });
+    const specB = makeSpec({ intent: "sunny meadow at noon" });
+
+    const tokensA = placeholderSeedExpander.expand({
+      seedCode,
+      decoder: specA.decoder,
+      seed: hashSpec(specA),
+    }).tokens;
+
+    const tokensB = placeholderSeedExpander.expand({
+      seedCode,
+      decoder: specB.decoder,
+      seed: hashSpec(specB),
+    }).tokens;
+
+    // Different specs should produce different outputs via different hash seeds
+    expect(tokensA).not.toEqual(tokensB);
+  });
+
+  it("different lighting moods produce different adapter outputs", () => {
+    const specA = makeSpec({ lighting: { mood: "warm golden", key: "low side" } });
+    const specB = makeSpec({ lighting: { mood: "cold fluorescent", key: "overhead" } });
+
+    const tokensA = placeholderSeedExpander.expand({
+      seedCode,
+      decoder: specA.decoder,
+      seed: hashSpec(specA),
+    }).tokens;
+
+    const tokensB = placeholderSeedExpander.expand({
+      seedCode,
+      decoder: specB.decoder,
+      seed: hashSpec(specB),
+    }).tokens;
+
+    expect(tokensA).not.toEqual(tokensB);
+  });
+
+  it("seed code prefix truncation produces structured degradation", () => {
+    const spec = makeSpec({ intent: "coastal cliffs at sunset", subject: "rocky cliffs" });
+    const seed = hashSpec(spec);
+
+    const results: { length: number; tokens: number[] }[] = [];
+
+    for (const prefixLen of [8, 4, 2, 1]) {
+      const truncatedSeedCode = ImageVisualSeedCodeSchema.parse({
+        family: "vqvae",
+        mode: "prefix",
+        tokens: seedCode.tokens.slice(0, prefixLen),
+      });
+
+      const result = placeholderSeedExpander.expand({
+        seedCode: truncatedSeedCode,
+        decoder: spec.decoder,
+        seed,
+      });
+
+      results.push({ length: prefixLen, tokens: [...result.tokens] });
+    }
+
+    // All prefix lengths should produce valid latent grids
+    for (const r of results) {
+      expect(r.tokens.length).toBe(32 * 32); // default latentResolution
+      expect(r.tokens.every((t) => t >= 0 && t < 8192)).toBe(true);
+    }
+
+    // Different prefix lengths should produce different outputs
+    // (verifying the seed code actually influences the result)
+    expect(results[0]!.tokens).not.toEqual(results[1]!.tokens);
+    expect(results[1]!.tokens).not.toEqual(results[2]!.tokens);
+  });
+
+  it("identical specs produce identical outputs (baseline determinism)", () => {
+    const spec = makeSpec({ intent: "test determinism" });
+    const seed = hashSpec(spec);
+
+    const a = placeholderSeedExpander.expand({ seedCode, decoder: spec.decoder, seed });
+    const b = placeholderSeedExpander.expand({ seedCode, decoder: spec.decoder, seed });
+
+    expect(a.tokens).toEqual(b.tokens);
+  });
+});
+
+/** Reproduce the FNV-1a hash from adapter.ts for test isolation. */
+function hashSpec(parsed: ImageSceneSpec): number {
+  const source = JSON.stringify({
+    intent: parsed.intent,
+    subject: parsed.subject,
+    composition: parsed.composition,
+    lighting: parsed.lighting,
+    style: parsed.style,
+    constraints: parsed.constraints,
+    renderHints: parsed.renderHints,
+    decoder: parsed.decoder,
+  });
+  let hash = 2166136261;
+  for (let i = 0; i < source.length; i += 1) {
+    hash ^= source.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}

--- a/packages/codec-image/test/seed-expander-clean-repaint.test.ts
+++ b/packages/codec-image/test/seed-expander-clean-repaint.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+import { placeholderSeedExpander } from "../src/adapters/seed-expander.js";
+import { tileMosaicSeedExpander } from "../src/adapters/seed-expander-tile-mosaic.js";
+import { ImageVisualSeedCodeSchema, type ImageSceneSpec } from "../src/schema.js";
+
+describe("clean-repaint conditioning", () => {
+  const decoder: ImageSceneSpec["decoder"] = {
+    family: "llamagen",
+    codebook: "stub-codebook",
+    codebookVersion: "v0",
+    latentResolution: [4, 4], // 16-token target grid
+  };
+
+  const baseSeedCode = ImageVisualSeedCodeSchema.parse({
+    family: "vqvae",
+    mode: "prefix",
+    tokens: [3, 17, 9, 220],
+  });
+
+  const knownPositions = [
+    true,
+    false,
+    false,
+    false,
+    false,
+    false,
+    true,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    true,
+  ];
+
+  const knownTokens = [1111, 0, 0, 0, 0, 0, 2222, 0, 0, 0, 0, 0, 0, 0, 0, 3333];
+
+  describe("placeholderSeedExpander", () => {
+    it("preserves known positions exactly", () => {
+      const result = placeholderSeedExpander.expand({
+        seedCode: baseSeedCode,
+        decoder,
+        seed: 7,
+        knownPositions,
+        knownTokens,
+      });
+
+      expect(result.tokens[0]).toBe(1111);
+      expect(result.tokens[6]).toBe(2222);
+      expect(result.tokens[15]).toBe(3333);
+    });
+
+    it("still fills unknown positions deterministically", () => {
+      const result = placeholderSeedExpander.expand({
+        seedCode: baseSeedCode,
+        decoder,
+        seed: 7,
+        knownPositions,
+        knownTokens,
+      });
+
+      // Unknown positions should not be the known values
+      expect(result.tokens[1]).not.toBe(0); // position 1 is unknown, gets filled
+      expect(result.tokens.length).toBe(16);
+    });
+
+    it("produces identical output for same inputs (determinism)", () => {
+      const a = placeholderSeedExpander.expand({
+        seedCode: baseSeedCode,
+        decoder,
+        seed: 7,
+        knownPositions,
+        knownTokens,
+      });
+      const b = placeholderSeedExpander.expand({
+        seedCode: baseSeedCode,
+        decoder,
+        seed: 7,
+        knownPositions,
+        knownTokens,
+      });
+      expect(a.tokens).toEqual(b.tokens);
+    });
+
+    it("behaves identically to baseline when no mask is provided", () => {
+      const withMask = placeholderSeedExpander.expand({
+        seedCode: baseSeedCode,
+        decoder,
+        seed: 7,
+      });
+      const withoutMask = placeholderSeedExpander.expand({
+        seedCode: baseSeedCode,
+        decoder,
+        seed: 7,
+        knownPositions: undefined,
+        knownTokens: undefined,
+      });
+      expect(withMask.tokens).toEqual(withoutMask.tokens);
+    });
+
+    it("rejects clean-repaint arrays that do not match the latent grid", () => {
+      expect(() =>
+        placeholderSeedExpander.expand({
+          seedCode: baseSeedCode,
+          decoder,
+          seed: 7,
+          knownPositions: [true],
+          knownTokens,
+        }),
+      ).toThrow(/knownPositions length 1 does not match totalTokens 16/);
+      expect(() =>
+        placeholderSeedExpander.expand({
+          seedCode: baseSeedCode,
+          decoder,
+          seed: 7,
+          knownPositions,
+          knownTokens: [1111],
+        }),
+      ).toThrow(/knownTokens length 1 does not match totalTokens 16/);
+    });
+  });
+
+  describe("tileMosaicSeedExpander", () => {
+    it("preserves known positions exactly", () => {
+      const result = tileMosaicSeedExpander.expand({
+        seedCode: baseSeedCode,
+        decoder,
+        seed: 7,
+        knownPositions,
+        knownTokens,
+      });
+
+      expect(result.tokens[0]).toBe(1111);
+      expect(result.tokens[6]).toBe(2222);
+      expect(result.tokens[15]).toBe(3333);
+    });
+
+    it("fills unknown positions with tile-mosaic algorithm", () => {
+      const result = tileMosaicSeedExpander.expand({
+        seedCode: baseSeedCode,
+        decoder,
+        seed: 7,
+        knownPositions,
+        knownTokens,
+      });
+
+      expect(result.tokens.length).toBe(16);
+      // All tokens should be non-negative
+      for (const token of result.tokens) {
+        expect(token).toBeGreaterThanOrEqual(0);
+      }
+    });
+
+    it("rejects clean-repaint arrays that do not match the latent grid", () => {
+      expect(() =>
+        tileMosaicSeedExpander.expand({
+          seedCode: baseSeedCode,
+          decoder,
+          seed: 7,
+          knownPositions: [true],
+          knownTokens,
+        }),
+      ).toThrow(/knownPositions length 1 does not match totalTokens 16/);
+    });
+  });
+});

--- a/research/validation/phase0a_emission_entropy.py
+++ b/research/validation/phase0a_emission_entropy.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""
+Phase 0a: LLM emission entropy test.
+
+Prompts a frontier LLM with the VSC preamble for N image prompts × M runs at
+temperature=0.3. Measures per-position token entropy and inter-run Hamming
+distance to assess whether the LLM emits structured or random seed codes.
+
+Usage:
+    python phase0a_emission_entropy.py [--provider anthropic|openai] [--runs 10] [--prompts 10]
+
+Requires:
+    pip install anthropic  # or openai
+
+@see docs/research/2026-05-22-ir-reliability-validation.md §Phase 0a
+@see docs/research/2026-05-22-seed-code-stability-analysis.md §Empirical validation
+@see https://github.com/p-to-q/wittgenstein/issues/451
+"""
+
+import argparse
+import json
+import math
+import os
+import sys
+from collections import Counter
+from typing import Any
+
+VSC_PREAMBLE = """You are the image planner for Wittgenstein.
+
+Return valid JSON only. Do not return markdown fences. Do not return prose explanations.
+
+Your job is to emit a Visual Seed Code contract for the sole neural image pipeline.
+
+Before emitting seedCode.tokens, populate semantic.reasoning with your visual plan:
+  - spatialPlan: describe the spatial layout (horizon, subject placement, regions).
+  - colorPlan: describe the dominant color scheme and transitions.
+  - depthPlan: describe foreground / midground / background allocation.
+  - tokenStrategy: describe which seed tokens encode which visual regions.
+
+Emit exactly this JSON shape:
+{
+  "schemaVersion": "witt.image.spec/v0.1",
+  "mode": "one-shot-vsc",
+  "semantic": {
+    "intent": "<user prompt>",
+    "subject": "<main subject>",
+    "reasoning": {
+      "spatialPlan": "<spatial layout description>",
+      "colorPlan": "<color scheme description>",
+      "depthPlan": "<depth allocation>",
+      "tokenStrategy": "<token allocation plan>"
+    }
+  },
+  "seedCode": {
+    "schemaVersion": "witt.image.seed/v0.1",
+    "family": "vqvae",
+    "mode": "prefix",
+    "tokens": [<32 integers in range 0-4095>]
+  }
+}
+
+Use exactly 32 tokens in range 0-4095. Each token represents a compressed visual feature.
+Early tokens should encode gross layout; later tokens should encode fine details."""
+
+IMAGE_PROMPTS = [
+    "A stormy ocean at midnight with lightning",
+    "A cozy cabin in a snowy forest",
+    "A bustling Tokyo street at night with neon signs",
+    "A single red rose on a white marble table",
+    "An astronaut floating above Earth at sunset",
+    "A medieval castle on a cliff overlooking a misty valley",
+    "A golden retriever running through autumn leaves",
+    "A minimalist Bauhaus-style poster in red, yellow, and blue",
+    "An underwater coral reef with tropical fish",
+    "A desert sand dune at dawn with long shadows",
+]
+
+EXPECTED_TOKENS = 32
+TOKEN_MIN = 0
+TOKEN_MAX = 4095
+REASONING_FIELDS = ("spatialPlan", "colorPlan", "depthPlan", "tokenStrategy")
+
+
+def positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
+def call_anthropic(prompt: str, temperature: float = 0.3) -> str:
+    """Call Anthropic API."""
+    try:
+        import anthropic
+    except ImportError:
+        print("pip install anthropic", file=sys.stderr)
+        sys.exit(1)
+
+    client = anthropic.Anthropic()
+    message = client.messages.create(
+        model="claude-sonnet-4-20250514",
+        max_tokens=2048,
+        temperature=temperature,
+        system=VSC_PREAMBLE,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return message.content[0].text
+
+
+def call_openai(prompt: str, temperature: float = 0.3) -> str:
+    """Call OpenAI API."""
+    try:
+        from openai import OpenAI
+    except ImportError:
+        print("pip install openai", file=sys.stderr)
+        sys.exit(1)
+
+    client = OpenAI()
+    response = client.chat.completions.create(
+        model="gpt-4o",
+        temperature=temperature,
+        messages=[
+            {"role": "system", "content": VSC_PREAMBLE},
+            {"role": "user", "content": prompt},
+        ],
+    )
+    return response.choices[0].message.content or ""
+
+
+def extract_tokens(response: str) -> list[int] | None:
+    """Extract seedCode.tokens from LLM response JSON."""
+    try:
+        # Try to find JSON in the response
+        text = response.strip()
+        if text.startswith("```"):
+            # Strip markdown fences
+            lines = text.split("\n")
+            text = "\n".join(lines[1:-1])
+        data = json.loads(text)
+        tokens = data.get("seedCode", {}).get("tokens", [])
+        if isinstance(tokens, list) and len(tokens) == EXPECTED_TOKENS:
+            parsed_tokens = [int(t) for t in tokens]
+            if all(TOKEN_MIN <= token <= TOKEN_MAX for token in parsed_tokens):
+                return parsed_tokens
+    except (json.JSONDecodeError, KeyError, ValueError, TypeError):
+        pass
+    return None
+
+
+def extract_reasoning(response: str) -> dict[str, str] | None:
+    """Extract semantic.reasoning from LLM response JSON."""
+    try:
+        text = response.strip()
+        if text.startswith("```"):
+            lines = text.split("\n")
+            text = "\n".join(lines[1:-1])
+        data = json.loads(text)
+        reasoning = data.get("semantic", {}).get("reasoning")
+        if not isinstance(reasoning, dict):
+            return None
+
+        extracted: dict[str, str] = {}
+        for field in REASONING_FIELDS:
+            value = reasoning.get(field)
+            if not isinstance(value, str) or not value.strip():
+                return None
+            extracted[field] = value
+        return extracted
+    except (json.JSONDecodeError, KeyError, ValueError, TypeError):
+        return None
+
+
+def entropy(values: list[int]) -> float:
+    """Shannon entropy of a discrete distribution."""
+    counts = Counter(values)
+    total = len(values)
+    if total == 0:
+        return 0.0
+    return -sum(
+        (c / total) * math.log2(c / total) for c in counts.values() if c > 0
+    )
+
+
+def hamming_distance(a: list[int], b: list[int]) -> int:
+    """Count positions where a[i] != b[i]."""
+    return sum(1 for x, y in zip(a, b) if x != y)
+
+
+def run_experiment(
+    provider: str, num_prompts: int, num_runs: int, temperature: float
+) -> dict[str, Any]:
+    """Run the full experiment and return results."""
+    call_fn = call_anthropic if provider == "anthropic" else call_openai
+    prompts = IMAGE_PROMPTS[:num_prompts]
+    actual_prompts = len(prompts)
+
+    results: dict[str, Any] = {
+        "provider": provider,
+        "temperature": temperature,
+        "num_prompts": actual_prompts,
+        "requested_prompts": num_prompts,
+        "num_runs": num_runs,
+        "per_prompt": [],
+    }
+
+    for i, prompt in enumerate(prompts):
+        print(f"\n[{i+1}/{len(prompts)}] Prompt: {prompt}")
+        all_tokens: list[list[int]] = []
+        reasoning_present = 0
+        parse_failures = 0
+
+        for run in range(num_runs):
+            print(f"  Run {run+1}/{num_runs}...", end=" ", flush=True)
+            try:
+                response = call_fn(prompt, temperature=temperature)
+                tokens = extract_tokens(response)
+                reasoning = extract_reasoning(response)
+
+                if tokens is not None:
+                    all_tokens.append(tokens)
+                    print(f"OK ({len(tokens)} tokens)", end="")
+                else:
+                    parse_failures += 1
+                    print("PARSE_FAIL", end="")
+
+                if reasoning is not None:
+                    reasoning_present += 1
+                    print(f" +reasoning", end="")
+                print()
+
+            except Exception as e:
+                parse_failures += 1
+                print(f"ERROR: {e}")
+
+        if len(all_tokens) < 2:
+            print(f"  WARNING: Only {len(all_tokens)} successful runs, skipping analysis")
+            results["per_prompt"].append({
+                "prompt": prompt,
+                "successful_runs": len(all_tokens),
+                "parse_failures": parse_failures,
+                "reasoning_rate": reasoning_present / num_runs if num_runs > 0 else 0,
+                "analysis": "insufficient_data",
+            })
+            continue
+
+        # Normalize to same length (pad shorter with -1)
+        max_len = max(len(t) for t in all_tokens)
+        padded = [t + [-1] * (max_len - len(t)) for t in all_tokens]
+
+        # Per-position entropy
+        per_position_entropy = []
+        for pos in range(max_len):
+            values_at_pos = [t[pos] for t in padded if t[pos] != -1]
+            per_position_entropy.append(entropy(values_at_pos))
+
+        # Pairwise Hamming distances
+        hamming_distances = []
+        for j in range(len(all_tokens)):
+            for k in range(j + 1, len(all_tokens)):
+                min_len = min(len(all_tokens[j]), len(all_tokens[k]))
+                hd = hamming_distance(all_tokens[j][:min_len], all_tokens[k][:min_len])
+                hamming_distances.append(hd / min_len if min_len > 0 else 0)
+
+        # Token range statistics
+        all_flat = [t for seq in all_tokens for t in seq]
+        token_range = (min(all_flat), max(all_flat)) if all_flat else (0, 0)
+
+        prompt_result = {
+            "prompt": prompt,
+            "successful_runs": len(all_tokens),
+            "parse_failures": parse_failures,
+            "reasoning_rate": reasoning_present / num_runs,
+            "token_lengths": [len(t) for t in all_tokens],
+            "token_range": token_range,
+            "per_position_entropy": {
+                "mean": sum(per_position_entropy) / len(per_position_entropy),
+                "max": max(per_position_entropy),
+                "min": min(per_position_entropy),
+                "first_8_mean": sum(per_position_entropy[:8]) / min(8, len(per_position_entropy)),
+                "last_8_mean": sum(per_position_entropy[-8:]) / min(8, len(per_position_entropy)),
+            },
+            "hamming_distance": {
+                "mean": sum(hamming_distances) / len(hamming_distances) if hamming_distances else 0,
+                "max": max(hamming_distances) if hamming_distances else 0,
+                "min": min(hamming_distances) if hamming_distances else 0,
+            },
+        }
+
+        # Interpretation
+        mean_entropy = prompt_result["per_position_entropy"]["mean"]
+        if mean_entropy < 1.0:
+            prompt_result["interpretation"] = "LOW_ENTROPY — LLM has strong prior (Scenario B1/B2)"
+        elif mean_entropy < 3.0:
+            prompt_result["interpretation"] = "MODERATE_ENTROPY — some structure, some randomness"
+        else:
+            prompt_result["interpretation"] = "HIGH_ENTROPY — LLM may be guessing (Scenario B3)"
+
+        first_8 = prompt_result["per_position_entropy"]["first_8_mean"]
+        last_8 = prompt_result["per_position_entropy"]["last_8_mean"]
+        if first_8 < last_8 * 0.7:
+            prompt_result["ordering_signal"] = "POSITIVE — early tokens more stable than late tokens"
+        elif first_8 > last_8 * 1.3:
+            prompt_result["ordering_signal"] = "NEGATIVE — early tokens less stable (concerning)"
+        else:
+            prompt_result["ordering_signal"] = "NEUTRAL — no clear importance ordering"
+
+        results["per_prompt"].append(prompt_result)
+
+        print(f"  Entropy: mean={mean_entropy:.2f}, first_8={first_8:.2f}, last_8={last_8:.2f}")
+        print(f"  Hamming: mean={prompt_result['hamming_distance']['mean']:.2%}")
+        print(f"  Interpretation: {prompt_result['interpretation']}")
+        print(f"  Ordering: {prompt_result['ordering_signal']}")
+
+    # Aggregate
+    all_entropies = [
+        p["per_position_entropy"]["mean"]
+        for p in results["per_prompt"]
+        if isinstance(p.get("per_position_entropy"), dict)
+    ]
+    all_hamming = [
+        p["hamming_distance"]["mean"]
+        for p in results["per_prompt"]
+        if isinstance(p.get("hamming_distance"), dict)
+    ]
+    results["aggregate"] = {
+        "mean_entropy": sum(all_entropies) / len(all_entropies) if all_entropies else None,
+        "mean_hamming": sum(all_hamming) / len(all_hamming) if all_hamming else None,
+        "parse_success_rate": sum(
+            p["successful_runs"] for p in results["per_prompt"]
+        ) / (actual_prompts * num_runs) if actual_prompts * num_runs > 0 else 0,
+        "reasoning_rate": sum(
+            p.get("reasoning_rate", 0) for p in results["per_prompt"]
+        ) / actual_prompts if actual_prompts > 0 else 0,
+    }
+
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Phase 0a: LLM emission entropy test for Visual Seed Code"
+    )
+    parser.add_argument(
+        "--provider",
+        choices=["anthropic", "openai"],
+        default="anthropic",
+        help="LLM provider (default: anthropic)",
+    )
+    parser.add_argument("--runs", type=positive_int, default=5, help="Runs per prompt (default: 5)")
+    parser.add_argument("--prompts", type=positive_int, default=5, help="Number of prompts (default: 5)")
+    parser.add_argument("--temperature", type=float, default=0.3, help="Sampling temperature")
+    parser.add_argument("--output", type=str, default=None, help="Output JSON path")
+    args = parser.parse_args()
+
+    results = run_experiment(args.provider, args.prompts, args.runs, args.temperature)
+
+    # Print summary
+    print("\n" + "=" * 60)
+    print("AGGREGATE RESULTS")
+    print("=" * 60)
+    agg = results["aggregate"]
+    print(f"  Parse success rate: {agg['parse_success_rate']:.0%}")
+    print(f"  Reasoning compliance rate: {agg['reasoning_rate']:.0%}")
+    if agg["mean_entropy"] is not None:
+        print(f"  Mean per-position entropy: {agg['mean_entropy']:.2f} bits")
+        print(f"  Mean inter-run Hamming distance: {agg['mean_hamming']:.2%}")
+    print()
+
+    if agg["mean_entropy"] is not None:
+        if agg["mean_entropy"] < 1.0:
+            print("VERDICT: Scenario B1/B2 — LLM has strong prior over seed code tokens.")
+            print("  The VSC thesis is supported at the emission level.")
+        elif agg["mean_entropy"] < 3.0:
+            print("VERDICT: Mixed signal — some structure, needs further investigation.")
+            print("  Adapter training may compensate for partial randomness.")
+        else:
+            print("VERDICT: Scenario B3 — LLM appears to be guessing token values.")
+            print("  Consider: semantic-only IR + strong adapter, or paired training data.")
+
+    # Save results
+    output_path = args.output or f"phase0a_results_{args.provider}.json"
+    with open(output_path, "w") as f:
+        json.dump(results, f, indent=2)
+    print(f"\nResults saved to {output_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

The codec slice of #455, rebuilt cleanly on current `main`. #455 couldn't merge as-is (stale base, a dead competing `manifest.py`, and the docs already overlapping #535). This PR carries **only** the genuinely-new, leak-clean codec work.

All 7 files were **unchanged on main since #455's merge-base**, so taking #455's versions reverts no later work (verified per-file).

### Included
- **`schema.ts`** — optional `semantic.reasoning` block (`spatialPlan` / `colorPlan` / `depthPlan` / `tokenStrategy`), CoT-inspired, additive + backward-compatible; preamble asks the LLM to populate it before emitting `seedCode` tokens. Design doc: `docs/research/2026-05-22-cot-inspired-improvements.md` (#454).
- **`seed-expander.ts` + `seed-expander-tile-mosaic.ts`** — Cola-DLM-style clean-repaint: optional `knownPositions`/`knownTokens` with `validateCleanRepaintInputs()` that fails loudly on malformed masks. Default render path unchanged.
- **tests** — `codec.test.ts` updates + `phase0-seed-degradation.test.ts` + `seed-expander-clean-repaint.test.ts`.
- **`research/validation/phase0a_emission_entropy.py`** — standalone IR-emission entropy probe (no manifest dependency; gated behind explicit `anthropic`/`openai` install).

### Deliberately NOT included
- The 4-file **dead manifest subsystem** from #455 (`manifest.py` 107L + `smoke_manifest.py` + `test_manifest.py` + `__init__.py` re-export) — it re-introduced a `TrainingManifest` contract incompatible with the 258-line spine merged in #493, and imported symbols that don't exist there. Fully redundant → dropped.
- The 7 docs — already landed via #535.

## ⚠️ Review flag (contract surface)

`semantic.reasoning` is a codec contract-surface addition. It's optional + backward-compatible, but per **ADR-0013** + engineering-discipline ("codec-shape assumptions require a second independent review pass") it should get a confirming codec/core look against **RFC-0007 / ADR-0018** before merge. Flagging explicitly — not treating it as routine.

## Verification

- Leak scan on all 7 files: **clean**.
- `phase0a_emission_entropy.py` parses; TS brace-balanced. **Full typecheck/test deferred to CI** (`Verify (Node + Python)`) — I have not claimed local pass; gate merge on the CI result.

## Test plan

- [ ] CI `Verify (Node + Python)` green (this is the real gate — not yet observed at PR-open time)
- [ ] Codec/core confirming review of the `semantic.reasoning` contract addition
- [ ] #455 can then be closed (its docs are in #535, its manifest subsystem is correctly dropped, its codec work is here)

Refs #455