### PR TITLE
docs(release): close M1B readiness ledger

### DIFF
--- a/docs/exec-plans/active/v0.3-roadmap.md
+++ b/docs/exec-plans/active/v0.3-roadmap.md
@@ -2,7 +2,7 @@
 
 **Date opened:** 2026-05-04
 **Last refreshed:** 2026-05-31
-**Status:** 🟡 Active as a maintainer-facing truth surface. v0.3 gates are closed; the repo is now in post-alpha.3 M1B decoder delivery, training-infra review, and release-readiness follow-through, not generic prerelease triage.
+**Status:** 🟡 Active as a maintainer-facing truth surface. v0.3 gates are closed; the repo is now in post-alpha.3 M1B decoder delivery and training-infra review. The M1B audit-delivery release-readiness ledger is closed; do not treat that as a completed decoder-delivery claim.
 **Engineering source of truth:** [`codec-v2-port.md`](codec-v2-port.md) — that file owns the M-phase contract, current blocker, and rollback criteria. This page is the maintainer-facing index.
 
 ---
@@ -51,7 +51,8 @@ Use this split when landing cold:
   This is the concrete "which decoder-family manifest do we actually bless and fetch"
   question. `#403` stays parked behind it.
 - **Post-merge re-audit ledger:** [#439](https://github.com/p-to-q/wittgenstein/issues/439)
-  This is the maintainer loop for merged but lower-confidence implementation blocks.
+  is closed. Lower-confidence implementation blocks now have written verdicts
+  or successor issues.
 - **Second-pass research ledger:** [#440](https://github.com/p-to-q/wittgenstein/issues/440)
   is closed by the dated backlog closeout note. New uncertain research should
   enter the #477/#478/#479/#480 patterns or a concrete successor issue rather
@@ -60,8 +61,10 @@ Use this split when landing cold:
   This is the first concrete high-risk lane under the re-audit ledger. It owns
   the framework / reuse / manifest / DVC / eval review before GPU-scale training
   starts.
-- **Release-readiness umbrella:** [#507](https://github.com/p-to-q/wittgenstein/issues/507)
-  owns the M1B audit-delivery prerelease criteria and wording constraints.
+- **Release-readiness ledger:** [#507](https://github.com/p-to-q/wittgenstein/issues/507)
+  is closed by `docs/release/m1b-closeout-ledger.md`. It permits only the
+  "M1B audit delivery" framing; #402/#441/#473 still own decoder delivery,
+  training architecture, and gate/blessing decisions.
 
 Recommended execution order before any owner override:
 

--- a/docs/release/m1b-closeout-ledger.md
+++ b/docs/release/m1b-closeout-ledger.md
@@ -1,148 +1,96 @@
 # M1B closeout ledger
 
-Status: draft release-readiness ledger  
-Last reviewed: 2026-05-28
+Status: final release-readiness ledger for #507
+Last reviewed: 2026-05-31
 
 ## Purpose
 
-Map the active M1B stack and prevent overclaiming.
+Map the M1B audit-delivery stack after the May 2026 closeout and prevent
+release overclaiming.
 
-## Current stack
+This ledger closes the release-readiness umbrella. It is not a decoder-delivery
+claim, a trained-tokenizer claim, or an end-to-end M1B image-quality claim.
 
-- #507 — umbrella issue for M1B audit-delivery closeout and prerelease criteria.
-- #457 — M1B decoder audit delivery surface.
-- #491 — VQGAN-class Gate C/D receipt.
-- #492 — LlamaGen decoder bridge manifest + provenance.
-- #493 — tokenizer scaffold with manifest spine and smoke-validated DDP loop.
-- #455 — research handoff and experiment hooks.
-- #402 — canonical lazy weight fetch + sha256 delivery gate.
+## Final audit-delivery state
 
-## #457 — audit delivery surface
+| Lane                              | Final state                                                                                                   | What it proves                                                                                                                                                      | What remains                                                                                                                                                                 |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Audit delivery surface            | #457 was superseded by #527, then #528 merged the same delivery surface plus the second CodeRabbit fix round. | Decoder-family manifests, gate audit receipts, preflight, doctor/install visibility, artifact validators, fixtures, and self-check scripts can be reviewed in repo. | Real bridge loading, lazy fetch/cache, license refusal, runtime failure behavior, and sha verification remain #402/#403 delivery work.                                       |
+| VQGAN-class Gate C/D evidence     | #491 merged; #334 and #335 closed; parent #329 closed as the VQGAN-class four-gate audit.                     | VQGAN-class clears the audit-plan unblock criterion under the documented structural-parity and ONNX/CPU evidence.                                                   | This is candidate audit clearance, not final product image quality or end-to-end VSC-to-PNG delivery.                                                                        |
+| LlamaGen bridge manifest          | #492 merged.                                                                                                  | Candidate provenance, hash, license, and runtime-tier metadata are pinned in a repo-owned manifest.                                                                 | The manifest is not the loader. #402 still owns lazy fetch, cache promotion, sha mismatch handling, and opt-in research-weight policy.                                       |
+| Training scaffold                 | #493 merged.                                                                                                  | The training home, manifest spine, and DDP smoke floor exist for owner review.                                                                                      | No trained tokenizer, adapter, dataset acceptance, or releasable weights are claimed. #441/#399/#400 keep owning the training architecture and receipt infrastructure.       |
+| Research handoff                  | #455 closed as superseded by #535 and #536.                                                                   | The useful docs slice, radar Gate E, clean-repaint hooks, optional visual-reasoning block, and Phase 0a probe survived as clean PRs.                                | The incompatible dead manifest slice was intentionally dropped in favor of the #493 training manifest spine. Future codec-shape review can target the additive #536 surface. |
+| Lab receipt reconciliation        | #474 closed.                                                                                                  | The #491/#492/#528 evidence path was reconciled into issue closures without over-reading it as decoder delivery.                                                    | Gate-policy and blessing semantics that outlive the specific VQGAN receipt stay with #473 and #402.                                                                          |
+| Owner/research/governance ledgers | #435, #439, and #440 are closed.                                                                              | Owner routing, post-merge re-audit, and second-pass research backlog all produced bounded successor lanes.                                                          | The successor lanes are concrete issues, not this release-readiness umbrella.                                                                                                |
 
-Proves:
+## Release wording
 
-- audit surface is visible;
-- fixtures/preflight/review pack can exist;
-- local/lab boundaries can be documented.
+Safe wording:
 
-Does not prove:
+- "M1B audit delivery closeout."
+- "VQGAN-class candidate cleared the four-gate audit."
+- "Decoder manifests, audit receipts, validators, preflight checks, and review
+  gates are now in repo."
+- "#402/#441/#473 remain open for decoder delivery, training architecture, and
+  gate/blessing policy."
 
-- real weights load;
-- VSC emission works;
-- image quality is acceptable;
-- training decisions are resolved.
+Unsafe wording:
 
-Review focus:
+- "M1B completed."
+- "Wittgenstein ships a working LlamaGen decoder bridge."
+- "Image quality is validated end to end."
+- "A tokenizer, adapter, or image-emitting model has been trained."
+- "Weights are bundled or automatically fetched in the npm package."
 
-- schema/manifest correctness;
-- structured failure behavior;
-- no hidden fallback.
+## Prerelease criteria outcome
 
-## #491 — Gate C/D receipt
+| Criterion from #507                                | Outcome                                                                                                 |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Audit surface merged or accepted                   | Satisfied by #528, the merged successor to #457/#527.                                                   |
+| #491/#492 claims narrowed                          | Satisfied by the #329/#334/#335/#474 closeout chain and the #492 manifest/provenance scope.             |
+| #493 fixed or deferred                             | Satisfied by #493 merge after the #514 tooling unblock. It remains a scaffold/smoke claim only.         |
+| #455 preserved/sliced/deferred intentionally       | Satisfied by #535/#536 plus the explicit drop of the obsolete manifest subsystem.                       |
+| ML-owner review visible                            | Satisfied as routing: #435 closed owner map; #441/#473 remain the open ML/research decision lanes.      |
+| #402 implemented or explicitly pending             | Explicitly pending. This ledger says release notes may claim audit delivery only, not decoder delivery. |
+| Release notes say audit delivery, not M1B complete | Satisfied here and in `docs/acceptance/m1b-image.md`.                                                   |
 
-Proves:
+## Remaining open gates
 
-- a VQGAN-class candidate may have determinism and ONNX/CPU feasibility evidence under stated conditions.
+Close #507, but keep these lanes visible:
 
-Does not prove:
+- #402: canonical decoder bridge delivery, lazy weight fetch/cache, sha
+  verification, license refusal, runtime errors, and no silent fallback.
+- #403: install/doctor tier readiness, parked behind #402.
+- #473: Gate C/D threshold policy and manifest-declared blessing rules.
+- #441: Phase 1 training-stack architecture and reuse review.
+- #399/#400: experiment tracking and DVC/GPU sweep receipt infrastructure.
+- #393/#394/#396/#397/#398: actual model, tokenizer, adapter, eval, and
+  distillation work.
 
-- product bridge implementation;
-- user install success;
-- final M1B quality;
-- own-trained tokenizer quality.
+Non-M1B lanes remain separate:
 
-Review focus:
+- #263: sensor operator receipts and measurement gates.
+- #476: MP4 cross-machine structural parity and receipt portability.
 
-- narrow "unblocked" wording to exact gates;
-- preserve environment, scripts, hashes, hardware, and thresholds;
-- do not turn doc-only evidence into product claim.
+## Closeout verdict
 
-## #492 — bridge manifest / provenance
+#507 can close. It has decided the release-readiness question for the current
+phase: a future note may be framed as "M1B audit delivery," but not as a
+capability release for completed M1B image depth.
 
-Proves:
-
-- candidate metadata can be pinned.
-
-Does not prove:
-
-- lazy fetch works;
-- license refusal is implemented;
-- runtime availability is tested;
-- real artifacts are emitted.
-
-Review focus:
-
-- align with #402;
-- avoid redistribution overclaim;
-- validate manifest contract.
-
-## #493 — tokenizer scaffold
-
-Proves:
-
-- training code layout and manifest spine may exist;
-- DDP smoke can be exercised.
-
-Does not prove:
-
-- tokenizer is trained;
-- reconstruction quality;
-- dataset/license acceptance;
-- releaseable weights.
-
-Review focus:
-
-- ML-specialist review;
-- static checks;
-- dataset/license framing;
-- do not call smoke validation training success.
-
-## #455 — research handoff
-
-Proves:
-
-- research context and hooks exist.
-
-Does not prove:
-
-- route is chosen;
-- metrics pass.
-
-Review focus:
-
-- preserve useful context;
-- slice if too large;
-- keep owner instructions visible.
-
-## #402 — delivery gate
-
-This remains mandatory for a real decoder delivery story. Acceptance requires typed manifest schema, lazy fetch/cache, sha verification, license refusal, runtime errors, tests, npm weight exclusion, and no silent fallback.
-
-## Prerelease criteria
-
-A small prerelease is reasonable only if:
-
-- #457 is merged or accepted as audit surface;
-- #491/#492 claims are narrowed;
-- #493 is fixed or deferred;
-- #455 is preserved/sliced/deferred intentionally;
-- ML-owner review is visible;
-- #402 is implemented or explicitly called pending;
-- release notes say "audit delivery" and not "M1B complete."
+Future public release work should happen in a release PR or a narrower
+successor issue. Do not reopen #507 for decoder wiring, training, or lab
+execution; route those through the concrete gates above.
 
 ## Source anchors
 
-This draft pack was written from a GitHub-only static review on 2026-05-28. Recheck referenced issues/PRs before merge.
-
-- Repository / README: https://github.com/p-to-q/wittgenstein
-- README.md: https://github.com/p-to-q/wittgenstein/blob/main/README.md
-- CHANGELOG.md: https://github.com/p-to-q/wittgenstein/blob/main/CHANGELOG.md
-- docs/implementation-status.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/implementation-status.md
-- docs/exec-plans/active/codec-v2-port.md: https://github.com/p-to-q/wittgenstein/blob/main/docs/exec-plans/active/codec-v2-port.md
 - Issue #507: https://github.com/p-to-q/wittgenstein/issues/507
 - Issue #402: https://github.com/p-to-q/wittgenstein/issues/402
-- PR #457: https://github.com/p-to-q/wittgenstein/pull/457
+- Issue #441: https://github.com/p-to-q/wittgenstein/issues/441
+- Issue #473: https://github.com/p-to-q/wittgenstein/issues/473
 - PR #491: https://github.com/p-to-q/wittgenstein/pull/491
 - PR #492: https://github.com/p-to-q/wittgenstein/pull/492
 - PR #493: https://github.com/p-to-q/wittgenstein/pull/493
-- PR #455: https://github.com/p-to-q/wittgenstein/pull/455
+- PR #528: https://github.com/p-to-q/wittgenstein/pull/528
+- PR #535: https://github.com/p-to-q/wittgenstein/pull/535
+- PR #536: https://github.com/p-to-q/wittgenstein/pull/536

--- a/docs/research/2026-05-31-second-pass-research-backlog-closeout.md
+++ b/docs/research/2026-05-31-second-pass-research-backlog-closeout.md
@@ -41,7 +41,7 @@ one of the four patterns above or a concrete successor issue.
 | Decoder bridge delivery | `koriyoshi2041` / image bridge reviewer | `docs/research/2026-05-31-horizontal-engineering-matrix.md`, `docs/research/2026-05-31-local-optima-first-pass.md`, #402          | The bridge stays codec-owned; remote model metadata cannot be truth; lazy fetch must preserve local SHA/license/runtime failures.               | #402 owns lazy fetch, cache layout, SHA verification, license refusal, and optional ONNX Runtime wiring.               |
 | Video M4                | video/rendering reviewer                | `docs/research/2026-05-26-video-mp4-renderer-validation.md`, `docs/research/2026-05-31-architecture-benchmark-prior-art.md`, #476 | HyperFrames is a reference shape, not a vendored dependency; same-platform byte parity and cross-machine structural parity are separate claims. | #476 owns cross-machine structural parity and receipt portability.                                                     |
 | Dependency/tooling      | release/package reviewer                | `docs/research/2026-05-31-reusable-module-radar.md`, #543, `docs/research/2026-05-31-retrospective-research-debt-ledger.md`       | The repo keeps local extracted helpers first; DVC/Aim/HF Hub are adapt-only in their owning issues; Execa/MCP/Remotion are not imported now.    | Future dependency proposals should cite #306/#477 and land through the issue that owns the surface, not this umbrella. |
-| Public/adopter surface  | maintainer/release reviewer             | `docs/release/m1b-closeout-ledger.md`, `docs/research/2026-05-31-research-presentation-audit.md`, #507, this PR's roadmap refresh | Release wording is constrained to audit delivery / receipts / review gates, not "M1B complete" or trained weights.                              | #507 owns release-readiness and prerelease framing.                                                                    |
+| Public/adopter surface  | maintainer/release reviewer             | `docs/release/m1b-closeout-ledger.md`, `docs/research/2026-05-31-research-presentation-audit.md`, #507, this PR's roadmap refresh | Release wording is constrained to audit delivery / receipts / review gates, not "M1B complete" or trained weights.                              | #507 closes the release-readiness umbrella; future public-release work should be a release PR or narrower successor.   |
 
 ## Remaining Open Gates
 
@@ -53,7 +53,10 @@ open:
 - #399/#400: experiment tracking plus DVC/GPU sweep infrastructure.
 - #263: sensor measurement and operator receipt gate.
 - #476: MP4 cross-machine structural parity.
-- #507: M1B release-readiness and prerelease criteria.
+
+The #507 release-readiness umbrella is no longer an execution gate once the
+final closeout ledger lands; it exists to constrain wording, not to carry
+decoder, training, or lab work.
 
 These are not failures of #440. They are the concrete issues #440 was meant to
 create or route toward.


### PR DESCRIPTION
## Summary

Closes #507 by converting the stale 2026-05-28 M1B closeout draft into a final 2026-05-31 release-readiness ledger.

This PR updates the release-facing docs to reflect the actual merged/superseded state after the current closeout sweep:

- #457 -> #527 -> #528 is now recorded as the merged audit-delivery surface.
- #491/#492/#329/#334/#335/#474 are recorded as the VQGAN-class audit evidence and reconciliation chain.
- #493 is framed as training scaffold + smoke/manifest floor, not trained weights.
- #455 is recorded as split into #535/#536, with the incompatible manifest slice intentionally dropped in favor of the #493 spine.
- #435/#439/#440 are recorded as closed routing ledgers with concrete successor lanes.

## Boundaries

This intentionally does **not** claim M1B is complete. It keeps the remaining work routed to the concrete gates:

- #402/#403 for decoder delivery, lazy fetch/cache, SHA verification, license refusal, runtime errors, and install/doctor readiness.
- #441/#399/#400 for training-stack and receipt infrastructure.
- #473 for Gate C/D threshold and blessing semantics.
- #263 and #476 for non-M1B sensor/video receipt work.

The safe public framing is "M1B audit delivery closeout," not "M1B completed" and not a capability release for trained weights or a wired LlamaGen decoder bridge.

## Validation

Local verification in an isolated worktree:

- `pnpm install --frozen-lockfile --offline`
- `pnpm exec prettier --check docs/release/m1b-closeout-ledger.md docs/exec-plans/active/v0.3-roadmap.md docs/research/2026-05-31-second-pass-research-backlog-closeout.md`
- `typos --config typos.toml docs/release/m1b-closeout-ledger.md docs/exec-plans/active/v0.3-roadmap.md docs/research/2026-05-31-second-pass-research-backlog-closeout.md`
- `git diff --check`
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

Closes #507.

## Doctrine guardrail response

This is execution/drift correction, not new doctrine. The PR reconciles the existing #507 release-readiness ledger against the current merged PR and issue state, and keeps the previously accepted wording constraint: audit delivery may be claimed, completed M1B decoder delivery/training may not. It does not introduce a new modality route, change codec doctrine, or alter an ADR/RFC decision.
