### PR TITLE
feat(cli): verify image install manifest flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,10 @@ WITTGENSTEIN_IMAGE_ADAPTER_LEGACY_PATH=
 # Legacy names (still supported): first slot = preferred, second = legacy backup
 # WITTGENSTEIN_IMAGE_ADAPTER_MLP_PATH=
 # WITTGENSTEIN_IMAGE_ADAPTER_MLP_FALLBACK_PATH=
+
+# Optional image decoder install/readiness surface.
+# The manifest path points at a `witt.image.decoder-manifest/v0.1` JSON file.
+# The cache dir contains `<family>/<weightsSha256>/<weightsFilename>` and any
+# declared sidecar assets, verified by `wittgenstein install image --json`.
+# WITTGENSTEIN_DECODER_MANIFEST=
+# WITTGENSTEIN_DECODER_CACHE_DIR=

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -56,10 +56,22 @@ bridges remain explicit opt-in install surfaces tracked in #403. Decoder-weight
 loaders must verify SHA-256 before use and refuse research-only weights unless
 the caller opts in with `--allow-research-weights`.
 
-`wittgenstein install image --dry-run` is the current no-download planning
-surface for the Tier 1 bridge. A non-dry-run install intentionally fails with a
-structured `TIER_INSTALL_BLOCKED_BY_DECODER_MANIFEST` error until the concrete
-decoder-family manifest and fetch recipe land.
+`wittgenstein install image --dry-run` is the no-download planning surface for
+the Tier 1 bridge. A non-dry-run install reads
+`WITTGENSTEIN_DECODER_MANIFEST`, validates the decoder-family manifest and Gate
+C/D audit receipts, verifies cached asset SHA-256 values from
+`WITTGENSTEIN_DECODER_CACHE_DIR` (or the default decoder cache), and checks that
+the required runtime peer resolves. It exits 0 with `status: "ready"` only after
+that preflight passes:
+
+```bash
+WITTGENSTEIN_DECODER_MANIFEST=/path/to/decoder-manifest.json \
+WITTGENSTEIN_DECODER_CACHE_DIR=/path/to/decoder-cache \
+wittgenstein install image --json
+```
+
+Until a blessed manifest and matching cached assets exist, the command exits
+non-zero with a structured decoder-preflight receipt.
 
 ## Skill-Ready Expectations
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -45,3 +45,12 @@ pnpm --filter @wittgenstein/cli run smoke
 - `tts` is a convenience alias for the `audio` codec's `speech` route.
 - `--route` remains available for one minor version as a deprecated compatibility hint.
 - `install image --dry-run` plans the optional image decoder tier without downloading weights.
+- Once a decoder-family manifest is blessed and its declared assets are cached, specialists can smoke the Tier 1 install path with:
+
+```bash
+WITTGENSTEIN_DECODER_MANIFEST=/path/to/decoder-manifest.json \
+WITTGENSTEIN_DECODER_CACHE_DIR=/path/to/decoder-cache \
+wittgenstein install image --json
+```
+
+The command exits 0 only when the manifest, Gate C/D audit receipts, cached SHA-256 values, and `onnxruntime-node` peer check pass.

--- a/packages/cli/src/commands/decoder-manifest.ts
+++ b/packages/cli/src/commands/decoder-manifest.ts
@@ -1,0 +1,208 @@
+import { readFile } from "node:fs/promises";
+import { dirname, isAbsolute, resolve } from "node:path";
+import {
+  DecoderFamilyManifestSchema,
+  preflightImageDecoder,
+  type DecoderFamilyManifest,
+  type DecoderPreflightOptions,
+  type DecoderPreflightReceipt,
+} from "@wittgenstein/codec-image";
+
+const DECODER_DELIVERY_TRACKER = "https://github.com/p-to-q/wittgenstein/issues/402";
+
+export type DecoderManifestSelectionStatus = "not-selected" | "read-error" | "loaded";
+
+export interface DecoderManifestSelection {
+  readonly status: DecoderManifestSelectionStatus;
+  readonly manifestPath: string | null;
+  readonly manifestInput: unknown;
+  readonly parsedManifest: DecoderFamilyManifest | null;
+  readonly auditReceipts: ReadonlyMap<string, unknown>;
+  readonly errorMessage: string | null;
+}
+
+export interface SelectedImageDecoderPreflight {
+  readonly selection: DecoderManifestSelection;
+  readonly preflight: DecoderPreflightReceipt;
+}
+
+export async function preflightSelectedImageDecoder(options: {
+  readonly workspaceRoot: string;
+  readonly cacheDir?: string;
+  readonly allowResearchWeights?: boolean;
+  readonly checkRuntime?: boolean;
+}): Promise<SelectedImageDecoderPreflight> {
+  const selection = await readSelectedDecoderManifest(options.workspaceRoot);
+
+  if (selection.status === "not-selected") {
+    return {
+      selection,
+      preflight: await preflightImageDecoder(),
+    };
+  }
+
+  if (selection.status === "read-error") {
+    return {
+      selection,
+      preflight: manifestInvalidPreflight(selection.errorMessage ?? "Unknown manifest read error."),
+    };
+  }
+
+  const preflightOptions: DecoderPreflightOptions = {
+    manifest: selection.manifestInput,
+    auditReceipts: selection.auditReceipts,
+    ...(options.cacheDir ? { cacheDir: options.cacheDir } : {}),
+    ...(options.allowResearchWeights !== undefined
+      ? { allowResearchWeights: options.allowResearchWeights }
+      : {}),
+    ...(options.checkRuntime !== undefined ? { checkRuntime: options.checkRuntime } : {}),
+  };
+
+  return {
+    selection,
+    preflight: await preflightImageDecoder(preflightOptions),
+  };
+}
+
+export function readDecoderCacheDir(workspaceRoot: string): string | undefined {
+  const cacheDir = process.env.WITTGENSTEIN_DECODER_CACHE_DIR;
+  if (!cacheDir) {
+    return undefined;
+  }
+
+  return isAbsolute(cacheDir) ? cacheDir : resolve(workspaceRoot, cacheDir);
+}
+
+export function auditStatuses(
+  manifest: DecoderFamilyManifest,
+): Record<"gateA" | "gateB" | "gateC" | "gateD", string> {
+  return {
+    gateA: manifest.audits.gateA.status,
+    gateB: manifest.audits.gateB.status,
+    gateC: manifest.audits.gateC.status,
+    gateD: manifest.audits.gateD.status,
+  };
+}
+
+export function weightsCachedFromPreflight(receipt: DecoderPreflightReceipt): boolean | null {
+  if (receipt.status === "ready") return true;
+  if (receipt.reason === "weights-not-installed" || receipt.reason === "weights-invalid") {
+    return false;
+  }
+  return null;
+}
+
+async function readSelectedDecoderManifest(
+  workspaceRoot: string,
+): Promise<DecoderManifestSelection> {
+  const selectedManifest = process.env.WITTGENSTEIN_DECODER_MANIFEST;
+  if (!selectedManifest) {
+    return {
+      status: "not-selected",
+      manifestPath: null,
+      manifestInput: undefined,
+      parsedManifest: null,
+      auditReceipts: new Map(),
+      errorMessage: null,
+    };
+  }
+
+  const manifestPath = isAbsolute(selectedManifest)
+    ? selectedManifest
+    : resolve(workspaceRoot, selectedManifest);
+
+  let manifestInput: unknown;
+  try {
+    manifestInput = JSON.parse(await readFile(manifestPath, "utf8"));
+  } catch (error) {
+    return {
+      status: "read-error",
+      manifestPath,
+      manifestInput: undefined,
+      parsedManifest: null,
+      auditReceipts: new Map(),
+      errorMessage: errorMessage(error),
+    };
+  }
+
+  const parsedManifest = DecoderFamilyManifestSchema.safeParse(manifestInput);
+  const parsed = parsedManifest.success ? parsedManifest.data : null;
+
+  return {
+    status: "loaded",
+    manifestPath,
+    manifestInput,
+    parsedManifest: parsed,
+    auditReceipts: parsed
+      ? await readAuditReceipts(parsed, workspaceRoot, dirname(manifestPath))
+      : new Map(),
+    errorMessage: null,
+  };
+}
+
+async function readAuditReceipts(
+  manifest: DecoderFamilyManifest,
+  workspaceRoot: string,
+  manifestDir: string,
+): Promise<Map<string, unknown>> {
+  const receipts = new Map<string, unknown>();
+
+  for (const gate of ["gateC", "gateD"] as const) {
+    const receiptPath = manifest.audits[gate].receipt;
+    if (!receiptPath) continue;
+
+    const input = await readJsonFromCandidates(
+      resolveReceiptCandidates(receiptPath, workspaceRoot, manifestDir),
+    );
+    if (input !== undefined) {
+      receipts.set(receiptPath, input);
+    }
+  }
+
+  return receipts;
+}
+
+function resolveReceiptCandidates(
+  receiptPath: string,
+  workspaceRoot: string,
+  manifestDir: string,
+): string[] {
+  if (isAbsolute(receiptPath)) {
+    return [receiptPath];
+  }
+
+  return [resolve(workspaceRoot, receiptPath), resolve(manifestDir, receiptPath)];
+}
+
+async function readJsonFromCandidates(paths: readonly string[]): Promise<unknown | undefined> {
+  for (const path of paths) {
+    try {
+      return JSON.parse(await readFile(path, "utf8"));
+    } catch {
+      // Keep trying all supported resolution roots. The preflight validator
+      // reports the manifest-declared receipt as missing if none resolve.
+    }
+  }
+
+  return undefined;
+}
+
+function manifestInvalidPreflight(message: string): DecoderPreflightReceipt {
+  return {
+    schemaVersion: "witt.image.decoder-preflight/v0.1",
+    status: "blocked",
+    reason: "manifest-invalid",
+    decoderId: null,
+    family: null,
+    runtimeTier: null,
+    installHint: "wittgenstein install image",
+    tracker: DECODER_DELIVERY_TRACKER,
+    details: {
+      issues: [{ path: "", message }],
+    },
+  };
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,16 +1,15 @@
 import { createRequire } from "node:module";
 import { existsSync } from "node:fs";
-import { readFile } from "node:fs/promises";
-import { dirname, isAbsolute, resolve } from "node:path";
 import { loadWittgensteinConfig } from "@wittgenstein/core";
-import {
-  DecoderFamilyManifestSchema,
-  preflightImageDecoder,
-  type DecoderFamilyManifest,
-  type DecoderPreflightReceipt,
-} from "@wittgenstein/codec-image";
+import type { DecoderPreflightReceipt } from "@wittgenstein/codec-image";
 import { firstOutputLine, spawnVersionCheck } from "@wittgenstein/process-runner";
 import type { Command } from "commander";
+import {
+  auditStatuses,
+  preflightSelectedImageDecoder,
+  readDecoderCacheDir,
+  weightsCachedFromPreflight,
+} from "./decoder-manifest.js";
 import { resolveExecutionRoot } from "./shared.js";
 import { runtimeTierReadiness } from "../tiers.js";
 
@@ -244,11 +243,19 @@ function checkChromeCandidate(candidate: string): DoctorCheck {
 }
 
 async function checkImageDecoderReadiness(workspaceRoot: string): Promise<ImageDecoderDoctor> {
-  const selectedManifest = process.env.WITTGENSTEIN_DECODER_MANIFEST;
   const onnxRuntime = checkOptionalNodePeer("onnxruntime-node", "wittgenstein install image");
   const blockers = imageDecoderBlockers();
+  const cacheDir = readDecoderCacheDir(workspaceRoot);
+  const { selection, preflight } = await preflightSelectedImageDecoder({
+    workspaceRoot,
+    ...(cacheDir ? { cacheDir } : {}),
+    // Doctor is an audit surface: surface research-only posture and peer
+    // availability without opting users into a decode runtime.
+    allowResearchWeights: true,
+    checkRuntime: false,
+  });
 
-  if (!selectedManifest) {
+  if (selection.status === "not-selected") {
     return {
       status: "not-selected",
       manifestPath: null,
@@ -273,17 +280,10 @@ async function checkImageDecoderReadiness(workspaceRoot: string): Promise<ImageD
     };
   }
 
-  const manifestPath = isAbsolute(selectedManifest)
-    ? selectedManifest
-    : resolve(workspaceRoot, selectedManifest);
-
-  let manifestInput: unknown;
-  try {
-    manifestInput = JSON.parse(await readFile(manifestPath, "utf8"));
-  } catch (error) {
+  if (selection.status === "read-error") {
     return {
       status: "blocked",
-      manifestPath,
+      manifestPath: selection.manifestPath,
       family: null,
       decoderId: null,
       manifestStatus: null,
@@ -292,37 +292,23 @@ async function checkImageDecoderReadiness(workspaceRoot: string): Promise<ImageD
       weightsCached: null,
       decoderManifest: {
         status: "missing",
-        path: manifestPath,
-        message: `Could not read decoder-family manifest: ${errorMessage(error)}`,
+        path: selection.manifestPath!,
+        message: `Could not read decoder-family manifest: ${selection.errorMessage}`,
       },
       onnxRuntime,
-      reason: "manifest-invalid",
-      installHint: "wittgenstein install image",
-      tracker: "https://github.com/p-to-q/wittgenstein/issues/402",
-      details: {
-        issues: [{ path: "", message: errorMessage(error) }],
-      },
+      reason: preflight.reason,
+      installHint: preflight.installHint,
+      tracker: preflight.tracker,
+      details: preflight.details,
       blockers,
     };
   }
 
-  const parsedManifest = DecoderFamilyManifestSchema.safeParse(manifestInput);
-  const auditReceipts = parsedManifest.success
-    ? await readAuditReceipts(parsedManifest.data, workspaceRoot, dirname(manifestPath))
-    : new Map<string, unknown>();
-  const preflight = await preflightImageDecoder({
-    manifest: manifestInput,
-    auditReceipts,
-    // Doctor is an audit surface: surface research-only posture and peer
-    // availability without opting users into a decode runtime.
-    allowResearchWeights: true,
-    checkRuntime: false,
-  });
-  const parsed = parsedManifest.success ? parsedManifest.data : null;
+  const parsed = selection.parsedManifest;
 
   return {
     status: preflight.status,
-    manifestPath,
+    manifestPath: selection.manifestPath,
     family: parsed?.family ?? preflight.family,
     decoderId: parsed?.decoderId ?? preflight.decoderId,
     manifestStatus: parsed?.status ?? null,
@@ -330,9 +316,9 @@ async function checkImageDecoderReadiness(workspaceRoot: string): Promise<ImageD
     audits: parsed ? auditStatuses(parsed) : null,
     weightsCached: weightsCachedFromPreflight(preflight),
     decoderManifest: {
-      status: parsedManifest.success ? "ok" : "invalid",
-      path: manifestPath,
-      message: parsedManifest.success
+      status: parsed ? "ok" : "invalid",
+      path: selection.manifestPath!,
+      message: parsed
         ? "Decoder-family manifest loaded from WITTGENSTEIN_DECODER_MANIFEST."
         : "Decoder-family manifest did not match the expected schema.",
     },
@@ -351,74 +337,6 @@ function imageDecoderBlockers(): ImageDecoderDoctor["blockers"] {
     gateCDeterminism: "https://github.com/p-to-q/wittgenstein/issues/334",
     gateDOnnxCpu: "https://github.com/p-to-q/wittgenstein/issues/335",
   };
-}
-
-async function readAuditReceipts(
-  manifest: DecoderFamilyManifest,
-  workspaceRoot: string,
-  manifestDir: string,
-): Promise<Map<string, unknown>> {
-  const receipts = new Map<string, unknown>();
-
-  for (const gate of ["gateC", "gateD"] as const) {
-    const receiptPath = manifest.audits[gate].receipt;
-    if (!receiptPath) continue;
-
-    const input = await readJsonFromCandidates(
-      resolveReceiptCandidates(receiptPath, workspaceRoot, manifestDir),
-    );
-    if (input !== undefined) {
-      receipts.set(receiptPath, input);
-    }
-  }
-
-  return receipts;
-}
-
-function resolveReceiptCandidates(
-  receiptPath: string,
-  workspaceRoot: string,
-  manifestDir: string,
-): string[] {
-  if (isAbsolute(receiptPath)) {
-    return [receiptPath];
-  }
-
-  return [resolve(workspaceRoot, receiptPath), resolve(manifestDir, receiptPath)];
-}
-
-async function readJsonFromCandidates(paths: readonly string[]): Promise<unknown | undefined> {
-  for (const path of paths) {
-    try {
-      return JSON.parse(await readFile(path, "utf8"));
-    } catch {
-      // Try the next resolution root. If every candidate fails, preflight will
-      // report the receipt as missing for the manifest's declared path.
-    }
-  }
-
-  return undefined;
-}
-
-function auditStatuses(manifest: DecoderFamilyManifest): NonNullable<ImageDecoderDoctor["audits"]> {
-  return {
-    gateA: manifest.audits.gateA.status,
-    gateB: manifest.audits.gateB.status,
-    gateC: manifest.audits.gateC.status,
-    gateD: manifest.audits.gateD.status,
-  };
-}
-
-function weightsCachedFromPreflight(receipt: DecoderPreflightReceipt): boolean | null {
-  if (receipt.status === "ready") return true;
-  if (receipt.reason === "weights-not-installed" || receipt.reason === "weights-invalid") {
-    return false;
-  }
-  return null;
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }
 
 function checkOptionalNodePeer(packageName: string, installHint: string): DoctorCheck {

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -1,27 +1,13 @@
 import type { Command } from "commander";
+import { preflightSelectedImageDecoder, readDecoderCacheDir } from "./decoder-manifest.js";
+import { resolveExecutionRoot } from "./shared.js";
 import { buildInstallTierPlan, resolveInstallTier } from "../tiers.js";
 
 interface InstallCommandOptions {
   dryRun?: boolean;
   gpu?: boolean;
   allowResearchWeights?: boolean;
-}
-
-interface ImageDecoderPreflightReceipt {
-  schemaVersion: "witt.image.decoder-preflight/v0.1";
-  status: "blocked";
-  reason: "manifest-missing";
-  decoderId: null;
-  family: null;
-  runtimeTier: "node-onnx-cpu" | "node-onnx-gpu";
-  installHint: string;
-  tracker: string;
-  details: {
-    message: string;
-    decisionTracker: string;
-    gateCDeterminism: string;
-    gateDOnnxCpu: string;
-  };
+  json?: boolean;
 }
 
 export function registerInstallCommand(program: Command): void {
@@ -35,7 +21,9 @@ export function registerInstallCommand(program: Command): void {
       "--allow-research-weights",
       "allow research-only decoder weights for benchmarking per ADR-0020",
     )
-    .action((tier: string, options: InstallCommandOptions) => {
+    .option("--json", "print structured JSON output (default)")
+    .action(async (tier: string, options: InstallCommandOptions) => {
+      const workspaceRoot = resolveExecutionRoot();
       const resolvedTier = resolveInstallTier(tier, { gpu: options.gpu ?? false });
 
       if (!resolvedTier) {
@@ -51,15 +39,47 @@ export function registerInstallCommand(program: Command): void {
       const plan = buildInstallTierPlan(resolvedTier, {
         allowResearchWeights: options.allowResearchWeights ?? false,
       });
+      const cacheDir = readDecoderCacheDir(workspaceRoot);
 
       if (options.dryRun) {
+        const decoderPreflight = imageDecoderPreflightForPlan(plan);
         console.log(
           JSON.stringify(
             {
               ok: true,
               action: "plan-only",
+              status: decoderPreflight.status,
               plan,
-              decoderPreflight: imageDecoderPreflightForPlan(plan),
+              decoderPreflight,
+            },
+            null,
+            2,
+          ),
+        );
+        return;
+      }
+
+      const { selection, preflight } = await preflightSelectedImageDecoder({
+        workspaceRoot,
+        ...(cacheDir ? { cacheDir } : {}),
+        allowResearchWeights: options.allowResearchWeights ?? false,
+        checkRuntime: true,
+      });
+
+      if (preflight.status === "ready") {
+        console.log(
+          JSON.stringify(
+            {
+              ok: true,
+              action: "install-ready",
+              status: "ready",
+              manifestPath: selection.manifestPath,
+              decoderId: preflight.decoderId,
+              family: preflight.family,
+              runtimeTier: preflight.runtimeTier,
+              weightsRestriction: weightsRestrictionFromPreflight(preflight),
+              plan,
+              decoderPreflight: preflight,
             },
             null,
             2,
@@ -69,18 +89,40 @@ export function registerInstallCommand(program: Command): void {
       }
 
       printInstallError({
-        code: "TIER_INSTALL_BLOCKED_BY_DECODER_MANIFEST",
-        message:
-          "Image tier installation requires a concrete decoder-family manifest before weights can be fetched.",
+        code:
+          preflight.reason === "manifest-missing"
+            ? "TIER_INSTALL_BLOCKED_BY_DECODER_MANIFEST"
+            : "TIER_INSTALL_BLOCKED_BY_DECODER_PREFLIGHT",
+        message: installBlockedMessage(preflight.reason),
+        status: "blocked",
+        manifestPath: selection.manifestPath,
+        decoderId: preflight.decoderId,
+        family: preflight.family,
+        runtimeTier: preflight.runtimeTier,
+        weightsRestriction: weightsRestrictionFromPreflight(preflight),
         plan,
+        decoderPreflight: preflight,
       });
       process.exitCode = 1;
     });
 }
 
-function imageDecoderPreflightForPlan(
-  plan: ReturnType<typeof buildInstallTierPlan>,
-): ImageDecoderPreflightReceipt {
+function imageDecoderPreflightForPlan(plan: ReturnType<typeof buildInstallTierPlan>): {
+  schemaVersion: "witt.image.decoder-preflight/v0.1";
+  status: "blocked";
+  reason: "manifest-missing";
+  decoderId: null;
+  family: null;
+  runtimeTier: "node-onnx-cpu" | "node-onnx-gpu";
+  installHint: string;
+  tracker: string;
+  details: {
+    message: string;
+    decisionTracker: string;
+    gateCDeterminism: string;
+    gateDOnnxCpu: string;
+  };
+} {
   return {
     schemaVersion: "witt.image.decoder-preflight/v0.1",
     status: "blocked",
@@ -98,6 +140,30 @@ function imageDecoderPreflightForPlan(
       gateDOnnxCpu: "https://github.com/p-to-q/wittgenstein/issues/335",
     },
   };
+}
+
+function installBlockedMessage(reason: string | null): string {
+  if (reason === "manifest-missing") {
+    return "Image tier installation requires a concrete decoder-family manifest before weights can be fetched.";
+  }
+
+  return "Image tier installation is blocked by decoder preflight checks.";
+}
+
+function weightsRestrictionFromPreflight(preflight: {
+  details: Record<string, unknown>;
+}): "permissive" | "research-only" | null {
+  const weights = preflight.details["weights"];
+  if (!isRecord(weights)) {
+    return null;
+  }
+
+  const restriction = weights["weightsRestriction"];
+  return restriction === "permissive" || restriction === "research-only" ? restriction : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }
 
 function printInstallError(error: Record<string, unknown>): void {

--- a/packages/cli/test/doctor.test.ts
+++ b/packages/cli/test/doctor.test.ts
@@ -203,6 +203,7 @@ describe("doctor tier readiness", () => {
 function runDoctor(envOverrides: NodeJS.ProcessEnv = {}) {
   const env = { ...process.env };
   delete env.WITTGENSTEIN_DECODER_MANIFEST;
+  delete env.WITTGENSTEIN_DECODER_CACHE_DIR;
   delete env.WITTGENSTEIN_HYPERFRAMES_RENDER;
   delete env.WITTGENSTEIN_HYPERFRAMES_BACKEND;
 

--- a/packages/cli/test/install.flow.test.ts
+++ b/packages/cli/test/install.flow.test.ts
@@ -1,0 +1,364 @@
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(testDir, "..");
+const cliBin = resolve(packageRoot, "src/cli-main.ts");
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("install image decoder manifest flow", () => {
+  it("reports ready when a blessed manifest, receipts, cached weights, and runtime peer resolve", () => {
+    const fixture = writeDecoderFixture();
+
+    const install = runInstall(["image", "--json"], {
+      WITTGENSTEIN_DECODER_MANIFEST: fixture.manifestPath,
+      WITTGENSTEIN_DECODER_CACHE_DIR: fixture.decoderCacheDir,
+    });
+
+    expect(install.status).toBe(0);
+    const payload = JSON.parse(install.stdout) as {
+      ok: boolean;
+      action: string;
+      status: string;
+      manifestPath: string;
+      decoderId: string;
+      family: string;
+      weightsRestriction: string;
+      decoderPreflight: {
+        status: string;
+        reason: string | null;
+        decoderId: string;
+        family: string;
+        runtimeTier: string;
+        details: {
+          weights: {
+            source: string;
+            weightsSha256: string;
+            codebookSha256: string;
+            weightsRestriction: string;
+          };
+        };
+      };
+    };
+
+    expect(payload.ok).toBe(true);
+    expect(payload.action).toBe("install-ready");
+    expect(payload.status).toBe("ready");
+    expect(payload.manifestPath).toBe(fixture.manifestPath);
+    expect(payload.decoderId).toBe("llamagen-vqgan-phase0");
+    expect(payload.family).toBe("llamagen");
+    expect(payload.weightsRestriction).toBe("permissive");
+    expect(payload.decoderPreflight).toMatchObject({
+      status: "ready",
+      reason: null,
+      decoderId: "llamagen-vqgan-phase0",
+      family: "llamagen",
+      runtimeTier: "node-onnx-cpu",
+    });
+    expect(payload.decoderPreflight.details.weights).toMatchObject({
+      source: "cache-hit",
+      weightsSha256: fixture.weightsSha,
+      codebookSha256: fixture.codebookSha,
+      weightsRestriction: "permissive",
+    });
+  });
+
+  it("blocks when no manifest is selected", () => {
+    const install = runInstall(["image", "--json"]);
+
+    expect(install.status).toBe(1);
+    const payload = JSON.parse(install.stderr) as InstallBlockedPayload;
+
+    expect(payload.code).toBe("TIER_INSTALL_BLOCKED_BY_DECODER_MANIFEST");
+    expect(payload.status).toBe("blocked");
+    expect(payload.manifestPath).toBeNull();
+    expect(payload.decoderPreflight.reason).toBe("manifest-missing");
+  });
+
+  it("blocks invalid manifests with structured preflight issues", () => {
+    const dir = makeTempDir();
+    const manifestPath = join(dir, "invalid-decoder-manifest.json");
+    writeFileSync(manifestPath, JSON.stringify({ schemaVersion: "wrong" }));
+
+    const install = runInstall(["image", "--json"], {
+      WITTGENSTEIN_DECODER_MANIFEST: manifestPath,
+      WITTGENSTEIN_DECODER_CACHE_DIR: join(dir, "decoder-cache"),
+    });
+
+    expect(install.status).toBe(1);
+    const payload = JSON.parse(install.stderr) as InstallBlockedPayload;
+
+    expect(payload.code).toBe("TIER_INSTALL_BLOCKED_BY_DECODER_PREFLIGHT");
+    expect(payload.status).toBe("blocked");
+    expect(payload.manifestPath).toBe(manifestPath);
+    expect(payload.decoderPreflight.reason).toBe("manifest-invalid");
+    expect(payload.decoderPreflight.details.issues.length).toBeGreaterThan(0);
+  });
+
+  it("blocks manifests that are not blessed", () => {
+    const fixture = writeDecoderFixture({ manifestStatus: "candidate" });
+
+    const install = runInstall(["image", "--json"], {
+      WITTGENSTEIN_DECODER_MANIFEST: fixture.manifestPath,
+      WITTGENSTEIN_DECODER_CACHE_DIR: fixture.decoderCacheDir,
+    });
+
+    expect(install.status).toBe(1);
+    const payload = JSON.parse(install.stderr) as InstallBlockedPayload;
+
+    expect(payload.decoderPreflight.reason).toBe("manifest-not-blessed");
+    expect(payload.decoderPreflight.decoderId).toBe("llamagen-vqgan-phase0");
+    expect(payload.decoderPreflight.details.status).toBe("candidate");
+  });
+
+  it.each(["missing", "invalid"] as const)(
+    "blocks blessed manifests whose audit receipt is %s",
+    (receiptState) => {
+      const fixture = writeDecoderFixture({ receiptState });
+
+      const install = runInstall(["image", "--json"], {
+        WITTGENSTEIN_DECODER_MANIFEST: fixture.manifestPath,
+        WITTGENSTEIN_DECODER_CACHE_DIR: fixture.decoderCacheDir,
+      });
+
+      expect(install.status).toBe(1);
+      const payload = JSON.parse(install.stderr) as InstallBlockedPayload;
+
+      expect(payload.decoderPreflight.reason).toBe("audit-receipt-invalid");
+      expect(payload.decoderPreflight.details.issues.length).toBeGreaterThanOrEqual(1);
+    },
+  );
+
+  it("blocks when declared weights are not installed", () => {
+    const fixture = writeDecoderFixture({ cacheState: "missing" });
+
+    const install = runInstall(["image", "--json"], {
+      WITTGENSTEIN_DECODER_MANIFEST: fixture.manifestPath,
+      WITTGENSTEIN_DECODER_CACHE_DIR: fixture.decoderCacheDir,
+    });
+
+    expect(install.status).toBe(1);
+    const payload = JSON.parse(install.stderr) as InstallBlockedPayload;
+
+    expect(payload.decoderPreflight.reason).toBe("weights-not-installed");
+    expect(payload.decoderPreflight.installHint).toBe("wittgenstein install image");
+  });
+
+  it("blocks and removes corrupted cached weights", () => {
+    const fixture = writeDecoderFixture({ cacheState: "invalid" });
+
+    const install = runInstall(["image", "--json"], {
+      WITTGENSTEIN_DECODER_MANIFEST: fixture.manifestPath,
+      WITTGENSTEIN_DECODER_CACHE_DIR: fixture.decoderCacheDir,
+    });
+
+    expect(install.status).toBe(1);
+    const payload = JSON.parse(install.stderr) as InstallBlockedPayload;
+
+    expect(payload.decoderPreflight.reason).toBe("weights-invalid");
+    expect(payload.decoderPreflight.details.code).toBe("WEIGHTS_SHA256_MISMATCH");
+    expect(existsSync(fixture.weightsPath)).toBe(false);
+  });
+});
+
+interface InstallBlockedPayload {
+  ok: boolean;
+  code: string;
+  status: string;
+  manifestPath: string | null;
+  decoderPreflight: {
+    reason: string | null;
+    decoderId: string | null;
+    installHint: string | null;
+    details: Record<string, unknown>;
+  };
+}
+
+type ManifestStatus = "candidate" | "blessed" | "rejected";
+type CacheState = "valid" | "missing" | "invalid";
+type ReceiptState = "valid" | "missing" | "invalid";
+
+interface DecoderFixtureOptions {
+  readonly manifestStatus?: ManifestStatus;
+  readonly cacheState?: CacheState;
+  readonly receiptState?: ReceiptState;
+}
+
+interface DecoderFixture {
+  readonly manifestPath: string;
+  readonly decoderCacheDir: string;
+  readonly weightsPath: string;
+  readonly weightsSha: string;
+  readonly codebookSha: string;
+}
+
+function runInstall(args: string[], envOverrides: NodeJS.ProcessEnv = {}) {
+  const env = { ...process.env };
+  delete env.WITTGENSTEIN_DECODER_MANIFEST;
+  delete env.WITTGENSTEIN_DECODER_CACHE_DIR;
+
+  return spawnSync("node", ["--import", "tsx", cliBin, "install", ...args], {
+    cwd: packageRoot,
+    encoding: "utf8",
+    env: { ...env, ...envOverrides },
+  });
+}
+
+function writeDecoderFixture(options: DecoderFixtureOptions = {}): DecoderFixture {
+  const root = makeTempDir();
+  const decoderCacheDir = join(root, "decoder-cache");
+  const manifestPath = join(root, "decoder-manifest.json");
+  const receiptPath = join(root, "vqgan-gates.json");
+  const weights = new TextEncoder().encode("weights");
+  const codebook = new TextEncoder().encode("codebook");
+  const weightsSha = sha256(weights);
+  const codebookSha = sha256(codebook);
+  const family = "llamagen";
+  const cacheDir = join(decoderCacheDir, family, weightsSha);
+  const manifestStatus = options.manifestStatus ?? "blessed";
+  const receiptState = options.receiptState ?? "valid";
+  const cacheState = options.cacheState ?? "valid";
+  const weightsPath = join(cacheDir, "vqgan.onnx");
+
+  if (cacheState !== "missing") {
+    mkdirSync(cacheDir, { recursive: true });
+    writeFileSync(weightsPath, cacheState === "valid" ? weights : "corrupt");
+    writeFileSync(join(cacheDir, "codebook.bin"), codebook);
+  }
+
+  if (receiptState === "valid") {
+    writeFileSync(receiptPath, JSON.stringify(auditReceipt()));
+  } else if (receiptState === "invalid") {
+    writeFileSync(receiptPath, JSON.stringify({ schema_version: "wrong" }));
+  }
+
+  const empiricalAudits =
+    manifestStatus === "blessed"
+      ? {
+          gateC: {
+            status: "passed",
+            tracker: "https://github.com/p-to-q/wittgenstein/issues/334",
+            receipt: receiptPath,
+          },
+          gateD: {
+            status: "passed",
+            tracker: "https://github.com/p-to-q/wittgenstein/issues/335",
+            receipt: receiptPath,
+          },
+        }
+      : {
+          gateC: {
+            status: "blocked",
+            tracker: "https://github.com/p-to-q/wittgenstein/issues/334",
+          },
+          gateD: {
+            status: "blocked",
+            tracker: "https://github.com/p-to-q/wittgenstein/issues/335",
+          },
+        };
+
+  writeFileSync(
+    manifestPath,
+    JSON.stringify({
+      schemaVersion: "witt.image.decoder-manifest/v0.1",
+      family,
+      decoderId: "llamagen-vqgan-phase0",
+      status: manifestStatus,
+      decisionTracker: "https://github.com/p-to-q/wittgenstein/issues/402",
+      implementationTracker: "https://github.com/p-to-q/wittgenstein/issues/329",
+      upstream: {
+        repoId: "FoundationVision/LlamaGen",
+        revision: "pin-before-blessing",
+        sourceUrl: "https://github.com/FoundationVision/LlamaGen",
+      },
+      assets: {
+        family,
+        repoId: "FoundationVision/LlamaGen",
+        revision: "pin-before-blessing",
+        weightsFilename: "vqgan.onnx",
+        weightsSha256: weightsSha,
+        codebookFilename: "codebook.bin",
+        codebookSha256: codebookSha,
+        license: {
+          code: "MIT",
+          weights: "permissive",
+        },
+      },
+      capabilities: {
+        supportedShapes: [{ shape: "2D", tokenGrid: [16, 16], outputPixels: [256, 256] }],
+        codebook: "llamagen-vqgan",
+        codebookVersion: "pin-before-blessing",
+        determinismClass: "structural-parity",
+        runtimeTier: "node-onnx-cpu",
+        ...(manifestStatus === "blessed" ? { decoderHash: "1".repeat(64) } : {}),
+      },
+      audits: {
+        gateA: { status: "passed", tracker: "https://github.com/p-to-q/wittgenstein/issues/329" },
+        gateB: { status: "passed", tracker: "https://github.com/p-to-q/wittgenstein/issues/329" },
+        ...empiricalAudits,
+      },
+      notes: ["install flow test fixture"],
+    }),
+  );
+
+  return { manifestPath, decoderCacheDir, weightsPath, weightsSha, codebookSha };
+}
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "witt-cli-install-flow-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function auditReceipt() {
+  return {
+    schema_version: "m1b-vqgan-gate-audit.v0",
+    candidate: "vqgan-class/llamagen",
+    status: "passed",
+    git_sha: "abc123",
+    generated_at: "2026-05-26T00:00:00Z",
+    python_version: "3.13.0",
+    platform: "test",
+    gates: [
+      {
+        gate: "C",
+        tracker: "https://github.com/p-to-q/wittgenstein/issues/334",
+        status: "passed",
+        required_inputs: ["weights", "roundtrip metrics"],
+        metrics: {
+          roundtrip_passed: true,
+          sample_count: 3,
+          token_hamming_rate: 0.0,
+          pass_check: { passed: true, required: {} },
+        },
+      },
+      {
+        gate: "D",
+        tracker: "https://github.com/p-to-q/wittgenstein/issues/335",
+        status: "passed",
+        required_inputs: ["weights", "onnx", "cpu metrics"],
+        metrics: {
+          onnx_cpu_passed: true,
+          cpu_decode_seconds: 1.25,
+          output_shape: [256, 256, 3],
+          pass_check: { passed: true, required: {} },
+        },
+      },
+    ],
+  };
+}
+
+function sha256(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}


### PR DESCRIPTION
Closes #483.

## Summary
- Adds a shared CLI decoder-manifest preflight helper used by both `doctor` and `install image`.
- Makes non-dry-run `wittgenstein install image --json` unblock to `status: "ready"` when a blessed manifest, Gate C/D receipts, cached SHA-verified assets, and the required runtime peer all pass.
- Returns structured blocked receipts for manifest/readiness failures while preserving `install image --dry-run` as the no-download planning path.
- Documents `WITTGENSTEIN_DECODER_MANIFEST`, `WITTGENSTEIN_DECODER_CACHE_DIR`, and the manual smoke command.

## Issue Fit
- Happy-path integration test builds a synthetic blessed `DecoderFamilyManifest`, fake weights/codebook matching declared SHA-256 values, and matching Gate C/D audit receipts.
- The test runs `node --import tsx src/cli-main.ts install image --json` with `WITTGENSTEIN_DECODER_MANIFEST` and `WITTGENSTEIN_DECODER_CACHE_DIR` set.
- It asserts top-level `status: "ready"`, `decoderId`, `family`, and `weightsRestriction`, plus nested preflight cache-hit details.
- Failure coverage includes no manifest, invalid manifest, unblessed manifest, missing audit receipt, invalid audit receipt, missing weights, and corrupted cached weights.

## Design Notes
- `--dry-run` remains a plan-only surface and does not inspect or fetch assets. This matches common installer dry-run semantics such as npm's documented `--dry-run` behavior: https://docs.npmjs.com/cli/v11/commands/npm-install/
- This PR does not add a network fetch recipe. It verifies the post-blessing cached-assets path requested by #483 and keeps absent assets blocked as `weights-not-installed`.
- `doctor` now reuses the same manifest/audit/cache reader, so readiness and install reporting do not drift.

## Self-Review
- Engineer: factored manifest selection, audit receipt resolution, cache-dir resolution, and receipt summaries into one helper instead of duplicating them in `doctor` and `install`.
- Research: kept the Gate C/D receipt requirements explicit and required a blessed manifest before install can report ready.
- Hacker: blocked malformed inputs and missing assets; covered corrupted weights and asserted the bad cache file is removed after SHA mismatch.

## Validation
- `pnpm --filter @wittgenstein/cli test -- install.flow.test.ts doctor.test.ts install.test.ts`
- `pnpm --filter @wittgenstein/cli typecheck`
- `pnpm --filter @wittgenstein/cli lint`
- `pnpm --filter @wittgenstein/cli test`
- `pnpm --filter @wittgenstein/cli build`
- `pnpm lint:deps`
- `pnpm lint:publish-surface`
- `pnpm exec prettier --check packages/cli/src/commands/decoder-manifest.ts packages/cli/src/commands/doctor.ts packages/cli/src/commands/install.ts packages/cli/test/install.flow.test.ts packages/cli/test/doctor.test.ts packages/cli/README.md docs/distribution.md`
- `git diff --check`
- `git diff --cached --check`
- `pnpm --filter @wittgenstein/codec-image typecheck`
- `pnpm --filter @wittgenstein/codec-image test -- decoder-preflight.test.ts decoder-family-manifest.test.ts decoder-weights.test.ts`
- `pnpm run doctor`
- `node --import tsx src/cli-main.ts install image --json` from `packages/cli` exits 1 as expected without `WITTGENSTEIN_DECODER_MANIFEST`, returning structured `TIER_INSTALL_BLOCKED_BY_DECODER_MANIFEST` JSON.
