### PR TITLE
fix(video): record MP4 receipt portability sweep

### DIFF
--- a/docs/codecs/video.md
+++ b/docs/codecs/video.md
@@ -100,6 +100,14 @@ for the fixture. It exits non-zero when a requested backend fails the gate. Set
 `WITTGENSTEIN_VALIDATE_VIDEO_BACKENDS=distilled-internal,npx-cli` to compare both
 backends.
 
+The validation JSON records an `environment` block (OS, Node, FFmpeg, ffprobe,
+and optional `WITTGENSTEIN_VALIDATION_ENVIRONMENT_ID`) and a `portability`
+summary with the structure and portable receipt fields to compare across
+machines. `WITTGENSTEIN_VIDEO_VALIDATION_DIR` may be relative or absolute; the
+script resolves it before handing frame paths to FFmpeg. The #476 cross-machine
+sweep is recorded in
+`docs/research/2026-05-31-video-mp4-receipt-portability.md`.
+
 ## Benchmark Direction
 
 With the opt-in MP4 branch wired, video should align with common evaluation practice instead of ad-hoc scores once the local-compute gate is run:

--- a/docs/research/2026-05-31-video-mp4-receipt-portability.md
+++ b/docs/research/2026-05-31-video-mp4-receipt-portability.md
@@ -1,0 +1,76 @@
+---
+date: 2026-05-31
+status: validation note
+labels: [research-derived, m4-video, receipts, eval]
+tracks: [#476, #359, #456]
+---
+
+# Video MP4 receipt portability sweep
+
+## Question
+
+#476 asks whether the repo-owned MP4 renderer's structural receipt floor travels
+across machines and toolchain versions. The policy under test is:
+
+- same-platform MP4 bytes must be stable for a fixed backend;
+- cross-platform MP4 bytes are informational, not a release promise;
+- cross-platform ffprobe structure and portable `videoRender` receipt fields
+  are the acceptance floor.
+
+The sweep used the existing validation script:
+
+```bash
+node --import tsx research/validation/video_mp4_renderer_validate.ts
+```
+
+MP4 mode was enabled with `WITTGENSTEIN_VALIDATE_VIDEO_MP4=1`.
+
+## Environments
+
+| Environment                 | OS / arch                    |  Node.js | FFmpeg / ffprobe                  | Chrome / Chromium     |
+| --------------------------- | ---------------------------- | -------: | --------------------------------- | --------------------- |
+| `macos-local-arm64`         | Darwin 25.0.0 arm64          |  v25.6.1 | 8.0.1 / 8.0.1                     | Chrome/148.0.7778.181 |
+| `linux-docker-arm64-node22` | Linux 6.12.54-linuxkit arm64 | v22.22.3 | 5.1.9-0+deb12u1 / 5.1.9-0+deb12u1 | Chrome/148.0.7778.178 |
+
+Both runs used the `distilled-internal` backend and the fixed 3 second,
+72-frame inline-SVG fixture from
+`research/validation/video_mp4_renderer_validate.ts`.
+
+## Results
+
+| Field                         |                                                                                                                  macOS local |                                                       Linux Docker | Cross-environment result |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------: | -----------------------------------------------------------------: | ------------------------ |
+| HTML SHA-256                  |                                                           `e8cc3f665892ca0152c63bef568543cf2dfa972d8bcbe07829e82f30f84c14b1` | `e8cc3f665892ca0152c63bef568543cf2dfa972d8bcbe07829e82f30f84c14b1` | byte parity              |
+| MP4 SHA-256                   |                                                           `4b28221cfe49cf76b7fc3789d86c66d5885875c1b0e4f1c3d8aa33e42f834c0d` | `fa59cb32596aa2d9c19ca5bc784729fc6706d028b013ea3bc8a47fb98acf0879` | byte drift, expected     |
+| MP4 bytes                     |                                                                                                                       17,471 |                                                             17,249 | byte drift, expected     |
+| Same-platform backend verdict |                                                                                                    `byte-parity-on-platform` |                                          `byte-parity-on-platform` | pass                     |
+| ffprobe structure             |                                                                             H.264, 1920x1080, 24/1 fps, 3.000000s, 72 frames |                   H.264, 1920x1080, 24/1 fps, 3.000000s, 72 frames | structural parity        |
+| Portable receipt fields       | `hyperframes-mp4`, `distilled-internal`, `structural-parity-cross-platform`, 24 fps, standard, 72 frames, 1920x1080, 3s, MP4 |                                                               same | receipt parity           |
+
+The observed MP4 byte drift matches the prior policy: Chrome and FFmpeg
+versions differ, and MP4 bytes are not a portable invariant. The stable
+invariants are the ffprobe structure and the portable receipt signature.
+
+## Implementation feedback
+
+The sweep found one validation-path bug and one receipt fidelity weakness:
+
+1. `WITTGENSTEIN_VIDEO_VALIDATION_DIR` failed when set to a relative path,
+   because FFmpeg received a frame path that was later reinterpreted relative
+   to the encode cwd. The validation script now resolves that base directory
+   before creating the temporary run directory.
+2. The Linux run proved that `ffmpeg -version` can exceed the 1 second default
+   version-probe budget while still returning useful data under a 5 second
+   probe. The MP4 renderer now gives FFmpeg version receipts that 5 second
+   ceiling instead of falling back prematurely to the literal `ffmpeg`.
+
+The validation script now emits an `environment` object and a `portability`
+summary so future machine-to-machine sweeps can compare the policy fields
+directly instead of hand-copying from nested receipt JSON.
+
+## Verdict
+
+#476 can close on the current policy. Same-platform byte parity passed on both
+machines for the default backend. Cross-machine MP4 bytes differed, as expected,
+while cross-machine structure and portable receipt fields matched. No new
+implementation issue is needed for structural parity failure.

--- a/packages/codec-video/src/mp4-renderer.ts
+++ b/packages/codec-video/src/mp4-renderer.ts
@@ -173,10 +173,12 @@ async function encodeFrames(
 function readFfmpegVersion(): string {
   // `ffmpeg -version` is a synchronous version probe — the encode timeout
   // (10-minute render budget) is the wrong policy here; use the
-  // process-runner default (1s) which is the right floor for version checks.
+  // process-runner probe shape but allow a 5s ceiling. The cross-environment
+  // #476 sweep showed Linux containers can exceed the 1s default while still
+  // returning a useful receipt version.
   // On failure, fall back to the literal "ffmpeg" — the encode call below
   // will surface any real process error via runProcess.
-  const result = spawnVersionCheck("ffmpeg", ["-version"]);
+  const result = spawnVersionCheck("ffmpeg", ["-version"], { timeoutMs: 5_000 });
   if (result.ok) {
     return firstOutputLine(result.stdout, result.stderr) || "ffmpeg";
   }

--- a/research/validation/video_mp4_renderer_validate.ts
+++ b/research/validation/video_mp4_renderer_validate.ts
@@ -1,8 +1,9 @@
 import { createHash } from "node:crypto";
 import { spawnSync } from "node:child_process";
 import { mkdir, readFile, rm, stat } from "node:fs/promises";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { mkdtemp } from "node:fs/promises";
+import { arch, platform, release } from "node:os";
 import { videoCodec } from "../../packages/codec-video/src/index.js";
 import type { VideoComposition } from "../../packages/codec-video/src/schema.js";
 
@@ -61,6 +62,7 @@ async function main(): Promise<void> {
           {
             ok: true,
             mode: "html-only",
+            environment: environmentReceipt(),
             skippedMp4:
               "Set WITTGENSTEIN_VALIDATE_VIDEO_MP4=1 and WITTGENSTEIN_HYPERFRAMES_RENDER=1 with Chrome + FFmpeg installed to run MP4 validation.",
             html: htmlReceipt,
@@ -78,9 +80,7 @@ async function main(): Promise<void> {
       .map((value) => value.trim())
       .filter((value) => value === "distilled-internal" || value === "npx-cli");
     if (backends.length === 0) {
-      throw new Error(
-        "No valid MP4 backends selected. Use distilled-internal and/or npx-cli.",
-      );
+      throw new Error("No valid MP4 backends selected. Use distilled-internal and/or npx-cli.");
     }
     const mp4 = [];
     for (const backend of backends) {
@@ -102,9 +102,15 @@ async function main(): Promise<void> {
         {
           ok,
           mode: "mp4-double-render",
+          environment: environmentReceipt(),
           validatedBackends: mp4.length,
           html: htmlReceipt,
           mp4,
+          portability: {
+            policy:
+              "same-platform byte parity is required per backend; cross-platform MP4 bytes are informational; cross-platform structural parity is the portability floor.",
+            backends: mp4.map((result) => portabilitySummary(result)),
+          },
         },
         null,
         2,
@@ -120,6 +126,21 @@ async function main(): Promise<void> {
       await rm(dir, { recursive: true, force: true });
     }
   }
+}
+
+function environmentReceipt() {
+  return {
+    os: {
+      platform: platform(),
+      release: release(),
+      arch: arch(),
+    },
+    nodeVersion: process.version,
+    ffmpegVersion: toolVersion("ffmpeg"),
+    ffprobeVersion: toolVersion("ffprobe"),
+    ci: process.env.CI === "1" || process.env.CI === "true",
+    environmentId: process.env.WITTGENSTEIN_VALIDATION_ENVIRONMENT_ID,
+  };
 }
 
 async function renderMp4(value: VideoComposition, dir: string, label: string) {
@@ -139,6 +160,28 @@ async function renderMp4(value: VideoComposition, dir: string, label: string) {
     bytes: file.size,
     structure: probeVideo(result.artifactPath),
     videoRender: result.metadata.videoRender,
+  };
+}
+
+function portabilitySummary(result: {
+  backend: string;
+  first: Awaited<ReturnType<typeof renderMp4>>;
+  second: Awaited<ReturnType<typeof renderMp4>>;
+  verdict: "byte-parity-on-platform" | "failed";
+}) {
+  const firstStructure = videoStructureSignature(result.first.structure);
+  const secondStructure = videoStructureSignature(result.second.structure);
+  const firstReceipt = videoReceiptSignature(result.first.videoRender);
+  const secondReceipt = videoReceiptSignature(result.second.videoRender);
+  return {
+    backend: result.backend,
+    samePlatformByteParity: result.verdict === "byte-parity-on-platform",
+    samePlatformStructuralParity: sameJson(firstStructure, secondStructure),
+    samePlatformPortableReceiptParity: sameJson(firstReceipt, secondReceipt),
+    firstStructure,
+    secondStructure,
+    firstReceipt,
+    secondReceipt,
   };
 }
 
@@ -170,8 +213,68 @@ function validVideoStructure(structure: ReturnType<typeof probeVideo>): boolean 
   );
 }
 
+function videoStructureSignature(structure: ReturnType<typeof probeVideo>) {
+  if (!structure.ok) {
+    return {
+      ok: false,
+      message: structure.message,
+    };
+  }
+  const stream = structure.value.streams?.[0];
+  return {
+    ok: true,
+    codec: stream?.codec_name ?? null,
+    width: stream?.width ?? null,
+    height: stream?.height ?? null,
+    fps: stream?.r_frame_rate ?? null,
+    duration: stream?.duration ?? null,
+    frameCount: stream?.nb_frames ?? null,
+  };
+}
+
+function videoReceiptSignature(receipt: Awaited<ReturnType<typeof renderMp4>>["videoRender"]) {
+  return {
+    renderPath: receipt?.renderPath ?? null,
+    backend: receipt?.backend ?? null,
+    backendVersion: receipt?.backendVersion ?? null,
+    determinismClass: receipt?.determinismClass ?? null,
+    fps: receipt?.fps ?? null,
+    quality: receipt?.quality ?? null,
+    frameCount: receipt?.frameCount ?? null,
+    width: receipt?.width ?? null,
+    height: receipt?.height ?? null,
+    durationSec: receipt?.durationSec ?? null,
+    outputKind: receipt?.outputKind ?? null,
+  };
+}
+
+function sameJson(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
 function sha256(data: Buffer): string {
   return createHash("sha256").update(data).digest("hex");
+}
+
+function toolVersion(command: "ffmpeg" | "ffprobe"): string {
+  const result = spawnSync(command, ["-version"], { encoding: "utf8", timeout: 5_000 });
+  if (result.status !== 0) {
+    return result.stderr.trim() || `${command} unavailable`;
+  }
+  return firstLine(result.stdout, result.stderr) || command;
+}
+
+function firstLine(...values: string[]): string {
+  for (const value of values) {
+    const line = value
+      .split(/\r?\n/u)
+      .map((entry) => entry.trim())
+      .find((entry) => entry.length > 0);
+    if (line !== undefined) {
+      return line;
+    }
+  }
+  return "";
 }
 
 function probeVideo(path: string) {
@@ -215,8 +318,9 @@ async function createValidationDir(): Promise<string> {
   const baseDir =
     process.env.WITTGENSTEIN_VIDEO_VALIDATION_DIR ??
     join(process.cwd(), "artifacts", "tmp", "video-mp4-renderer");
-  await mkdir(baseDir, { recursive: true });
-  return mkdtemp(join(baseDir, "run-"));
+  const resolvedBaseDir = resolve(baseDir);
+  await mkdir(resolvedBaseDir, { recursive: true });
+  return mkdtemp(join(resolvedBaseDir, "run-"));
 }
 
 void main();


### PR DESCRIPTION
Closes #476.

## What changed

- Extended `research/validation/video_mp4_renderer_validate.ts` with an `environment` block and a `portability` summary so future cross-machine runs compare normalized structure and portable receipt fields directly.
- Fixed the validation script's relative `WITTGENSTEIN_VIDEO_VALIDATION_DIR` path bug by resolving the base directory before FFmpeg receives frame paths.
- Raised the MP4 renderer's `ffmpeg -version` receipt probe budget from the 1s default to 5s after the Linux sweep showed the command can be slow but still useful.
- Added `docs/research/2026-05-31-video-mp4-receipt-portability.md` and linked it from `docs/codecs/video.md`.

## Research review

Two environments ran the existing validation script in MP4 mode:

| Environment | Toolchain | Result |
|---|---|---|
| macOS local arm64 | Node v25.6.1, FFmpeg/ffprobe 8.0.1, Chrome/148.0.7778.181 | same-platform byte parity passed |
| Linux Docker arm64 | Node v22.22.3, FFmpeg/ffprobe 5.1.9, Chrome/148.0.7778.178 | same-platform byte parity passed |

Cross-machine result: HTML bytes matched exactly, MP4 bytes differed (`17471` vs `17249` bytes; different SHA-256), ffprobe structure matched (`h264`, `1920x1080`, `24/1`, `3.000000s`, `72` frames), and portable `videoRender` receipt fields matched. That preserves the current policy: MP4 bytes are not a cross-machine invariant; structure + portable receipt fields are the floor.

## Engineer review

This keeps #476 inside the existing validation surface. No new renderer backend, no training path, no model dependency, no schema expansion. The code change makes the existing script more useful for future sweeps and fixes a real path portability issue discovered during the run.

The FFmpeg version timeout change is deliberately narrow: it only affects the MP4 renderer receipt probe, not the encode timeout and not the shared default version-check policy for doctor-style probes.

## Hacker review

The weak point in media portability is accidental overclaiming. This PR makes the validation output harder to misread by separating:

- same-platform byte parity;
- cross-platform byte drift;
- ffprobe structural parity;
- portable receipt parity;
- toolchain/version evidence that explains expected byte drift.

The Linux run also exposed that a too-short version probe can hide useful toolchain data behind the fallback string `ffmpeg`, so the receipt path now gives that probe enough budget to explain itself.

## Validation

- `pnpm install --frozen-lockfile --offline`
- `node --import tsx research/validation/video_mp4_renderer_validate.ts`
- macOS MP4 sweep: `WITTGENSTEIN_VALIDATE_VIDEO_MP4=1 WITTGENSTEIN_KEEP_VIDEO_VALIDATION_ARTIFACTS=1 WITTGENSTEIN_VALIDATION_ENVIRONMENT_ID=macos-local-arm64 WITTGENSTEIN_VIDEO_VALIDATION_DIR=artifacts/tmp/issue-476-sweep/macos-current node --import tsx research/validation/video_mp4_renderer_validate.ts`
- Linux Docker MP4 sweep using the same script with `PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium`
- `pnpm exec eslint research/validation/video_mp4_renderer_validate.ts packages/codec-video/src/mp4-renderer.ts --ext .ts`
- `pnpm exec prettier --check docs/research/2026-05-31-video-mp4-receipt-portability.md packages/codec-video/src/mp4-renderer.ts research/validation/video_mp4_renderer_validate.ts`
- `typos --config typos.toml docs/codecs/video.md docs/research/2026-05-31-video-mp4-receipt-portability.md packages/codec-video/src/mp4-renderer.ts research/validation/video_mp4_renderer_validate.ts`
- `git diff --check`
- `pnpm format:check`
- `pnpm lint`
- `pnpm lint:deps`
- `pnpm lint:publish-surface`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:golden`
- `pnpm reviewer-bench`
