### PR TITLE
docs(research): close second-pass backlog ledger

### DIFF
--- a/docs/exec-plans/active/v0.3-roadmap.md
+++ b/docs/exec-plans/active/v0.3-roadmap.md
@@ -1,8 +1,8 @@
 # v0.3 Roadmap — index
 
 **Date opened:** 2026-05-04
-**Last refreshed:** 2026-05-26
-**Status:** 🟡 Active as a maintainer-facing truth surface. v0.3 gates are closed; the repo is now in post-alpha.3 M1B owner-review and delivery follow-through, not generic prerelease triage.
+**Last refreshed:** 2026-05-31
+**Status:** 🟡 Active as a maintainer-facing truth surface. v0.3 gates are closed; the repo is now in post-alpha.3 M1B decoder delivery, training-infra review, and release-readiness follow-through, not generic prerelease triage.
 **Engineering source of truth:** [`codec-v2-port.md`](codec-v2-port.md) — that file owns the M-phase contract, current blocker, and rollback criteria. This page is the maintainer-facing index.
 
 ---
@@ -44,25 +44,29 @@ recent delivery / harness / reproducibility foundations landed in PRs #427–#43
 
 Use this split when landing cold:
 
-- **Owner-review hub:** [#435](https://github.com/p-to-q/wittgenstein/issues/435)
-  This is the current maintainer/model-owner pack for `moapacha` + `koriyoshi2041`.
+- **Owner-review map:** [#435](https://github.com/p-to-q/wittgenstein/issues/435)
+  is closed. It assigned the owner-review route and recorded the preferred M1B
+  execution order; it does not mean training or decoder delivery is complete.
 - **Current decoder-delivery decision:** [#402](https://github.com/p-to-q/wittgenstein/issues/402)
   This is the concrete "which decoder-family manifest do we actually bless and fetch"
   question. `#403` stays parked behind it.
 - **Post-merge re-audit ledger:** [#439](https://github.com/p-to-q/wittgenstein/issues/439)
   This is the maintainer loop for merged but lower-confidence implementation blocks.
 - **Second-pass research ledger:** [#440](https://github.com/p-to-q/wittgenstein/issues/440)
-  This keeps uncertain implementation choices tied to research outputs that must
-  change PR scope, issue priority, or acceptance gates.
+  is closed by the dated backlog closeout note. New uncertain research should
+  enter the #477/#478/#479/#480 patterns or a concrete successor issue rather
+  than this umbrella.
 - **Training-stack re-audit:** [#441](https://github.com/p-to-q/wittgenstein/issues/441)
   This is the first concrete high-risk lane under the re-audit ledger. It owns
   the framework / reuse / manifest / DVC / eval review before GPU-scale training
   starts.
+- **Release-readiness umbrella:** [#507](https://github.com/p-to-q/wittgenstein/issues/507)
+  owns the M1B audit-delivery prerelease criteria and wording constraints.
 
 Recommended execution order before any owner override:
 
-1. Close the VQGAN-class candidate audits: [#334](https://github.com/p-to-q/wittgenstein/issues/334) and [#335](https://github.com/p-to-q/wittgenstein/issues/335).
-2. Land the first [#441](https://github.com/p-to-q/wittgenstein/issues/441)
+1. Treat [#334](https://github.com/p-to-q/wittgenstein/issues/334) and [#335](https://github.com/p-to-q/wittgenstein/issues/335) as closed empirical inputs, not as the final decoder-delivery claim.
+2. Land the next [#441](https://github.com/p-to-q/wittgenstein/issues/441)
    verdict: what is safe to build before GPU work, and what needs model-owner
    sign-off.
 3. Use those results to settle [#402](https://github.com/p-to-q/wittgenstein/issues/402).

--- a/docs/research/2026-05-31-second-pass-research-backlog-closeout.md
+++ b/docs/research/2026-05-31-second-pass-research-backlog-closeout.md
@@ -1,0 +1,79 @@
+---
+date: 2026-05-31
+status: issue #440 closeout
+labels: [research-derived, backlog, second-pass, closeout]
+tracks: [#440, #477, #478, #479, #480, #441, #402, #399, #400, #263, #476, #507]
+---
+
+# Second-Pass Research Backlog Closeout
+
+## Purpose
+
+This note closes #440 as a scheduling and routing ledger. It does not claim
+that every downstream research or implementation lane is done. It says the
+umbrella has finished its job: uncertain implementation choices now have
+bounded research outputs, first artifact targets, owners, and successor issues
+rather than living in an unbounded backlog.
+
+The remaining work belongs in the named owner lanes below.
+
+## Closure Model
+
+#440 defined four cross-sections for research closure. All four now have
+durable artifacts:
+
+| Cross-section             | Tracker | Status   | Durable artifact                                                 | How to use it next                                                                   |
+| ------------------------- | ------- | -------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| Historical research debt  | #480    | `closed` | `docs/research/2026-05-31-retrospective-research-debt-ledger.md` | Classify old claims before turning them into current direction.                      |
+| Local architecture optima | #478    | `closed` | `docs/research/2026-05-31-local-optima-first-pass.md`            | Use for file-backed seam decisions and falsifiers.                                   |
+| Horizontal prior art      | #477    | `closed` | `docs/research/2026-05-31-horizontal-engineering-matrix.md`      | Use for copy/adapt/reject/watch decisions before importing patterns or dependencies. |
+| Focused blocker spike     | #479    | `closed` | `docs/research/2026-05-31-focused-spike-template.md`             | Use for future time-boxed unknowns with kill criteria.                               |
+
+That means new research should no longer enter #440 directly. It should enter
+one of the four patterns above or a concrete successor issue.
+
+## Lane Closeout Map
+
+| #440 lane               | Owner lane                              | First artifact target                                                                                                             | What changed because of the research                                                                                                            | Surviving work                                                                                                         |
+| ----------------------- | --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Training stack          | `koriyoshi2041` with `moapacha` review  | `docs/research/2026-05-16-training-stack-re-audit.md`, #441, `docs/research/2026-05-31-training-homes-decision.md`                | The path narrowed to receipt-first PyTorch/DDP smoke before GPU scale; `research/training/` and `python/image_adapter/` are named separately.   | #441 remains the owner review lane; #399/#400 own tracker and data/sweep infrastructure before expensive training.     |
+| Sensor CSV/HTML/Loupe   | `moapacha` / implementation reviewer    | `docs/codecs/sensor.md`, `docs/research/2026-05-31-independent-second-pass-cross-check-closeout.md`, #263                         | Loupe/CSV/HTML stays as the current product surface; `patchGrammar` remains internal until measurement rather than being promoted by prose.     | #263 owns operator receipts and measurement gates; #153 stays parked until measurement justifies new operators.        |
+| Decoder bridge delivery | `koriyoshi2041` / image bridge reviewer | `docs/research/2026-05-31-horizontal-engineering-matrix.md`, `docs/research/2026-05-31-local-optima-first-pass.md`, #402          | The bridge stays codec-owned; remote model metadata cannot be truth; lazy fetch must preserve local SHA/license/runtime failures.               | #402 owns lazy fetch, cache layout, SHA verification, license refusal, and optional ONNX Runtime wiring.               |
+| Video M4                | video/rendering reviewer                | `docs/research/2026-05-26-video-mp4-renderer-validation.md`, `docs/research/2026-05-31-architecture-benchmark-prior-art.md`, #476 | HyperFrames is a reference shape, not a vendored dependency; same-platform byte parity and cross-machine structural parity are separate claims. | #476 owns cross-machine structural parity and receipt portability.                                                     |
+| Dependency/tooling      | release/package reviewer                | `docs/research/2026-05-31-reusable-module-radar.md`, #543, `docs/research/2026-05-31-retrospective-research-debt-ledger.md`       | The repo keeps local extracted helpers first; DVC/Aim/HF Hub are adapt-only in their owning issues; Execa/MCP/Remotion are not imported now.    | Future dependency proposals should cite #306/#477 and land through the issue that owns the surface, not this umbrella. |
+| Public/adopter surface  | maintainer/release reviewer             | `docs/release/m1b-closeout-ledger.md`, `docs/research/2026-05-31-research-presentation-audit.md`, #507, this PR's roadmap refresh | Release wording is constrained to audit delivery / receipts / review gates, not "M1B complete" or trained weights.                              | #507 owns release-readiness and prerelease framing.                                                                    |
+
+## Remaining Open Gates
+
+The backlog is closed, but several execution lanes are intentionally still
+open:
+
+- #402: decoder bridge delivery contract.
+- #441: Phase 1 training-stack and reuse review.
+- #399/#400: experiment tracking plus DVC/GPU sweep infrastructure.
+- #263: sensor measurement and operator receipt gate.
+- #476: MP4 cross-machine structural parity.
+- #507: M1B release-readiness and prerelease criteria.
+
+These are not failures of #440. They are the concrete issues #440 was meant to
+create or route toward.
+
+## What Not To Reopen Here
+
+- Do not use #440 for broad "more research" work.
+- Do not relabel historical debt as current direction without first going
+  through the #480-style ledger pattern.
+- Do not use local-optimum notes to bypass owner decisions for model/training
+  or decoder delivery.
+- Do not treat external prior art as a dependency recommendation unless the
+  owning issue accepts it and preserves Wittgenstein's receipt spine.
+
+## Closeout Verdict
+
+#440 can close. Each lane has an owner lane, a first durable artifact, and a
+successor routing decision. The #477/#478/#479/#480 cross-section remains
+available as a repeatable research process, while the surviving implementation
+and owner-review work continues in concrete issues.
+
+No model training, lab execution, runtime dependency, or doctrine rewrite is
+part of this closeout.


### PR DESCRIPTION
## Summary
- Adds a #440 closeout note that turns the second-pass research backlog into concrete owner lanes and successor issues.
- Maps all #440 lanes to durable artifacts and current open gates: #402, #441, #399/#400, #263, #476, and #507.
- Refreshes the v0.3 roadmap current-mainline section so #435/#440/#334/#335 are no longer presented as open prerequisite work.

Closes #440.

## Self-review
- Documentation-only; no runtime code, model path, or training files changed.
- Does not claim downstream execution is complete; it closes the scheduling umbrella and preserves concrete open gates.
- Keeps new research routed through #477/#478/#479/#480 patterns or specific successor issues.
- Commit includes the requested Jah-yee co-author trailer.

## Validation
- pnpm install --frozen-lockfile --offline
- pnpm exec prettier --check docs/research/2026-05-31-second-pass-research-backlog-closeout.md docs/exec-plans/active/v0.3-roadmap.md
- typos --config typos.toml docs/research/2026-05-31-second-pass-research-backlog-closeout.md docs/exec-plans/active/v0.3-roadmap.md
- git diff --check
- pnpm format:check
- pnpm lint
- pnpm typecheck
- pnpm test