### PR TITLE
feat(runtime): normalize doctor probe receipts

### DIFF
--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -2,7 +2,11 @@ import { createRequire } from "node:module";
 import { existsSync } from "node:fs";
 import { loadWittgensteinConfig } from "@wittgenstein/core";
 import type { DecoderPreflightReceipt } from "@wittgenstein/codec-image";
-import { firstOutputLine, spawnVersionCheck } from "@wittgenstein/process-runner";
+import {
+  createRuntimeProbeReceipt,
+  probeRuntimeCommandVersion,
+  type RuntimeProbeReceipt,
+} from "@wittgenstein/process-runner";
 import type { Command } from "commander";
 import {
   auditStatuses,
@@ -13,11 +17,10 @@ import {
 import { resolveExecutionRoot } from "./shared.js";
 import { runtimeTierReadiness } from "../tiers.js";
 
-type DoctorCheckStatus = "ok" | "missing" | "invalid" | "skipped";
+type DoctorCheck = RuntimeProbeReceipt;
 
-interface DoctorCheck {
-  status: DoctorCheckStatus;
-  version?: string;
+interface DoctorFileCheck {
+  status: "ok" | "missing" | "invalid" | "skipped";
   path?: string;
   message?: string;
 }
@@ -45,7 +48,7 @@ interface ImageDecoderDoctor {
     gateD: string;
   } | null;
   weightsCached: boolean | null;
-  decoderManifest: DoctorCheck;
+  decoderManifest: DoctorFileCheck;
   onnxRuntime: DoctorCheck;
   reason: DecoderPreflightReceipt["reason"] | null;
   installHint: string | null;
@@ -95,17 +98,15 @@ export function registerDoctorCommand(program: Command): void {
 function checkVideoRenderDependencies(): VideoRenderDoctor {
   const enabled = process.env.WITTGENSTEIN_HYPERFRAMES_RENDER === "1";
   if (!enabled) {
-    const skipped: DoctorCheck = {
-      status: "skipped",
-      message: "Set WITTGENSTEIN_HYPERFRAMES_RENDER=1 to enable MP4 render dependency checks.",
-    };
+    const skippedMessage =
+      "Set WITTGENSTEIN_HYPERFRAMES_RENDER=1 to enable MP4 render dependency checks.";
     return {
       enabled,
       backend: readVideoBackend(),
-      hyperframesNode: skipped,
-      hyperframesCli: skipped,
-      ffmpeg: skipped,
-      chrome: skipped,
+      hyperframesNode: skippedVideoProbe("node", skippedMessage),
+      hyperframesCli: skippedVideoProbe("hyperframes", skippedMessage),
+      ffmpeg: skippedVideoProbe("ffmpeg", skippedMessage),
+      chrome: skippedVideoProbe("chrome", skippedMessage),
     };
   }
 
@@ -116,17 +117,21 @@ function checkVideoRenderDependencies(): VideoRenderDoctor {
     hyperframesNode:
       backend === "npx-cli"
         ? checkNodeForHyperframesCli()
-        : {
+        : createRuntimeProbeReceipt({
             status: "skipped",
+            runtime: "node",
+            tier: "video",
             message: "Only checked when WITTGENSTEIN_HYPERFRAMES_BACKEND=npx-cli.",
-          },
+          }),
     hyperframesCli:
       backend === "npx-cli"
         ? checkHyperframesCli()
-        : {
+        : createRuntimeProbeReceipt({
             status: "skipped",
+            runtime: "hyperframes",
+            tier: "video",
             message: "Only checked when WITTGENSTEIN_HYPERFRAMES_BACKEND=npx-cli.",
-          },
+          }),
     ffmpeg: checkCommandVersion("ffmpeg", ["-version"], "Install FFmpeg for video MP4 rendering."),
     chrome: checkChrome(),
   };
@@ -135,17 +140,21 @@ function checkVideoRenderDependencies(): VideoRenderDoctor {
 function checkNodeForHyperframesCli(): DoctorCheck {
   const major = Number.parseInt(process.versions.node.split(".")[0] ?? "0", 10);
   if (major >= 22) {
-    return {
+    return createRuntimeProbeReceipt({
       status: "ok",
+      runtime: "node",
+      tier: "video",
       version: process.version,
-    };
+    });
   }
-  return {
+  return createRuntimeProbeReceipt({
     status: "missing",
+    runtime: "node",
+    tier: "video",
     version: process.version,
     message:
       "HyperFrames CLI currently requires Node.js >=22. Use the distilled internal backend on Node 20, or run the npx backend under Node 22+.",
-  };
+  });
 }
 
 function readVideoBackend(): "distilled-internal" | "npx-cli" {
@@ -155,52 +164,41 @@ function readVideoBackend(): "distilled-internal" | "npx-cli" {
 }
 
 function checkHyperframesCli(): DoctorCheck {
-  const result = spawnVersionCheck("npx", ["--no-install", "hyperframes", "--version"], {
+  return probeRuntimeCommandVersion({
+    runtime: "hyperframes",
+    tier: "video",
+    command: "npx",
+    args: ["--no-install", "hyperframes", "--version"],
     env: {
       HYPERFRAMES_NO_TELEMETRY: process.env.HYPERFRAMES_NO_TELEMETRY ?? "1",
       HYPERFRAMES_NO_UPDATE_CHECK: process.env.HYPERFRAMES_NO_UPDATE_CHECK ?? "1",
     },
-  });
-
-  if (result.ok) {
-    return {
-      status: "ok",
-      version: firstOutputLine(result.stdout, result.stderr),
-    };
-  }
-
-  return {
-    status: "missing",
-    message:
+    missingMessage:
       "Install HyperFrames locally, or unset WITTGENSTEIN_HYPERFRAMES_BACKEND to use the distilled internal renderer.",
-  };
+  });
 }
 
 function checkCommandVersion(command: string, args: string[], missingMessage: string): DoctorCheck {
-  const result = spawnVersionCheck(command, args);
-
-  if (result.ok) {
-    return {
-      status: "ok",
-      version: firstOutputLine(result.stdout, result.stderr),
-    };
-  }
-
-  return {
-    status: "missing",
-    message: missingMessage,
-  };
+  return probeRuntimeCommandVersion({
+    runtime: command,
+    tier: "video",
+    command,
+    args,
+    missingMessage,
+  });
 }
 
 function checkChrome(): DoctorCheck {
   const envPath = process.env.PUPPETEER_EXECUTABLE_PATH;
   if (envPath) {
     if (!existsSync(envPath)) {
-      return {
+      return createRuntimeProbeReceipt({
         status: "missing",
+        runtime: "chrome",
+        tier: "video",
         path: envPath,
         message: "PUPPETEER_EXECUTABLE_PATH is set but does not point to an existing file.",
-      };
+      });
     }
 
     return checkChromeCandidate(envPath);
@@ -222,24 +220,23 @@ function checkChrome(): DoctorCheck {
     }
   }
 
-  return {
+  return createRuntimeProbeReceipt({
+    runtime: "chrome",
+    tier: "video",
     status: "missing",
     message: "Install Chrome/Chromium or set PUPPETEER_EXECUTABLE_PATH for video MP4 rendering.",
-  };
+  });
 }
 
 function checkChromeCandidate(candidate: string): DoctorCheck {
-  const result = spawnVersionCheck(candidate, ["--version"]);
-
-  if (result.ok) {
-    return {
-      status: "ok",
-      path: candidate,
-      version: firstOutputLine(result.stdout, result.stderr),
-    };
-  }
-
-  return { status: "missing" };
+  return probeRuntimeCommandVersion({
+    runtime: "chrome",
+    tier: "video",
+    command: candidate,
+    args: ["--version"],
+    path: candidate,
+    missingMessage: "Chrome/Chromium candidate did not respond to --version.",
+  });
 }
 
 async function checkImageDecoderReadiness(workspaceRoot: string): Promise<ImageDecoderDoctor> {
@@ -343,14 +340,29 @@ function checkOptionalNodePeer(packageName: string, installHint: string): Doctor
   const requireFromDoctor = createRequire(import.meta.url);
   try {
     const resolvedPath = requireFromDoctor.resolve(packageName);
-    return {
+    return createRuntimeProbeReceipt({
       status: "ok",
+      runtime: packageName,
+      tier: "image",
       path: resolvedPath,
-    };
+      installHint,
+    });
   } catch {
-    return {
+    return createRuntimeProbeReceipt({
       status: "missing",
+      runtime: packageName,
+      tier: "image",
+      installHint,
       message: `${packageName} is optional and not installed. Run \`${installHint}\` after a decoder manifest is selected.`,
-    };
+    });
   }
+}
+
+function skippedVideoProbe(runtime: string, message: string): DoctorCheck {
+  return createRuntimeProbeReceipt({
+    status: "skipped",
+    runtime,
+    tier: "video",
+    message,
+  });
 }

--- a/packages/cli/test/doctor.test.ts
+++ b/packages/cli/test/doctor.test.ts
@@ -30,10 +30,10 @@ describe("doctor tier readiness", () => {
       videoRender: {
         enabled: boolean;
         backend: string;
-        hyperframesNode: { status: string };
-        hyperframesCli: { status: string };
-        ffmpeg: { status: string };
-        chrome: { status: string };
+        hyperframesNode: { status: string; runtime: string; tier: string };
+        hyperframesCli: { status: string; runtime: string; tier: string };
+        ffmpeg: { status: string; runtime: string; tier: string };
+        chrome: { status: string; runtime: string; tier: string };
       };
       imageDecoder: {
         status: string;
@@ -47,7 +47,14 @@ describe("doctor tier readiness", () => {
         decoderManifest: { status: string; message: string };
         reason: string | null;
         installHint: string | null;
-        onnxRuntime: { status: string; message?: string; path?: string };
+        onnxRuntime: {
+          status: string;
+          runtime: string;
+          tier: string;
+          installHint?: string;
+          message?: string;
+          path?: string;
+        };
         blockers: {
           decoderDelivery: string;
           gateCDeterminism: string;
@@ -64,6 +71,22 @@ describe("doctor tier readiness", () => {
     expect(payload.videoRender.hyperframesCli.status).toBe("skipped");
     expect(payload.videoRender.ffmpeg.status).toBe("skipped");
     expect(payload.videoRender.chrome.status).toBe("skipped");
+    expect(payload.videoRender.hyperframesNode).toMatchObject({
+      runtime: "node",
+      tier: "video",
+    });
+    expect(payload.videoRender.hyperframesCli).toMatchObject({
+      runtime: "hyperframes",
+      tier: "video",
+    });
+    expect(payload.videoRender.ffmpeg).toMatchObject({
+      runtime: "ffmpeg",
+      tier: "video",
+    });
+    expect(payload.videoRender.chrome).toMatchObject({
+      runtime: "chrome",
+      tier: "video",
+    });
     expect(payload.imageDecoder.status).toBe("not-selected");
     expect(payload.imageDecoder.manifestPath).toBeNull();
     expect(payload.imageDecoder.family).toBeNull();
@@ -76,6 +99,9 @@ describe("doctor tier readiness", () => {
     expect(payload.imageDecoder.reason).toBe("manifest-missing");
     expect(payload.imageDecoder.installHint).toBe("wittgenstein install image");
     expect(["ok", "missing"]).toContain(payload.imageDecoder.onnxRuntime.status);
+    expect(payload.imageDecoder.onnxRuntime.runtime).toBe("onnxruntime-node");
+    expect(payload.imageDecoder.onnxRuntime.tier).toBe("image");
+    expect(payload.imageDecoder.onnxRuntime.installHint).toBe("wittgenstein install image");
     expect(payload.imageDecoder.blockers.decoderDelivery).toMatch(/issues\/402$/);
     expect(payload.imageDecoder.blockers.gateCDeterminism).toMatch(/issues\/334$/);
     expect(payload.imageDecoder.blockers.gateDOnnxCpu).toMatch(/issues\/335$/);
@@ -89,10 +115,10 @@ describe("doctor tier readiness", () => {
       videoRender: {
         enabled: boolean;
         backend: string;
-        hyperframesNode: { status: string };
-        hyperframesCli: { status: string };
-        ffmpeg: { status: string };
-        chrome: { status: string };
+        hyperframesNode: { status: string; runtime: string; tier: string };
+        hyperframesCli: { status: string; runtime: string; tier: string };
+        ffmpeg: { status: string; runtime: string; tier: string };
+        chrome: { status: string; runtime: string; tier: string };
       };
     };
 
@@ -102,6 +128,10 @@ describe("doctor tier readiness", () => {
     expect(payload.videoRender.hyperframesCli.status).toBe("skipped");
     expect(["ok", "missing"]).toContain(payload.videoRender.ffmpeg.status);
     expect(["ok", "missing"]).toContain(payload.videoRender.chrome.status);
+    expect(payload.videoRender.ffmpeg.runtime).toBe("ffmpeg");
+    expect(payload.videoRender.ffmpeg.tier).toBe("video");
+    expect(payload.videoRender.chrome.runtime).toBe("chrome");
+    expect(payload.videoRender.chrome.tier).toBe("video");
   });
 
   it("checks HyperFrames CLI when the npx backend is selected", () => {
@@ -115,8 +145,8 @@ describe("doctor tier readiness", () => {
       videoRender: {
         enabled: boolean;
         backend: string;
-        hyperframesNode: { status: string };
-        hyperframesCli: { status: string };
+        hyperframesNode: { status: string; runtime: string; tier: string };
+        hyperframesCli: { status: string; runtime: string; tier: string };
       };
     };
 
@@ -124,6 +154,10 @@ describe("doctor tier readiness", () => {
     expect(payload.videoRender.backend).toBe("npx-cli");
     expect(["ok", "missing"]).toContain(payload.videoRender.hyperframesNode.status);
     expect(["ok", "missing"]).toContain(payload.videoRender.hyperframesCli.status);
+    expect(payload.videoRender.hyperframesNode.runtime).toBe("node");
+    expect(payload.videoRender.hyperframesNode.tier).toBe("video");
+    expect(payload.videoRender.hyperframesCli.runtime).toBe("hyperframes");
+    expect(payload.videoRender.hyperframesCli.tier).toBe("video");
   });
 
   it("reports a ready image decoder when the selected blessed manifest has cached weights", () => {
@@ -145,7 +179,7 @@ describe("doctor tier readiness", () => {
         audits: Record<string, string>;
         weightsCached: boolean;
         decoderManifest: { status: string; path: string };
-        onnxRuntime: { status: string };
+        onnxRuntime: { status: string; runtime: string; tier: string; installHint?: string };
         reason: string | null;
         details: { weights: { source: string; weightsSha256: string; codebookSha256: string } };
       };
@@ -166,6 +200,9 @@ describe("doctor tier readiness", () => {
     expect(payload.imageDecoder.weightsCached).toBe(true);
     expect(payload.imageDecoder.decoderManifest.status).toBe("ok");
     expect(["ok", "missing"]).toContain(payload.imageDecoder.onnxRuntime.status);
+    expect(payload.imageDecoder.onnxRuntime.runtime).toBe("onnxruntime-node");
+    expect(payload.imageDecoder.onnxRuntime.tier).toBe("image");
+    expect(payload.imageDecoder.onnxRuntime.installHint).toBe("wittgenstein install image");
     expect(payload.imageDecoder.reason).toBeNull();
     expect(payload.imageDecoder.details.weights.source).toBe("cache-hit");
     expect(payload.imageDecoder.details.weights.weightsSha256).toBe(fixture.weightsSha);

--- a/packages/process-runner/src/index.ts
+++ b/packages/process-runner/src/index.ts
@@ -157,6 +157,102 @@ export interface SpawnVersionCheckResult {
   readonly timedOut: boolean;
 }
 
+export type RuntimeProbeStatus = "ok" | "missing" | "invalid" | "skipped";
+export type RuntimeProbeTier = "image" | "audio" | "video" | "sensor";
+
+export interface RuntimeProbeReceipt {
+  readonly status: RuntimeProbeStatus;
+  readonly runtime: string;
+  readonly tier?: RuntimeProbeTier;
+  readonly version?: string;
+  readonly path?: string;
+  readonly installHint?: string;
+  readonly tracker?: string;
+  readonly message?: string;
+}
+
+export type RuntimeProbeReceiptInput = RuntimeProbeReceipt;
+
+/**
+ * Build a stable optional-runtime probe receipt for doctor-style surfaces.
+ * This intentionally does not load optional peers or decide codec readiness; it
+ * only normalizes the receipt shape shared by CLI probes. Codec-local runtime
+ * loaders keep their domain-specific error classes and install hints.
+ *
+ * Undefined optional fields are omitted so JSON output remains compact and
+ * backwards-compatible with older doctor assertions that only inspected
+ * `status`, `version`, `path`, or `message`.
+ */
+export function createRuntimeProbeReceipt(input: RuntimeProbeReceiptInput): RuntimeProbeReceipt {
+  return {
+    status: input.status,
+    runtime: input.runtime,
+    ...(input.tier !== undefined ? { tier: input.tier } : {}),
+    ...(input.version !== undefined ? { version: input.version } : {}),
+    ...(input.path !== undefined ? { path: input.path } : {}),
+    ...(input.installHint !== undefined ? { installHint: input.installHint } : {}),
+    ...(input.tracker !== undefined ? { tracker: input.tracker } : {}),
+    ...(input.message !== undefined ? { message: input.message } : {}),
+  };
+}
+
+export interface RuntimeCommandVersionProbeOptions extends SpawnVersionCheckOptions {
+  readonly runtime: string;
+  readonly tier?: RuntimeProbeTier;
+  readonly command: string;
+  readonly args: ReadonlyArray<string>;
+  readonly path?: string;
+  readonly installHint?: string;
+  readonly tracker?: string;
+  readonly missingMessage: string;
+}
+
+/**
+ * Probe a command-shaped optional runtime (`ffmpeg --version`, Chrome
+ * `--version`, `npx --no-install hyperframes --version`) and return the shared
+ * doctor receipt. Failed probes deliberately map to `missing`, matching the
+ * existing doctor contract where a non-zero version probe means the runtime is
+ * not usable for this surface.
+ */
+export function probeRuntimeCommandVersion(
+  options: RuntimeCommandVersionProbeOptions,
+): RuntimeProbeReceipt {
+  const {
+    runtime,
+    tier,
+    command,
+    args,
+    path,
+    installHint,
+    tracker,
+    missingMessage,
+    ...probeOptions
+  } = options;
+  const result = spawnVersionCheck(command, args, probeOptions);
+
+  if (result.ok) {
+    return createRuntimeProbeReceipt({
+      status: "ok",
+      runtime,
+      ...(tier ? { tier } : {}),
+      version: firstOutputLine(result.stdout, result.stderr),
+      ...(path ? { path } : {}),
+      ...(installHint ? { installHint } : {}),
+      ...(tracker ? { tracker } : {}),
+    });
+  }
+
+  return createRuntimeProbeReceipt({
+    status: "missing",
+    runtime,
+    ...(tier ? { tier } : {}),
+    ...(path ? { path } : {}),
+    ...(installHint ? { installHint } : {}),
+    ...(tracker ? { tracker } : {}),
+    message: missingMessage,
+  });
+}
+
 /**
  * Synchronous `<cmd> [args...]` probe with a standardized timeout policy.
  * Designed for the `<binary> --version` shape used by doctor and runtime

--- a/packages/process-runner/test/process-runner.test.ts
+++ b/packages/process-runner/test/process-runner.test.ts
@@ -7,7 +7,9 @@
 import { describe, expect, it } from "vitest";
 import {
   DEFAULT_VERSION_CHECK_TIMEOUT_MS,
+  createRuntimeProbeReceipt,
   firstOutputLine,
+  probeRuntimeCommandVersion,
   runProcess,
   spawnVersionCheck,
 } from "../src/index.js";
@@ -177,5 +179,61 @@ describe("spawnVersionCheck (#487 item 3)", () => {
     );
     expect(result.ok).toBe(true);
     expect(result.stdout.trim()).toBe("present");
+  });
+});
+
+describe("runtime probe receipts (#543)", () => {
+  it("builds compact skipped receipts without undefined optional fields", () => {
+    const receipt = createRuntimeProbeReceipt({
+      status: "skipped",
+      runtime: "ffmpeg",
+      tier: "video",
+      message: "set WITTGENSTEIN_HYPERFRAMES_RENDER=1",
+    });
+
+    expect(receipt).toEqual({
+      status: "skipped",
+      runtime: "ffmpeg",
+      tier: "video",
+      message: "set WITTGENSTEIN_HYPERFRAMES_RENDER=1",
+    });
+    expect("version" in receipt).toBe(false);
+    expect("path" in receipt).toBe(false);
+  });
+
+  it("converts a successful command version probe into a ready runtime receipt", () => {
+    const receipt = probeRuntimeCommandVersion({
+      runtime: "node",
+      tier: "video",
+      command: "node",
+      args: ["--version"],
+      missingMessage: "node missing",
+    });
+
+    expect(receipt.status).toBe("ok");
+    expect(receipt.runtime).toBe("node");
+    expect(receipt.tier).toBe("video");
+    expect(receipt.version).toMatch(/^v\d+\./);
+  });
+
+  it("converts a missing command version probe into a missing runtime receipt", () => {
+    const receipt = probeRuntimeCommandVersion({
+      runtime: "definitely-missing-runtime",
+      tier: "image",
+      command: "definitely-not-a-real-binary-xyz",
+      args: ["--version"],
+      installHint: "wittgenstein install image",
+      tracker: "https://github.com/p-to-q/wittgenstein/issues/543",
+      missingMessage: "install the runtime",
+    });
+
+    expect(receipt).toEqual({
+      status: "missing",
+      runtime: "definitely-missing-runtime",
+      tier: "image",
+      installHint: "wittgenstein install image",
+      tracker: "https://github.com/p-to-q/wittgenstein/issues/543",
+      message: "install the runtime",
+    });
   });
 });


### PR DESCRIPTION
Closes #543.

## Summary
- Adds a shared `RuntimeProbeReceipt` shape plus `createRuntimeProbeReceipt()` and `probeRuntimeCommandVersion()` in `@wittgenstein/process-runner`.
- Updates `wittgenstein doctor` video and image optional-runtime probes to use the shared receipt shape while preserving existing `status` / `version` / `path` / `message` fields.
- Keeps codec-local runtime loaders unchanged: `ensureOnnxRuntime()` and `ensurePuppeteerCore()` still own their domain-specific errors and install hints.

## Acceptance mapping
- Doctor output remains backward-compatible for existing tests and now includes normalized `runtime`, `tier`, and `installHint` where applicable.
- Repeated command-version probe assembly for FFmpeg, Chrome, HyperFrames CLI, and Node is consolidated behind `probeRuntimeCommandVersion()`.
- Optional Node peer checks use the shared receipt builder without introducing a generic runtime loader.
- No optional runtime becomes a hard dependency; this only changes probe receipts and tests.
- Tests cover skipped MP4 probes, missing command probes, ok command probes, and ready/missing optional peer surfaces through `doctor.test.ts` and `process-runner.test.ts`.

## Self-review
- Engineering: the shared helper is deliberately in `process-runner`, where version-probe policy already lives, avoiding a `packages/schemas` dependency on operational runtime checks.
- Research/architecture: this follows the #478 local-optimum recommendation: normalize receipt shape, but do not move codec runtime semantics out of the codec packages.
- Hacker/adversarial: the tests pin compact receipts without undefined fields and preserve doctor behavior across disabled MP4 mode, enabled MP4 mode, npx backend probing, and image decoder readiness.

## Validation
- `pnpm install --frozen-lockfile --offline`
- `pnpm exec prettier --check packages/process-runner/src/index.ts packages/process-runner/test/process-runner.test.ts packages/cli/src/commands/doctor.ts packages/cli/test/doctor.test.ts`
- `git diff --check`
- `pnpm --filter @wittgenstein/process-runner lint`
- `pnpm --filter @wittgenstein/process-runner test`
- `pnpm --filter @wittgenstein/cli test -- doctor.test.ts`
- `pnpm lint:deps`
- `pnpm lint:publish-surface`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build` (passes; existing Vite chunk-size warning only)
- `pnpm run doctor`
