### PR TITLE
feat(audio): add route plan receipts

### DIFF
--- a/docs/codecs/audio.md
+++ b/docs/codecs/audio.md
@@ -57,6 +57,8 @@ The LLM does not emit raw audio, MIDI bytes, or sample arrays. It emits a _plan_
 - Output is backend-specific and recorded in `audioRender`. Procedural speech emits
   16-bit WAV; Kokoro emits 24 kHz float WAV with `determinismClass:
 "structural-parity"`.
+- The route-specific plan receipt is recorded in `audioPlan`: script text/hash,
+  voice/prosody, ambient choice, timing, and backend.
 
 Any future fallback to Piper must leave manifest evidence of the concrete decoder
 actually used (`decoderId`, `determinismClass`). The v0.3 decision is simpler:
@@ -67,13 +69,17 @@ tested macOS and Linux targets.
 
 - Deterministic ambient texture render from a small operator library (filtered noise, granular layers, periodic events).
 - No LLM-driven sample generation at render time; the LLM's job is fully captured by the AudioPlan.
-- Output: 16-bit stereo WAV.
+- Output: 16-bit mono WAV.
+- The route-specific plan receipt is recorded in `audioPlan`: operator graph,
+  effective ambient category, seed, envelope level/duration, and filter.
 
 ### Music route
 
 - Tiny symbolic synth: chord progression → instrument-tagged note events → additive synthesis.
 - Optional ambient layer.
 - Not a music-generation model. Quality is _structurally correct_, not _aesthetically frontier_. The thesis surface is "the LLM plans music; the synth renders the plan."
+- The route-specific plan receipt is recorded in `audioPlan`: motif text/hash,
+  rhythm/key/duration, event-grid step count, chord frequencies, and ambient layer.
 
 ## Decoder Choices and Why
 
@@ -104,7 +110,9 @@ waveform-direct.
 - `expand` — LLM call(s) producing the AudioPlan; one round by default, two with `--expand`.
 - `adapt` — pass-through at v0.3.
 - `decode` — route-internal render: `speech.ts` / `soundscape.ts` / `music.ts`.
-- `package` — codec authors its own manifest rows: `route`, `seed`, `model_id`, `quality.structural`, optional `quality.partial`.
+- `package` — codec authors its own manifest rows: `route`, `audioRender`,
+  `audioPlan`, `quality.structural`, optional `quality.partial`, decoder hash,
+  and artifact SHA-256.
 
 ## Failure Modes
 
@@ -151,14 +159,14 @@ remains a v0.3 concern via M5b benchmarks and a future frozen-vocoder integratio
 
 For agents reading this doc cold, the lineage from M2 closure to today's main HEAD:
 
-| Step | Surface | Note |
-|---|---|---|
-| Codec-audio M2 port | `docs/exec-plans/active/codec-v2-port.md` §M2 | Three internal routes (speech / soundscape / music); `Codec<AudioRequest, AudioArtifact>` shape; ADR-0008 codec protocol |
-| Speech backend ratification | ADR-0015 | Kokoro-82M-family default target; Piper fallback ratified-but-not-wired |
-| Slice E receipt | `docs/research/2026-05-06-m2-slice-e-kokoro-sweep-verdict.md` | Kokoro is same-platform deterministic, **not** byte-identical across macOS arm64 vs Linux x64 → procedural-audio-runtime stays default at v0.3, Kokoro opt-in via `WITTGENSTEIN_AUDIO_BACKEND=kokoro` |
-| Route enum tightening | PR #245 | `RunManifest.route` enforces `speech` / `soundscape` / `music` per #190 partial closeout |
-| Audio code-layer research | PR #274 | Per-route distinct shapes recommended (SSML enrichment for speech, MIDI event-grid for music, sensor-style operator-graph for soundscape); RFC-routed only, NOT yet ratified |
-| Sub-RFC ordering (proposed) | per #274 §"Suggested follow-ups" | Soundscape operator-graph first, MIDI event-grid second, SSML enrichment last |
-| Implementation slices | #261 | Gated on at least one sub-RFC ratification |
+| Step                        | Surface                                                       | Note                                                                                                                                                                                                  |
+| --------------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Codec-audio M2 port         | `docs/exec-plans/active/codec-v2-port.md` §M2                 | Three internal routes (speech / soundscape / music); `Codec<AudioRequest, AudioArtifact>` shape; ADR-0008 codec protocol                                                                              |
+| Speech backend ratification | ADR-0015                                                      | Kokoro-82M-family default target; Piper fallback ratified-but-not-wired                                                                                                                               |
+| Slice E receipt             | `docs/research/2026-05-06-m2-slice-e-kokoro-sweep-verdict.md` | Kokoro is same-platform deterministic, **not** byte-identical across macOS arm64 vs Linux x64 → procedural-audio-runtime stays default at v0.3, Kokoro opt-in via `WITTGENSTEIN_AUDIO_BACKEND=kokoro` |
+| Route enum tightening       | PR #245                                                       | `RunManifest.route` enforces `speech` / `soundscape` / `music` per #190 partial closeout                                                                                                              |
+| Audio code-layer research   | PR #274                                                       | Per-route distinct shapes recommended (SSML enrichment for speech, MIDI event-grid for music, sensor-style operator-graph for soundscape); RFC-routed only, NOT yet ratified                          |
+| Sub-RFC ordering (proposed) | per #274 §"Suggested follow-ups"                              | Soundscape operator-graph first, MIDI event-grid second, SSML enrichment last                                                                                                                         |
+| Implementation slices       | #261                                                          | Gated on at least one sub-RFC ratification                                                                                                                                                            |
 
 > **Audio routes do NOT share a single token shape.** This is the central claim of #274 and the inverse of image's Visual Seed Code framing: speech is text-shaped (script + optional prosody enrichment), music is event-grid-shaped (chords / note timings), soundscape is operator-graph-shaped (deterministic operators over time). Forcing them under one VQ-tokenizer story would re-introduce the category error the image-route correction (RFC-0006 / ADR-0018) just fixed for image. Future work should respect this asymmetry.

--- a/docs/codecs/audio.md
+++ b/docs/codecs/audio.md
@@ -159,14 +159,32 @@ remains a v0.3 concern via M5b benchmarks and a future frozen-vocoder integratio
 
 For agents reading this doc cold, the lineage from M2 closure to today's main HEAD:
 
-| Step                        | Surface                                                       | Note                                                                                                                                                                                                  |
-| --------------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Codec-audio M2 port         | `docs/exec-plans/active/codec-v2-port.md` §M2                 | Three internal routes (speech / soundscape / music); `Codec<AudioRequest, AudioArtifact>` shape; ADR-0008 codec protocol                                                                              |
-| Speech backend ratification | ADR-0015                                                      | Kokoro-82M-family default target; Piper fallback ratified-but-not-wired                                                                                                                               |
-| Slice E receipt             | `docs/research/2026-05-06-m2-slice-e-kokoro-sweep-verdict.md` | Kokoro is same-platform deterministic, **not** byte-identical across macOS arm64 vs Linux x64 → procedural-audio-runtime stays default at v0.3, Kokoro opt-in via `WITTGENSTEIN_AUDIO_BACKEND=kokoro` |
-| Route enum tightening       | PR #245                                                       | `RunManifest.route` enforces `speech` / `soundscape` / `music` per #190 partial closeout                                                                                                              |
-| Audio code-layer research   | PR #274                                                       | Per-route distinct shapes recommended (SSML enrichment for speech, MIDI event-grid for music, sensor-style operator-graph for soundscape); RFC-routed only, NOT yet ratified                          |
-| Sub-RFC ordering (proposed) | per #274 §"Suggested follow-ups"                              | Soundscape operator-graph first, MIDI event-grid second, SSML enrichment last                                                                                                                         |
-| Implementation slices       | #261                                                          | Gated on at least one sub-RFC ratification                                                                                                                                                            |
+- **Codec-audio M2 port**
+  (`docs/exec-plans/active/codec-v2-port.md` §M2): three internal routes
+  (`speech` / `soundscape` / `music`), `Codec<AudioRequest, AudioArtifact>`
+  shape, and ADR-0008 codec protocol.
+- **Speech backend ratification** (ADR-0015): Kokoro-82M-family default
+  target; Piper fallback ratified but not wired.
+- **Slice E receipt**
+  (`docs/research/2026-05-06-m2-slice-e-kokoro-sweep-verdict.md`): Kokoro
+  is same-platform deterministic, **not** byte-identical across macOS arm64 vs
+  Linux x64; procedural-audio-runtime stays default at v0.3, with Kokoro opt-in
+  via `WITTGENSTEIN_AUDIO_BACKEND=kokoro`.
+- **Route enum tightening** (PR #245): `RunManifest.route` enforces `speech` /
+  `soundscape` / `music` per #190 partial closeout.
+- **Audio code-layer research** (PR #274): per-route distinct shapes
+  recommended: SSML enrichment for speech, MIDI event-grid for music, and
+  sensor-style operator-graph for soundscape. This is RFC-routed only, not yet
+  ratified.
+- **Sub-RFC ordering (proposed)** (per #274 §"Suggested follow-ups"):
+  soundscape operator-graph first, MIDI event-grid second, SSML enrichment last.
+- **Implementation slices** (#261): gated on at least one sub-RFC ratification.
 
-> **Audio routes do NOT share a single token shape.** This is the central claim of #274 and the inverse of image's Visual Seed Code framing: speech is text-shaped (script + optional prosody enrichment), music is event-grid-shaped (chords / note timings), soundscape is operator-graph-shaped (deterministic operators over time). Forcing them under one VQ-tokenizer story would re-introduce the category error the image-route correction (RFC-0006 / ADR-0018) just fixed for image. Future work should respect this asymmetry.
+> **Audio routes do NOT share a single token shape.** This is the central claim
+> of #274 and the inverse of image's Visual Seed Code framing: speech is
+> text-shaped (script + optional prosody enrichment), music is event-grid-shaped
+> (chords / note timings), and soundscape is operator-graph-shaped
+> (deterministic operators over time). Forcing them under one VQ-tokenizer story
+> would re-introduce the category error the image-route correction
+> (RFC-0006 / ADR-0018) just fixed for image. Future work should respect this
+> asymmetry.

--- a/docs/codecs/audio.md
+++ b/docs/codecs/audio.md
@@ -79,7 +79,8 @@ tested macOS and Linux targets.
 - Optional ambient layer.
 - Not a music-generation model. Quality is _structurally correct_, not _aesthetically frontier_. The thesis surface is "the LLM plans music; the synth renders the plan."
 - The route-specific plan receipt is recorded in `audioPlan`: motif text/hash,
-  rhythm/key/duration, event-grid step count, chord frequencies, and ambient layer.
+  rhythm/key/duration, event-grid step count, chord frequencies, and ambient
+  layer.
 
 ## Decoder Choices and Why
 

--- a/packages/codec-audio/src/codec.ts
+++ b/packages/codec-audio/src/codec.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import type { AudioRequest, CostUsdReason, RenderCtx } from "@wittgenstein/schemas";
 import { Modality, codecV2 } from "@wittgenstein/schemas";
+import type { AudioPlanManifest, AudioRenderManifest } from "@wittgenstein/schemas";
 import {
   AudioPlanSchema,
   AudioRequestSchema,
@@ -13,7 +14,9 @@ import {
 import { renderSpeechRoute } from "./routes/speech/index.js";
 import { renderSoundscapeRoute } from "./routes/soundscape/index.js";
 import { renderMusicRoute } from "./routes/music/index.js";
+import { resolveAmbientCategory } from "./routes/shared.js";
 import type { AudioArtifact, AudioRoute } from "./types.js";
+import type { AmbientCategory } from "./ambient-adapter.js";
 import { getKokoroDecoder } from "./decoders/kokoro/index.js";
 
 interface AudioCodecLlmService {
@@ -107,6 +110,9 @@ function hashString(value: string): string {
 function hashBytes(value: Uint8Array): string {
   return createHash("sha256").update(value).digest("hex");
 }
+
+const MUSIC_CHORD_FREQUENCIES_HZ = [220, 261.63, 329.63, 392, 440] as const;
+const MUSIC_GRID_STEP_FRAMES = 5_512;
 
 interface WavMeta {
   readonly sampleRateHz: number;
@@ -202,7 +208,9 @@ const ROUTE_KEYWORDS: Record<Exclude<AudioRoute, "speech">, RegExp> = {
 // `ROUTE_KEYWORDS`. If a future PR adds a route to `AudioRouteSchema`
 // without a keyword entry, this type assertion fails the build.
 const _routeKeywordKeysCheck: ReadonlySet<Exclude<AudioRoute, "speech">> = new Set(
-  AudioRouteSchema.options.filter((route): route is Exclude<AudioRoute, "speech"> => route !== "speech"),
+  AudioRouteSchema.options.filter(
+    (route): route is Exclude<AudioRoute, "speech"> => route !== "speech",
+  ),
 );
 void (_routeKeywordKeysCheck satisfies ReadonlySet<keyof typeof ROUTE_KEYWORDS>);
 
@@ -266,6 +274,95 @@ function isAmbientCategory(value: unknown): value is AudioPlan["ambient"]["categ
     value === "forest" ||
     value === "electronic"
   );
+}
+
+function buildAudioPlanReceipt(options: {
+  readonly plan: AudioPlan;
+  readonly route: AudioRoute;
+  readonly audioRender: AudioRenderManifest;
+  readonly seed: number | null;
+  readonly backend: "procedural-audio-runtime" | "Kokoro-82M-family-decoder";
+}): AudioPlanManifest {
+  const { plan, route, audioRender, seed, backend } = options;
+  if (route === "speech") {
+    return {
+      route,
+      script: plan.script,
+      scriptSha256: hashString(plan.script),
+      scriptChars: Array.from(plan.script).length,
+      voice: plan.voice,
+      prosody: {
+        tone: plan.voice.tone,
+        language: plan.voice.language,
+      },
+      timing: {
+        durationSec: audioRender.durationSec,
+        timelineEvents: plan.timeline.length,
+      },
+      ambient: {
+        category: resolveAmbientCategory(plan, plan.script),
+        level: plan.ambient.level,
+      },
+      backend,
+    };
+  }
+
+  if (route === "soundscape") {
+    const resolvedCategory = resolveAmbientCategory(plan, `${plan.script} ${plan.music.motif}`);
+    const effectiveCategory = resolvedCategory === "silence" ? "forest" : resolvedCategory;
+    const filter = ambientFilterForCategory(effectiveCategory);
+    return {
+      route,
+      operatorGraph: {
+        source: "procedural-ambient",
+        category: effectiveCategory,
+        seed,
+        nodes:
+          filter.type === "low-pass"
+            ? [`ambient:${effectiveCategory}`, `filter:${filter.type}`]
+            : [`ambient:${effectiveCategory}`],
+      },
+      envelope: {
+        durationSec: audioRender.durationSec,
+        level: plan.ambient.level,
+      },
+      filter,
+    };
+  }
+
+  const resolvedCategory = resolveAmbientCategory(plan, `${plan.script} ${plan.music.motif}`);
+  const stepSec = MUSIC_GRID_STEP_FRAMES / audioRender.sampleRateHz;
+  return {
+    route,
+    motif: plan.music.motif,
+    motifSha256: hashString(plan.music.motif),
+    rhythm: {
+      bpm: plan.music.bpm,
+      key: plan.music.key,
+      durationSec: audioRender.durationSec,
+    },
+    eventGrid: {
+      stepSec,
+      steps: Math.max(1, Math.ceil(audioRender.durationSec / stepSec)),
+    },
+    chord: {
+      frequenciesHz: [...MUSIC_CHORD_FREQUENCIES_HZ],
+    },
+    ambient: {
+      category: resolvedCategory,
+      level: plan.ambient.level * 0.8,
+    },
+  };
+}
+
+function ambientFilterForCategory(
+  category: AmbientCategory,
+): { type: "none" } | { type: "low-pass"; alpha: number } {
+  if (category === "rain") return { type: "low-pass", alpha: 0.24 };
+  if (category === "wind") return { type: "low-pass", alpha: 0.12 };
+  if (category === "city") return { type: "low-pass", alpha: 0.3 };
+  if (category === "forest") return { type: "low-pass", alpha: 0.35 };
+  return { type: "none" };
 }
 
 export class AudioCodec extends codecV2.BaseCodec<AudioRequest, AudioArtifact> {
@@ -409,6 +506,13 @@ export class AudioCodec extends codecV2.BaseCodec<AudioRequest, AudioArtifact> {
       decoderId,
       decoderHash,
     };
+    const audioPlan = buildAudioPlanReceipt({
+      plan: payload.plan,
+      route,
+      audioRender,
+      seed: ctx.seed,
+      backend: slot,
+    });
 
     return {
       outPath: artifactPath,
@@ -437,6 +541,7 @@ export class AudioCodec extends codecV2.BaseCodec<AudioRequest, AudioArtifact> {
           },
         },
         audioRender,
+        audioPlan,
         decoderHash: {
           value: decoderHash,
           frozen: true,
@@ -458,6 +563,7 @@ export class AudioCodec extends codecV2.BaseCodec<AudioRequest, AudioArtifact> {
     return [
       { key: "route", value: art.metadata.route },
       { key: "audioRender", value: art.metadata.audioRender },
+      { key: "audioPlan", value: art.metadata.audioPlan },
       { key: "quality.structural", value: art.metadata.quality.structural },
       { key: "quality.partial", value: art.metadata.quality.partial },
       { key: "metadata.warnings", value: art.metadata.warnings.length },

--- a/packages/codec-audio/src/types.ts
+++ b/packages/codec-audio/src/types.ts
@@ -1,4 +1,9 @@
-import type { AudioRenderManifest, CostUsdReason, codecV2 } from "@wittgenstein/schemas";
+import type {
+  AudioPlanManifest,
+  AudioRenderManifest,
+  CostUsdReason,
+  codecV2,
+} from "@wittgenstein/schemas";
 import type { AudioPlan } from "./schema.js";
 
 export type AudioRoute = "speech" | "soundscape" | "music";
@@ -26,6 +31,7 @@ export interface AudioArtifactMetadata extends codecV2.BaseArtifactMetadata {
     };
   };
   readonly audioRender: AudioRenderManifest;
+  readonly audioPlan: AudioPlanManifest;
   readonly decoderHash: {
     readonly value: string;
     readonly frozen: true;

--- a/packages/codec-audio/test/codec.test.ts
+++ b/packages/codec-audio/test/codec.test.ts
@@ -68,6 +68,31 @@ describe("@wittgenstein/codec-audio", () => {
       determinismClass: "byte-parity",
       decoderId: "procedural-audio-runtime",
     });
+    expect(art.metadata.audioPlan).toMatchObject({
+      route: "speech",
+      script: "Wittgenstein ships a hackathon-ready audio demo.",
+      scriptChars: 48,
+      voice: {
+        speaker: "neutral",
+        tone: "clear",
+        language: "en",
+      },
+      prosody: {
+        tone: "clear",
+        language: "en",
+      },
+      timing: {
+        timelineEvents: 0,
+      },
+      ambient: {
+        category: "rain",
+        level: 0.22,
+      },
+      backend: "procedural-audio-runtime",
+    });
+    expect(art.metadata.audioPlan.route).toBe(art.metadata.route);
+    expect(art.metadata.audioPlan.scriptSha256).toHaveLength(64);
+    expect(art.metadata.audioPlan.timing.durationSec).toBeGreaterThan(0);
     expect(art.metadata.warnings).toEqual([
       expect.objectContaining({
         code: "audio/route-deprecated",
@@ -118,6 +143,26 @@ describe("@wittgenstein/codec-audio", () => {
     );
 
     expect(art.metadata.route).toBe("music");
+    expect(art.metadata.audioPlan).toMatchObject({
+      route: "music",
+      motif: "A small procedural melody.",
+      rhythm: {
+        bpm: 120,
+        key: "C",
+      },
+      eventGrid: {
+        stepSec: 5_512 / 22_050,
+      },
+      chord: {
+        frequenciesHz: [220, 261.63, 329.63, 392, 440],
+      },
+      ambient: {
+        level: 0.17600000000000002,
+      },
+    });
+    expect(art.metadata.audioPlan.route).toBe(art.metadata.route);
+    expect(art.metadata.audioPlan.motifSha256).toHaveLength(64);
+    expect(art.metadata.audioPlan.eventGrid.steps).toBeGreaterThan(0);
     expect(art.metadata.warnings).toEqual([
       expect.objectContaining({
         code: "audio/route-deprecated",
@@ -207,6 +252,24 @@ describe("@wittgenstein/codec-audio", () => {
     );
 
     expect(art.metadata.route).toBe("soundscape");
+    expect(art.metadata.audioPlan).toMatchObject({
+      route: "soundscape",
+      operatorGraph: {
+        source: "procedural-ambient",
+        category: "rain",
+        seed: 7,
+        nodes: ["ambient:rain", "filter:low-pass"],
+      },
+      envelope: {
+        level: 0.22,
+      },
+      filter: {
+        type: "low-pass",
+        alpha: 0.24,
+      },
+    });
+    expect(art.metadata.audioPlan.route).toBe(art.metadata.route);
+    expect(art.metadata.audioPlan.envelope.durationSec).toBeGreaterThan(0);
     expect(art.metadata.warnings).toEqual([]);
     expect(warnings).toEqual([]);
   });

--- a/packages/codec-audio/test/parity.test.ts
+++ b/packages/codec-audio/test/parity.test.ts
@@ -127,6 +127,7 @@ function expectStableAudioRender(
       decoderId: "procedural-audio-runtime",
     });
     expect(run.art.metadata.audioRender.durationSec).toBeGreaterThan(0);
+    expect(run.art.metadata.audioPlan.route).toBe(route);
     expect(run.art.metadata.quality.structural).toEqual({
       schemaValidated: true,
       route,
@@ -137,6 +138,7 @@ function expectStableAudioRender(
     });
     expect(manifestRows.route).toBe(route);
     expect(manifestRows.audioRender).toEqual(run.art.metadata.audioRender);
+    expect(manifestRows.audioPlan).toEqual(run.art.metadata.audioPlan);
     expect(manifestRows["artifact.sha256"]).toBe(run.sha256);
   }
 }

--- a/packages/schemas/src/manifest.ts
+++ b/packages/schemas/src/manifest.ts
@@ -1,5 +1,81 @@
 import { z } from "zod";
 
+const AudioRouteSchema = z.enum(["speech", "soundscape", "music"]);
+const AudioAmbientCategorySchema = z.enum([
+  "auto",
+  "silence",
+  "rain",
+  "wind",
+  "city",
+  "forest",
+  "electronic",
+]);
+
+export const AudioPlanManifestSchema = z.discriminatedUnion("route", [
+  z.object({
+    route: z.literal("speech"),
+    script: z.string(),
+    scriptSha256: z.string(),
+    scriptChars: z.number().int().nonnegative(),
+    voice: z.object({
+      speaker: z.string(),
+      tone: z.string(),
+      language: z.string(),
+    }),
+    prosody: z.object({
+      tone: z.string(),
+      language: z.string(),
+    }),
+    timing: z.object({
+      durationSec: z.number().positive(),
+      timelineEvents: z.number().int().nonnegative(),
+    }),
+    ambient: z.object({
+      category: AudioAmbientCategorySchema,
+      level: z.number().min(0).max(1),
+    }),
+    backend: z.enum(["procedural-audio-runtime", "Kokoro-82M-family-decoder"]),
+  }),
+  z.object({
+    route: z.literal("soundscape"),
+    operatorGraph: z.object({
+      source: z.literal("procedural-ambient"),
+      category: AudioAmbientCategorySchema,
+      seed: z.number().int().nullable(),
+      nodes: z.array(z.string()).min(1),
+    }),
+    envelope: z.object({
+      durationSec: z.number().positive(),
+      level: z.number().min(0).max(1),
+    }),
+    filter: z.object({
+      type: z.enum(["none", "low-pass"]),
+      alpha: z.number().positive().max(1).optional(),
+    }),
+  }),
+  z.object({
+    route: z.literal("music"),
+    motif: z.string(),
+    motifSha256: z.string(),
+    rhythm: z.object({
+      bpm: z.number().positive(),
+      key: z.string(),
+      durationSec: z.number().positive(),
+    }),
+    eventGrid: z.object({
+      stepSec: z.number().positive(),
+      steps: z.number().int().positive(),
+    }),
+    chord: z.object({
+      frequenciesHz: z.array(z.number().positive()).min(1),
+    }),
+    ambient: z.object({
+      category: AudioAmbientCategorySchema,
+      level: z.number().min(0).max(1),
+    }),
+  }),
+]);
+
 export const AudioRenderManifestSchema = z.object({
   sampleRateHz: z.number().int().positive(),
   channels: z.number().int().positive(),
@@ -39,7 +115,6 @@ export const VideoRenderManifestSchema = z
     }
   });
 
-const AudioRouteSchema = z.enum(["speech", "soundscape", "music"]);
 const ImageRouteSchema = z.enum(["raster"]);
 const SensorRouteSchema = z.enum(["ecg", "temperature", "gyro"]);
 const VideoRouteSchema = z.enum(["hyperframes-mp4", "hyperframes-html"]);
@@ -113,6 +188,7 @@ export const RunManifestSchema = z
     artifactSha256: z.string().nullable(),
     artifactSidecars: z.array(ArtifactSidecarSchema).optional(),
     audioRender: AudioRenderManifestSchema.optional(),
+    audioPlan: AudioPlanManifestSchema.optional(),
     videoRender: VideoRenderManifestSchema.optional(),
 
     /**
@@ -174,6 +250,35 @@ export const RunManifestSchema = z
           message: `Audio manifests must use one of: ${AudioRouteSchema.options.join(", ")}.`,
         });
       }
+    }
+
+    if (manifest.codec === "audio" && manifest.ok && manifest.audioRender === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["audioRender"],
+        message: "Successful audio manifests must record audioRender receipts.",
+      });
+    }
+
+    if (manifest.codec === "audio" && manifest.ok && manifest.audioPlan === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["audioPlan"],
+        message: "Successful audio manifests must record route-specific audioPlan receipts.",
+      });
+    }
+
+    if (
+      manifest.codec === "audio" &&
+      manifest.route !== undefined &&
+      manifest.audioPlan !== undefined &&
+      manifest.route !== manifest.audioPlan.route
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["audioPlan", "route"],
+        message: "Audio manifests must keep route and audioPlan.route in sync.",
+      });
     }
 
     if (manifest.codec === "image" && manifest.route !== undefined) {
@@ -256,6 +361,7 @@ export const RunManifestSchema = z
   });
 
 export type AudioRenderManifest = z.infer<typeof AudioRenderManifestSchema>;
+export type AudioPlanManifest = z.infer<typeof AudioPlanManifestSchema>;
 export type VideoRenderManifest = z.infer<typeof VideoRenderManifestSchema>;
 export type ArtifactSidecar = z.infer<typeof ArtifactSidecarSchema>;
 export type LicenseManifest = z.infer<typeof LicenseManifestSchema>;

--- a/packages/schemas/test/contract.test.ts
+++ b/packages/schemas/test/contract.test.ts
@@ -177,9 +177,7 @@ describe("@wittgenstein/schemas", () => {
     expect(parsed.success).toBe(false);
     if (!parsed.success) {
       expect(parsed.error.issues).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ path: ["videoRender", "renderPath"] }),
-        ]),
+        expect.arrayContaining([expect.objectContaining({ path: ["videoRender", "renderPath"] })]),
       );
     }
   });
@@ -252,6 +250,41 @@ describe("@wittgenstein/schemas", () => {
     });
 
     expect(parsed.success).toBe(false);
+  });
+
+  it("requires route-specific audioPlan receipts on successful audio manifests (Issue #261)", () => {
+    const parsed = RunManifestSchema.safeParse({
+      ...audioManifestFields("speech"),
+      audioPlan: undefined,
+    });
+
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.issues).toEqual(
+        expect.arrayContaining([expect.objectContaining({ path: ["audioPlan"] })]),
+      );
+    }
+  });
+
+  it("rejects mismatched audio route and audioPlan route (Issue #261)", () => {
+    const parsed = RunManifestSchema.safeParse({
+      ...audioManifestFields("speech"),
+      audioPlan: audioPlanReceipt("music"),
+    });
+
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.issues).toEqual(
+        expect.arrayContaining([expect.objectContaining({ path: ["audioPlan", "route"] })]),
+      );
+    }
+  });
+
+  it("accepts canonical route-specific audioPlan receipts (Issue #261)", () => {
+    for (const route of ["speech", "soundscape", "music"] as const) {
+      const parsed = RunManifestSchema.safeParse(audioManifestFields(route));
+      expect(parsed.success).toBe(true);
+    }
   });
 
   it("rejects invalid image routes (Issue #190)", () => {
@@ -623,6 +656,116 @@ describe("@wittgenstein/schemas", () => {
     error: null,
   });
 
+  const audioManifestFields = (route: "speech" | "soundscape" | "music") => ({
+    runId: `run-audio-route-${route}`,
+    gitSha: "abc123",
+    lockfileHash: "def456",
+    nodeVersion: process.version,
+    wittgensteinVersion: "0.0.0",
+    command: "wittgenstein audio",
+    args: ["hello"],
+    seed: 7,
+    codec: "audio",
+    route,
+    license: { weightsRestriction: "permissive" },
+    llmProvider: "anthropic",
+    llmModel: "claude-opus-4-7",
+    llmTokens: { input: 10, output: 20 },
+    costUsd: 0,
+    promptRaw: "hello",
+    promptExpanded: "hello",
+    llmOutputRaw: "{}",
+    llmOutputParsed: {},
+    artifactPath: "/tmp/out.wav",
+    artifactSha256: "sha256",
+    audioRender: {
+      sampleRateHz: 22_050,
+      channels: 1,
+      durationSec: 3,
+      container: "wav",
+      bitDepth: 16,
+      determinismClass: "byte-parity",
+      decoderId: "procedural-audio-runtime",
+      decoderHash: "sha256-placeholder",
+    },
+    audioPlan: audioPlanReceipt(route),
+    startedAt: new Date().toISOString(),
+    durationMs: 10,
+    ok: true,
+    error: null,
+  });
+
+  const audioPlanReceipt = (route: "speech" | "soundscape" | "music") => {
+    if (route === "speech") {
+      return {
+        route,
+        script: "hello",
+        scriptSha256: "sha256-placeholder",
+        scriptChars: 5,
+        voice: {
+          speaker: "neutral",
+          tone: "clear",
+          language: "en",
+        },
+        prosody: {
+          tone: "clear",
+          language: "en",
+        },
+        timing: {
+          durationSec: 3,
+          timelineEvents: 0,
+        },
+        ambient: {
+          category: "rain",
+          level: 0.22,
+        },
+        backend: "procedural-audio-runtime",
+      };
+    }
+
+    if (route === "soundscape") {
+      return {
+        route,
+        operatorGraph: {
+          source: "procedural-ambient",
+          category: "forest",
+          seed: 7,
+          nodes: ["ambient:forest", "filter:low-pass"],
+        },
+        envelope: {
+          durationSec: 3,
+          level: 0.22,
+        },
+        filter: {
+          type: "low-pass",
+          alpha: 0.35,
+        },
+      };
+    }
+
+    return {
+      route,
+      motif: "minimal",
+      motifSha256: "sha256-placeholder",
+      rhythm: {
+        bpm: 120,
+        key: "C",
+        durationSec: 3,
+      },
+      eventGrid: {
+        stepSec: 5_512 / 22_050,
+        steps: 13,
+      },
+      chord: {
+        frequenciesHz: [220, 261.63, 329.63, 392, 440],
+      },
+      ambient: {
+        category: "electronic",
+        level: 0.176,
+      },
+    };
+  };
+
   const videoManifestFields = (route: string) => ({
     runId: `run-video-route-${route}`,
     gitSha: "abc123",
@@ -650,7 +793,9 @@ describe("@wittgenstein/schemas", () => {
       backend: "distilled-internal",
       backendVersion: "internal",
       determinismClass:
-        route === "hyperframes-html" ? "byte-parity-on-platform" : "structural-parity-cross-platform",
+        route === "hyperframes-html"
+          ? "byte-parity-on-platform"
+          : "structural-parity-cross-platform",
       fps: 24,
       quality: "standard",
       frameCount: route === "hyperframes-html" ? 0 : 72,


### PR DESCRIPTION
Closes #261.

## Summary

- adds `AudioPlanManifestSchema` and `RunManifest.audioPlan` for route-specific audio plan receipts
- emits `audioPlan` from `@wittgenstein/codec-audio` alongside the existing `audioRender` backend/WAV receipt
- records route-specific evidence:
  - speech: script text/hash, voice/prosody, timing, ambient, backend
  - soundscape: procedural operator graph, effective ambient category, seed, envelope, filter
  - music: motif text/hash, rhythm/key/duration, event-grid, chord frequencies, ambient layer
- requires successful audio manifests to include both `audioRender` and `audioPlan`, and keeps manifest route in sync with `audioPlan.route`
- updates docs to describe `audioPlan` and fixes the stale soundscape "stereo" wording to current mono WAV behavior

## Guardrail note

This is execution/drift correction for #261 and #274, not new doctrine. It preserves the existing ADR-0005 decoder/generator boundary, ADR-0008 codec protocol, ADR-0015 speech backend target, and the RFC-0006 / ADR-0018 image-route boundary referenced in the audio docs.

## Self-review

- This does not rewrite M2 audio routes, add neural generation, or reopen Kokoro/Piper defaults.
- `audioRender` remains the backend/WAV receipt; `audioPlan` is separate so plan inspection does not overload renderer fields.
- The shared schema is narrow and product-consumed by `RunManifest`; research-only fixtures remain outside `packages/schemas`.
- Route-specific validation already existed for bad routes and deprecation warnings; this PR adds the missing route-specific receipt surface.
- Reviewdog MD013 comments on the lineage table were addressed by converting that block to wrapped list prose; added Markdown lines now stay within 80 columns.

## Validation

- `pnpm install --frozen-lockfile --offline`
- `pnpm --filter @wittgenstein/schemas typecheck && pnpm --filter @wittgenstein/schemas test -- contract.test.ts`
- `pnpm --filter @wittgenstein/codec-audio typecheck && pnpm --filter @wittgenstein/codec-audio test`
- `pnpm exec prettier --check packages/schemas/src/manifest.ts packages/schemas/test/contract.test.ts packages/codec-audio/src/types.ts packages/codec-audio/src/codec.ts packages/codec-audio/test/codec.test.ts packages/codec-audio/test/parity.test.ts docs/codecs/audio.md`
- `pnpm exec prettier --check docs/codecs/audio.md`
- `git diff --check`
- `git diff --check origin/main...HEAD`
- `typos --config typos.toml docs/codecs/audio.md packages/schemas/src/manifest.ts packages/schemas/test/contract.test.ts packages/codec-audio/src/codec.ts packages/codec-audio/test/codec.test.ts packages/codec-audio/test/parity.test.ts`
- `typos --config typos.toml docs/codecs/audio.md`
- `git diff origin/main...HEAD -- docs/codecs/audio.md | awk '/^\\+[^+]/ && length($0)>81 { bad=1; print } END { exit bad }'`
- `pnpm lint:deps && pnpm lint:publish-surface`
- `pnpm typecheck && pnpm test && pnpm build`
- `pnpm lint`
- `pnpm format:check`
- CLI smoke: `pnpm --filter @wittgenstein/cli exec wittgenstein audio "Forest rain ambience with a soft morning texture." --dry-run --out artifacts/tmp/audio-plan-smoke.wav --seed 7 --config /dev/null` produced a successful manifest containing `audioRender` plus soundscape `audioPlan` (`operatorGraph.category=rain`, `seed=7`, `filter.alpha=0.24`); temporary artifact/run directory removed after inspection.