### PR TITLE
feat(schemas): add training run manifest contract

### DIFF
--- a/docs/contributing/training-setup.md
+++ b/docs/contributing/training-setup.md
@@ -43,22 +43,37 @@ For planned operational training runs, the Docker path is preferred for
 any receipt you intend to publish. Once implemented, the image SHA will go
 into the training manifest alongside the git SHA of the harness.
 
-## Manifest spine + experiment tracking
+## Training-run manifest + experiment tracking
 
-This section describes the intended Phase-1 behavior; manifest emission is
-not implemented in this skeleton yet. Each future training run will write
-a Wittgenstein manifest receipt under
-`research/training/_shared/manifests/<run-id>/`. The receipt will record:
+Each future publishable training run writes a
+`witt.training.run-manifest/v0.1` receipt validated by
+`TrainingRunManifestSchema` from `@wittgenstein/schemas`. The receipt lives
+next to the checkpoint in the run artifact directory, for example
+`research/training/_shared/runs/<run-id>/manifest.json`, or in the run's lab
+artifact bundle. It records:
 
 - Dataset hash (DVC-pinned)
 - Git SHA of the harness at training time
-- Docker image SHA (when applicable)
-- Seed, lockfile hash
+- Git SHA of the training code at training time
+- Docker image SHA and lockfile SHA (when applicable)
+- Seed, step count, wall-clock duration, and hardware
 - Per-eval-step metric snapshots
+- Checkpoint path, SHA-256, byte size, and weights license
 
-The same receipt will be mirrored to Aim (local) and W&B (when a project
-key is set via `WANDB_PROJECT`). Aim is the default because the manifest
-spine is the canonical record and Aim stays local + offline-friendly.
+Do not put a freeform hyperparameter blob inside the receipt. Training
+configuration stays in the training program's own config file; the receipt
+may point at that file with a path and SHA-256. The same receipt can be
+mirrored to Aim (local) and W&B (when a project key is set via
+`WANDB_PROJECT`). Aim is the default because the manifest spine is the
+canonical record and Aim stays local + offline-friendly.
+
+The three manifest surfaces are intentionally separate:
+
+- `TrainingRunManifest` is upstream evidence for a checkpoint-producing run.
+- `DecoderFamilyManifest` blesses a specific checkpoint as a decoder asset;
+  its `assets.trainingProvenance` reference points back to the training-run
+  receipt and must match the checkpoint SHA-256.
+- `RunManifest` records an inference call that may load that decoder asset.
 
 ## Data versioning
 

--- a/packages/codec-image/src/decoders/manifest.ts
+++ b/packages/codec-image/src/decoders/manifest.ts
@@ -89,6 +89,17 @@ export const DecoderFamilyManifestSchema = z
       });
     }
 
+    if (
+      manifest.assets.trainingProvenance &&
+      manifest.assets.trainingProvenance.checkpointSha256 !== manifest.assets.weightsSha256
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["assets", "trainingProvenance", "checkpointSha256"],
+        message: "trainingProvenance.checkpointSha256 must match assets.weightsSha256.",
+      });
+    }
+
     if (manifest.status === "blessed") {
       for (const gate of ["gateA", "gateB", "gateC", "gateD"] as const) {
         if (manifest.audits[gate].status !== "passed") {

--- a/packages/codec-image/src/decoders/weights.ts
+++ b/packages/codec-image/src/decoders/weights.ts
@@ -2,7 +2,11 @@ import { createHash } from "node:crypto";
 import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { z } from "zod";
-import { CLOSED_TRACKERS, TRACKERS } from "@wittgenstein/schemas";
+import {
+  CLOSED_TRACKERS,
+  TRACKERS,
+  TrainingRunManifestReferenceSchema,
+} from "@wittgenstein/schemas";
 import type { LoadDecoderBridgeOptions } from "./types.js";
 
 export const DecoderWeightsManifestSchema = z
@@ -21,6 +25,7 @@ export const DecoderWeightsManifestSchema = z
       code: z.string().min(1),
       weights: z.enum(["permissive", "research-only"]),
     }),
+    trainingProvenance: TrainingRunManifestReferenceSchema.optional(),
   })
   .refine((manifest) => Boolean(manifest.codebookFilename) === Boolean(manifest.codebookSha256), {
     message: "codebookFilename and codebookSha256 must be provided together",

--- a/packages/codec-image/test/decoder-family-manifest.test.ts
+++ b/packages/codec-image/test/decoder-family-manifest.test.ts
@@ -76,6 +76,47 @@ describe("decoder family manifest contract", () => {
     expect(DecoderFamilyManifestSchema.parse(manifest).status).toBe("blessed");
   });
 
+  it("allows decoder assets to reference the training-run receipt that produced their checkpoint", () => {
+    const manifest = candidateManifest({
+      assets: {
+        ...candidateManifest().assets,
+        trainingProvenance: {
+          runId: "tokenizer-20260530T210000Z-a1b2c3d4",
+          manifestPath:
+            "research/training/_shared/runs/tokenizer-20260530T210000Z-a1b2c3d4/manifest.json",
+          manifestSha256: "2".repeat(64),
+          checkpointSha256: SHA_ZERO,
+        },
+      },
+    });
+
+    const parsed = DecoderFamilyManifestSchema.parse(manifest);
+
+    expect(parsed.assets.trainingProvenance?.runId).toBe("tokenizer-20260530T210000Z-a1b2c3d4");
+  });
+
+  it("rejects decoder training provenance that points at a different checkpoint", () => {
+    const manifest = candidateManifest({
+      assets: {
+        ...candidateManifest().assets,
+        trainingProvenance: {
+          runId: "tokenizer-20260530T210000Z-a1b2c3d4",
+          manifestPath:
+            "research/training/_shared/runs/tokenizer-20260530T210000Z-a1b2c3d4/manifest.json",
+          manifestSha256: "2".repeat(64),
+          checkpointSha256: SHA_ONE,
+        },
+      },
+    });
+
+    const result = DecoderFamilyManifestSchema.safeParse(manifest);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.map((issue) => issue.path.join("."))).toContain(
+      "assets.trainingProvenance.checkpointSha256",
+    );
+  });
+
   it("accepts lab environment metadata on Gate C/D receipts", () => {
     const parsed = validateDecoderManifestAuditReceipts(
       blessedManifest(),

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -2,6 +2,7 @@ export * from "./codec.js";
 export * from "./config.js";
 export * from "./modality.js";
 export * from "./manifest.js";
+export * from "./training-manifest.js";
 export * from "./trackers.js";
 export * as codecV2 from "./codec/v2/index.js";
 export * as llm from "./llm/index.js";

--- a/packages/schemas/src/training-manifest.ts
+++ b/packages/schemas/src/training-manifest.ts
@@ -1,0 +1,125 @@
+import { z } from "zod";
+import { ModalitySchema } from "./modality.js";
+
+const Sha256Schema = z.string().regex(/^[a-f0-9]{64}$/);
+const GitShaSchema = z.string().regex(/^(?:[a-f0-9]{40}|[a-f0-9]{64})$/);
+const TimestampSchema = z.string().datetime({ offset: true });
+
+export const TrainingRunManifestSchemaVersion = "witt.training.run-manifest/v0.1" as const;
+
+export const TrainingSubprogramSchema = z.enum(["tokenizer", "adapter", "llm-head"]);
+
+export const TrainingRunDatasetSchema = z
+  .object({
+    dvcRev: z.string().min(1),
+    name: z.string().min(1),
+    sha256: Sha256Schema,
+  })
+  .strict();
+
+export const TrainingRunHardwareSchema = z
+  .object({
+    gpuModel: z.string().min(1),
+    gpuCount: z.number().int().positive(),
+    nodeCount: z.number().int().positive(),
+  })
+  .strict();
+
+export const TrainingRunEvalMetricSchema = z
+  .object({
+    name: z.string().min(1),
+    value: z.number().finite(),
+    unit: z.string().min(1).optional(),
+    higherIsBetter: z.boolean().optional(),
+  })
+  .strict();
+
+export const TrainingRunEvalSnapshotSchema = z
+  .object({
+    modality: ModalitySchema,
+    dataset: z
+      .object({
+        name: z.string().min(1),
+        split: z.string().min(1),
+        sha256: Sha256Schema,
+      })
+      .strict(),
+    step: z.number().int().nonnegative(),
+    generatedAt: TimestampSchema,
+    metrics: z.array(TrainingRunEvalMetricSchema).min(1),
+  })
+  .strict();
+
+export const TrainingRunCheckpointSchema = z
+  .object({
+    path: z.string().min(1),
+    sha256: Sha256Schema,
+    bytes: z.number().int().positive(),
+    weightsLicense: z.enum(["permissive", "research-only"]),
+  })
+  .strict();
+
+export const TrainingRunConfigReferenceSchema = z
+  .object({
+    path: z.string().min(1),
+    sha256: Sha256Schema,
+  })
+  .strict();
+
+export const TrainingRunManifestSchema = z
+  .object({
+    schemaVersion: z.literal(TrainingRunManifestSchemaVersion),
+    runId: z.string().min(1),
+    subprogram: TrainingSubprogramSchema,
+    startedAt: TimestampSchema,
+    finishedAt: TimestampSchema.nullable(),
+
+    harnessGitSha: GitShaSchema,
+    trainingCodeGitSha: GitShaSchema,
+    dockerImageSha: z
+      .string()
+      .regex(/^sha256:[a-f0-9]{64}$/)
+      .nullable(),
+    lockfileSha256: Sha256Schema.nullable(),
+    dataset: TrainingRunDatasetSchema,
+    seed: z.number().int(),
+    stepCount: z.number().int().nonnegative(),
+    wallClockSec: z.number().nonnegative(),
+    hardware: TrainingRunHardwareSchema,
+    evalSnapshots: z.array(TrainingRunEvalSnapshotSchema),
+    checkpoint: TrainingRunCheckpointSchema,
+    trainingConfig: TrainingRunConfigReferenceSchema.optional(),
+  })
+  .strict()
+  .superRefine((manifest, ctx) => {
+    if (manifest.finishedAt === null) {
+      return;
+    }
+
+    if (Date.parse(manifest.finishedAt) < Date.parse(manifest.startedAt)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["finishedAt"],
+        message: "finishedAt must be greater than or equal to startedAt.",
+      });
+    }
+  });
+
+export const TrainingRunManifestReferenceSchema = z
+  .object({
+    runId: z.string().min(1),
+    manifestPath: z.string().min(1),
+    manifestSha256: Sha256Schema,
+    checkpointSha256: Sha256Schema,
+  })
+  .strict();
+
+export type TrainingSubprogram = z.infer<typeof TrainingSubprogramSchema>;
+export type TrainingRunDataset = z.infer<typeof TrainingRunDatasetSchema>;
+export type TrainingRunHardware = z.infer<typeof TrainingRunHardwareSchema>;
+export type TrainingRunEvalMetric = z.infer<typeof TrainingRunEvalMetricSchema>;
+export type TrainingRunEvalSnapshot = z.infer<typeof TrainingRunEvalSnapshotSchema>;
+export type TrainingRunCheckpoint = z.infer<typeof TrainingRunCheckpointSchema>;
+export type TrainingRunConfigReference = z.infer<typeof TrainingRunConfigReferenceSchema>;
+export type TrainingRunManifest = z.infer<typeof TrainingRunManifestSchema>;
+export type TrainingRunManifestReference = z.infer<typeof TrainingRunManifestReferenceSchema>;

--- a/packages/schemas/test/fixtures/training-run-manifest.json
+++ b/packages/schemas/test/fixtures/training-run-manifest.json
@@ -1,0 +1,59 @@
+{
+  "schemaVersion": "witt.training.run-manifest/v0.1",
+  "runId": "tokenizer-20260530T210000Z-a1b2c3d4",
+  "subprogram": "tokenizer",
+  "startedAt": "2026-05-30T21:00:00Z",
+  "finishedAt": "2026-05-30T22:25:30Z",
+  "harnessGitSha": "1111111111111111111111111111111111111111",
+  "trainingCodeGitSha": "2222222222222222222222222222222222222222",
+  "dockerImageSha": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+  "lockfileSha256": "9999999999999999999999999999999999999999999999999999999999999999",
+  "dataset": {
+    "dvcRev": "imagenet-cc12m-v0.1",
+    "name": "imagenet-train-smoke",
+    "sha256": "4444444444444444444444444444444444444444444444444444444444444444"
+  },
+  "seed": 1234,
+  "stepCount": 4096,
+  "wallClockSec": 5130.25,
+  "hardware": {
+    "gpuModel": "A100-SXM4-80GB",
+    "gpuCount": 8,
+    "nodeCount": 1
+  },
+  "evalSnapshots": [
+    {
+      "modality": "image",
+      "dataset": {
+        "name": "imagenet-val",
+        "split": "val-50k",
+        "sha256": "5555555555555555555555555555555555555555555555555555555555555555"
+      },
+      "step": 4096,
+      "generatedAt": "2026-05-30T22:24:00Z",
+      "metrics": [
+        {
+          "name": "rfid",
+          "value": 1.93,
+          "unit": "score",
+          "higherIsBetter": false
+        },
+        {
+          "name": "clip_score",
+          "value": 0.284,
+          "higherIsBetter": true
+        }
+      ]
+    }
+  ],
+  "checkpoint": {
+    "path": "research/training/_shared/runs/tokenizer-20260530T210000Z-a1b2c3d4/ckpts/final.safetensors",
+    "sha256": "6666666666666666666666666666666666666666666666666666666666666666",
+    "bytes": 73400320,
+    "weightsLicense": "research-only"
+  },
+  "trainingConfig": {
+    "path": "research/training/tokenizer/configs/phase1-tokenizer.json",
+    "sha256": "7777777777777777777777777777777777777777777777777777777777777777"
+  }
+}

--- a/packages/schemas/test/training-manifest.test.ts
+++ b/packages/schemas/test/training-manifest.test.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  TrainingRunManifestReferenceSchema,
+  TrainingRunManifestSchema,
+  TrainingRunManifestSchemaVersion,
+  type TrainingRunManifest,
+} from "../src/index.js";
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const fixturePath = join(testDir, "fixtures", "training-run-manifest.json");
+
+describe("TrainingRunManifestSchema", () => {
+  it("round-trips a representative training-run receipt fixture without information loss", () => {
+    const fixture = readTrainingManifestFixture();
+
+    const parsed = TrainingRunManifestSchema.parse(fixture);
+
+    expect(parsed).toEqual(fixture);
+    expect(parsed.schemaVersion).toBe(TrainingRunManifestSchemaVersion);
+    expect(parsed.subprogram).toBe("tokenizer");
+    expect(parsed.checkpoint.weightsLicense).toBe("research-only");
+  });
+
+  it("rejects receipts that smuggle hyperparameters as a freeform top-level blob", () => {
+    const fixture = readTrainingManifestFixture();
+
+    const parsed = TrainingRunManifestSchema.safeParse({
+      ...fixture,
+      hyperparameters: {
+        lr: 0.0001,
+      },
+    });
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error?.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "unrecognized_keys",
+          keys: ["hyperparameters"],
+        }),
+      ]),
+    );
+  });
+
+  it("rejects impossible run windows", () => {
+    const fixture = readTrainingManifestFixture();
+
+    const parsed = TrainingRunManifestSchema.safeParse({
+      ...fixture,
+      finishedAt: "2026-05-30T20:59:59Z",
+    });
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error?.issues.map((issue) => issue.path.join("."))).toContain("finishedAt");
+  });
+
+  it("validates a compact reference suitable for downstream decoder-family manifests", () => {
+    const fixture = readTrainingManifestFixture();
+
+    expect(
+      TrainingRunManifestReferenceSchema.parse({
+        runId: fixture.runId,
+        manifestPath:
+          "research/training/_shared/runs/tokenizer-20260530T210000Z-a1b2c3d4/manifest.json",
+        manifestSha256: "8888888888888888888888888888888888888888888888888888888888888888",
+        checkpointSha256: fixture.checkpoint.sha256,
+      }),
+    ).toEqual({
+      runId: fixture.runId,
+      manifestPath:
+        "research/training/_shared/runs/tokenizer-20260530T210000Z-a1b2c3d4/manifest.json",
+      manifestSha256: "8888888888888888888888888888888888888888888888888888888888888888",
+      checkpointSha256: fixture.checkpoint.sha256,
+    });
+  });
+});
+
+function readTrainingManifestFixture(): TrainingRunManifest {
+  return JSON.parse(readFileSync(fixturePath, "utf8")) as TrainingRunManifest;
+}

--- a/research/training/README.md
+++ b/research/training/README.md
@@ -42,18 +42,22 @@ Subprograms share dataset loading, eval, and manifest-emission helpers from
 
 ## What a training run produces
 
-Every training run emits, alongside the model checkpoint, a Wittgenstein
-manifest receipt (the same spine the harness uses for generation):
+Every publishable training run emits, alongside the model checkpoint, a
+Wittgenstein `TrainingRunManifest` receipt validated by
+`TrainingRunManifestSchema` from `@wittgenstein/schemas`:
 
 - Dataset hash (DVC-pinned)
 - Training step count + wall-clock + GPU type
 - Eval-metric snapshot (FID / CLIP / rFID per modality)
 - Git SHA of the harness at training time
-- Seed + lockfile hash
+- Git SHA of the training code at training time
+- Seed, lockfile SHA, checkpoint SHA-256, and weights-license posture
 
 A frozen checkpoint released to HuggingFace Hub ships with this manifest
-beside it. The CLI's `wittgenstein replay <manifest>` works equally for a
-generation receipt and a training receipt — same spine.
+beside it. A downstream `DecoderFamilyManifest` can then bless that exact
+checkpoint by pointing `assets.trainingProvenance` at the training receipt.
+The inference-time `RunManifest` remains a separate receipt for a concrete
+artifact-producing CLI call that may load the blessed decoder.
 
 ## Receipt smoke
 


### PR DESCRIPTION
Closes #482.

## Summary
- Adds `TrainingRunManifestSchema`, `TrainingRunManifest` types, and a compact `TrainingRunManifestReferenceSchema` export from `@wittgenstein/schemas`.
- Adds a representative `witt.training.run-manifest/v0.1` fixture and a round-trip test that proves parsing preserves the full receipt.
- Adds `assets.trainingProvenance` to decoder weight manifests and validates that the referenced training checkpoint SHA matches the decoder asset SHA.
- Documents the three separate receipt surfaces: `TrainingRunManifest` as upstream checkpoint evidence, `DecoderFamilyManifest` as the blessing record, and inference `RunManifest` as the artifact-producing call record.

## Acceptance Mapping
- `TrainingRunManifest` type + zod schema exported: `packages/schemas/src/training-manifest.ts` and `packages/schemas/src/index.ts`.
- Round-trip fixture test: `packages/schemas/test/fixtures/training-run-manifest.json` and `packages/schemas/test/training-manifest.test.ts`.
- Cross-reference path from decoder-family manifest: `assets.trainingProvenance` uses `TrainingRunManifestReferenceSchema`, with a `checkpointSha256 === assets.weightsSha256` guard in `DecoderFamilyManifestSchema`.
- Relationship docs: `docs/contributing/training-setup.md` and `research/training/README.md`.

## Design Notes
- The schema is framework-agnostic: it records hashes, timestamps, hardware, eval snapshots, checkpoint identity, and weights-license posture, but no PyTorch/Lightning/W&B-specific runtime fields.
- It deliberately rejects a freeform top-level hyperparameter blob. Training config stays in the training program's own config file and can be referenced by path + SHA-256 via `trainingConfig`.
- `evalSnapshots` are structured as named metric rows instead of a freeform metrics object, so downstream review packs can compare claims without parsing prose.
- The decoder provenance reference is intentionally compact: it is enough for a blessed decoder asset to point back to the exact training receipt and checkpoint without embedding the whole training receipt inside the decoder manifest.

## Self-Review
- Engineer: kept the schema in `@wittgenstein/schemas`, reused the existing codec-image dependency direction, and avoided importing `research/` from package code.
- Research: separated evidence roles cleanly: training run produces checkpoint evidence, decoder manifest blesses a checkpoint, inference manifest records concrete use.
- Hacker: made unknown top-level receipt keys fail, validated impossible time windows, and added a negative decoder-provenance test so a manifest cannot claim one training receipt while shipping another checkpoint SHA.

## Validation
- `pnpm install --frozen-lockfile --offline`
- `pnpm --filter @wittgenstein/schemas test -- training-manifest.test.ts contract.test.ts`
- `pnpm --filter @wittgenstein/schemas test`
- `pnpm --filter @wittgenstein/schemas typecheck`
- `pnpm --filter @wittgenstein/schemas lint`
- `pnpm --filter @wittgenstein/schemas build`
- `pnpm --filter @wittgenstein/codec-image test -- decoder-family-manifest.test.ts decoder-weights.test.ts`
- `pnpm --filter @wittgenstein/codec-image test`
- `pnpm --filter @wittgenstein/codec-image typecheck`
- `pnpm --filter @wittgenstein/codec-image lint`
- `pnpm --filter @wittgenstein/codec-image build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build` (passes; existing Vite chunk-size warning only)
- `pnpm lint:deps`
- `pnpm lint:publish-surface`
- `pnpm exec prettier --check packages/schemas/src/training-manifest.ts packages/schemas/src/index.ts packages/schemas/test/training-manifest.test.ts packages/schemas/test/fixtures/training-run-manifest.json packages/codec-image/src/decoders/weights.ts packages/codec-image/src/decoders/manifest.ts packages/codec-image/test/decoder-family-manifest.test.ts docs/contributing/training-setup.md research/training/README.md`
- `git diff --check`
- `git diff --cached --check`
