### PR TITLE
feat(m1b): record Phase 0b IR sensitivity baseline

### DIFF
--- a/docs/research/2026-05-22-ir-reliability-validation.md
+++ b/docs/research/2026-05-22-ir-reliability-validation.md
@@ -130,12 +130,12 @@ This is the **most likely scenario** and is what Wittgenstein's L4 adapter is de
 
 ## Validation timeline
 
-| Phase              | What                                                                                                     | When                                   | Blocks on                                          |
-| ------------------ | -------------------------------------------------------------------------------------------------------- | -------------------------------------- | -------------------------------------------------- |
-| **Phase 0** (now)  | LLM emission distribution analysis: prompt LLM 100x, collect seed codes, measure entropy and structure   | Immediate                              | Nothing — uses current preamble + any frontier LLM |
-| **Phase 0b** (now) | Semantic IR field sensitivity: with placeholder adapter, vary one field at a time, measure output change | Immediate                              | Nothing — uses current code                        |
-| **Phase 1** (M1B)  | Criterion 2: Seed code ↔ image content mutual information                                                | After tokenizer family selected (#283) | Tokenizer selection                                |
-| **Phase 2** (M1B)  | Criteria 1, 3, 4: Full adapter training + held-out eval + CLIPScore                                      | After adapter training infrastructure  | Research program Track 1                           |
+| Phase              | What                                                                                                                             | When                                   | Blocks on                                          |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- | -------------------------------------------------- |
+| **Phase 0** (now)  | LLM emission distribution analysis: prompt LLM 100x, collect seed codes, measure entropy and structure                           | Immediate                              | Nothing — uses current preamble + any frontier LLM |
+| **Phase 0b** (now) | Semantic IR field sensitivity: with current Visual Seed Code seed-expander path, vary one field at a time, measure output change | Immediate                              | Nothing — uses current code                        |
+| **Phase 1** (M1B)  | Criterion 2: Seed code ↔ image content mutual information                                                                        | After tokenizer family selected (#283) | Tokenizer selection                                |
+| **Phase 2** (M1B)  | Criteria 1, 3, 4: Full adapter training + held-out eval + CLIPScore                                                              | After adapter training infrastructure  | Research program Track 1                           |
 
 ### Phase 0 actions (can execute now)
 
@@ -155,13 +155,24 @@ Prompt a frontier LLM with the VSC preamble for 10 different image prompts, 10 r
 
 **Action 0b: Semantic IR field sensitivity**
 
-Using the current placeholder adapter:
+Using the current Visual Seed Code seed-expander path:
 
 1. Fix all fields except one (e.g., `lighting.mood`)
 2. Generate images with `mood = "warm golden"` vs `mood = "cold fluorescent"`
 3. Compare output PNGs pixel-by-pixel
 
-**Expected result:** With current SHA256-hash feature engineering, the outputs WILL differ (different hash → different seed → different image). But the difference will be random, not semantically meaningful. This establishes the **baseline** against which a trained adapter can be measured.
+**Expected result:** With the current per-spec hash seed, the outputs WILL differ (different hashed scene fields → different seed-expander input → different image). But the difference will be random, not semantically meaningful. This establishes the **baseline** against which a trained adapter can be measured.
+
+**Implementation status (2026-05-31):** `research/validation/phase0b_semantic_ir_sensitivity.ts`
+turns this into a repeatable receipt. It records token and PNG-byte deltas
+across varied Semantic IR fields and labels the result explicitly as a
+Visual Seed Code seed-expander hash baseline. This is intentionally weaker
+than the later CLIP/SigLIP criterion: it proves the current output changes when
+fields change, while also preserving the finding that the changes are
+hash-driven rather than semantically aligned. Separately, the v0.1 learned MLP
+runtime now declares the SHA feature schema
+(`witt.image.adapter.features/sha256-canonical-json-v0`) so future CLIP/SigLIP
+adapters cannot silently reuse the baseline contract.
 
 ---
 
@@ -206,7 +217,7 @@ The maintainer's concern touches a deeper issue: Wittgenstein defines IR as a **
 
 1. Execute Phase 0a and 0b immediately (no dependencies)
 2. Add "prefix degradation curve" and "emission distribution analysis" to the M1B prep checklist
-3. Upgrade adapter feature engineering from SHA256-hash to CLIP/SigLIP embedding (tracked as adapter architecture decision)
+3. Upgrade adapter feature engineering from SHA256-hash to CLIP/SigLIP embedding (tracked as adapter architecture decision). The v0.1 MLP runtime now declares `featureSchema: witt.image.adapter.features/sha256-canonical-json-v0`; CLIP/SigLIP-conditioned adapters require a new runtime contract rather than silently reusing the SHA baseline.
 4. File issue for Semantic IR field-sensitivity baseline measurement
 
 ## Cross-references

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "train:audio-adapter": "node scripts/train-audio-ambient-adapter.mjs",
     "m1b:audit-self-check": "node scripts/m1b-audit-self-check.mjs",
     "m1b:audit-artifact-check": "node scripts/m1b-audit-artifact-check.mjs",
+    "m1b:phase0b-ir-sensitivity": "tsx research/validation/phase0b_semantic_ir_sensitivity.ts",
     "m1b:staging-plan-check": "node scripts/m1b-staging-plan-check.mjs",
     "doctor": "pnpm --filter @wittgenstein/cli exec wittgenstein doctor",
     "release:npm-cli": "pnpm --filter @wittgenstein/cli run release:npm",

--- a/packages/codec-image/src/adapters/README.md
+++ b/packages/codec-image/src/adapters/README.md
@@ -2,11 +2,11 @@
 
 ## Runtime
 
-- **`mlp-runtime.ts`** — loads `witt.image.adapter.mlp/v0.1` JSON (from `python/image_adapter/train.py`). Forward pass must stay aligned with Python training code.
+- **`mlp-runtime.ts`** — loads `witt.image.adapter.mlp/v0.1` JSON (from `python/image_adapter/train.py`). Forward pass must stay aligned with Python training code. v0.1 weights use `featureSchema: witt.image.adapter.features/sha256-canonical-json-v0`; legacy weights may omit the field, but CLIP/SigLIP-conditioned adapters must use a new declared runtime contract rather than this SHA baseline.
 - **`adapter-resolve.ts`** — tries **preferred (new)** then **legacy (backup)**:
   - `WITTGENSTEIN_IMAGE_ADAPTER_PREFERRED_PATH` → else `WITTGENSTEIN_IMAGE_ADAPTER_MLP_PATH`
-  - then `WITTGENSTEIN_IMAGE_ADAPTER_LEGACY_PATH` → else `WITTGENSTEIN_IMAGE_ADAPTER_MLP_FALLBACK_PATH`  
-  Skips unloadable files and `tokenGrid` mismatches before the deterministic placeholder.
+  - then `WITTGENSTEIN_IMAGE_ADAPTER_LEGACY_PATH` → else `WITTGENSTEIN_IMAGE_ADAPTER_MLP_FALLBACK_PATH`
+  - skips unloadable files and `tokenGrid` mismatches before the deterministic placeholder.
 - **`placeholder.ts`** — legacy placeholder metadata for checkpoints (optional).
 
 ## Expected future contents

--- a/packages/codec-image/src/adapters/mlp-runtime.ts
+++ b/packages/codec-image/src/adapters/mlp-runtime.ts
@@ -4,9 +4,22 @@ import type { ImageSceneSpec, ImageLatentCodes } from "../schema.js";
 import { ImageLatentCodesSchema } from "../schema.js";
 
 export const MLP_ADAPTER_VERSION = "witt.image.adapter.mlp/v0.1";
+export const MLP_ADAPTER_FEATURE_SCHEMA_SHA256 =
+  "witt.image.adapter.features/sha256-canonical-json-v0";
+
+export type MlpAdapterFeatureSchema = typeof MLP_ADAPTER_FEATURE_SCHEMA_SHA256;
 
 export interface MlpAdapterWeights {
   version: typeof MLP_ADAPTER_VERSION;
+  /**
+   * Feature-extractor contract for `w1` input rows.
+   *
+   * v0.1 weights historically omitted this field; omitted means the legacy
+   * SHA256-over-canonical-JSON vector below. CLIP/SigLIP-conditioned adapters
+   * must not masquerade as v0.1 weights because the input semantics and
+   * dimensionality are different.
+   */
+  featureSchema?: MlpAdapterFeatureSchema;
   codebookSize: number;
   tokenGrid: [number, number];
   inputDim: number;
@@ -18,6 +31,20 @@ export interface MlpAdapterWeights {
   family: ImageLatentCodes["family"];
   codebook: string;
   codebookVersion: string;
+}
+
+export function adapterFeatureSchema(weights: {
+  featureSchema?: unknown;
+}): MlpAdapterFeatureSchema {
+  const schema = weights.featureSchema ?? MLP_ADAPTER_FEATURE_SCHEMA_SHA256;
+  if (schema !== MLP_ADAPTER_FEATURE_SCHEMA_SHA256) {
+    throw new Error(
+      `Unsupported adapter featureSchema: ${String(
+        schema,
+      )}. v0.1 runtime only supports ${MLP_ADAPTER_FEATURE_SCHEMA_SHA256}; CLIP/SigLIP adapters require a new declared runtime contract.`,
+    );
+  }
+  return schema;
 }
 
 function canonicalJson(value: unknown): string {
@@ -108,6 +135,7 @@ export async function loadMlpAdapterFromJsonPath(filePath: string): Promise<MlpA
   if (w.version !== MLP_ADAPTER_VERSION) {
     throw new Error(`Unsupported adapter version: ${String(w.version)}`);
   }
+  adapterFeatureSchema(w);
   if (
     typeof w.codebookSize !== "number" ||
     !Array.isArray(w.tokenGrid) ||
@@ -124,7 +152,11 @@ export async function loadMlpAdapterFromJsonPath(filePath: string): Promise<MlpA
   return w as MlpAdapterWeights;
 }
 
-export function predictLatentsFromMlp(spec: ImageSceneSpec, weights: MlpAdapterWeights): ImageLatentCodes {
+export function predictLatentsFromMlp(
+  spec: ImageSceneSpec,
+  weights: MlpAdapterWeights,
+): ImageLatentCodes {
+  adapterFeatureSchema(weights);
   const features = sceneSpecToFeatureVector(spec);
   const logits = forwardMlp(features, weights);
   const tokens = logitsToTokens(logits, weights.codebookSize);

--- a/packages/codec-image/test/mlp-runtime.test.ts
+++ b/packages/codec-image/test/mlp-runtime.test.ts
@@ -1,6 +1,12 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  MLP_ADAPTER_FEATURE_SCHEMA_SHA256,
+  adapterFeatureSchema,
   forwardMlp,
+  loadMlpAdapterFromJsonPath,
   logitsToTokens,
   sceneSpecToFeatureVector,
   type MlpAdapterWeights,
@@ -61,5 +67,34 @@ describe("mlp-runtime", () => {
     expect(logits.length).toBe(16);
     const tokens = logitsToTokens(logits, 8192);
     expect(tokens.length).toBe(16);
+    expect(adapterFeatureSchema(weights)).toBe(MLP_ADAPTER_FEATURE_SCHEMA_SHA256);
+  });
+
+  it("rejects CLIP/SigLIP-like feature schemas under the v0.1 SHA runtime", async () => {
+    const dir = await mkdtemp(resolve(tmpdir(), "wittgenstein-mlp-runtime-"));
+    const path = resolve(dir, "weights.json");
+    const inputDim = 128;
+    const hiddenDim = 2;
+    const numTokens = 16;
+    const weights = {
+      version: "witt.image.adapter.mlp/v0.1",
+      featureSchema: "witt.image.adapter.features/clip-text-embedding-v0",
+      codebookSize: 8192,
+      tokenGrid: [4, 4],
+      inputDim,
+      hiddenDim,
+      w1: new Array(hiddenDim * inputDim).fill(0),
+      b1: new Array(hiddenDim).fill(0),
+      w2: new Array(numTokens * hiddenDim).fill(0),
+      b2: new Array(numTokens).fill(0),
+      family: "llamagen",
+      codebook: "stub-codebook",
+      codebookVersion: "v0",
+    };
+    await writeFile(path, JSON.stringify(weights), "utf8");
+
+    await expect(loadMlpAdapterFromJsonPath(path)).rejects.toThrow(
+      /CLIP\/SigLIP adapters require a new declared runtime contract/,
+    );
   });
 });

--- a/python/image_adapter/README.md
+++ b/python/image_adapter/README.md
@@ -26,16 +26,16 @@ Apple Silicon: PyTorch uses MPS when available.
 
 ## Scripts
 
-| Script | Purpose |
-| --- | --- |
-| `prepare_dataset.py` | `raw/metadata.jsonl` + images → `train/scenes.jsonl` |
-| `encode_offline.py` | images → `target_tokens` (stub grid quantizer) → `train/encoded.jsonl` |
-| `train.py` | trains MLP (PyTorch), writes `adapter_mlp.json` |
-| `train_numpy.py` | same JSON contract, **pure NumPy + Adam** (no torch) — good for CI / parity with polyglot-style loops |
-| `eval_metrics.py` | token MAE / exact-match rate on a held-out file |
-| `eval_all.py` | one-shot runner: token metrics + spectrum health checks |
-| `spectrum_check.py` | singular-value spectrum + effective-rank health checks for adapter weights (detect rank-collapse) |
-| `build_natural_dataset.py` | optional: generate or download a larger, category-bounded dataset |
+| Script                     | Purpose                                                                                               |
+| -------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `prepare_dataset.py`       | `raw/metadata.jsonl` + images → `train/scenes.jsonl`                                                  |
+| `encode_offline.py`        | images → `target_tokens` (stub grid quantizer) → `train/encoded.jsonl`                                |
+| `train.py`                 | trains MLP (PyTorch), writes `adapter_mlp.json`                                                       |
+| `train_numpy.py`           | same JSON contract, **pure NumPy + Adam** (no torch) — good for CI / parity with polyglot-style loops |
+| `eval_metrics.py`          | token MAE / exact-match rate on a held-out file                                                       |
+| `eval_all.py`              | one-shot runner: token metrics + spectrum health checks                                               |
+| `spectrum_check.py`        | singular-value spectrum + effective-rank health checks for adapter weights (detect rank-collapse)     |
+| `build_natural_dataset.py` | optional: generate or download a larger, category-bounded dataset                                     |
 
 CI owns only the stdlib compile pass plus the pure-NumPy smoke:
 
@@ -47,6 +47,12 @@ python3 -m unittest discover -s python/image_adapter -p 'test_*.py' -v
 That proves the exported `witt.image.adapter.mlp/v0.1` JSON contract stays
 loadable. It does not claim the PyTorch trainer, real dataset build, or model
 quality gate has run.
+
+Current exports declare the SHA feature schema
+(`witt.image.adapter.features/sha256-canonical-json-v0`). Older weights without
+that field are treated as this same SHA/canonical-JSON feature contract; any
+future CLIP/SigLIP feature extractor must use a new explicit contract instead
+of reusing v0.1 silently.
 
 ## Environment (runtime)
 

--- a/python/image_adapter/eval_metrics.py
+++ b/python/image_adapter/eval_metrics.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import torch
 import torch.nn as nn
 
-from features import scene_dict_to_feature_vector
+from features import FEATURE_SCHEMA_SHA256, scene_dict_to_feature_vector
 
 
 class MlpAdapter(nn.Module):
@@ -28,6 +28,12 @@ def load_weights(path: Path) -> tuple[MlpAdapter, dict]:
     raw = json.loads(path.read_text(encoding="utf-8"))
     if raw.get("version") != "witt.image.adapter.mlp/v0.1":
         raise SystemExit("Unsupported adapter file")
+    feature_schema = raw.get("featureSchema", FEATURE_SCHEMA_SHA256)
+    if feature_schema != FEATURE_SCHEMA_SHA256:
+        raise SystemExit(
+            "Unsupported adapter featureSchema "
+            f"{feature_schema!r}; this evaluator only supports {FEATURE_SCHEMA_SHA256}"
+        )
     gw, gh = raw["tokenGrid"]
     num_tokens = gw * gh
     hidden = raw["hiddenDim"]

--- a/python/image_adapter/features.py
+++ b/python/image_adapter/features.py
@@ -7,6 +7,9 @@ import json
 from typing import Any, Mapping
 
 
+FEATURE_SCHEMA_SHA256 = "witt.image.adapter.features/sha256-canonical-json-v0"
+
+
 def canonicalize(value: Any) -> Any:
     if isinstance(value, list):
         return [canonicalize(x) for x in value]

--- a/python/image_adapter/spectrum_check.py
+++ b/python/image_adapter/spectrum_check.py
@@ -21,6 +21,8 @@ from typing import Iterable
 
 import numpy as np
 
+from features import FEATURE_SCHEMA_SHA256
+
 
 @dataclass(frozen=True)
 class SpectrumSummary:
@@ -109,6 +111,12 @@ def load_mlp_adapter_json(path: Path) -> dict:
     raw = json.loads(path.read_text(encoding="utf-8"))
     if raw.get("version") != "witt.image.adapter.mlp/v0.1":
         raise SystemExit("Unsupported adapter file (expected witt.image.adapter.mlp/v0.1)")
+    feature_schema = raw.get("featureSchema", FEATURE_SCHEMA_SHA256)
+    if feature_schema != FEATURE_SCHEMA_SHA256:
+        raise SystemExit(
+            "Unsupported adapter featureSchema "
+            f"{feature_schema!r}; this checker only supports {FEATURE_SCHEMA_SHA256}"
+        )
     return raw
 
 
@@ -165,4 +173,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-

--- a/python/image_adapter/test_train_numpy_smoke.py
+++ b/python/image_adapter/test_train_numpy_smoke.py
@@ -84,6 +84,10 @@ class TrainNumpySmokeTest(unittest.TestCase):
             payload = json.loads(out_path.read_text(encoding="utf-8"))
 
         self.assertEqual(payload["version"], "witt.image.adapter.mlp/v0.1")
+        self.assertEqual(
+            payload["featureSchema"],
+            "witt.image.adapter.features/sha256-canonical-json-v0",
+        )
         self.assertEqual(payload["codebookSize"], 8)
         self.assertEqual(payload["tokenGrid"], [2, 2])
         self.assertEqual(payload["inputDim"], 128)

--- a/python/image_adapter/train.py
+++ b/python/image_adapter/train.py
@@ -11,7 +11,7 @@ import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader, TensorDataset
 
-from features import scene_dict_to_feature_vector
+from features import FEATURE_SCHEMA_SHA256, scene_dict_to_feature_vector
 
 MLP_VERSION = "witt.image.adapter.mlp/v0.1"
 
@@ -109,6 +109,7 @@ def main() -> None:
     dec = spec0["decoder"]
     payload = {
         "version": MLP_VERSION,
+        "featureSchema": FEATURE_SCHEMA_SHA256,
         "codebookSize": codebook_size,
         "tokenGrid": [gw, gh],
         "inputDim": 128,

--- a/python/image_adapter/train_numpy.py
+++ b/python/image_adapter/train_numpy.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 import numpy as np
 
-from features import scene_dict_to_feature_vector
+from features import FEATURE_SCHEMA_SHA256, scene_dict_to_feature_vector
 
 MLP_VERSION = "witt.image.adapter.mlp/v0.1"
 INPUT_DIM = 128
@@ -101,6 +101,7 @@ def export_json(
 ) -> None:
     payload = {
         "version": MLP_VERSION,
+        "featureSchema": FEATURE_SCHEMA_SHA256,
         "codebookSize": codebook_size,
         "tokenGrid": [gw, gh],
         "inputDim": INPUT_DIM,

--- a/research/validation/fixtures/phase0b-semantic-ir-sensitivity.fixture.json
+++ b/research/validation/fixtures/phase0b-semantic-ir-sensitivity.fixture.json
@@ -1,0 +1,119 @@
+{
+  "schemaVersion": "witt.research.phase0b-semantic-ir-sensitivity/v0.1",
+  "issue": 452,
+  "generatedAt": "2026-05-31T00:00:00.000Z",
+  "measurement": "Phase 0b semantic IR field sensitivity",
+  "adapter": {
+    "codePath": "visual-seed-code",
+    "seedExpanderId": "placeholder-seed-expander/v0",
+    "seedSensitivitySource": "adapter.hashSpecToSeed(scene)",
+    "learnedMlpFeatureSchema": "witt.image.adapter.features/sha256-canonical-json-v0",
+    "learnedMlpUsed": false,
+    "semanticAlignment": "not_measured_seed_expander_hash_baseline"
+  },
+  "controls": {
+    "seedCode": {
+      "schemaVersion": "witt.image.seed/v0.1",
+      "family": "vqvae",
+      "mode": "prefix",
+      "tokens": [42, 17, 88, 201, 15, 33, 77, 100]
+    },
+    "decoder": {
+      "family": "llamagen",
+      "codebook": "stub-codebook",
+      "codebookVersion": "v0",
+      "latentResolution": [4, 4]
+    },
+    "variedFields": [
+      "intent",
+      "lighting.mood",
+      "composition.framing",
+      "style.palette",
+      "constraints.negative"
+    ]
+  },
+  "cases": [
+    {
+      "field": "intent",
+      "baseValue": "stormy ocean at midnight",
+      "variantValue": "sunny meadow at noon",
+      "tokenHammingRate": 1,
+      "meanAbsoluteTokenDelta": 5536,
+      "maxAbsoluteTokenDelta": 5536,
+      "baseLatentSha256": "d078d418debbdeb2c4a2cb452d6bc2a93317d56d7f315fc2b17269c1efe0a021",
+      "variantLatentSha256": "85626357558e82d3aa48ae52fa0ff784208c2e2d4873f21b4f2645b1cf979078",
+      "basePngSha256": "57301486eff736cab8237a59679b7ff4dc8c5cb115df32c1105e8e622138a950",
+      "variantPngSha256": "a8d43a05b666f5e78d10e6274ecb6e23f6d72c06e874b9ff994715f97be85cec",
+      "pngByteHammingRate": 0.9978643473509256,
+      "pngLengthDelta": 214829,
+      "verdict": "output_changed_hash_baseline"
+    },
+    {
+      "field": "lighting.mood",
+      "baseValue": "warm golden",
+      "variantValue": "cold fluorescent",
+      "tokenHammingRate": 1,
+      "meanAbsoluteTokenDelta": 2158,
+      "maxAbsoluteTokenDelta": 2158,
+      "baseLatentSha256": "d078d418debbdeb2c4a2cb452d6bc2a93317d56d7f315fc2b17269c1efe0a021",
+      "variantLatentSha256": "626bb4a94796acab93b0571d67c9d9c7c62a11285eaaedf88d2f5bf504733f14",
+      "basePngSha256": "57301486eff736cab8237a59679b7ff4dc8c5cb115df32c1105e8e622138a950",
+      "variantPngSha256": "f71c39b803c81c6b7a13749b2110570f4fb51b1be0901c4699f779a91d18f555",
+      "pngByteHammingRate": 0.9960485156707231,
+      "pngLengthDelta": 23374,
+      "verdict": "output_changed_hash_baseline"
+    },
+    {
+      "field": "composition.framing",
+      "baseValue": "wide establishing shot",
+      "variantValue": "tight macro detail",
+      "tokenHammingRate": 1,
+      "meanAbsoluteTokenDelta": 2171,
+      "maxAbsoluteTokenDelta": 2171,
+      "baseLatentSha256": "d078d418debbdeb2c4a2cb452d6bc2a93317d56d7f315fc2b17269c1efe0a021",
+      "variantLatentSha256": "64561cc5878e81a27d239601a049878ae8596b3cbb3d89946232671097df29e5",
+      "basePngSha256": "57301486eff736cab8237a59679b7ff4dc8c5cb115df32c1105e8e622138a950",
+      "variantPngSha256": "a8d43a05b666f5e78d10e6274ecb6e23f6d72c06e874b9ff994715f97be85cec",
+      "pngByteHammingRate": 0.9978643473509256,
+      "pngLengthDelta": 214829,
+      "verdict": "output_changed_hash_baseline"
+    },
+    {
+      "field": "style.palette",
+      "baseValue": ["amber", "deep blue", "white"],
+      "variantValue": ["acid green", "magenta", "black"],
+      "tokenHammingRate": 1,
+      "meanAbsoluteTokenDelta": 436,
+      "maxAbsoluteTokenDelta": 436,
+      "baseLatentSha256": "d078d418debbdeb2c4a2cb452d6bc2a93317d56d7f315fc2b17269c1efe0a021",
+      "variantLatentSha256": "47e4727fb38ddde0a3766de333429e5799cb34bfb126965a915996eff9199a14",
+      "basePngSha256": "57301486eff736cab8237a59679b7ff4dc8c5cb115df32c1105e8e622138a950",
+      "variantPngSha256": "2686f6f1fb1ae0d156778a94c2ea621078dab401562c7cf04b5bd8b7cc5b90c4",
+      "pngByteHammingRate": 0.9960590491234641,
+      "pngLengthDelta": 21245,
+      "verdict": "output_changed_hash_baseline"
+    },
+    {
+      "field": "constraints.negative",
+      "baseValue": ["no text", "no watermark"],
+      "variantValue": ["no people", "no buildings"],
+      "tokenHammingRate": 1,
+      "meanAbsoluteTokenDelta": 349,
+      "maxAbsoluteTokenDelta": 349,
+      "baseLatentSha256": "d078d418debbdeb2c4a2cb452d6bc2a93317d56d7f315fc2b17269c1efe0a021",
+      "variantLatentSha256": "d98b5301a765ba4fd8c12416c212efe56bfdb0e9f71ff83be92b988cc33876ee",
+      "basePngSha256": "57301486eff736cab8237a59679b7ff4dc8c5cb115df32c1105e8e622138a950",
+      "variantPngSha256": "a8d43a05b666f5e78d10e6274ecb6e23f6d72c06e874b9ff994715f97be85cec",
+      "pngByteHammingRate": 0.9978643473509256,
+      "pngLengthDelta": 214829,
+      "verdict": "output_changed_hash_baseline"
+    }
+  ],
+  "aggregate": {
+    "caseCount": 5,
+    "meanTokenHammingRate": 1,
+    "meanPngByteHammingRate": 0.9971401213693929,
+    "allCasesChanged": true
+  },
+  "interpretation": "Current Visual Seed Code output is field-sensitive because adapter.hashSpecToSeed(scene) changes the seed-expander input. This is a null baseline receipt, not evidence of learned MLP or CLIP/SigLIP semantic conditioning."
+}

--- a/research/validation/phase0b_semantic_ir_sensitivity.ts
+++ b/research/validation/phase0b_semantic_ir_sensitivity.ts
@@ -1,0 +1,366 @@
+#!/usr/bin/env tsx
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import type { RenderCtx } from "@wittgenstein/schemas";
+import { format as formatPrettier } from "prettier";
+import {
+  MLP_ADAPTER_FEATURE_SCHEMA_SHA256,
+  adapterFeatureSchema,
+} from "../../packages/codec-image/src/adapters/mlp-runtime.js";
+import { selectSeedExpander } from "../../packages/codec-image/src/adapters/seed-expander-resolve.js";
+import { adaptSceneToLatents } from "../../packages/codec-image/src/pipeline/adapter.js";
+import { decodeLatentsToRaster } from "../../packages/codec-image/src/pipeline/decoder.js";
+import {
+  ImageSceneSpecSchema,
+  ImageVisualSeedCodeSchema,
+  type ImageLatentCodes,
+  type ImageSceneSpec,
+} from "../../packages/codec-image/src/schema.js";
+import type { ImageAdapterReceipt } from "../../packages/codec-image/src/types.js";
+
+const DEFAULT_OUT = "artifacts/m1b-audit/phase0b-semantic-ir-sensitivity.json";
+const SCHEMA_VERSION = "witt.research.phase0b-semantic-ir-sensitivity/v0.1";
+
+interface CaseSpec {
+  readonly field: string;
+  readonly base: unknown;
+  readonly variant: unknown;
+}
+
+const CASES: readonly CaseSpec[] = [
+  {
+    field: "intent",
+    base: "stormy ocean at midnight",
+    variant: "sunny meadow at noon",
+  },
+  {
+    field: "lighting.mood",
+    base: "warm golden",
+    variant: "cold fluorescent",
+  },
+  {
+    field: "composition.framing",
+    base: "wide establishing shot",
+    variant: "tight macro detail",
+  },
+  {
+    field: "style.palette",
+    base: ["amber", "deep blue", "white"],
+    variant: ["acid green", "magenta", "black"],
+  },
+  {
+    field: "constraints.negative",
+    base: ["no text", "no watermark"],
+    variant: ["no people", "no buildings"],
+  },
+];
+
+function parseArgs(argv: readonly string[]): {
+  out: string;
+  generatedAt: string;
+  seedExpander: string;
+} {
+  let out = DEFAULT_OUT;
+  let generatedAt = new Date().toISOString();
+  let seedExpander = "placeholder";
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--") {
+      continue;
+    } else if (arg === "--out") {
+      out = requiredValue(argv, (index += 1), arg);
+    } else if (arg === "--generated-at") {
+      generatedAt = requiredValue(argv, (index += 1), arg);
+    } else if (arg === "--seed-expander") {
+      seedExpander = requiredValue(argv, (index += 1), arg);
+    } else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${String(arg)}`);
+    }
+  }
+
+  return { out, generatedAt, seedExpander };
+}
+
+function requiredValue(argv: readonly string[], index: number, flag: string): string {
+  const value = argv[index];
+  if (!value) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function printHelp(): void {
+  console.log(`Usage: pnpm exec tsx research/validation/phase0b_semantic_ir_sensitivity.ts [options]
+
+Options:
+  --out <path>             Output receipt path (default: ${DEFAULT_OUT})
+  --generated-at <iso>     Override timestamp for deterministic fixtures
+  --seed-expander <id>     Seed expander selector (default: placeholder)
+
+This runner measures Phase 0b adapter-output sensitivity for #452. It is a
+seed-expander hash baseline: it proves semantic fields perturb the current
+Visual Seed Code output path, but also records that the perturbation is driven
+by the per-spec hash seed rather than semantically aligned CLIP/SigLIP
+conditioning.`);
+}
+
+function setPath(value: unknown, field: string, replacement: unknown): unknown {
+  const cloned = JSON.parse(JSON.stringify(value)) as Record<string, unknown>;
+  const parts = field.split(".");
+  let cursor = cloned;
+  for (const part of parts.slice(0, -1)) {
+    const next = cursor[part];
+    if (typeof next !== "object" || next === null || Array.isArray(next)) {
+      throw new Error(`Cannot set ${field}; ${part} is not an object`);
+    }
+    cursor = next as Record<string, unknown>;
+  }
+  cursor[parts[parts.length - 1]!] = replacement;
+  return cloned;
+}
+
+function baseScene(): ImageSceneSpec {
+  return ImageSceneSpecSchema.parse({
+    schemaVersion: "witt.image.spec/v0.1",
+    mode: "one-shot-vsc",
+    intent: "stormy ocean at midnight",
+    subject: "rocky coast",
+    composition: {
+      framing: "wide establishing shot",
+      camera: "low horizon",
+      depthPlan: ["foreground rocks", "midground waves", "background storm clouds"],
+    },
+    lighting: {
+      mood: "warm golden",
+      key: "low side",
+    },
+    style: {
+      references: ["phase0b baseline"],
+      palette: ["amber", "deep blue", "white"],
+    },
+    constraints: {
+      mustHave: ["visible horizon"],
+      negative: ["no text", "no watermark"],
+    },
+    renderHints: {
+      detailLevel: "medium",
+      tokenBudget: 1024,
+      seed: null,
+    },
+    decoder: {
+      family: "llamagen",
+      codebook: "stub-codebook",
+      codebookVersion: "v0",
+      latentResolution: [4, 4],
+    },
+    seedCode: ImageVisualSeedCodeSchema.parse({
+      schemaVersion: "witt.image.seed/v0.1",
+      family: "vqvae",
+      mode: "prefix",
+      tokens: [42, 17, 88, 201, 15, 33, 77, 100],
+    }),
+  });
+}
+
+function renderCtx(outPath: string): RenderCtx {
+  const logger = {
+    debug: () => undefined,
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+  };
+  return {
+    runId: "phase0b-semantic-ir-sensitivity",
+    runDir: dirname(outPath),
+    seed: null,
+    outPath,
+    logger,
+  };
+}
+
+async function adaptAndDecode(
+  scene: ImageSceneSpec,
+  label: string,
+): Promise<{
+  latents: ImageLatentCodes;
+  pngBytes: Uint8Array;
+  adapterReceipt: ImageAdapterReceipt;
+}> {
+  const ctx = renderCtx(`artifacts/tmp/phase0b-${label}.png`);
+  const { latents, receipt } = await adaptSceneToLatents(scene, ctx);
+  const raster = await decodeLatentsToRaster(latents, ctx);
+  return {
+    latents,
+    pngBytes: raster.pngBytes,
+    adapterReceipt: receipt,
+  };
+}
+
+function sha256(bytes: Uint8Array | string): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function tokenDelta(
+  a: readonly number[],
+  b: readonly number[],
+): {
+  hammingRate: number;
+  meanAbsoluteDelta: number;
+  maxAbsoluteDelta: number;
+} {
+  if (a.length !== b.length) {
+    throw new Error(`Token length mismatch: ${a.length} vs ${b.length}`);
+  }
+  let changed = 0;
+  let totalAbs = 0;
+  let maxAbs = 0;
+  for (let index = 0; index < a.length; index += 1) {
+    const delta = Math.abs((a[index] ?? 0) - (b[index] ?? 0));
+    if (delta > 0) {
+      changed += 1;
+    }
+    totalAbs += delta;
+    maxAbs = Math.max(maxAbs, delta);
+  }
+  return {
+    hammingRate: changed / Math.max(1, a.length),
+    meanAbsoluteDelta: totalAbs / Math.max(1, a.length),
+    maxAbsoluteDelta: maxAbs,
+  };
+}
+
+function byteDelta(
+  a: Uint8Array,
+  b: Uint8Array,
+): {
+  byteHammingRate: number;
+  lengthDelta: number;
+} {
+  const width = Math.max(a.length, b.length);
+  let changed = Math.abs(a.length - b.length);
+  for (let index = 0; index < Math.min(a.length, b.length); index += 1) {
+    if (a[index] !== b[index]) {
+      changed += 1;
+    }
+  }
+  return {
+    byteHammingRate: changed / Math.max(1, width),
+    lengthDelta: b.length - a.length,
+  };
+}
+
+async function buildReceipt(options: {
+  generatedAt: string;
+  seedExpander: string;
+}): Promise<Record<string, unknown>> {
+  const selectedSeedExpander = selectSeedExpander(options.seedExpander);
+  process.env.WITTGENSTEIN_IMAGE_SEED_EXPANDER = options.seedExpander;
+  const featureSchema = adapterFeatureSchema({});
+  const base = baseScene();
+  const rows = [];
+
+  for (const caseSpec of CASES) {
+    const baseCase = ImageSceneSpecSchema.parse(setPath(base, caseSpec.field, caseSpec.base));
+    const variantCase = ImageSceneSpecSchema.parse(setPath(base, caseSpec.field, caseSpec.variant));
+
+    const baseOutput = await adaptAndDecode(baseCase, `${caseSpec.field}-base`);
+    const variantOutput = await adaptAndDecode(variantCase, `${caseSpec.field}-variant`);
+    assertSeedExpanderReceipt(baseOutput.adapterReceipt, selectedSeedExpander.id, caseSpec.field);
+    assertSeedExpanderReceipt(
+      variantOutput.adapterReceipt,
+      selectedSeedExpander.id,
+      caseSpec.field,
+    );
+    const token = tokenDelta(baseOutput.latents.tokens, variantOutput.latents.tokens);
+    const png = byteDelta(baseOutput.pngBytes, variantOutput.pngBytes);
+
+    rows.push({
+      field: caseSpec.field,
+      baseValue: caseSpec.base,
+      variantValue: caseSpec.variant,
+      tokenHammingRate: token.hammingRate,
+      meanAbsoluteTokenDelta: token.meanAbsoluteDelta,
+      maxAbsoluteTokenDelta: token.maxAbsoluteDelta,
+      baseLatentSha256: sha256(JSON.stringify(baseOutput.latents.tokens)),
+      variantLatentSha256: sha256(JSON.stringify(variantOutput.latents.tokens)),
+      basePngSha256: sha256(baseOutput.pngBytes),
+      variantPngSha256: sha256(variantOutput.pngBytes),
+      pngByteHammingRate: png.byteHammingRate,
+      pngLengthDelta: png.lengthDelta,
+      verdict:
+        token.hammingRate > 0 ? "output_changed_hash_baseline" : "output_unchanged_hash_baseline",
+    });
+  }
+
+  const meanTokenHammingRate =
+    rows.reduce((sum, row) => sum + row.tokenHammingRate, 0) / Math.max(1, rows.length);
+  const meanPngByteHammingRate =
+    rows.reduce((sum, row) => sum + row.pngByteHammingRate, 0) / Math.max(1, rows.length);
+
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    issue: 452,
+    generatedAt: options.generatedAt,
+    measurement: "Phase 0b semantic IR field sensitivity",
+    adapter: {
+      codePath: "visual-seed-code",
+      seedExpanderId: selectedSeedExpander.id,
+      seedSensitivitySource: "adapter.hashSpecToSeed(scene)",
+      learnedMlpFeatureSchema: featureSchema,
+      learnedMlpUsed: false,
+      semanticAlignment: "not_measured_seed_expander_hash_baseline",
+    },
+    controls: {
+      seedCode: base.seedCode,
+      decoder: base.decoder,
+      variedFields: CASES.map((entry) => entry.field),
+    },
+    cases: rows,
+    aggregate: {
+      caseCount: rows.length,
+      meanTokenHammingRate,
+      meanPngByteHammingRate,
+      allCasesChanged: rows.every((row) => row.tokenHammingRate > 0),
+    },
+    interpretation:
+      "Current Visual Seed Code output is field-sensitive because adapter.hashSpecToSeed(scene) changes the seed-expander input. This is a null baseline receipt, not evidence of learned MLP or CLIP/SigLIP semantic conditioning.",
+  };
+}
+
+function assertSeedExpanderReceipt(
+  receipt: ImageAdapterReceipt,
+  expectedSeedExpanderId: string,
+  field: string,
+): void {
+  if (receipt.outcome !== "visual-seed-code" || receipt.seedExpanderId !== expectedSeedExpanderId) {
+    throw new Error(
+      `Phase 0b case ${field} expected visual-seed-code via ${expectedSeedExpanderId}; got outcome=${receipt.outcome}, seedExpanderId=${receipt.seedExpanderId}`,
+    );
+  }
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const receipt = await buildReceipt(args);
+  const out = resolve(args.out);
+  await mkdir(dirname(out), { recursive: true });
+  await writeFile(out, await formatPrettier(JSON.stringify(receipt), { parser: "json" }), "utf8");
+
+  const reloaded = JSON.parse(await readFile(out, "utf8")) as {
+    aggregate?: { allCasesChanged?: boolean };
+  };
+  if (reloaded.aggregate?.allCasesChanged !== true) {
+    throw new Error("Phase 0b receipt did not show output changes for all cases.");
+  }
+  console.log(`Phase 0b receipt written to ${out}`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/research/validation/test_phase0b_semantic_ir_sensitivity.py
+++ b/research/validation/test_phase0b_semantic_ir_sensitivity.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "phase0b-semantic-ir-sensitivity.fixture.json"
+
+
+class Phase0BSemanticIRSensitivityFixtureTests(unittest.TestCase):
+    def test_fixture_records_hash_baseline_not_semantic_alignment(self) -> None:
+        receipt = json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+        self.assertEqual(
+            receipt["schemaVersion"],
+            "witt.research.phase0b-semantic-ir-sensitivity/v0.1",
+        )
+        self.assertEqual(receipt["issue"], 452)
+        self.assertEqual(receipt["adapter"]["codePath"], "visual-seed-code")
+        self.assertEqual(
+            receipt["adapter"]["seedExpanderId"],
+            "placeholder-seed-expander/v0",
+        )
+        self.assertFalse(receipt["adapter"]["learnedMlpUsed"])
+        self.assertEqual(
+            receipt["adapter"]["learnedMlpFeatureSchema"],
+            "witt.image.adapter.features/sha256-canonical-json-v0",
+        )
+        self.assertEqual(
+            receipt["adapter"]["semanticAlignment"],
+            "not_measured_seed_expander_hash_baseline",
+        )
+        self.assertTrue(receipt["aggregate"]["allCasesChanged"])
+
+    def test_each_case_has_token_and_png_delta_receipts(self) -> None:
+        receipt = json.loads(FIXTURE.read_text(encoding="utf-8"))
+        cases = receipt["cases"]
+
+        self.assertGreaterEqual(len(cases), 5)
+        for case in cases:
+            self.assertGreater(case["tokenHammingRate"], 0)
+            self.assertGreater(case["meanAbsoluteTokenDelta"], 0)
+            self.assertRegex(case["baseLatentSha256"], r"^[0-9a-f]{64}$")
+            self.assertRegex(case["variantLatentSha256"], r"^[0-9a-f]{64}$")
+            self.assertRegex(case["basePngSha256"], r"^[0-9a-f]{64}$")
+            self.assertRegex(case["variantPngSha256"], r"^[0-9a-f]{64}$")
+            self.assertIn(case["verdict"], {"output_changed_hash_baseline"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds a repeatable Phase 0b Semantic IR field-sensitivity runner for #452 plus a committed fixture receipt.
- Varies `intent`, `lighting.mood`, `composition.framing`, `style.palette`, and `constraints.negative` under fixed Visual Seed Code + decoder controls, then records token deltas, PNG-byte deltas, and SHA256 receipts.
- Marks the measurement honestly as a `visual-seed-code` seed-expander hash baseline. The runner asserts the actual pipeline receipt used `visual-seed-code` and the selected seed expander before accepting the result.
- Declares the v0.1 learned MLP feature schema as `witt.image.adapter.features/sha256-canonical-json-v0` across Node runtime and Python exporters/evaluators, while rejecting CLIP/SigLIP-like schemas under the SHA runtime contract.

## Decision / Scope

Refs #452, but intentionally does **not** close it.

This PR closes one missing engineering/research gap from the previous audit: measured Phase 0b output deltas now exist as a reproducible receipt instead of only a deterministic unit-test claim. It does **not** claim semantic alignment. The receipt explicitly says the current changes are hash-driven, not learned MLP or CLIP/SigLIP semantic conditioning.

Still missing before #452 can close:

- live Phase 0a repeated LLM emission results;
- CLIP/SigLIP adapter-conditioning implementation, or an explicit architecture decision replacing it;
- semantic image-alignment metrics beyond this null baseline.

I also checked the local environment before choosing this scope: no OpenAI or Anthropic API key is present, so this PR does not fabricate Phase 0a live LLM evidence.

## Verification

- `pnpm install --frozen-lockfile --offline`
- `pnpm m1b:phase0b-ir-sensitivity -- --out research/validation/fixtures/phase0b-semantic-ir-sensitivity.fixture.json --generated-at 2026-05-31T00:00:00.000Z`
- `pnpm m1b:phase0b-ir-sensitivity -- --out /tmp/phase0b-semantic-ir-sensitivity.check.json --generated-at 2026-05-31T00:00:00.000Z && diff -u research/validation/fixtures/phase0b-semantic-ir-sensitivity.fixture.json /tmp/phase0b-semantic-ir-sensitivity.check.json`
- `python3 -m unittest research.validation.test_phase0b_semantic_ir_sensitivity`
- `python3 -m compileall python/image_adapter`
- `python3 -m unittest discover -s python/image_adapter -p 'test_*.py' -v`
- `pnpm test:image-adapter`
- `pnpm --filter @wittgenstein/codec-image test -- mlp-runtime.test.ts phase0-seed-degradation.test.ts`
- `pnpm --filter @wittgenstein/codec-image typecheck`
- `pnpm --filter @wittgenstein/codec-image lint`
- `pnpm --filter @wittgenstein/codec-image test`
- `pnpm --filter @wittgenstein/codec-image build`
- `pnpm exec prettier --check package.json docs/research/2026-05-22-ir-reliability-validation.md packages/codec-image/src/adapters/README.md python/image_adapter/README.md packages/codec-image/src/adapters/mlp-runtime.ts packages/codec-image/test/mlp-runtime.test.ts research/validation/phase0b_semantic_ir_sensitivity.ts research/validation/fixtures/phase0b-semantic-ir-sensitivity.fixture.json`
- `git diff --check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm lint:no-research-imports`
- `pnpm lint:deps`
