### PR TITLE
chore(audit): cross-section sweep — CI regex, PII, license, lint, workspace

### DIFF
--- a/.github/workflows/status-labeler.yml
+++ b/.github/workflows/status-labeler.yml
@@ -141,7 +141,7 @@ jobs:
 
             function shouldEscalateNeedsMlSpecialistFromText(pr) {
               const text = `${pr.title || ""}\n${pr.body || ""}`;
-              return /Visual Seed Code|\\bVSC\\b|SeedExpander|decoder bridge/i.test(text);
+              return /Visual Seed Code|\bVSC\b|SeedExpander|decoder bridge/i.test(text);
             }
 
             async function addNeedsMlSpecialistIfApplicable(pr) {

--- a/apps/site/src/sections/HumanReadabilitySection.tsx
+++ b/apps/site/src/sections/HumanReadabilitySection.tsx
@@ -50,7 +50,7 @@ export default function HumanReadabilitySection() {
           >
             <span className="text-[hsl(var(--coral))]">User prompt</span>
             {"\n    →  schema preamble + "}
-            <span className="text-[hsl(var(--coral))]">Visual Seed Code (VSC)</span> - bearing image contract
+            <span className="text-[hsl(var(--coral))]">Visual Seed Code (VSC)</span>-bearing image contract
             {"\n          →  "}
             <span className="text-[hsl(var(--coral))]">LLM</span>
             {" (planner)"}

--- a/docs/research/2026-05-26-m1b-pr-boundary-audit.md
+++ b/docs/research/2026-05-26-m1b-pr-boundary-audit.md
@@ -98,7 +98,7 @@ split out into a separate governance/docs hygiene PR, or left out of the M1B PR:
 - `docs/v02-alignment-review.md`
 - `docs/v02-final-audit.md`
 
-Observed pattern: these changes replace `max` / `max.zhuang.yan@gmail.com` with
+Observed pattern: these changes replace a contributor's personal name / email with
 `@Jah-yee @Moapacha`. That is governance / attribution hygiene, not decoder
 delivery. Mixing it into M1B would expand review scope and trigger
 doctrine-surface review obligations unrelated to #334/#335/#402.

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,13 +1,10 @@
 import { createRequire } from "node:module";
-import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { loadWittgensteinConfig } from "@wittgenstein/core";
 import { firstOutputLine, spawnVersionCheck } from "@wittgenstein/process-runner";
 import type { Command } from "commander";
 import { resolveExecutionRoot } from "./shared.js";
 import { runtimeTierReadiness } from "../tiers.js";
-
-const OPTIONAL_DEPENDENCY_CHECK_TIMEOUT_MS = 10_000;
 
 type DoctorCheckStatus = "ok" | "missing" | "skipped";
 

--- a/packages/codec-image/src/decoders/llamagen/README.md
+++ b/packages/codec-image/src/decoders/llamagen/README.md
@@ -16,7 +16,7 @@ shared [`../weights.ts`](../weights.ts) cache + sha256 resolver and the
 ## Provenance
 
 - **Upstream source repo** — `FoundationVision/LlamaGen` ([github](https://github.com/FoundationVision/LlamaGen),
-  Apache-2.0). The `repoId` + `revision` in the manifest point at the
+  MIT). The `repoId` + `revision` in the manifest point at the
   audited snapshot (`81e41139…`) of the VQ tokenizer source code.
 - **Upstream weights** — `vq_ds16_c2i.pt` (~287 MB FP32, ~72M
   parameters, K=16384, embed dim D=8, downsample factor p=16).

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,8 +1,9 @@
 packages:
   - "packages/*"
-  - "apps/*"
-  - "!apps/wittgenstein-kimi"
-  # apps/_vercel-kimi-out/ is gitignored build output from the Kimi deck.
-  # Excluded from the workspace too so locally generated artifacts can't
-  # trip `pnpm install --frozen-lockfile` for maintainers who built it.
-  - "!apps/_vercel-kimi-out"
+  # Explicit app allowlist instead of `apps/*`: ad-hoc or build-output dirs
+  # (gitignored `apps/_vercel-kimi-out/`, a stray Finder `apps/site copy/`)
+  # must not get pulled into the workspace and trip
+  # `pnpm install --frozen-lockfile`. `apps/wittgenstein-kimi` is
+  # intentionally omitted (standalone Kimi deck, not a workspace member).
+  - "apps/presentation"
+  - "apps/site"

--- a/scripts/check-npm-publish-tarball.mjs
+++ b/scripts/check-npm-publish-tarball.mjs
@@ -6,7 +6,8 @@
  * Per the delivery doctrine
  * (`docs/research/2026-05-13-delivery-and-componentization.md`), a user
  * running `npm install @wittgenstein/cli` must never pull in `research/`,
- * `bench/`, `examples/`, or large binary artifacts. This guard runs
+ * `benchmarks/`, `examples/`, `python/`, `polyglot-mini/`, or large binary
+ * artifacts. This guard runs
  * `npm pack --dry-run --json` per publishable package and verifies the
  * file list contains none of those.
  *


### PR DESCRIPTION
## Summary

Post-merge audit sweep of the **#495–#536** batch. Seven small, independently-verified fixes across CI, docs, lint, privacy, and workspace hygiene. No behavior change to shipped code paths; one real CI-logic bug and one PII leak.

| # | Surface | Finding | Source |
|---|---------|---------|--------|
| 1 | CI | `status-labeler.yml` regex `\\bVSC\\b` was a double-escaped backslash → matched literal text, not a word boundary. The JS ML-specialist text gate silently failed on a bare `VSC` token (masked by the path-only `labeler.yml`, but defective). | #500/#536 area |
| 2 | Privacy | Personal name+email leaked in `docs/research/2026-05-26-m1b-pr-boundary-audit.md` — ironically in the paragraph describing that scrub. Redacted. | #528 |
| 3 | Docs | llamagen `README.md` provenance claimed **Apache-2.0**; the vendored `LICENSE.llamagen`, `manifest.json` (`code: MIT`), and the guardrail test are all **MIT** (upstream is MIT). Prose corrected. | #527/#536 |
| 4 | Lint | Dead `spawnSync` import + unused `OPTIONAL_DEPENDENCY_CHECK_TIMEOUT_MS` in `doctor.ts` (ESLint warnings; `createRequire` replaced the spawn path). | #506 |
| 5 | Docs | Tarball-guard header docstring still listed `bench/`; updated to the real `FORBIDDEN_PATTERNS` (`research/`, `benchmarks/`, `examples/`, `python/`, `polyglot-mini/`). | #518 |
| 6 | Site | `HumanReadabilitySection` `(VSC) - bearing` → `(VSC)-bearing`. | #524 |
| 7 | Workspace | Hardened `pnpm-workspace.yaml` `apps/*` glob → explicit allowlist so a stray `apps/site copy/` or build-output dir can't enter the workspace and trip `pnpm install --frozen-lockfile`. **Closes #465.** | #465 |

## Test plan

- [x] `pnpm -r --filter @wittgenstein/cli --filter @wittgenstein/site typecheck` — clean
- [x] `eslint src/commands/doctor.ts` — clean (was 2 warnings)
- [x] `node scripts/check-npm-publish-tarball.mjs` — passes
- [x] `pnpm install --frozen-lockfile` — lockfile-neutral (effective members unchanged: `presentation`, `site`)
- [x] `prettier --check` on edited YAML — clean

> Out of scope (flagged separately): a pre-existing `/Users/dujiayi/…` home-path leak in 23 artifact/script files (separate privacy PR), and ML-owned codec-image findings (clamp bypass, receipt drift, test gaps) routed to the model specialist.