### PR TITLE
docs(training): decide image adapter placement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,9 @@ jobs:
       - name: Python unit tests (polyglot-mini/train)
         run: python -m unittest discover -s polyglot-mini/train -p 'test_*.py' -v
 
+      - name: Install Python deps (image adapter NumPy smoke)
+        run: python -m pip install "numpy>=1.26.0"
+
       - name: Python compile (image adapter)
         run: python -m compileall python/image_adapter
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
               - "fixtures/**"
               - "benchmarks/**"
               - "examples/**"
+              - "python/**"
+              - "data/image_adapter/**"
               - "research/**"
               - "package.json"
               - "pnpm-lock.yaml"
@@ -123,6 +125,12 @@ jobs:
 
       - name: Python unit tests (polyglot-mini/train)
         run: python -m unittest discover -s polyglot-mini/train -p 'test_*.py' -v
+
+      - name: Python compile (image adapter)
+        run: python -m compileall python/image_adapter
+
+      - name: Python unit tests (image adapter NumPy smoke)
+        run: python -m unittest discover -s python/image_adapter -p 'test_*.py' -v
 
       - name: Python smoke (sensor + image + platform-aware tts)
         env:

--- a/.github/workflows/review-request-ml-expert.yml
+++ b/.github/workflows/review-request-ml-expert.yml
@@ -45,6 +45,15 @@ jobs:
               return;
             }
 
+            const author = context.payload.pull_request.user?.login;
+            if (author === reviewer) {
+              core.info(
+                `PR #${pull_number} is authored by "${reviewer}"; ` +
+                  "skipping self-review request.",
+              );
+              return;
+            }
+
             const { data: requested } = await github.rest.pulls.listRequestedReviewers({
               owner,
               repo,

--- a/docs/research/2026-05-13-delivery-and-componentization.md
+++ b/docs/research/2026-05-13-delivery-and-componentization.md
@@ -168,14 +168,16 @@ python -m pip install -r requirements.txt    # the heavy stack
 wittgenstein train-sweep configs/phase1-ablation.yaml
 ```
 
-Tier 3 is the elite infra. It does NOT live under `packages/*` — it
-lives under `research/training/`, with its own `requirements.txt`,
-its own Dockerfile, its own dataset pipeline. **`research/` is
-explicitly excluded from npm publish** (via package.json `files`).
+Tier 3 is the elite infra. It does NOT live under `packages/*` — its canonical
+GPU home is `research/training/`, with its own `requirements.txt`, its own
+Dockerfile, its own dataset pipeline. `python/image_adapter/` is the narrow
+M1B scene-spec-to-VQ-latent MLP bridge surface, kept separate while it remains
+a small adapter/parity lane. **`research/` and `python/` are explicitly
+excluded from npm publish**.
 
-A user pip-installs `@wittgenstein/cli` and gets ZERO PyTorch in their
-dep tree. A contributor explicitly enters `research/training/` to
-pick up the heavy stack.
+A user pip-installs `@wittgenstein/cli` and gets ZERO PyTorch in their dep
+tree. A contributor explicitly enters `research/training/` for the heavy
+stack, or `python/image_adapter/` for the narrow scene-latent MLP bridge.
 
 ### Audience 5 — maintainer
 
@@ -273,16 +275,17 @@ Output: a markdown report (one page) with pass/fail per modality, a
 table of receipts, and citations into the research / ADR docs. Time
 budget: ≤ 5 minutes on a 2024-era laptop, no GPU required.
 
-### 6. `research/training/` strictly outside npm publish
+### 6. Training/research Python strictly outside npm publish
 
-`packages/*/package.json` already declares a `files` whitelist that
-excludes `research/`. This needs to remain the explicit invariant:
+`packages/*/package.json` already declares a `files` whitelist that excludes
+training/research Python surfaces. This needs to remain the explicit
+invariant:
 
-- No package ever imports from `research/training/`.
+- No package ever imports from `research/training/` or `python/image_adapter/`.
 - Training scripts may import from `packages/*` (one-way dep, contributor
   uses the harness inside training jobs).
-- npm publish never includes `research/`, `bench/`, `examples/`, or any
-  GB-class artifact.
+- npm publish never includes `research/`, `python/`, `benchmarks/`,
+  `examples/`, or any GB-class artifact.
 
 A small CI check can guard this — a script that diffs the npm `tarball`
 contents against an expected-files manifest and fails on drift.
@@ -327,7 +330,7 @@ spine/replay/cold-checkout):
 | **Optional/peer deps for heavy runtimes** | Tier discipline at the npm layer | new tracker |
 | **`wittgenstein install <tier>` CLI + doctor tier readiness** | User-visible tier surface | new tracker |
 | **`examples/reviewer-bench/`** | Reviewer one-command verification | new tracker |
-| **`research/training/` isolation from npm publish** | Doctrine: contributor stack ≠ user stack | new tracker |
+| **Training Python isolation** | Contributor stack stays out of user stack | new tracker |
 | **Per-tier `wittgenstein doctor` info** | Compass for what's possible | rolled into install-CLI tracker |
 | **Public benchmark page** | Tier 4, auto-generated | Phase 2 |
 | **Latency budgets in CI** | Catch performance regressions | future |
@@ -358,7 +361,7 @@ spine/replay/cold-checkout):
 | 2 | **`wittgenstein install <tier>` CLI + doctor tier readiness** | The user-visible install surface |
 | 3 | **Optional/peer-dep declarations for heavy runtimes** | Tier discipline at the npm dep layer |
 | 4 | **`examples/reviewer-bench/` reviewer one-command verification** | The reviewer surface |
-| 5 | **`research/training/` isolation + npm-publish guard** | Doctrine: contributor stack stays out of user stack |
+| 5 | **Training Python isolation + npm guard** | Contributor stack stays out of user stack |
 
 Each is sized small/medium. None require GPU compute to implement; all
 are pure engineering. They unblock the user/reviewer surfaces in
@@ -369,7 +372,7 @@ parallel with the Phase 1 training work, not after it.
 | Question | Answer |
 |---|---|
 | Does the elite infra ship to every user? | **No.** Tier 0 stays tiny. |
-| Does the elite infra exist in the project? | **Yes.** Under `research/training/`, with its own dep stack. |
+| Does the elite infra exist in the project? | **Yes.** See the placement decision above. |
 | Where do the **published benchmark numbers** come from? | **The elite tier.** GPU canonical, full ablation matrix, own-trained models. No compromises on the headline number. |
 | Does the user pay for the elite infra they don't use? | **No.** Lazy fetch + peer deps + tiered installer. |
 | Does the reviewer need GPU to verify? | **No.** `examples/reviewer-bench/` runs on a laptop in 5 minutes — verifies engineering claims (manifests, replay, receipts). For the **quality** claim, the reviewer reads the published benchmark page (Tier 4 artifact) — they don't have to re-run it. |

--- a/docs/research/2026-05-31-training-homes-decision.md
+++ b/docs/research/2026-05-31-training-homes-decision.md
@@ -1,0 +1,88 @@
+---
+date: 2026-05-31
+status: issue #519 placement decision
+labels: [research-derived, governance, training, ci]
+tracks: [#519, #507, #518, #441, #435]
+---
+
+# Training Homes Placement Decision
+
+Issue #519 found a real tree-shape inconsistency: the doctrine named
+`research/training/` as the training home, while the M1B adapter work added
+`python/image_adapter/`. The fix is not a move today. The fix is to name the
+two surfaces, constrain them, and add the missing CI floor.
+
+## Decision
+
+Keep both directories for now, with different names and different authority.
+
+`research/training/` is the canonical Phase-1 training home. It owns GPU
+tokenizer work, the learned seed-code adapter, the native image-emitting LLM
+head, shared training manifests, lab execution, and eval helpers.
+
+`python/image_adapter/` is a narrow M1B image-adapter bridge. It owns the
+scene-spec-to-discrete-latent MLP, tiny data-prep scripts, PyTorch/NumPy
+parity, and local bridge experiments.
+
+The phrase "adapter training" is now ambiguous unless it includes the path:
+
+- `research/training/adapter/` means the learned MaskGIT-style L4 seed-code
+  adapter.
+- `python/image_adapter/` means the scene-spec-to-VQ-latent MLP bridge.
+
+This preserves the existing M1B adapter work without blessing `python/` as a
+second general training tree.
+
+## Why Not Move It Now
+
+A directory move would be mostly churn today:
+
+- `python/image_adapter/` already has data-prep scripts, env docs, and runtime
+  handoff names used by the current image-adapter demo path.
+- #518 already fenced `python/` out of the npm tarball, so there is no current
+  publish-surface leak.
+- The ongoing model-training work should not be interrupted by a cosmetic
+  placement migration.
+
+Moving becomes correct only if the surface grows into shared manifests, common
+datasets, lab execution, or multi-GPU training. At that point, move or split the
+grown part into `research/training/image-adapter/` through a focused PR.
+
+## CI Floor
+
+The missing engineering floor was real. `python/image_adapter/train_numpy.py`
+claimed to be good for CI, but CI did not run it. The minimum lane is now:
+
+```bash
+python3 -m compileall python/image_adapter
+python3 -m unittest discover -s python/image_adapter -p 'test_*.py' -v
+```
+
+The smoke uses a synthetic four-row encoded dataset and verifies that
+`train_numpy.py` exports the `witt.image.adapter.mlp/v0.1` JSON contract:
+version, codebook metadata, token grid, hidden/input dimensions, and flattened
+weight shapes. It does not claim PyTorch training, real image data, or quality
+metrics.
+
+CI also treats `python/**` and `data/image_adapter/**` as code-scope changes,
+so edits to this surface no longer bypass the Node/Python verification job.
+
+## Publish Boundary
+
+`python/image_adapter/` follows the same one-way rule as `research/training/`:
+
+```text
+training/research Python  --may import-->  packages/<pkg>/src/
+packages/<pkg>/src/       --must not---->  training/research Python
+```
+
+The publish guard already blocks `research/`, `python/`, `polyglot-mini/`,
+`benchmarks/`, `examples/`, and heavyweight model artifacts from npm tarballs.
+The import guard now also rejects package-source imports from `python/`, not
+only `research/`.
+
+## Closeout
+
+#519 can close when this decision, the README cross-links, the CI scope update,
+the NumPy smoke, and the import-guard widening land together. No model
+training, lab run, or directory migration is required for this closeout.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lint:publish-surface": "pnpm lint:no-research-imports && pnpm lint:npm-publish-tarball",
     "test": "pnpm -r test",
     "test:golden": "pnpm -r --filter \"./packages/codec-*\" --if-present run test:golden",
+    "test:image-adapter": "python3 python/image_adapter/test_train_numpy_smoke.py",
     "sweep:audio-kokoro": "tsx scripts/audio-kokoro-sweep.ts",
     "launch:check": "pnpm typecheck && pnpm --filter @wittgenstein/codec-audio test && pnpm --filter @wittgenstein/codec-sensor test",
     "benchmark": "node --import tsx benchmarks/harness.ts",

--- a/python/image_adapter/README.md
+++ b/python/image_adapter/README.md
@@ -1,6 +1,21 @@
 # Image adapter (Python)
 
+Status: recognized narrow training surface for #519. It is intentionally
+separate from `research/training/` while it remains a scene-spec-to-VQ-latent
+MLP bridge with small parity scripts. It is not a second generic training
+home.
+
 Trains a **small MLP** that maps a canonical `ImageSceneSpec` (JSON, no `providerLatents`) to discrete latent indices. No LLM fine-tuning.
+
+Naming boundary:
+
+- `python/image_adapter/`: scene-spec-to-discrete-latent MLP bridge.
+- `research/training/adapter/`: learned MaskGIT-style L4 seed-code adapter.
+
+If this surface grows into shared manifests, lab/GPU execution, or a common
+Phase-1 dataset pipeline, move or split that grown part under
+`research/training/image-adapter/` instead of letting `python/` become a
+second training tree.
 
 ## Requirements
 
@@ -21,6 +36,17 @@ Apple Silicon: PyTorch uses MPS when available.
 | `eval_all.py` | one-shot runner: token metrics + spectrum health checks |
 | `spectrum_check.py` | singular-value spectrum + effective-rank health checks for adapter weights (detect rank-collapse) |
 | `build_natural_dataset.py` | optional: generate or download a larger, category-bounded dataset |
+
+CI owns only the stdlib compile pass plus the pure-NumPy smoke:
+
+```bash
+python3 -m compileall python/image_adapter
+python3 -m unittest discover -s python/image_adapter -p 'test_*.py' -v
+```
+
+That proves the exported `witt.image.adapter.mlp/v0.1` JSON contract stays
+loadable. It does not claim the PyTorch trainer, real dataset build, or model
+quality gate has run.
 
 ## Environment (runtime)
 

--- a/python/image_adapter/test_train_numpy_smoke.py
+++ b/python/image_adapter/test_train_numpy_smoke.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+def _scene(index: int) -> dict:
+    return {
+        "kind": "image_scene_spec",
+        "prompt": f"bounded fixture scene {index}",
+        "style": "ci-smoke",
+        "decoder": {
+            "family": "fixture-vqgan",
+            "codebook": "fixture-codebook",
+            "codebookVersion": "ci-smoke-v1",
+            "latentResolution": [2, 2],
+        },
+    }
+
+
+class TrainNumpySmokeTest(unittest.TestCase):
+    def test_train_numpy_exports_mlp_json_contract(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            data_path = tmpdir / "encoded.jsonl"
+            out_path = tmpdir / "adapter_mlp_numpy.json"
+
+            rows = [
+                {
+                    "image_scene_spec": _scene(i),
+                    "target_tokens": [i % 8, (i + 1) % 8, (i + 2) % 8, (i + 3) % 8],
+                    "codebook_size": 8,
+                }
+                for i in range(4)
+            ]
+            data_path.write_text(
+                "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+                encoding="utf-8",
+            )
+
+            script = Path(__file__).with_name("train_numpy.py")
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(script),
+                    "--data",
+                    str(data_path),
+                    "--out",
+                    str(out_path),
+                    "--epochs",
+                    "2",
+                    "--batch-size",
+                    "2",
+                    "--hidden",
+                    "8",
+                    "--seed",
+                    "7",
+                ],
+                check=True,
+                text=True,
+                capture_output=True,
+            )
+
+            payload = json.loads(out_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(payload["version"], "witt.image.adapter.mlp/v0.1")
+        self.assertEqual(payload["codebookSize"], 8)
+        self.assertEqual(payload["tokenGrid"], [2, 2])
+        self.assertEqual(payload["inputDim"], 128)
+        self.assertEqual(payload["hiddenDim"], 8)
+        self.assertEqual(payload["family"], "fixture-vqgan")
+        self.assertEqual(payload["codebook"], "fixture-codebook")
+        self.assertEqual(payload["codebookVersion"], "ci-smoke-v1")
+        self.assertEqual(len(payload["w1"]), 8 * 128)
+        self.assertEqual(len(payload["b1"]), 8)
+        self.assertEqual(len(payload["w2"]), 4 * 8)
+        self.assertEqual(len(payload["b2"]), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/image_adapter/test_train_numpy_smoke.py
+++ b/python/image_adapter/test_train_numpy_smoke.py
@@ -43,27 +43,43 @@ class TrainNumpySmokeTest(unittest.TestCase):
             )
 
             script = Path(__file__).with_name("train_numpy.py")
-            subprocess.run(
-                [
-                    sys.executable,
-                    str(script),
-                    "--data",
-                    str(data_path),
-                    "--out",
-                    str(out_path),
-                    "--epochs",
-                    "2",
-                    "--batch-size",
-                    "2",
-                    "--hidden",
-                    "8",
-                    "--seed",
-                    "7",
-                ],
-                check=True,
-                text=True,
-                capture_output=True,
-            )
+            command = [
+                sys.executable,
+                str(script),
+                "--data",
+                str(data_path),
+                "--out",
+                str(out_path),
+                "--epochs",
+                "2",
+                "--batch-size",
+                "2",
+                "--hidden",
+                "8",
+                "--seed",
+                "7",
+            ]
+            try:
+                result = subprocess.run(
+                    command,
+                    check=False,
+                    text=True,
+                    capture_output=True,
+                    timeout=120,
+                )
+            except subprocess.TimeoutExpired as error:
+                self.fail(
+                    "train_numpy.py timed out "
+                    f"after {error.timeout}s\nstdout:\n{error.stdout or ''}\n"
+                    f"stderr:\n{error.stderr or ''}",
+                )
+
+            if result.returncode != 0:
+                self.fail(
+                    "train_numpy.py failed "
+                    f"with exit {result.returncode}\nstdout:\n{result.stdout}\n"
+                    f"stderr:\n{result.stderr}",
+                )
 
             payload = json.loads(out_path.read_text(encoding="utf-8"))
 

--- a/research/training/README.md
+++ b/research/training/README.md
@@ -1,11 +1,11 @@
 # Wittgenstein training stack
 
-This folder hosts the **GPU training programs** for Wittgenstein-native
-models: tokenizers, learned adapters, and the native LLM head distilled from
-a teacher. It is **not** part of the TypeScript build graph and is **not**
-shipped in any npm tarball. The published packages depend on
-`@wittgenstein/core` and `@wittgenstein/codec-*` only — never on anything
-under `research/`.
+This folder hosts the canonical **GPU training programs** for
+Wittgenstein-native models: tokenizers, learned adapters, and the native LLM
+head distilled from a teacher. It is **not** part of the TypeScript build
+graph and is **not** shipped in any npm tarball. The published packages
+depend on `@wittgenstein/core` and `@wittgenstein/codec-*` only — never on
+anything under `research/` or `python/`.
 
 The directional rule (one-way only):
 
@@ -26,6 +26,29 @@ See the operating doctrine:
 - [docs/research/2026-05-13-m1b-prep-research.md](../../docs/research/2026-05-13-m1b-prep-research.md) — Phase-0 literature floor (LlamaGen, Open-MAGVIT2, TiTok, VAR)
 - [docs/research/2026-05-27-pre-training-readiness.md](../../docs/research/2026-05-27-pre-training-readiness.md) — engineering-readiness audit run right before specialist kickoff (Tier-0 self-check, latent bugs found + fixed, open handoff issues)
 - [docs/contributing/training-setup.md](../../docs/contributing/training-setup.md) — environment setup for contributors
+
+## Relationship to `python/image_adapter/`
+
+`python/image_adapter/` is a recognized but narrow M1B adapter-training
+surface, not a second general home for Phase-1 GPU training. It owns the
+scene-spec-to-VQ-latent MLP bridge and its small NumPy/PyTorch parity
+scripts. This directory remains the canonical home for the larger Phase-1
+GPU programs.
+
+Use the names precisely:
+
+- `research/training/adapter/`: learned MaskGIT-style L4 seed-code adapter.
+- `python/image_adapter/`: scene-spec-to-discrete-latent MLP bridge.
+
+If the image-adapter trainer grows into shared datasets, training manifests,
+or multi-GPU/lab execution, move or split that grown surface under
+`research/training/image-adapter/` through a focused PR. Until then, the
+publish guard and CI smoke cover it as a separate training/research Python
+surface.
+
+See the [training homes placement decision][training-homes-decision] for #519.
+
+[training-homes-decision]: ../../docs/research/2026-05-31-training-homes-decision.md
 
 ## Subprograms
 

--- a/research/training/README.md
+++ b/research/training/README.md
@@ -10,13 +10,13 @@ anything under `research/` or `python/`.
 The directional rule (one-way only):
 
 ```
-research/training/  ──may import──▶  packages/<pkg>/src/
-packages/<pkg>/src/ ──MUST NOT────▶  research/training/
+training/research Python  ──may import──▶  packages/<pkg>/src/
+packages/<pkg>/src/       ──MUST NOT────▶  research/ or python/
 ```
 
 CI enforces the publish surface via
 `scripts/check-npm-publish-tarball.mjs` and prevents
-`packages/*/src` -> `research/` imports via
+`packages/*/src` -> training/research Python imports via
 `scripts/check-no-research-imports.mjs`.
 
 See the operating doctrine:

--- a/scripts/check-no-research-imports.mjs
+++ b/scripts/check-no-research-imports.mjs
@@ -1,15 +1,16 @@
 #!/usr/bin/env node
 // CI guard: verify no file under packages/<pkg>/src/ imports from
-// research/. The training stack lives in research/training/ and MUST
-// stay outside the npm publish surface — packages depend on
-// core/codec-* only, never on training code.
+// training/research Python surfaces. The training stack lives in
+// research/training/ plus the narrow python/image_adapter trainer and MUST
+// stay outside the npm publish surface — packages depend on core/codec-*
+// only, never on training code.
 //
 // Per the delivery doctrine
 // (docs/research/2026-05-13-delivery-and-componentization.md):
 //
 //     Training scripts may import from packages/<pkg> (one-way dep,
 //     contributor uses the harness inside training jobs). No file
-//     under packages/<pkg>/src/ may import from research/.
+//     under packages/<pkg>/src/ may import from training/research Python.
 //
 // Run: node scripts/check-no-research-imports.mjs
 // Exits 0 on clean, 1 on any forbidden import.
@@ -59,28 +60,41 @@ function normalizeRel(path) {
   return path.split("\\").join("/");
 }
 
-function isResearchRel(rel) {
+function isTrainingSurfaceRel(rel) {
   const normalized = normalizeRel(rel);
-  return normalized === "research" || normalized.startsWith("research/");
+  return (
+    normalized === "research" ||
+    normalized.startsWith("research/") ||
+    normalized === "python" ||
+    normalized.startsWith("python/")
+  );
 }
 
-function importsResearch(specifier, filePath) {
-  // Relative imports: resolve and check if the target lands inside research/.
+function importsTrainingSurface(specifier, filePath) {
+  // Relative imports: resolve and check if the target lands inside a
+  // training/research Python surface.
   if (specifier.startsWith(".")) {
     const targetAbs = resolve(dirname(filePath), specifier);
-    return isResearchRel(relative(repoRoot, targetAbs));
+    return isTrainingSurfaceRel(relative(repoRoot, targetAbs));
   }
-  // Absolute import specifiers: catch repo-root `/research/...` imports and
-  // absolute filesystem paths that resolve inside this checkout's research/.
+  // Absolute import specifiers: catch repo-root `/research/...` or
+  // `/python/...` imports and absolute filesystem paths that resolve inside
+  // this checkout's training/research Python surfaces.
   if (specifier.startsWith("/")) {
-    if (specifier === "/research" || specifier.startsWith("/research/")) {
+    if (
+      specifier === "/research" ||
+      specifier.startsWith("/research/") ||
+      specifier === "/python" ||
+      specifier.startsWith("/python/")
+    ) {
       return true;
     }
-    return isResearchRel(relative(repoRoot, specifier));
+    return isTrainingSurfaceRel(relative(repoRoot, specifier));
   }
-  // Package names: look for any hint at "research" — we don't publish a
-  // @wittgenstein/research package, so any such bare specifier is a leak.
-  return /^research\/|^@wittgenstein\/training\//.test(specifier);
+  // Package names: look for any hint at the training surfaces — we don't
+  // publish @wittgenstein/research, @wittgenstein/training, or repo-root
+  // python packages, so any such bare specifier is a leak.
+  return /^research\/|^python\/|^@wittgenstein\/(?:research|training)\//.test(specifier);
 }
 
 async function main() {
@@ -106,7 +120,7 @@ async function main() {
       const text = await readFile(file, "utf8");
       const imports = findImports(text);
       for (const spec of imports) {
-        if (importsResearch(spec, file)) {
+        if (importsTrainingSurface(spec, file)) {
           violations.push({
             file: relative(repoRoot, file),
             spec,
@@ -117,17 +131,22 @@ async function main() {
   }
 
   if (violations.length === 0) {
-    process.stdout.write("✓ no packages/*/src file imports from research/.\n");
+    process.stdout.write(
+      "✓ no packages/*/src file imports from training/research Python surfaces.\n",
+    );
     process.exit(0);
   }
 
-  process.stderr.write(`✗ ${violations.length} forbidden research/ import(s):\n\n`);
+  const violationSummary =
+    `✗ ${violations.length} forbidden training/research ` + "Python import(s):\n\n";
+  process.stderr.write(violationSummary);
   for (const v of violations) {
     process.stderr.write(`  ${v.file}\n    imports: ${v.spec}\n`);
   }
   process.stderr.write(
-    "\nTraining code lives in research/training/ and stays outside the\n" +
-      "npm publish surface. See docs/research/2026-05-13-delivery-and-componentization.md.\n",
+    "\nTraining code lives in research/training/ or python/image_adapter/ and stays\n" +
+      "outside the npm publish surface. See " +
+      "docs/research/2026-05-13-delivery-and-componentization.md.\n",
   );
   process.exit(1);
 }


### PR DESCRIPTION
Closes #519.

## Summary

- documents the #519 placement decision: keep `research/training/` as the canonical Phase-1 GPU training home and recognize `python/image_adapter/` only as the narrow scene-spec-to-VQ-latent MLP bridge
- clarifies the naming collision between `research/training/adapter/` and `python/image_adapter/` in both READMEs and the delivery doctrine
- adds a pure-NumPy CI smoke for `python/image_adapter/train_numpy.py` that generates a synthetic encoded dataset and verifies the exported `witt.image.adapter.mlp/v0.1` JSON contract
- makes `python/**` and `data/image_adapter/**` trigger the Node/Python CI path, and widens the package import guard so `packages/*/src` cannot import repo-root `python/` either

## Self-review

- This intentionally does not move training code or touch active model-training files.
- The decision is conservative: `python/image_adapter/` is documented as a narrow bridge lane, not a second generic training tree; if it grows into manifests, lab execution, or shared datasets, the doc requires a focused move/split into `research/training/image-adapter/`.
- The new test is contract-level and CPU-only. It proves the CI-advertised NumPy path exports the runtime JSON shape, but does not claim PyTorch training, real dataset quality, or lab evidence.
- The import guard and npm publish guard now agree on the boundary: training/research Python surfaces stay outside publish packages.

## Validation

- `pnpm install --frozen-lockfile --offline`
- `git diff --check`
- `python3 -m compileall python/image_adapter && python3 -m unittest discover -s python/image_adapter -p 'test_*.py' -v`
- `pnpm test:image-adapter`
- `pnpm exec prettier --check docs/research/2026-05-31-training-homes-decision.md`
- `pnpm format:check`
- `typos --config typos.toml .github/workflows/ci.yml package.json scripts/check-no-research-imports.mjs docs/research/2026-05-13-delivery-and-componentization.md docs/research/2026-05-31-training-homes-decision.md research/training/README.md python/image_adapter/README.md python/image_adapter/test_train_numpy_smoke.py`
- added-line length sanity on changed files: no added line over 120 chars
- `node scripts/check-no-research-imports.mjs`
- `pnpm lint:publish-surface`
- `pnpm format:check`
- `pnpm lint:deps && pnpm lint:publish-surface`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:golden`
- `pnpm reviewer-bench`
