### PR TITLE
feat(cli): inspect decoder manifests in doctor

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,6 +52,7 @@
     "smoke": "node ./bin/wittgenstein.js doctor"
   },
   "dependencies": {
+    "@wittgenstein/codec-image": "workspace:*",
     "@wittgenstein/codec-video": "workspace:*",
     "@wittgenstein/core": "workspace:*",
     "@wittgenstein/process-runner": "workspace:*",

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,12 +1,20 @@
 import { createRequire } from "node:module";
 import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { dirname, isAbsolute, resolve } from "node:path";
 import { loadWittgensteinConfig } from "@wittgenstein/core";
+import {
+  DecoderFamilyManifestSchema,
+  preflightImageDecoder,
+  type DecoderFamilyManifest,
+  type DecoderPreflightReceipt,
+} from "@wittgenstein/codec-image";
 import { firstOutputLine, spawnVersionCheck } from "@wittgenstein/process-runner";
 import type { Command } from "commander";
 import { resolveExecutionRoot } from "./shared.js";
 import { runtimeTierReadiness } from "../tiers.js";
 
-type DoctorCheckStatus = "ok" | "missing" | "skipped";
+type DoctorCheckStatus = "ok" | "missing" | "invalid" | "skipped";
 
 interface DoctorCheck {
   status: DoctorCheckStatus;
@@ -25,9 +33,25 @@ interface VideoRenderDoctor {
 }
 
 interface ImageDecoderDoctor {
-  status: "blocked";
+  status: "ready" | "blocked" | "not-selected";
+  manifestPath: string | null;
+  family: string | null;
+  decoderId: string | null;
+  manifestStatus: "blessed" | "candidate" | "rejected" | null;
+  weightsRestriction: "permissive" | "research-only" | null;
+  audits: {
+    gateA: string;
+    gateB: string;
+    gateC: string;
+    gateD: string;
+  } | null;
+  weightsCached: boolean | null;
   decoderManifest: DoctorCheck;
   onnxRuntime: DoctorCheck;
+  reason: DecoderPreflightReceipt["reason"] | null;
+  installHint: string | null;
+  tracker: string | null;
+  details: Record<string, unknown>;
   blockers: {
     decoderDelivery: string;
     gateCDeterminism: string;
@@ -60,7 +84,7 @@ export function registerDoctorCommand(program: Command): void {
             artifactsDir: config.runtime.artifactsDir,
             tiers: runtimeTierReadiness(),
             videoRender: checkVideoRenderDependencies(),
-            imageDecoder: checkImageDecoderReadiness(),
+            imageDecoder: await checkImageDecoderReadiness(workspaceRoot),
           },
           null,
           2,
@@ -219,21 +243,182 @@ function checkChromeCandidate(candidate: string): DoctorCheck {
   return { status: "missing" };
 }
 
-function checkImageDecoderReadiness(): ImageDecoderDoctor {
+async function checkImageDecoderReadiness(workspaceRoot: string): Promise<ImageDecoderDoctor> {
+  const selectedManifest = process.env.WITTGENSTEIN_DECODER_MANIFEST;
+  const onnxRuntime = checkOptionalNodePeer("onnxruntime-node", "wittgenstein install image");
+  const blockers = imageDecoderBlockers();
+
+  if (!selectedManifest) {
+    return {
+      status: "not-selected",
+      manifestPath: null,
+      family: null,
+      decoderId: null,
+      manifestStatus: null,
+      weightsRestriction: null,
+      audits: null,
+      weightsCached: null,
+      decoderManifest: {
+        status: "skipped",
+        message: "Set WITTGENSTEIN_DECODER_MANIFEST=<path> to inspect a decoder-family manifest.",
+      },
+      onnxRuntime,
+      reason: "manifest-missing",
+      installHint: "wittgenstein install image",
+      tracker: "https://github.com/p-to-q/wittgenstein/issues/402",
+      details: {
+        message: "No decoder-family manifest has been selected for the image tier.",
+      },
+      blockers,
+    };
+  }
+
+  const manifestPath = isAbsolute(selectedManifest)
+    ? selectedManifest
+    : resolve(workspaceRoot, selectedManifest);
+
+  let manifestInput: unknown;
+  try {
+    manifestInput = JSON.parse(await readFile(manifestPath, "utf8"));
+  } catch (error) {
+    return {
+      status: "blocked",
+      manifestPath,
+      family: null,
+      decoderId: null,
+      manifestStatus: null,
+      weightsRestriction: null,
+      audits: null,
+      weightsCached: null,
+      decoderManifest: {
+        status: "missing",
+        path: manifestPath,
+        message: `Could not read decoder-family manifest: ${errorMessage(error)}`,
+      },
+      onnxRuntime,
+      reason: "manifest-invalid",
+      installHint: "wittgenstein install image",
+      tracker: "https://github.com/p-to-q/wittgenstein/issues/402",
+      details: {
+        issues: [{ path: "", message: errorMessage(error) }],
+      },
+      blockers,
+    };
+  }
+
+  const parsedManifest = DecoderFamilyManifestSchema.safeParse(manifestInput);
+  const auditReceipts = parsedManifest.success
+    ? await readAuditReceipts(parsedManifest.data, workspaceRoot, dirname(manifestPath))
+    : new Map<string, unknown>();
+  const preflight = await preflightImageDecoder({
+    manifest: manifestInput,
+    auditReceipts,
+    // Doctor is an audit surface: surface research-only posture and peer
+    // availability without opting users into a decode runtime.
+    allowResearchWeights: true,
+    checkRuntime: false,
+  });
+  const parsed = parsedManifest.success ? parsedManifest.data : null;
+
   return {
-    status: "blocked",
+    status: preflight.status,
+    manifestPath,
+    family: parsed?.family ?? preflight.family,
+    decoderId: parsed?.decoderId ?? preflight.decoderId,
+    manifestStatus: parsed?.status ?? null,
+    weightsRestriction: parsed?.assets.license.weights ?? null,
+    audits: parsed ? auditStatuses(parsed) : null,
+    weightsCached: weightsCachedFromPreflight(preflight),
     decoderManifest: {
-      status: "missing",
-      message:
-        "No decoder-family manifest has been blessed for the image install tier yet; #402 owns the decision.",
+      status: parsedManifest.success ? "ok" : "invalid",
+      path: manifestPath,
+      message: parsedManifest.success
+        ? "Decoder-family manifest loaded from WITTGENSTEIN_DECODER_MANIFEST."
+        : "Decoder-family manifest did not match the expected schema.",
     },
-    onnxRuntime: checkOptionalNodePeer("onnxruntime-node", "wittgenstein install image"),
-    blockers: {
-      decoderDelivery: "https://github.com/p-to-q/wittgenstein/issues/402",
-      gateCDeterminism: "https://github.com/p-to-q/wittgenstein/issues/334",
-      gateDOnnxCpu: "https://github.com/p-to-q/wittgenstein/issues/335",
-    },
+    onnxRuntime,
+    reason: preflight.reason,
+    installHint: preflight.installHint,
+    tracker: preflight.tracker,
+    details: preflight.details,
+    blockers,
   };
+}
+
+function imageDecoderBlockers(): ImageDecoderDoctor["blockers"] {
+  return {
+    decoderDelivery: "https://github.com/p-to-q/wittgenstein/issues/402",
+    gateCDeterminism: "https://github.com/p-to-q/wittgenstein/issues/334",
+    gateDOnnxCpu: "https://github.com/p-to-q/wittgenstein/issues/335",
+  };
+}
+
+async function readAuditReceipts(
+  manifest: DecoderFamilyManifest,
+  workspaceRoot: string,
+  manifestDir: string,
+): Promise<Map<string, unknown>> {
+  const receipts = new Map<string, unknown>();
+
+  for (const gate of ["gateC", "gateD"] as const) {
+    const receiptPath = manifest.audits[gate].receipt;
+    if (!receiptPath) continue;
+
+    const input = await readJsonFromCandidates(
+      resolveReceiptCandidates(receiptPath, workspaceRoot, manifestDir),
+    );
+    if (input !== undefined) {
+      receipts.set(receiptPath, input);
+    }
+  }
+
+  return receipts;
+}
+
+function resolveReceiptCandidates(
+  receiptPath: string,
+  workspaceRoot: string,
+  manifestDir: string,
+): string[] {
+  if (isAbsolute(receiptPath)) {
+    return [receiptPath];
+  }
+
+  return [resolve(workspaceRoot, receiptPath), resolve(manifestDir, receiptPath)];
+}
+
+async function readJsonFromCandidates(paths: readonly string[]): Promise<unknown | undefined> {
+  for (const path of paths) {
+    try {
+      return JSON.parse(await readFile(path, "utf8"));
+    } catch {
+      // Try the next resolution root. If every candidate fails, preflight will
+      // report the receipt as missing for the manifest's declared path.
+    }
+  }
+
+  return undefined;
+}
+
+function auditStatuses(manifest: DecoderFamilyManifest): NonNullable<ImageDecoderDoctor["audits"]> {
+  return {
+    gateA: manifest.audits.gateA.status,
+    gateB: manifest.audits.gateB.status,
+    gateC: manifest.audits.gateC.status,
+    gateD: manifest.audits.gateD.status,
+  };
+}
+
+function weightsCachedFromPreflight(receipt: DecoderPreflightReceipt): boolean | null {
+  if (receipt.status === "ready") return true;
+  if (receipt.reason === "weights-not-installed" || receipt.reason === "weights-invalid") {
+    return false;
+  }
+  return null;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function checkOptionalNodePeer(packageName: string, installHint: string): DoctorCheck {

--- a/packages/cli/test/doctor.test.ts
+++ b/packages/cli/test/doctor.test.ts
@@ -1,18 +1,25 @@
+import { createHash } from "node:crypto";
 import { spawnSync } from "node:child_process";
-import { dirname, resolve } from "node:path";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 const testDir = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolve(testDir, "..");
 const cliBin = resolve(packageRoot, "src/cli-main.ts");
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 describe("doctor tier readiness", () => {
   it("prints the current tier readiness table", () => {
-    const doctor = spawnSync("node", ["--import", "tsx", cliBin, "doctor"], {
-      cwd: packageRoot,
-      encoding: "utf8",
-    });
+    const doctor = runDoctor();
 
     expect(doctor.status).toBe(0);
     const payload = JSON.parse(doctor.stdout) as {
@@ -30,7 +37,16 @@ describe("doctor tier readiness", () => {
       };
       imageDecoder: {
         status: string;
+        manifestPath: string | null;
+        family: string | null;
+        decoderId: string | null;
+        manifestStatus: string | null;
+        weightsRestriction: string | null;
+        audits: Record<string, string> | null;
+        weightsCached: boolean | null;
         decoderManifest: { status: string; message: string };
+        reason: string | null;
+        installHint: string | null;
         onnxRuntime: { status: string; message?: string; path?: string };
         blockers: {
           decoderDelivery: string;
@@ -48,9 +64,17 @@ describe("doctor tier readiness", () => {
     expect(payload.videoRender.hyperframesCli.status).toBe("skipped");
     expect(payload.videoRender.ffmpeg.status).toBe("skipped");
     expect(payload.videoRender.chrome.status).toBe("skipped");
-    expect(payload.imageDecoder.status).toBe("blocked");
-    expect(payload.imageDecoder.decoderManifest.status).toBe("missing");
-    expect(payload.imageDecoder.decoderManifest.message).toMatch(/#402/);
+    expect(payload.imageDecoder.status).toBe("not-selected");
+    expect(payload.imageDecoder.manifestPath).toBeNull();
+    expect(payload.imageDecoder.family).toBeNull();
+    expect(payload.imageDecoder.decoderId).toBeNull();
+    expect(payload.imageDecoder.manifestStatus).toBeNull();
+    expect(payload.imageDecoder.weightsRestriction).toBeNull();
+    expect(payload.imageDecoder.audits).toBeNull();
+    expect(payload.imageDecoder.weightsCached).toBeNull();
+    expect(payload.imageDecoder.decoderManifest.status).toBe("skipped");
+    expect(payload.imageDecoder.reason).toBe("manifest-missing");
+    expect(payload.imageDecoder.installHint).toBe("wittgenstein install image");
     expect(["ok", "missing"]).toContain(payload.imageDecoder.onnxRuntime.status);
     expect(payload.imageDecoder.blockers.decoderDelivery).toMatch(/issues\/402$/);
     expect(payload.imageDecoder.blockers.gateCDeterminism).toMatch(/issues\/334$/);
@@ -58,14 +82,7 @@ describe("doctor tier readiness", () => {
   });
 
   it("prints structured video dependency checks when HyperFrames MP4 rendering is enabled", () => {
-    const doctor = spawnSync("node", ["--import", "tsx", cliBin, "doctor"], {
-      cwd: packageRoot,
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        WITTGENSTEIN_HYPERFRAMES_RENDER: "1",
-      },
-    });
+    const doctor = runDoctor({ WITTGENSTEIN_HYPERFRAMES_RENDER: "1" });
 
     expect(doctor.status).toBe(0);
     const payload = JSON.parse(doctor.stdout) as {
@@ -88,14 +105,9 @@ describe("doctor tier readiness", () => {
   });
 
   it("checks HyperFrames CLI when the npx backend is selected", () => {
-    const doctor = spawnSync("node", ["--import", "tsx", cliBin, "doctor"], {
-      cwd: packageRoot,
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        WITTGENSTEIN_HYPERFRAMES_RENDER: "1",
-        WITTGENSTEIN_HYPERFRAMES_BACKEND: "npx-cli",
-      },
+    const doctor = runDoctor({
+      WITTGENSTEIN_HYPERFRAMES_RENDER: "1",
+      WITTGENSTEIN_HYPERFRAMES_BACKEND: "npx-cli",
     });
 
     expect(doctor.status).toBe(0);
@@ -113,4 +125,215 @@ describe("doctor tier readiness", () => {
     expect(["ok", "missing"]).toContain(payload.videoRender.hyperframesNode.status);
     expect(["ok", "missing"]).toContain(payload.videoRender.hyperframesCli.status);
   });
+
+  it("reports a ready image decoder when the selected blessed manifest has cached weights", () => {
+    const fixture = writeDecoderFixture();
+    const doctor = runDoctor({
+      WITTGENSTEIN_DECODER_MANIFEST: fixture.manifestPath,
+      XDG_CACHE_HOME: fixture.xdgCacheHome,
+    });
+
+    expect(doctor.status).toBe(0);
+    const payload = JSON.parse(doctor.stdout) as {
+      imageDecoder: {
+        status: string;
+        manifestPath: string;
+        family: string;
+        decoderId: string;
+        manifestStatus: string;
+        weightsRestriction: string;
+        audits: Record<string, string>;
+        weightsCached: boolean;
+        decoderManifest: { status: string; path: string };
+        onnxRuntime: { status: string };
+        reason: string | null;
+        details: { weights: { source: string; weightsSha256: string; codebookSha256: string } };
+      };
+    };
+
+    expect(payload.imageDecoder.status).toBe("ready");
+    expect(payload.imageDecoder.manifestPath).toBe(fixture.manifestPath);
+    expect(payload.imageDecoder.family).toBe("llamagen");
+    expect(payload.imageDecoder.decoderId).toBe("llamagen-vqgan-phase0");
+    expect(payload.imageDecoder.manifestStatus).toBe("blessed");
+    expect(payload.imageDecoder.weightsRestriction).toBe("permissive");
+    expect(payload.imageDecoder.audits).toEqual({
+      gateA: "passed",
+      gateB: "passed",
+      gateC: "passed",
+      gateD: "passed",
+    });
+    expect(payload.imageDecoder.weightsCached).toBe(true);
+    expect(payload.imageDecoder.decoderManifest.status).toBe("ok");
+    expect(["ok", "missing"]).toContain(payload.imageDecoder.onnxRuntime.status);
+    expect(payload.imageDecoder.reason).toBeNull();
+    expect(payload.imageDecoder.details.weights.source).toBe("cache-hit");
+    expect(payload.imageDecoder.details.weights.weightsSha256).toBe(fixture.weightsSha);
+    expect(payload.imageDecoder.details.weights.codebookSha256).toBe(fixture.codebookSha);
+  });
+
+  it("reports a structured blocked image decoder when the selected manifest is invalid", () => {
+    const dir = makeTempDir();
+    const manifestPath = join(dir, "invalid-decoder-manifest.json");
+    writeFileSync(manifestPath, JSON.stringify({ schemaVersion: "not-this" }));
+
+    const doctor = runDoctor({ WITTGENSTEIN_DECODER_MANIFEST: manifestPath });
+
+    expect(doctor.status).toBe(0);
+    const payload = JSON.parse(doctor.stdout) as {
+      imageDecoder: {
+        status: string;
+        manifestPath: string;
+        decoderManifest: { status: string; path: string; message: string };
+        reason: string;
+        weightsCached: boolean | null;
+        details: { issues: Array<{ path: string; message: string }> };
+      };
+    };
+
+    expect(payload.imageDecoder.status).toBe("blocked");
+    expect(payload.imageDecoder.manifestPath).toBe(manifestPath);
+    expect(payload.imageDecoder.decoderManifest.status).toBe("invalid");
+    expect(payload.imageDecoder.reason).toBe("manifest-invalid");
+    expect(payload.imageDecoder.weightsCached).toBeNull();
+    expect(payload.imageDecoder.details.issues.length).toBeGreaterThan(0);
+  });
 });
+
+function runDoctor(envOverrides: NodeJS.ProcessEnv = {}) {
+  const env = { ...process.env };
+  delete env.WITTGENSTEIN_DECODER_MANIFEST;
+  delete env.WITTGENSTEIN_HYPERFRAMES_RENDER;
+  delete env.WITTGENSTEIN_HYPERFRAMES_BACKEND;
+
+  return spawnSync("node", ["--import", "tsx", cliBin, "doctor"], {
+    cwd: packageRoot,
+    encoding: "utf8",
+    env: { ...env, ...envOverrides },
+  });
+}
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "witt-cli-doctor-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writeDecoderFixture(): {
+  manifestPath: string;
+  xdgCacheHome: string;
+  weightsSha: string;
+  codebookSha: string;
+} {
+  const dir = makeTempDir();
+  const xdgCacheHome = join(dir, "xdg-cache");
+  const manifestPath = join(dir, "decoder-manifest.json");
+  const receiptPath = join(dir, "vqgan-gates.json");
+  const weights = new TextEncoder().encode("weights");
+  const codebook = new TextEncoder().encode("codebook");
+  const weightsSha = sha256(weights);
+  const codebookSha = sha256(codebook);
+  const family = "llamagen";
+  const cacheDir = join(xdgCacheHome, "wittgenstein", "decoders", family, weightsSha);
+
+  mkdirSync(cacheDir, { recursive: true });
+  writeFileSync(join(cacheDir, "vqgan.onnx"), weights);
+  writeFileSync(join(cacheDir, "codebook.bin"), codebook);
+  writeFileSync(receiptPath, JSON.stringify(auditReceipt()));
+  writeFileSync(
+    manifestPath,
+    JSON.stringify({
+      schemaVersion: "witt.image.decoder-manifest/v0.1",
+      family,
+      decoderId: "llamagen-vqgan-phase0",
+      status: "blessed",
+      decisionTracker: "https://github.com/p-to-q/wittgenstein/issues/402",
+      implementationTracker: "https://github.com/p-to-q/wittgenstein/issues/329",
+      upstream: {
+        repoId: "FoundationVision/LlamaGen",
+        revision: "pin-before-blessing",
+        sourceUrl: "https://github.com/FoundationVision/LlamaGen",
+      },
+      assets: {
+        family,
+        repoId: "FoundationVision/LlamaGen",
+        revision: "pin-before-blessing",
+        weightsFilename: "vqgan.onnx",
+        weightsSha256: weightsSha,
+        codebookFilename: "codebook.bin",
+        codebookSha256: codebookSha,
+        license: {
+          code: "MIT",
+          weights: "permissive",
+        },
+      },
+      capabilities: {
+        supportedShapes: [{ shape: "2D", tokenGrid: [16, 16], outputPixels: [256, 256] }],
+        codebook: "llamagen-vqgan",
+        codebookVersion: "pin-before-blessing",
+        determinismClass: "structural-parity",
+        runtimeTier: "node-onnx-cpu",
+        decoderHash: "1".repeat(64),
+      },
+      audits: {
+        gateA: { status: "passed", tracker: "https://github.com/p-to-q/wittgenstein/issues/329" },
+        gateB: { status: "passed", tracker: "https://github.com/p-to-q/wittgenstein/issues/329" },
+        gateC: {
+          status: "passed",
+          tracker: "https://github.com/p-to-q/wittgenstein/issues/334",
+          receipt: receiptPath,
+        },
+        gateD: {
+          status: "passed",
+          tracker: "https://github.com/p-to-q/wittgenstein/issues/335",
+          receipt: receiptPath,
+        },
+      },
+      notes: ["doctor test fixture"],
+    }),
+  );
+
+  return { manifestPath, xdgCacheHome, weightsSha, codebookSha };
+}
+
+function auditReceipt() {
+  return {
+    schema_version: "m1b-vqgan-gate-audit.v0",
+    candidate: "vqgan-class/llamagen",
+    status: "passed",
+    git_sha: "abc123",
+    generated_at: "2026-05-26T00:00:00Z",
+    python_version: "3.13.0",
+    platform: "test",
+    gates: [
+      {
+        gate: "C",
+        tracker: "https://github.com/p-to-q/wittgenstein/issues/334",
+        status: "passed",
+        required_inputs: ["weights", "roundtrip metrics"],
+        metrics: {
+          roundtrip_passed: true,
+          sample_count: 3,
+          token_hamming_rate: 0.0,
+          pass_check: { passed: true, required: {} },
+        },
+      },
+      {
+        gate: "D",
+        tracker: "https://github.com/p-to-q/wittgenstein/issues/335",
+        status: "passed",
+        required_inputs: ["weights", "onnx", "cpu metrics"],
+        metrics: {
+          onnx_cpu_passed: true,
+          cpu_decode_seconds: 1.25,
+          output_shape: [256, 256, 3],
+          pass_check: { passed: true, required: {} },
+        },
+      },
+    ],
+  };
+}
+
+function sha256(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -6,6 +6,7 @@
   },
   "include": ["src/**/*"],
   "references": [
+    { "path": "../codec-image" },
     { "path": "../core" },
     { "path": "../process-runner" },
     { "path": "../schemas" }

--- a/packages/codec-image/src/index.ts
+++ b/packages/codec-image/src/index.ts
@@ -6,6 +6,10 @@
  *     and external consumers register / invoke.
  *   - Request / artifact / scene types needed to type call sites.
  *
+ * Decoder delivery inspection:
+ *   - decoder-family manifest parsing and preflight receipts are exported for
+ *     read-only CLI surfaces such as `wittgenstein doctor`.
+ *
  * What does NOT ship:
  *   - `./pipeline/*` — internal renderer pipeline that changes as the M1B
  *     decoder bridge lands. Pipeline internals are reachable from within
@@ -17,11 +21,7 @@
  *     discriminator RFC ([RFC-0007](../../../docs/rfcs/0007-image-seedcode-shape-discriminator.md)).
  */
 export { imageCodec, imageV2Codec, ImageCodec } from "./codec.js";
-export {
-  ImageSceneSpecSchema,
-  imageSchemaPreamble,
-  parseImageSceneSpec,
-} from "./schema.js";
+export { ImageSceneSpecSchema, imageSchemaPreamble, parseImageSceneSpec } from "./schema.js";
 export type { ImageSceneSpec } from "./schema.js";
 // `ImageRequest` + its schema live in `@wittgenstein/schemas` (the
 // modality-locked surface). Re-export from codec-image so consumers can
@@ -35,3 +35,18 @@ export type {
   ImageAdapterOutcome,
   ImageSemanticSource,
 } from "./types.js";
+export {
+  DecoderFamilyManifestSchema,
+  validateDecoderManifestAuditReceipts,
+} from "./decoders/manifest.js";
+export type {
+  DecoderFamilyManifest,
+  DecoderManifestAuditReceiptValidation,
+} from "./decoders/manifest.js";
+export { preflightImageDecoder } from "./decoders/preflight.js";
+export type {
+  DecoderPreflightOptions,
+  DecoderPreflightReason,
+  DecoderPreflightReceipt,
+  DecoderPreflightStatus,
+} from "./decoders/preflight.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,6 +263,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@wittgenstein/codec-image':
+        specifier: workspace:*
+        version: link:../codec-image
       '@wittgenstein/codec-video':
         specifier: workspace:*
         version: link:../codec-video


### PR DESCRIPTION
## Summary

Closes #484.

Adds a read-only decoder-manifest inspection path to `wittgenstein doctor`:

- `WITTGENSTEIN_DECODER_MANIFEST` unset now reports `imageDecoder.status: \"not-selected\"` with null manifest fields and the existing install hint.
- A selected decoder-family manifest is parsed through the shared codec-image manifest schema and preflight contract.
- A valid blessed manifest with cached assets reports `status: \"ready\"`, manifest identity, weights license posture, Gate A/B/C/D statuses, cache state, and `onnxruntime-node` peer resolution.
- Invalid or unreadable manifests report structured `blocked` output with preflight-style reason/details.

## Research / design notes

- Local doctrine: this follows #484 and reuses the #457 `preflightImageDecoder()` contract instead of duplicating manifest semantics in the CLI.
- ADR-0020: doctor surfaces `weightsRestriction` directly so research-only posture is visible before any image run.
- External diagnostic precedent checked: `npm doctor` and `brew doctor` are diagnostic environment/readiness surfaces, not install/fetch/decode flows. This PR keeps doctor read-only: it uses `require.resolve` for `onnxruntime-node`, reads JSON receipts/assets for cache verification, and does not create ONNX sessions.
  - https://docs.npmjs.com/cli/v9/commands/npm-doctor/
  - https://docs.brew.sh/Manpage#doctor-dr---list-checks---audit-debug-diagnostic_check-

## Self-review

Engineer review:
- Reused the codec-image schema and preflight path as the source of truth.
- Kept the optional peer check as `require.resolve` only, matching the issue non-goal.
- Added a public codec-image inspection export instead of deep-importing package internals from CLI.

Research review:
- The doctor output now exposes manifest status, license posture, empirical gate statuses, and cache state in one audit block.
- Missing receipts still block blessed readiness through the existing manifest receipt validator.

Hacker review:
- Invalid JSON/schema input stays structured and non-crashing.
- Relative receipt paths are resolved against both workspace root and the selected manifest directory.
- `WITTGENSTEIN_DECODER_MANIFEST` is cleared in tests by default to avoid environment bleed.

## Validation

- `pnpm --filter @wittgenstein/cli test -- doctor.test.ts`
- `pnpm --filter @wittgenstein/cli test`
- `pnpm --filter @wittgenstein/cli typecheck`
- `pnpm --filter @wittgenstein/cli lint`
- `pnpm --filter @wittgenstein/cli build`
- `pnpm --filter @wittgenstein/codec-image typecheck`
- `pnpm --filter @wittgenstein/codec-image lint`
- `pnpm --filter @wittgenstein/codec-image test -- decoder-preflight.test.ts decoder-family-manifest.test.ts decoder-weights.test.ts`
- `pnpm --filter @wittgenstein/codec-image test`
- `pnpm lint:deps`
- `pnpm lint:publish-surface`
- `pnpm exec prettier --check packages/cli/src/commands/doctor.ts packages/cli/test/doctor.test.ts packages/codec-image/src/index.ts packages/cli/package.json packages/cli/tsconfig.json`
- `git diff --check`
- `pnpm run doctor`