### PR TITLE
feat(image): record adapter fallback receipts

### DIFF
--- a/docs/codecs/image.md
+++ b/docs/codecs/image.md
@@ -102,8 +102,9 @@ The image codec records two distinct path facts so a maintainer can tell intent 
 
 - `manifest["image.code"].path` — _intent_: which hint did the LLM-emitted spec carry? One of `provider-latents` / `coarse-vq` / `visual-seed-code` / `semantic-fallback`.
 - `manifest.renderPath` — _outcome_: which adapter tier actually produced the latents? One of `provider-latents` / `coarse-vq` / `visual-seed-code` / `learned-mlp` / `placeholder`. Plumbed via `ImageAdapterOutcome` (PR #250). A bogus `providerLatents` that fails validation now surfaces as `renderPath: coarse-vq` (or further down the fall-through), not as a silent path swap.
+- `manifest["image.adapter"]` — _adapter receipt_: records the outcome, the decoder-facing paths that were attempted, fallback reasons, and the concrete `seedExpanderId` when the Visual Seed Code tier expands tokens.
 
-Both fields are written through the harness manifest spine. The important parity with audio and sensor is not the field name: audio reports its concrete backend under `audioRender.decoderId` / `determinismClass`, sensor reports its dashboard route through `renderPath`, and image reports adapter-tier outcome through `renderPath`. In all three cases, the manifest names the path that actually fired instead of silently swapping behavior.
+These fields are written through the harness manifest spine. The important parity with audio and sensor is not the field name: audio reports its concrete backend under `audioRender.decoderId` / `determinismClass`, sensor reports its dashboard route through `renderPath`, and image reports adapter-tier outcome through `renderPath`. In all three cases, the manifest names the path that actually fired instead of silently swapping behavior.
 
 ## Adapter Role
 

--- a/docs/exec-plans/active/codec-v2-port.md
+++ b/docs/exec-plans/active/codec-v2-port.md
@@ -11,17 +11,17 @@ The original plan body below is **preserved as-is** — its M-phase definitions 
 
 ### What's landed
 
-| Phase | Status | Evidence |
-|---|---|---|
-| **M0** — Protocol types | ✅ landed | `packages/schemas/src/codec/v2/*` shipped per ADR-0008 |
-| **M1A** — codec-image protocol port | ✅ landed | `ImageCodec extends BaseCodec`; harness modality-blind for image |
-| **M1A follow-ups** — image VSC reframe | ✅ landed | RFC-0006 / ADR-0018 ratify Visual Seed Code; `SeedExpander` seam at `packages/codec-image/src/adapters/seed-expander.ts` (PR #243); `tileMosaicSeedExpander` second impl (PR #252); `adapterOutcome` → `manifest.renderPath` (PR #250); image.md lineage receipt (PR #273) |
-| **M1B** — image trained projector | 🔴 **CURRENT MAINLINE BLOCKER** | Gated on radar (PR #272) + the four-step pre-wire audit named there. See "M1B unblock path" below |
-| **M2** — codec-audio | ✅ landed | M2 sweep gate closed; Kokoro structural-parity opt-in per ADR-0015 + Slice E |
-| **M3** — codec-sensor | ✅ landed | Sensor port complete; patchGrammar shipped post-M3 (#244 → #249 contract honesty) |
-| **M4** — Cleanup pass | 🟡 partial | Harness modality-blind for image / audio / sensor; soft→hard-warn for retired request fields **deferred** until #285 closes; `codec-video` work activated by #277 → #282 (distillation) instead of staying parked |
-| **M5a** — Image benchmark bridge | ⏸️ deferred | Original ordering (M1→M5a) preserved; M5a waits for M1B trained projector to wire so the metric has a real signal to measure |
-| **M5b** — Audio / sensor / video benchmark bridge | ⏸️ deferred | Same as M5a |
+| Phase                                             | Status                          | Evidence                                                                                                                                                                                                                                                                   |
+| ------------------------------------------------- | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **M0** — Protocol types                           | ✅ landed                       | `packages/schemas/src/codec/v2/*` shipped per ADR-0008                                                                                                                                                                                                                     |
+| **M1A** — codec-image protocol port               | ✅ landed                       | `ImageCodec extends BaseCodec`; harness modality-blind for image                                                                                                                                                                                                           |
+| **M1A follow-ups** — image VSC reframe            | ✅ landed                       | RFC-0006 / ADR-0018 ratify Visual Seed Code; `SeedExpander` seam at `packages/codec-image/src/adapters/seed-expander.ts` (PR #243); `tileMosaicSeedExpander` second impl (PR #252); `adapterOutcome` → `manifest.renderPath` (PR #250); image.md lineage receipt (PR #273) |
+| **M1B** — image trained projector                 | 🔴 **CURRENT MAINLINE BLOCKER** | Gated on radar (PR #272) + the four-step pre-wire audit named there. See "M1B unblock path" below                                                                                                                                                                          |
+| **M2** — codec-audio                              | ✅ landed                       | M2 sweep gate closed; Kokoro structural-parity opt-in per ADR-0015 + Slice E                                                                                                                                                                                               |
+| **M3** — codec-sensor                             | ✅ landed                       | Sensor port complete; patchGrammar shipped post-M3 (#244 → #249 contract honesty)                                                                                                                                                                                          |
+| **M4** — Cleanup pass                             | 🟡 partial                      | Harness modality-blind for image / audio / sensor; soft→hard-warn for retired request fields **deferred** until #285 closes; `codec-video` work activated by #277 → #282 (distillation) instead of staying parked                                                          |
+| **M5a** — Image benchmark bridge                  | ⏸️ deferred                     | Original ordering (M1→M5a) preserved; M5a waits for M1B trained projector to wire so the metric has a real signal to measure                                                                                                                                               |
+| **M5b** — Audio / sensor / video benchmark bridge | ⏸️ deferred                     | Same as M5a                                                                                                                                                                                                                                                                |
 
 ### Research receipts merged (2026-05-08 sweep)
 
@@ -50,15 +50,15 @@ The radar's recommended ranking (top 5: VQGAN-class, FSQ, OpenMAGVIT2/LFQ, TiTok
 
 ### Implementation issues now ready (post-merge sweep)
 
-| Issue | Lane | What gates it |
-|---|---|---|
-| **#283** | M1B precursor | Per-candidate license / weights / determinism / Node-ONNX audit |
-| **#282** | M4 video → distillation | HyperFrames-shaped renderer, repo-owned, distilled (not vendored) |
-| **#284** | M3 sensor follow-up | patchGrammar measurement vs flat operators (#155 active line) |
-| **#259** (existing) | M1B downstream | Image implementation slices after #283 produces a candidate |
-| **#261** (existing) | M2 follow-up | Audio implementation slices after audio sub-RFCs (#274 named: soundscape → MIDI → SSML) |
-| **#263** (existing) | M3 follow-up | Sensor implementation slices after #284 measurement |
-| **#265** (existing) | M4 video extension | Manifest receipts / doctor coverage post #282 |
+| Issue               | Lane                    | What gates it                                                                                                                      |
+| ------------------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| **#283**            | M1B precursor           | Per-candidate license / weights / determinism / Node-ONNX audit                                                                    |
+| **#282**            | M4 video → distillation | HyperFrames-shaped renderer, repo-owned, distilled (not vendored)                                                                  |
+| **#284**            | M3 sensor follow-up     | patchGrammar measurement vs flat operators (#155 active line)                                                                      |
+| **#259** (existing) | M1B downstream          | Closed by `m1b-image-implementation-slices.md`; remaining work is routed to #402/#403/#473/#441/#399/#400/#393/#394/#396/#397/#398 |
+| **#261** (existing) | M2 follow-up            | Audio implementation slices after audio sub-RFCs (#274 named: soundscape → MIDI → SSML)                                            |
+| **#263** (existing) | M3 follow-up            | Sensor implementation slices after #284 measurement                                                                                |
+| **#265** (existing) | M4 video extension      | Manifest receipts / doctor coverage post #282                                                                                      |
 
 ### What this status update does NOT do
 
@@ -71,6 +71,7 @@ The radar's recommended ranking (top 5: VQGAN-class, FSQ, OpenMAGVIT2/LFQ, TiTok
 ### Next maintainer-facing question — RESOLVED 2026-05-13
 
 **v0.3.0-alpha.2 cut timing.** With M1A / M2 / M3 closed and M1B blocked on #283 audits, the alpha.2 conversation was gated on the @Jah-yee disposition (per #246 / #248). Either:
+
 - Cut alpha.2 now, naming the blocker explicitly in release notes, OR
 - Hold alpha.2 until #283 produces at least one candidate clearance, then cut.
 

--- a/docs/exec-plans/active/m1b-image-implementation-slices.md
+++ b/docs/exec-plans/active/m1b-image-implementation-slices.md
@@ -1,0 +1,90 @@
+# M1B image implementation slices
+
+Status: #259 closeout ledger  
+Last reviewed: 2026-05-31
+
+## Purpose
+
+Close the decomposition task for Visual Seed Code, SeedExpander, receipts,
+CLI inspection, eval hooks, and fixtures. This is a slice map, not a claim that
+M1B image depth is complete.
+
+The current safe claim is:
+
+> The image implementation lane is decomposed into reviewable slices, with
+> landed seams and concrete successor issues for the remaining decoder,
+> training, and evaluation work.
+
+Unsafe claims:
+
+- "M1B is complete."
+- "The LlamaGen bridge is wired."
+- "The placeholder SeedExpander proves image quality."
+- "Training produced releaseable tokenizer or adapter weights."
+
+## Current evidence
+
+| Surface            | Current state                                                                                                              | Evidence                                                                             |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| Schema shape       | `seedCode`, optional `semantic`, optional `coarseVq`, and optional `providerLatents` are first-class codec-image fields.   | `packages/codec-image/src/schema.ts`, RFC-0006, ADR-0018                             |
+| SeedExpander seam  | The seam exists and has two deterministic placeholder-class implementations.                                               | `packages/codec-image/src/adapters/seed-expander.ts`, `seed-expander-tile-mosaic.ts` |
+| Clean repaint      | The SeedExpander ABI accepts known-position / known-token conditioning.                                                    | `packages/codec-image/test/seed-expander-clean-repaint.test.ts`, #536                |
+| Intent receipt     | `image.code` records which decoder-facing hint the spec carried.                                                           | `packages/codec-image/src/image-code-receipt.ts`                                     |
+| Fired path receipt | `renderPath` records which adapter tier actually produced latents.                                                         | `packages/codec-image/src/types.ts`, `packages/codec-image/src/codec.ts`             |
+| Adapter receipt    | `image.adapter` records attempted paths, fallback reasons, and the concrete `seedExpanderId` when VSC expands tokens.      | This closeout PR                                                                     |
+| CLI inspection     | `wittgenstein image --show-image-code` exposes the image-code receipt without printing opaque raw token arrays by default. | `packages/cli/src/commands/image.ts`, `packages/cli/test/image.test.ts`              |
+| Candidate audit    | VQGAN-class cleared the four-gate audit; candidate clearance is separate from product delivery.                            | #329, #334, #335, #491, #492, #474                                                   |
+| Release boundary   | Release wording is constrained to audit delivery, not completed M1B depth.                                                 | `docs/release/m1b-closeout-ledger.md`, #507                                          |
+
+## Slice checklist
+
+| Slice                                 | Status                                                                                   | PR-sized scope                                                                                                                    | Likely files                                                                                        | Validation                                                                                                               | Rollback criteria                                                                                          |
+| ------------------------------------- | ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| S1. Schema tightening                 | Landed for the current family-agnostic shape; future 1D/residual tightening stays gated. | Keep VSC fields accepted while avoiding premature tokenizer-family lock-in.                                                       | `packages/codec-image/src/schema.ts`, `packages/codec-image/test/codec.test.ts`                     | parse-valid / negative parse tests; RFC-0007 only activates if a 1D candidate clears gates.                              | Roll back if schema starts implying a family choice before #402/#473 settle blessing rules.                |
+| S2. SeedExpander seam                 | Landed as a seam; real trained expander remains future work.                             | Preserve deterministic placeholder implementations as ABI tests, not quality claims.                                              | `packages/codec-image/src/adapters/*`, `packages/codec-image/test/seed-expander*.test.ts`           | deterministic output tests, clean-repaint tests, distinct implementation tests.                                          | Roll back any implementation that silently changes golden images without updating receipts and docs.       |
+| S3. Manifest receipts                 | Landed and tightened in this PR.                                                         | Record intent (`image.code`), fired tier (`renderPath`), adapter details (`image.adapter`), and no silent fallback.               | `packages/codec-image/src/types.ts`, `codec.ts`, `pipeline/adapter.ts`, `docs/codecs/image.md`      | round-trip/golden manifest-row tests plus adapter receipt unit tests.                                                    | Roll back if manifests cannot explain why a fallback path fired.                                           |
+| S4. CLI inspection                    | Landed.                                                                                  | Keep human-facing summaries compact: semantic source and seed summary by default, raw image-code only behind `--show-image-code`. | `packages/cli/src/commands/image.ts`, `packages/cli/test/image.test.ts`                             | CLI JSON tests for `imageCode`, `semanticSummary`, and `seedSummary`.                                                    | Roll back if CLI starts dumping raw opaque token arrays by default.                                        |
+| S5. Eval hooks                        | Partially landed; active successor lanes remain.                                         | Treat parse-valid, adapter-valid, decoder-compat, deterministic replay, quality metrics, and Gate E as separate receipts.         | `research/validation/phase0a_emission_entropy.py`, `docs/acceptance/m1b-image.md`, future eval code | current probes plus future #393/#394 metrics.                                                                            | Roll back any metric that mixes candidate-decoder evidence with own-trained tokenizer evidence.            |
+| S6. Fixture / golden strategy         | Landed for lightweight receipts; heavy binary fixtures remain excluded.                  | Prefer JSON manifests and small audit fixtures; avoid committing model weights or large generated images.                         | `packages/codec-image/test/*`, `research/validation/fixtures/m1b-audit/*`, `.gitignore`             | `pnpm test`, artifact-check validators, tarball exclusion checks.                                                        | Roll back if fixtures make npm packages or CI dependent on private weights.                                |
+| S7. Decoder delivery                  | Open.                                                                                    | Wire lazy fetch/cache and the selected decoder-family bridge only after policy decisions.                                         | `packages/codec-image/src/decoders/*`, `packages/cli/src/commands/install.ts`, `doctor.ts`          | #402 acceptance: cache hit/miss, SHA mismatch, license refusal, runtime unavailable, corrupted cache, tarball exclusion. | Roll back if decoder loading falls back silently or fetches unverified bytes.                              |
+| S8. Training / adapter implementation | Open.                                                                                    | Train only narrow tokenizer/adapter/head slices after the receipt floor is in place.                                              | `research/training/*`, `python/image_adapter/*`, future package glue                                | #441/#399/#400 before expensive training; #393/#394/#396/#397/#398 for actual experiments.                               | Roll back if smoke runs are described as trained weights or if receipts omit dataset/runtime fingerprints. |
+
+## Successor issue map
+
+No new issue is needed for this decomposition. The ready work already has
+owners:
+
+- #402 owns decoder bridge delivery, lazy fetch/cache, SHA verification,
+  license refusal, runtime errors, and no silent fallback.
+- #403 owns install/doctor tier readiness after #402.
+- #473 owns Gate C/D threshold and manifest-declared blessing policy.
+- #441 owns Phase 1 training-stack architecture and reuse review.
+- #399/#400 own experiment tracking plus DVC/GPU sweep receipts.
+- #393/#394/#396/#397/#398 own the actual seed-length, eval, tokenizer,
+  adapter, and image-emitting-head work.
+
+## Research / engineer / hacker review
+
+Research verdict: the decomposition preserves the radar result without
+turning candidate audit clearance into product delivery. VQGAN-class evidence
+unblocks a candidate lane, but #402 and #473 still decide what gets blessed
+and fetched.
+
+Engineer verdict: the implementation is now split around stable contracts:
+schema, adapter ABI, manifest receipts, CLI inspection, validators, and
+follow-up delivery gates. The added `image.adapter` row closes the remaining
+receipt gap between "path intended" and "path fired."
+
+Hacker verdict: the main failure mode is silent fallback. The current manifest
+rows now expose intent, outcome, attempted paths, fallback reasons, and the
+placeholder seed-expander id, which makes accidental path swaps reviewable.
+
+## Closeout verdict
+
+#259 can close. Its job was to decompose the image implementation lane into
+small, reviewable slices after the radar. The remaining work is intentionally
+not parked in this umbrella; it is routed to the concrete successor issues
+above.
+
+Do not reopen #259 for decoder wiring, training, or eval execution. Use the
+successor issue map.

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -90,37 +90,37 @@ encode path is an opt-in repo-owned renderer (Chrome/Chromium + FFmpeg).
 
 ### @wittgenstein/codec-image
 
-| Component                                     | Status         | Notes                                                                                                                           |
-| --------------------------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| Schema + Zod image-code contract              | ✅ Ships       | Visual Seed Code contract now supports `seedCode`, optional `semantic`, optional `coarseVq`, and `providerLatents`              |
-| `expand.ts` — prompt → image code             | ⚠️ Partial     | LLM-driven; dry-run emits deterministic `witt-dry-run` seed tokens, while real prompt-stack quality remains a follow-up         |
-| `adapter.ts` — seed / semantic → latent codes | ⚠️ Partial     | Priority order now ships as `providerLatents -> coarseVq -> seedCode -> semantic fallback -> placeholder`; trained expander TBD |
-| Image-code manifest receipts                  | ✅ Ships       | `metadata.imageCode` / manifest `image.code` records fired path, semantic source, seed family/mode/length, and VQ grids         |
-| `decoder.ts` — latent codes → raster          | ⚠️ Partial     | `renderSky()` / `renderTerrain()` functional; `tryDecodeReferenceLandscape()` fires when reference weights present              |
-| `package.ts` — raster → PNG                   | ✅ Ships       |                                                                                                                                 |
-| `decoders/llamagen.ts`                        | 🔴 Stub        | Throws `NotImplementedError` — bridge to LlamaGen VQ-VAE decoder, not yet wired                                                 |
-| `decoders/seed.ts`                            | 🔴 Stub        | Throws `NotImplementedError` — bridge to SEED decoder                                                                           |
-| `training/`                                   | 📋 Recipe only | Seed-expansion training direction is locked; concrete tokenizer family, dataset, and weights remain open                        |
+| Component                                     | Status         | Notes                                                                                                                                                   |
+| --------------------------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Schema + Zod image-code contract              | ✅ Ships       | Visual Seed Code contract now supports `seedCode`, optional `semantic`, optional `coarseVq`, and `providerLatents`                                      |
+| `expand.ts` — prompt → image code             | ⚠️ Partial     | LLM-driven; dry-run emits deterministic `witt-dry-run` seed tokens, while real prompt-stack quality remains a follow-up                                 |
+| `adapter.ts` — seed / semantic → latent codes | ⚠️ Partial     | Priority order now ships as `providerLatents -> coarseVq -> seedCode -> semantic fallback -> placeholder`; trained expander TBD                         |
+| Image-code manifest receipts                  | ✅ Ships       | `metadata.imageCode` / manifest `image.code` records intent; `renderPath` and `image.adapter` record fired tier, fallback reasons, and seed-expander id |
+| `decoder.ts` — latent codes → raster          | ⚠️ Partial     | `renderSky()` / `renderTerrain()` functional; `tryDecodeReferenceLandscape()` fires when reference weights present                                      |
+| `package.ts` — raster → PNG                   | ✅ Ships       |                                                                                                                                                         |
+| `decoders/llamagen.ts`                        | 🔴 Stub        | Throws `NotImplementedError` — bridge to LlamaGen VQ-VAE decoder, not yet wired                                                                         |
+| `decoders/seed.ts`                            | 🔴 Stub        | Throws `NotImplementedError` — bridge to SEED decoder                                                                                                   |
+| `training/`                                   | 📋 Recipe only | Seed-expansion training direction is locked; concrete tokenizer family, dataset, and weights remain open                                                |
 
 ### @wittgenstein/codec-video
 
-| Component                  | Status     | Notes                                                                                          |
-| -------------------------- | ---------- | ---------------------------------------------------------------------------------------------- |
-| Schema + Zod               | ✅ Ships   | Validates `VideoComposition`                                                                   |
-| HTML composition renderer  | ✅ Ships   | Emits self-contained HyperFrames-shaped HTML via `scene-card` / `svg-slide` compositions       |
-| Distilled MP4 renderer     | ⚠️ Opt-in  | Default MP4 backend with `WITTGENSTEIN_HYPERFRAMES_RENDER=1`; local Chrome/Chromium + FFmpeg required |
-| Upstream CLI backend       | ⚠️ Opt-in  | `WITTGENSTEIN_HYPERFRAMES_BACKEND=npx-cli` keeps an explicit parity / experiment path          |
-| `videoRender` receipts     | ✅ Ships   | Records backend, FPS, quality, dimensions, frame count / duration, output kind, tool versions  |
+| Component                 | Status    | Notes                                                                                                 |
+| ------------------------- | --------- | ----------------------------------------------------------------------------------------------------- |
+| Schema + Zod              | ✅ Ships  | Validates `VideoComposition`                                                                          |
+| HTML composition renderer | ✅ Ships  | Emits self-contained HyperFrames-shaped HTML via `scene-card` / `svg-slide` compositions              |
+| Distilled MP4 renderer    | ⚠️ Opt-in | Default MP4 backend with `WITTGENSTEIN_HYPERFRAMES_RENDER=1`; local Chrome/Chromium + FFmpeg required |
+| Upstream CLI backend      | ⚠️ Opt-in | `WITTGENSTEIN_HYPERFRAMES_BACKEND=npx-cli` keeps an explicit parity / experiment path                 |
+| `videoRender` receipts    | ✅ Ships  | Records backend, FPS, quality, dimensions, frame count / duration, output kind, tool versions         |
 
 ### @wittgenstein/cli
 
-| Command               | Status   | Notes                                                     |
-| --------------------- | -------- | --------------------------------------------------------- |
-| `wittgenstein image`  | ✅ Ships | Calls codec-image; renders with available adapter/decoder |
-| `wittgenstein audio`  | ✅ Ships | Full speech + soundscape + music routes                   |
-| `wittgenstein sensor` | ✅ Ships | Full signal expand + Loupe dashboard                      |
+| Command               | Status     | Notes                                                                 |
+| --------------------- | ---------- | --------------------------------------------------------------------- |
+| `wittgenstein image`  | ✅ Ships   | Calls codec-image; renders with available adapter/decoder             |
+| `wittgenstein audio`  | ✅ Ships   | Full speech + soundscape + music routes                               |
+| `wittgenstein sensor` | ✅ Ships   | Full signal expand + Loupe dashboard                                  |
 | `wittgenstein video`  | ⚠️ Partial | Emits HTML by default; MP4 encode is repo-owned local renderer opt-in |
-| `wittgenstein doctor` | ✅ Ships | Checks node, pnpm, env vars, package links, optional video MP4 deps |
+| `wittgenstein doctor` | ✅ Ships   | Checks node, pnpm, env vars, package links, optional video MP4 deps   |
 
 ### @wittgenstein/sandbox
 

--- a/packages/codec-image/src/codec.ts
+++ b/packages/codec-image/src/codec.ts
@@ -20,7 +20,7 @@ import { adaptSceneToLatents } from "./pipeline/adapter.js";
 import { decodeLatentsToRaster } from "./pipeline/decoder.js";
 import { packageRasterAsPng } from "./pipeline/package.js";
 import { imageCodeReceipt } from "./image-code-receipt.js";
-import type { ImageAdapterOutcome, ImageArtifact } from "./types.js";
+import type { ImageAdapterOutcome, ImageAdapterReceipt, ImageArtifact } from "./types.js";
 
 interface ImageCodecLlmService {
   readonly provider: string;
@@ -57,6 +57,7 @@ interface AdaptedImagePayload {
   readonly scene: ImageSceneSpec;
   readonly latents: ImageLatentCodes;
   readonly adapterOutcome: ImageAdapterOutcome;
+  readonly adapterReceipt: ImageAdapterReceipt;
   readonly promptExpanded: string;
   readonly llmOutputRaw: string;
   readonly llmTokens: { input: number; output: number };
@@ -277,7 +278,7 @@ export class ImageCodec extends codecV2.BaseCodec<ImageRequest, ImageArtifact> {
 
   protected override async adapt(ir: codecV2.IR, ctx: codecV2.HarnessCtx): Promise<codecV2.IR> {
     const expanded = asScenePlan(ir);
-    const { latents, outcome } = await adaptSceneToLatents(
+    const { latents, outcome, receipt } = await adaptSceneToLatents(
       expanded.scene,
       this.createRenderCtx(ctx, codecV2.CodecPhase.Adapt),
     );
@@ -289,6 +290,7 @@ export class ImageCodec extends codecV2.BaseCodec<ImageRequest, ImageArtifact> {
         scene: expanded.scene,
         latents,
         adapterOutcome: outcome,
+        adapterReceipt: receipt,
         promptExpanded: expanded.promptExpanded,
         llmOutputRaw: expanded.llmOutputRaw,
         llmTokens: expanded.llmTokens,
@@ -329,6 +331,7 @@ export class ImageCodec extends codecV2.BaseCodec<ImageRequest, ImageArtifact> {
         llmOutputParsed: payload.scene,
         imageCode,
         adapterOutcome: payload.adapterOutcome,
+        adapterReceipt: payload.adapterReceipt,
         quality: {
           structural: {
             schemaValidated: true,
@@ -364,6 +367,7 @@ export class ImageCodec extends codecV2.BaseCodec<ImageRequest, ImageArtifact> {
       { key: "route", value: art.metadata.route },
       { key: "renderPath", value: art.metadata.adapterOutcome },
       { key: "image.code", value: art.metadata.imageCode },
+      { key: "image.adapter", value: art.metadata.adapterReceipt },
       { key: "quality.structural", value: art.metadata.quality.structural },
       { key: "quality.partial", value: art.metadata.quality.partial },
       { key: "metadata.warnings", value: art.metadata.warnings.length },

--- a/packages/codec-image/src/pipeline/adapter.ts
+++ b/packages/codec-image/src/pipeline/adapter.ts
@@ -9,13 +9,19 @@ import {
   type ImageLatentCodes,
   type ImageSceneSpec,
 } from "../schema.js";
-import type { ImageAdapterOutcome } from "../types.js";
+import type {
+  ImageAdapterFallbackReason,
+  ImageAdapterOutcome,
+  ImageAdapterReceipt,
+  ImageCodePath,
+} from "../types.js";
 
 export type { ImageLatentCodes };
 export { ImageLatentCodesSchema };
 
 /** v1 stub: tokens[0]=1, tokens[1]=byte length, tokens[2..]=UTF-8 bytes of caption. */
 export const STUB_LATENT_PROTOCOL_V1 = 1;
+export const PLACEHOLDER_SEED_EXPANDER_ID = "placeholder-seed-expander/v0";
 
 /**
  * Result of `adaptSceneToLatents`: the decoder-native latents plus a record
@@ -27,38 +33,52 @@ export const STUB_LATENT_PROTOCOL_V1 = 1;
 export interface AdaptSceneResult {
   readonly latents: ImageLatentCodes;
   readonly outcome: ImageAdapterOutcome;
+  readonly receipt: ImageAdapterReceipt;
 }
 
 export async function adaptSceneToLatents(
   parsed: ImageSceneSpec,
   ctx: RenderCtx,
 ): Promise<AdaptSceneResult> {
+  const attemptedPaths: ImageCodePath[] = [];
+  const fallbackReasons: ImageAdapterFallbackReason[] = [];
+
   if (parsed.providerLatents) {
+    attemptedPaths.push("provider-latents");
     const validated = ImageLatentCodesSchema.safeParse(parsed.providerLatents);
     if (validated.success) {
       ctx.logger.info("Using provider-included latents; skipping learned adapter.");
-      return { latents: validated.data, outcome: "provider-latents" };
+      return {
+        latents: validated.data,
+        outcome: "provider-latents",
+        receipt: adapterReceipt("provider-latents", attemptedPaths, fallbackReasons),
+      };
     }
+    fallbackReasons.push("provider-latents-invalid");
     ctx.logger.warn("providerLatents failed validation; falling back to adapter.", {
       issues: validated.error?.issues,
     });
   }
 
   if (parsed.coarseVq) {
+    attemptedPaths.push("coarse-vq");
     const validated = ImageCoarseVqSchema.safeParse(parsed.coarseVq);
     if (validated.success) {
       ctx.logger.info("Using coarseVq hints; expanding to decoder-native latents.");
       return {
         latents: expandCoarseVqToLatents(parsed, validated.data),
         outcome: "coarse-vq",
+        receipt: adapterReceipt("coarse-vq", attemptedPaths, fallbackReasons),
       };
     }
+    fallbackReasons.push("coarse-vq-invalid");
     ctx.logger.warn("coarseVq failed validation; falling back to next adapter tier.", {
       issues: validated.error?.issues,
     });
   }
 
   if (parsed.seedCode) {
+    attemptedPaths.push("visual-seed-code");
     const validated = ImageVisualSeedCodeSchema.safeParse(parsed.seedCode);
     if (validated.success) {
       ctx.logger.info("Using Visual Seed Code; expanding to decoder-native latents.");
@@ -69,11 +89,19 @@ export async function adaptSceneToLatents(
           seed: hashSpecToSeed(parsed),
         }),
         outcome: "visual-seed-code",
+        receipt: adapterReceipt("visual-seed-code", attemptedPaths, fallbackReasons, {
+          seedExpanderId: PLACEHOLDER_SEED_EXPANDER_ID,
+        }),
       };
     }
+    fallbackReasons.push("seed-code-invalid");
     ctx.logger.warn("seedCode failed validation; falling back to next adapter tier.", {
       issues: validated.error?.issues,
     });
+  }
+
+  if (attemptedPaths.length === 0) {
+    fallbackReasons.push("no-decoder-facing-code");
   }
 
   const resolved = await resolveMlpForScene(parsed, ctx);
@@ -81,12 +109,29 @@ export async function adaptSceneToLatents(
     return {
       latents: annotateLatents(parsed, await predictWithResolved(parsed, resolved)),
       outcome: "learned-mlp",
+      receipt: adapterReceipt("learned-mlp", attemptedPaths, fallbackReasons),
     };
   }
 
+  fallbackReasons.push("learned-mlp-unavailable");
   return {
     latents: annotateLatents(parsed, placeholderLatents(parsed, ctx)),
     outcome: "placeholder",
+    receipt: adapterReceipt("placeholder", attemptedPaths, fallbackReasons),
+  };
+}
+
+function adapterReceipt(
+  outcome: ImageAdapterOutcome,
+  attemptedPaths: readonly ImageCodePath[],
+  fallbackReasons: readonly ImageAdapterFallbackReason[],
+  options: { seedExpanderId?: string | null } = {},
+): ImageAdapterReceipt {
+  return {
+    outcome,
+    attemptedPaths: [...attemptedPaths],
+    fallbackReasons: [...fallbackReasons],
+    seedExpanderId: options.seedExpanderId ?? null,
   };
 }
 

--- a/packages/codec-image/src/pipeline/index.ts
+++ b/packages/codec-image/src/pipeline/index.ts
@@ -12,7 +12,7 @@ export async function renderImagePipeline(
   ctx: RenderCtx,
 ): Promise<RenderResult> {
   const expanded = await expandSceneSpec(parsed, ctx);
-  const { latents, outcome } = await adaptSceneToLatents(expanded, ctx);
+  const { latents, outcome, receipt } = await adaptSceneToLatents(expanded, ctx);
   const raster = await decodeLatentsToRaster(latents, ctx);
   const imageCode = imageCodeReceipt(parsed);
   const artifact: ImageArtifact = {
@@ -34,6 +34,7 @@ export async function renderImagePipeline(
       llmOutputParsed: parsed,
       imageCode,
       adapterOutcome: outcome,
+      adapterReceipt: receipt,
       quality: {
         structural: {
           schemaValidated: true,

--- a/packages/codec-image/src/types.ts
+++ b/packages/codec-image/src/types.ts
@@ -29,6 +29,20 @@ export type ImageAdapterOutcome =
   | "learned-mlp"
   | "placeholder";
 
+export type ImageAdapterFallbackReason =
+  | "provider-latents-invalid"
+  | "coarse-vq-invalid"
+  | "seed-code-invalid"
+  | "no-decoder-facing-code"
+  | "learned-mlp-unavailable";
+
+export interface ImageAdapterReceipt {
+  readonly outcome: ImageAdapterOutcome;
+  readonly attemptedPaths: readonly ImageCodePath[];
+  readonly fallbackReasons: readonly ImageAdapterFallbackReason[];
+  readonly seedExpanderId: string | null;
+}
+
 export type ImageSemanticSource = "emitted" | "legacy-top-level" | "absent";
 
 export interface ImageCodeReceipt {
@@ -67,6 +81,7 @@ export interface ImageArtifactMetadata extends codecV2.BaseArtifactMetadata {
    * `RenderResult.metadata.renderPath`.
    */
   readonly adapterOutcome: ImageAdapterOutcome;
+  readonly adapterReceipt: ImageAdapterReceipt;
   readonly quality: {
     readonly structural: {
       readonly schemaValidated: boolean;

--- a/packages/codec-image/test/codec.test.ts
+++ b/packages/codec-image/test/codec.test.ts
@@ -662,6 +662,14 @@ describe("image adapterOutcome (#247-style observability)", () => {
     return outcome;
   }
 
+  async function adaptReceipt(specJson: string) {
+    const parsed = imageCodec.parse(specJson);
+    if (!parsed.ok) throw new Error("parse failed");
+    const ctx = await makeRenderCtx({ runId: "receipt-test", seed: 7, label: "receipt" });
+    const { receipt } = await adaptSceneToLatents(parsed.value, ctx);
+    return receipt;
+  }
+
   it("reports provider-latents when validation succeeds", async () => {
     const outcome = await adaptOutcome(
       JSON.stringify({
@@ -732,6 +740,31 @@ describe("image adapterOutcome (#247-style observability)", () => {
     expect(outcome).toBe("visual-seed-code");
   });
 
+  it("records the concrete seed expander when the visual-seed-code tier fires", async () => {
+    const receipt = await adaptReceipt(
+      JSON.stringify({
+        mode: "one-shot-vsc",
+        decoder: {
+          family: "llamagen",
+          codebook: "stub-codebook",
+          codebookVersion: "v0",
+          latentResolution: [4, 4],
+        },
+        seedCode: {
+          family: "vqvae",
+          mode: "prefix",
+          tokens: [3, 17, 9, 220],
+        },
+      }),
+    );
+    expect(receipt).toEqual({
+      outcome: "visual-seed-code",
+      attemptedPaths: ["visual-seed-code"],
+      fallbackReasons: [],
+      seedExpanderId: "placeholder-seed-expander/v0",
+    });
+  });
+
   it("reports placeholder when no hints are provided and no learned MLP is resolved", async () => {
     const outcome = await adaptOutcome(
       JSON.stringify({
@@ -746,6 +779,25 @@ describe("image adapterOutcome (#247-style observability)", () => {
       }),
     );
     expect(outcome).toBe("placeholder");
+  });
+
+  it("records placeholder fallback reasons when no decoder-facing code is emitted", async () => {
+    const receipt = await adaptReceipt(
+      JSON.stringify({
+        decoder: {
+          family: "llamagen",
+          codebook: "stub-codebook",
+          codebookVersion: "v0",
+          latentResolution: [2, 2],
+        },
+      }),
+    );
+    expect(receipt).toEqual({
+      outcome: "placeholder",
+      attemptedPaths: [],
+      fallbackReasons: ["no-decoder-facing-code", "learned-mlp-unavailable"],
+      seedExpanderId: null,
+    });
   });
 
   it("propagates outcome to RenderResult.metadata.renderPath via the pipeline", async () => {

--- a/packages/codec-image/test/golden.test.ts
+++ b/packages/codec-image/test/golden.test.ts
@@ -48,10 +48,9 @@ describe("codec-image golden parity (Issue #347)", () => {
           sidecar: codecV2.createRunSidecar(),
           services: { dryRun: true, telemetry: { writeText: async () => {} } },
           fork: () => {
-            throw Object.assign(
-              new Error("Nested fork is not exercised by the golden test."),
-              { code: "UNEXPECTED_NESTED_FORK" as const },
-            );
+            throw Object.assign(new Error("Nested fork is not exercised by the golden test."), {
+              code: "UNEXPECTED_NESTED_FORK" as const,
+            });
           },
         }),
       },
@@ -92,6 +91,7 @@ describe("codec-image golden parity (Issue #347)", () => {
       "route",
       "renderPath",
       "image.code",
+      "image.adapter",
       "quality.structural",
       "quality.partial",
       "metadata.warnings",

--- a/packages/codec-image/test/round-trip.test.ts
+++ b/packages/codec-image/test/round-trip.test.ts
@@ -55,6 +55,7 @@ describe("image v2 round trip", () => {
       "route",
       "renderPath",
       "image.code",
+      "image.adapter",
       "quality.structural",
       "quality.partial",
       "metadata.warnings",
@@ -62,11 +63,14 @@ describe("image v2 round trip", () => {
       "L5.decoderHash",
       "artifact.sha256",
     ]);
-    expect(
-      imageV2Codec.manifestRows(art).find((row) => row.key === "renderPath")?.value,
-    ).toBe("visual-seed-code");
+    expect(imageV2Codec.manifestRows(art).find((row) => row.key === "renderPath")?.value).toBe(
+      "visual-seed-code",
+    );
     expect(imageV2Codec.manifestRows(art).find((row) => row.key === "image.code")?.value).toEqual(
       art.metadata.imageCode,
     );
+    expect(
+      imageV2Codec.manifestRows(art).find((row) => row.key === "image.adapter")?.value,
+    ).toEqual(art.metadata.adapterReceipt);
   });
 });


### PR DESCRIPTION
## Summary

Closes #259 by turning the VSC / SeedExpander / receipt / CLI / eval decomposition request into a concrete implementation-slice ledger, and by tightening the codec-image manifest receipt surface where the issue asked for intended path vs fired path vs fallback observability.

Code changes:

- Adds `ImageAdapterReceipt` with:
  - `outcome` — the adapter tier that actually fired.
  - `attemptedPaths` — decoder-facing image-code paths considered before the outcome.
  - `fallbackReasons` — why the pipeline moved down to a later tier.
  - `seedExpanderId` — currently `placeholder-seed-expander/v0` when VSC expands tokens.
- Emits a new `image.adapter` manifest row next to existing `image.code` and `renderPath` rows.
- Pins the new receipt behavior in codec-image tests.

Docs changes:

- Adds `docs/exec-plans/active/m1b-image-implementation-slices.md` as the #259 closeout ledger.
- Updates `codec-v2-port.md`, `docs/codecs/image.md`, and `docs/implementation-status.md` to point at the new decomposition and receipt shape.

## Research / Engineer / Hacker review

Research: this does not claim M1B is complete. It keeps VQGAN-class candidate clearance separate from product delivery and routes the remaining work to #402/#403/#473/#441/#399/#400/#393/#394/#396/#397/#398.

Engineer: the implementation makes the receipt spine stricter without selecting a decoder family or changing adapter priority. Existing `renderPath` remains the simple fired-tier field; `image.adapter` carries the richer fallback receipt.

Hacker: the silent-fallback failure mode is now easier to audit. A manifest can show spec intent (`image.code`), fired tier (`renderPath`), attempted paths / fallback reasons / seed-expander id (`image.adapter`).

## Validation

Local verification in an isolated worktree:

- `pnpm install --frozen-lockfile --offline`
- `pnpm --filter @wittgenstein/codec-image lint`
- `pnpm --filter @wittgenstein/codec-image typecheck`
- `pnpm --filter @wittgenstein/codec-image test`
- `pnpm exec prettier --check docs/exec-plans/active/m1b-image-implementation-slices.md docs/exec-plans/active/codec-v2-port.md docs/codecs/image.md docs/implementation-status.md packages/codec-image/src/types.ts packages/codec-image/src/pipeline/adapter.ts packages/codec-image/src/codec.ts packages/codec-image/src/pipeline/index.ts packages/codec-image/test/round-trip.test.ts packages/codec-image/test/golden.test.ts packages/codec-image/test/codec.test.ts`
- `typos --config typos.toml docs/exec-plans/active/m1b-image-implementation-slices.md docs/exec-plans/active/codec-v2-port.md docs/codecs/image.md docs/implementation-status.md packages/codec-image/src/types.ts packages/codec-image/src/pipeline/adapter.ts packages/codec-image/src/codec.ts packages/codec-image/src/pipeline/index.ts packages/codec-image/test/round-trip.test.ts packages/codec-image/test/golden.test.ts packages/codec-image/test/codec.test.ts`
- `git diff --check`
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

Closes #259.

## Doctrine guardrail response

This is execution/drift correction plus receipt observability under already-ratified image doctrine, not new doctrine. The image route remains the RFC-0006 / ADR-0018 Visual Seed Code route, and the PR does not introduce a new modality route, decoder family, or release claim. It closes #259 by decomposing the already-approved M1B image implementation lane and by making the existing adapter fallback behavior more auditable in manifests.
