### PR TITLE
feat(training): align manifest smoke with canonical schema

### DIFF
--- a/docs/contributing/training-setup.md
+++ b/docs/contributing/training-setup.md
@@ -57,6 +57,7 @@ artifact bundle. It records:
 - Git SHA of the training code at training time
 - Docker image SHA and lockfile SHA (when applicable)
 - Seed, step count, wall-clock duration, and hardware
+- Optimizer state SHA-256
 - Per-eval-step metric snapshots
 - Checkpoint path, SHA-256, byte size, and weights license
 

--- a/docs/research/2026-05-13-m1b-training-prep.md
+++ b/docs/research/2026-05-13-m1b-training-prep.md
@@ -155,6 +155,12 @@ The `polyglot-mini/train/m1b/` placement mirrors the existing M2 audio training 
 
 ### Manifest-schema contract (TS, lands when wiring starts)
 
+> 2026-05-31 update: this sketch is superseded by the canonical
+> `packages/schemas/src/training-manifest.ts`
+> `TrainingRunManifestSchema` and the Python emitter in
+> `research/training/_shared/manifest.py`. Keep this section as historical
+> prep context, not as the current receipt contract.
+
 Sketch of what `packages/codec-image/src/training/manifest-schema.ts` will export:
 
 ```ts

--- a/docs/research/2026-05-13-wittgenstein-research-program.md
+++ b/docs/research/2026-05-13-wittgenstein-research-program.md
@@ -39,8 +39,8 @@ This note is the answer to that reframe.
 - **[ADR-0018](../adrs/0018-hybrid-image-code-and-visual-seed-token.md) Visual Seed Code as primary image research surface.**
 - **Manifest spine.** Every run is reproducible from `git SHA + lockfile
   hash + seed + LLM I/O + artifact SHA-256`. **Extends to training:**
-  every training run gets a manifest with dataset hash, training step
-  count, optimizer state hash, eval-metric snapshot.
+  every training run gets a manifest with dataset hash, `stepCount`,
+  `optimizer.stateSha256`, and `evalSnapshots`.
 - **[ADR-0020](../adrs/0020-code-weights-license-divergence-policy.md) license posture.** Permissive code+weights canonical. Own-trained models
   make this *easier* to satisfy — we own the weights end-to-end.
 - **Codec Protocol v2 modality boundaries.** One codec per modality, one
@@ -92,8 +92,8 @@ What we invest in next:
 - **Experiment tracking integrated with the manifest spine.** Use
   `aim` (open-source, self-hostable, Apache-2.0) as the primary tracker;
   W&B as the secondary if a contributor prefers. Each training run's
-  `manifest.json` carries an `experiment.uri` field pointing at the
-  tracker entry.
+  config reference or issue-owned tracker receipt points at the tracker entry;
+  the canonical training manifest stays strict.
 - **Data versioning.** DVC for ImageNet / CC12M / COCO eval sets;
   dataset SHA-256 + URL + revision pinned in every training manifest.
 - **GPU CI lane.** Initially a manual sweep harness (`bench/gpu/`) that
@@ -247,7 +247,7 @@ Every eval run writes a Wittgenstein manifest carrying:
 - The eval set's DVC hash
 - The metric values (PSNR / SSIM / LPIPS / rFID / FID-30K / CLIP /
   human-score)
-- The experiment URI (aim / W&B link)
+- The tracker URI through the referenced training config or tracker receipt
 
 ---
 
@@ -350,10 +350,10 @@ direction-setting.
   are the canonical path for image too.
 - **Training manifest schema.** The current `RunManifestSchema` is
   inference-shaped. Training runs need a sibling schema with
-  `dataset.sha256`, `optimizer.state_hash`, `train.step`, `eval.metric_snapshot`.
+  `dataset.sha256`, `optimizer.stateSha256`, `stepCount`, and `evalSnapshots`.
   This wants an RFC.
-- **The `experiment.uri` field on manifests.** Tying every receipt to a
-  remote tracker entry. Small ADR.
+- **Tracker linkage.** Tying every receipt bundle to a remote tracker entry
+  without adding freeform top-level fields to the canonical manifest. Small ADR.
 
 ---
 

--- a/docs/research/2026-05-16-training-stack-re-audit.md
+++ b/docs/research/2026-05-16-training-stack-re-audit.md
@@ -93,6 +93,13 @@ These are low-risk and should happen before any expensive training:
 These do not require real ImageNet / CC12M / COCO access and do not commit
 the project to a GPU framework.
 
+**Implementation status (2026-05-31):** the manifest helper now writes the
+canonical `witt.training.run-manifest/v0.1` shape used by
+`TrainingRunManifestSchema`, including optimizer state SHA-256 and an explicit
+CPU-only smoke path with `gpuCount: 0`. The stdlib smoke does not train a model
+or import torch; it proves the receipt floor. The tokenizer training entrypoint
+now emits the same canonical receipt beside each checkpoint.
+
 ## What must wait for owner review
 
 These choices should not land as "obvious implementation" PRs:

--- a/docs/research/2026-05-31-training-stack-re-audit-closeout.md
+++ b/docs/research/2026-05-31-training-stack-re-audit-closeout.md
@@ -1,0 +1,91 @@
+---
+date: 2026-05-31
+status: closeout note
+labels: [research-derived, m1b-image, training, python, reproducibility, maintainer-audit]
+tracks: [#441, #435, #396, #397, #398, #399, #400]
+---
+
+# Phase 1 Training Stack Re-audit Closeout
+
+This closes the actionable #441 re-audit surface without approving an
+expensive training run. The durable boundary is:
+
+- `research/training/` remains the canonical home for tokenizer, adapter, and
+  LLM-head GPU training programs.
+- `python/image_adapter/` remains a narrow M1B scene-spec-to-latent bridge, not
+  a second general Phase 1 training stack.
+- `packages/schemas/src/training-manifest.ts` owns the canonical
+  `witt.training.run-manifest/v0.1` receipt contract.
+- Python training loops must emit that schema directly, rather than a separate
+  Python-only receipt shape.
+
+## Dated Sources Checked
+
+- 2026-05-16 local re-audit:
+  `docs/research/2026-05-16-training-stack-re-audit.md`.
+- 2026-05-27 pre-training readiness:
+  `docs/research/2026-05-27-pre-training-readiness.md`.
+- 2026-05-31 training-homes decision:
+  `docs/research/2026-05-31-training-homes-decision.md`.
+- PyTorch FSDP2 `fully_shard` docs, checked 2026-05-31:
+  https://docs.pytorch.org/docs/main/distributed.fsdp.fully_shard.html.
+- PyTorch `torchrun` docs, checked 2026-05-31:
+  https://docs.pytorch.org/docs/main/elastic/run.html.
+- DeepSpeed ZeRO docs, checked 2026-05-31:
+  https://deepspeed.readthedocs.io/en/stable/zero3.html.
+- DVC remote-storage docs, checked 2026-05-31:
+  https://doc.dvc.org/user-guide/data-management/remote-storage.
+- Hugging Face model-card docs, checked 2026-05-31:
+  https://huggingface.co/docs/hub/en/model-cards.
+
+## Decisions
+
+- **Framework base:** plain PyTorch plus `torchrun`/DDP remains the first
+  executable contract. FSDP2 and DeepSpeed remain escalation paths for memory
+  pressure, not the receipt owner.
+- **Receipt contract:** the TypeScript `TrainingRunManifestSchema` is canonical.
+  The Python helper now mirrors it, including optimizer state SHA-256,
+  checkpoint byte/SHA/license fields, dataset SHA, hardware, and config
+  reference.
+- **CPU smoke honesty:** schema hardware now permits `gpuCount: 0`. CPU-only
+  smoke receipts should say they are CPU receipts instead of inventing a GPU.
+- **Reuse strategy:** LlamaGen tokenizer reuse remains limited to the audited
+  shim already under `_shared/_third_party`. TiTok, Open-MAGVIT2, MaskGIT, or
+  broader VQGAN reuse still needs license and model-owner review before
+  becoming training code.
+- **Data and eval:** #400 still owns DVC remote/dataset snapshot policy. #394,
+  #399, and the Phase 1 trackers still own metric wrappers, tracker wiring, and
+  empirical model-quality gates.
+
+## Safe Before GPU
+
+The following is safe to merge before lab compute:
+
+- stdlib-only `research.training._shared.smoke_manifest`;
+- `research.training._shared.test_manifest`;
+- canonical Python manifest writer updates;
+- schema tests for optimizer receipts and CPU-only smoke;
+- tokenizer smoke validation that fails if the emitted manifest shape drifts.
+
+These changes are receipt-floor work. They do not claim model quality, dataset
+readiness, or checkpoint publishability.
+
+## Must Wait
+
+The following still require maintainer/model-owner review or real lab evidence:
+
+- final FSDP2/DeepSpeed/Fabric/Accelerate composition;
+- ImageNet/CC12M dataset snapshot, DVC remote provider, and credentials;
+- learned tokenizer/adapter/LLM-head quality claims;
+- Hugging Face org/repo layout and model-card publication;
+- any reuse expansion beyond the currently vendored LlamaGen-compatible shim.
+
+## Issue Acceptance Impact
+
+No #396-#400 acceptance text changes are required from this closeout. Their
+training/eval/data scopes remain correct; this PR only replaces an ambiguous
+manifest skeleton with a runnable, schema-aligned receipt floor.
+
+This note is ready for maintainer/model-owner sign-off on the Phase 1
+training-stack boundary. It does not approve expensive training, checkpoint
+publication, or quality claims.

--- a/packages/schemas/src/training-manifest.ts
+++ b/packages/schemas/src/training-manifest.ts
@@ -20,8 +20,21 @@ export const TrainingRunDatasetSchema = z
 export const TrainingRunHardwareSchema = z
   .object({
     gpuModel: z.string().min(1),
-    gpuCount: z.number().int().positive(),
+    gpuCount: z.number().int().nonnegative(),
     nodeCount: z.number().int().positive(),
+  })
+  .strict();
+
+export const TrainingRunOptimizerSchema = z
+  .object({
+    name: z.string().min(1),
+    stateSha256: Sha256Schema,
+    learningRate: z.number().finite().nonnegative(),
+    weightDecay: z.number().finite().nonnegative(),
+    betas: z.tuple([
+      z.number().finite().nonnegative().max(1),
+      z.number().finite().nonnegative().max(1),
+    ]),
   })
   .strict();
 
@@ -84,8 +97,9 @@ export const TrainingRunManifestSchema = z
     dataset: TrainingRunDatasetSchema,
     seed: z.number().int(),
     stepCount: z.number().int().nonnegative(),
-    wallClockSec: z.number().nonnegative(),
+    wallClockSec: z.number().finite().nonnegative(),
     hardware: TrainingRunHardwareSchema,
+    optimizer: TrainingRunOptimizerSchema,
     evalSnapshots: z.array(TrainingRunEvalSnapshotSchema),
     checkpoint: TrainingRunCheckpointSchema,
     trainingConfig: TrainingRunConfigReferenceSchema.optional(),
@@ -117,6 +131,7 @@ export const TrainingRunManifestReferenceSchema = z
 export type TrainingSubprogram = z.infer<typeof TrainingSubprogramSchema>;
 export type TrainingRunDataset = z.infer<typeof TrainingRunDatasetSchema>;
 export type TrainingRunHardware = z.infer<typeof TrainingRunHardwareSchema>;
+export type TrainingRunOptimizer = z.infer<typeof TrainingRunOptimizerSchema>;
 export type TrainingRunEvalMetric = z.infer<typeof TrainingRunEvalMetricSchema>;
 export type TrainingRunEvalSnapshot = z.infer<typeof TrainingRunEvalSnapshotSchema>;
 export type TrainingRunCheckpoint = z.infer<typeof TrainingRunCheckpointSchema>;

--- a/packages/schemas/test/fixtures/training-run-manifest.json
+++ b/packages/schemas/test/fixtures/training-run-manifest.json
@@ -21,6 +21,13 @@
     "gpuCount": 8,
     "nodeCount": 1
   },
+  "optimizer": {
+    "name": "AdamW",
+    "stateSha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "learningRate": 0.0001,
+    "weightDecay": 0.05,
+    "betas": [0.9, 0.95]
+  },
   "evalSnapshots": [
     {
       "modality": "image",

--- a/packages/schemas/test/training-manifest.test.ts
+++ b/packages/schemas/test/training-manifest.test.ts
@@ -21,7 +21,30 @@ describe("TrainingRunManifestSchema", () => {
     expect(parsed).toEqual(fixture);
     expect(parsed.schemaVersion).toBe(TrainingRunManifestSchemaVersion);
     expect(parsed.subprogram).toBe("tokenizer");
+    expect(parsed.optimizer.stateSha256).toMatch(/^[a-f0-9]{64}$/);
     expect(parsed.checkpoint.weightsLicense).toBe("research-only");
+  });
+
+  it("accepts a CPU-only smoke receipt without pretending a GPU ran", () => {
+    const fixture = readTrainingManifestFixture();
+
+    const parsed = TrainingRunManifestSchema.parse({
+      ...fixture,
+      runId: "tokenizer-stdlib-smoke",
+      hardware: {
+        gpuModel: "cpu:arm64",
+        gpuCount: 0,
+        nodeCount: 1,
+      },
+      evalSnapshots: [],
+      checkpoint: {
+        ...fixture.checkpoint,
+        weightsLicense: "permissive",
+      },
+    });
+
+    expect(parsed.hardware.gpuCount).toBe(0);
+    expect(parsed.evalSnapshots).toEqual([]);
   });
 
   it("rejects receipts that smuggle hyperparameters as a freeform top-level blob", () => {

--- a/research/training/README.md
+++ b/research/training/README.md
@@ -24,6 +24,7 @@ See the operating doctrine:
 - [docs/research/2026-05-13-wittgenstein-research-program.md](../../docs/research/2026-05-13-wittgenstein-research-program.md) — three-track framing (engineering / research / hacker)
 - [docs/research/2026-05-13-delivery-and-componentization.md](../../docs/research/2026-05-13-delivery-and-componentization.md) — tier doctrine + why training stays outside the publish surface
 - [docs/research/2026-05-13-m1b-prep-research.md](../../docs/research/2026-05-13-m1b-prep-research.md) — Phase-0 literature floor (LlamaGen, Open-MAGVIT2, TiTok, VAR)
+- [docs/research/2026-05-31-training-stack-re-audit-closeout.md](../../docs/research/2026-05-31-training-stack-re-audit-closeout.md) — #441 closeout: schema-aligned receipt floor + GPU wait lines
 - [docs/research/2026-05-27-pre-training-readiness.md](../../docs/research/2026-05-27-pre-training-readiness.md) — engineering-readiness audit run right before specialist kickoff (Tier-0 self-check, latent bugs found + fixed, open handoff issues)
 - [docs/contributing/training-setup.md](../../docs/contributing/training-setup.md) — environment setup for contributors
 
@@ -69,12 +70,14 @@ Every publishable training run emits, alongside the model checkpoint, a
 Wittgenstein `TrainingRunManifest` receipt validated by
 `TrainingRunManifestSchema` from `@wittgenstein/schemas`:
 
-- Dataset hash (DVC-pinned)
-- Training step count + wall-clock + GPU type
+- Dataset `dvcRev`, name, and SHA-256
+- Training step count, wall-clock, and hardware; CPU-only smoke receipts use
+  `gpuCount: 0` instead of pretending a GPU ran
 - Eval-metric snapshot (FID / CLIP / rFID per modality)
 - Git SHA of the harness at training time
 - Git SHA of the training code at training time
-- Seed, lockfile SHA, checkpoint SHA-256, and weights-license posture
+- Optimizer state SHA-256
+- Seed, lockfile SHA, checkpoint path/SHA-256/bytes, and weights-license posture
 
 A frozen checkpoint released to HuggingFace Hub ships with this manifest
 beside it. A downstream `DecoderFamilyManifest` can then bless that exact

--- a/research/training/_shared/_third_party/README.md
+++ b/research/training/_shared/_third_party/README.md
@@ -19,8 +19,10 @@ config defaults.
   research-program note. Our "Wittgenstein-native" lane = same
   architecture, our config (D=32 vs LlamaGen's D=8), our data,
   our weights, our license posture.
-- **Modifications:** None. Pure copy. If we ever need to modify, fork
-  to a `wittgenstein_*.py` sibling and document the diff here.
+- **Modifications:** local safety patch for smoke/receipt validation:
+  `codebook_used` is registered as a non-parameter integer buffer and updated
+  under `torch.no_grad()`, so codebook-usage accounting cannot enter optimizer
+  state or autograd.
 - **Update protocol:** When upstream lands a relevant fix, re-vendor
   by overwriting this file from the pinned upstream commit, update
   the "Pinned commit" line above, and re-run any training that

--- a/research/training/_shared/_third_party/llamagen_vq_model.py
+++ b/research/training/_shared/_third_party/llamagen_vq_model.py
@@ -209,7 +209,7 @@ class VectorQuantizer(nn.Module):
         if self.l2_norm:
             self.embedding.weight.data = F.normalize(self.embedding.weight.data, p=2, dim=-1)
         if self.show_usage:
-            self.register_buffer("codebook_used", nn.Parameter(torch.zeros(65536)))
+            self.register_buffer("codebook_used", torch.zeros(65536, dtype=torch.long))
 
     
     def forward(self, z):
@@ -239,10 +239,11 @@ class VectorQuantizer(nn.Module):
         codebook_usage = 0
 
         if self.show_usage and self.training:
-            cur_len = min_encoding_indices.shape[0]
-            self.codebook_used[:-cur_len] = self.codebook_used[cur_len:].clone()
-            self.codebook_used[-cur_len:] = min_encoding_indices
-            codebook_usage = len(torch.unique(self.codebook_used)) / self.n_e
+            with torch.no_grad():
+                cur_len = min(min_encoding_indices.shape[0], self.codebook_used.shape[0])
+                self.codebook_used[:-cur_len].copy_(self.codebook_used[cur_len:].clone())
+                self.codebook_used[-cur_len:].copy_(min_encoding_indices[-cur_len:].detach())
+                codebook_usage = len(torch.unique(self.codebook_used)) / self.n_e
 
         # compute loss for embedding
         if self.training:

--- a/research/training/_shared/eval.py
+++ b/research/training/_shared/eval.py
@@ -61,7 +61,7 @@ def evaluate_tokenizer_reconstruction(
     device: torch.device,
     cfg: TokenizerEvalConfig | None = None,
 ) -> dict[str, Any]:
-    """Run reconstruction eval; returns metric dict for manifest.eval.metrics.
+    """Run reconstruction eval; returns metrics for a TrainingRunEvalSnapshot.
 
     Caller is responsible for setting `model.eval()` (we don't toggle here
     so the caller's state stays explicit).

--- a/research/training/_shared/manifest.py
+++ b/research/training/_shared/manifest.py
@@ -1,141 +1,131 @@
-"""Training-manifest emitter — the receipt spine for training runs.
+"""TrainingRunManifest emitter — the receipt spine for training runs.
 
-Mirrors Wittgenstein's inference-side `RunManifest` shape (see
-`packages/schemas/src/runtime/manifest.ts`) but extends it with training-
-specific fields per `docs/research/2026-05-13-wittgenstein-research-program.md`:
+This module owns the Python-side writer for the canonical
+`witt.training.run-manifest/v0.1` JSON shape in
+`packages/schemas/src/training-manifest.ts`.
 
-  - `dataset.sha256` — SHA over the sorted list of input file paths + per-file SHA
-  - `optimizer.state_hash` — SHA over state_dict bytes at checkpoint time
-  - `train.step` — global step at checkpoint
-  - `eval.metric_snapshot` — pinned metric values
-
-Every checkpoint emits one manifest. The manifest + the checkpoint together
-constitute a publishable artifact bundle. `wittgenstein replay <manifest>`
-(future tracking #388) walks back from a manifest to reproduce the byte-pinned
-inference path.
-
-Doctrine: this module owns the receipt SHAPE; it does NOT own scheduling,
-storage, or upload. The caller (training loops) drives writes.
+The helper is intentionally mostly-stdlib. Training loops may pass torch
+optimizers/checkpoints to the capture helpers, but the CPU-only smoke path can
+prove receipt shape without importing torch or touching real datasets.
 """
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import os
 import platform
+import re
 import subprocess
-import sys
 import time
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 
-@dataclass(frozen=True)
-class RuntimeFingerprint:
-    """Captured once at training-start. Does not change across checkpoints."""
-
-    git_sha: str
-    lockfile_sha256: str
-    python_version: str
-    torch_version: str
-    cuda_version: str | None
-    cuda_device_count: int
-    cuda_device_name: str | None
-    cudnn_version: int | None
-    hostname: str
-    platform: str
+TRAINING_RUN_MANIFEST_SCHEMA_VERSION = "witt.training.run-manifest/v0.1"
+SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
+GIT_SHA_RE = re.compile(r"^(?:[a-f0-9]{40}|[a-f0-9]{64})$")
+SUBPROGRAMS = {"tokenizer", "adapter", "llm-head"}
+MODALITIES = {"image", "audio", "sensor", "svg", "video", "asciipng"}
+WEIGHTS_LICENSES = {"permissive", "research-only"}
 
 
 @dataclass(frozen=True)
-class DatasetFingerprint:
-    """SHA-256 over the canonical sorted-file enumeration + per-file SHA.
-
-    Matches the lockfile pattern at polyglot-mini/train/data_manifest.json
-    (PR #130). For very large datasets the per-file SHAs are stored separately;
-    the manifest itself carries only the aggregated root SHA + sample stats.
-    """
-
+class TrainingRunDataset:
+    dvcRev: str
     name: str
-    root_sha256: str
-    file_count: int
-    total_bytes: int
-    revision: str  # DVC tag or HF revision, "uncommitted" if neither
-    notes: str = ""
+    sha256: str
 
 
 @dataclass(frozen=True)
-class OptimizerCheckpoint:
-    """Captured at checkpoint-write time. SHA over state_dict bytes."""
+class TrainingRunHardware:
+    gpuModel: str
+    gpuCount: int
+    nodeCount: int
 
-    name: str  # e.g. "AdamW"
-    state_hash: str
-    lr: float
-    weight_decay: float
+
+@dataclass(frozen=True)
+class TrainingRunOptimizer:
+    name: str
+    stateSha256: str
+    learningRate: float
+    weightDecay: float
     betas: tuple[float, float]
 
 
 @dataclass(frozen=True)
-class TrainingCheckpoint:
-    """One checkpoint = one manifest. Run-id ties checkpoints in a single run."""
+class TrainingRunEvalMetric:
+    name: str
+    value: float
+    unit: str | None = None
+    higherIsBetter: bool | None = None
 
-    run_id: str
+
+@dataclass(frozen=True)
+class TrainingRunEvalDataset:
+    name: str
+    split: str
+    sha256: str
+
+
+@dataclass(frozen=True)
+class TrainingRunEvalSnapshot:
+    modality: str
+    dataset: TrainingRunEvalDataset
     step: int
-    epoch: float  # fractional epochs allowed
-    wall_clock_s: float
+    generatedAt: str
+    metrics: list[TrainingRunEvalMetric]
+
+
+@dataclass(frozen=True)
+class TrainingRunCheckpoint:
+    path: str
+    sha256: str
+    bytes: int
+    weightsLicense: str
+
+
+@dataclass(frozen=True)
+class TrainingRunConfigReference:
+    path: str
+    sha256: str
+
+
+@dataclass(frozen=True)
+class TrainingRunManifest:
+    schemaVersion: str
+    runId: str
+    subprogram: str
+    startedAt: str
+    finishedAt: str | None
+    harnessGitSha: str
+    trainingCodeGitSha: str
+    dockerImageSha: str | None
+    lockfileSha256: str | None
+    dataset: TrainingRunDataset
     seed: int
-    weights_path: str
-    weights_sha256: str
+    stepCount: int
+    wallClockSec: float
+    hardware: TrainingRunHardware
+    optimizer: TrainingRunOptimizer
+    evalSnapshots: list[TrainingRunEvalSnapshot]
+    checkpoint: TrainingRunCheckpoint
+    trainingConfig: TrainingRunConfigReference | None = None
 
 
-@dataclass(frozen=True)
-class EvalSnapshot:
-    """Metric values pinned at checkpoint time. Empty {} if no eval ran."""
-
-    eval_set: str  # e.g. "imagenet-val-50k"
-    eval_set_sha256: str
-    metrics: dict[str, Any] = field(default_factory=dict)
-    eval_step: int = -1  # which training step the eval ran AT
-    eval_wall_clock_s: float = 0.0
+def utc_now_iso() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
 
 
-@dataclass(frozen=True)
-class TrainingManifest:
-    """Sibling of `RunManifest` for training runs. JSON-serializable."""
-
-    schema_version: str  # "witt.training/v0.1"
-    program: str  # "tokenizer" | "adapter" | "llm-head"
-    family: str  # e.g. "wittgenstein-native-vqgan"
-    runtime: RuntimeFingerprint
-    dataset: DatasetFingerprint
-    optimizer: OptimizerCheckpoint
-    checkpoint: TrainingCheckpoint
-    eval: EvalSnapshot
-    config: dict[str, Any]  # hyperparams snapshot (full config dump)
-    experiment_uri: str = ""  # aim/W&B/MLflow link if registered, "" otherwise
-    notes: str = ""
-
-
-# ---------- Capture helpers ----------
-
-
-def _try_git_sha(repo_root: Path | None = None) -> str:
-    try:
-        r = subprocess.run(
-            ["git", "rev-parse", "HEAD"],
-            cwd=str(repo_root) if repo_root else None,
-            capture_output=True,
-            text=True,
-            check=True,
-            timeout=5,
-        )
-        return r.stdout.strip()
-    except Exception:
-        return "unknown"
-
-
-def _sha256_file(path: Path) -> str:
+def sha256_file(path: Path) -> str:
     h = hashlib.sha256()
     with path.open("rb") as f:
         for chunk in iter(lambda: f.read(1024 * 1024), b""):
@@ -143,25 +133,64 @@ def _sha256_file(path: Path) -> str:
     return h.hexdigest()
 
 
-def _sha256_bytes(data: bytes) -> str:
+def sha256_bytes(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
-def capture_runtime_fingerprint(repo_root: Path | None = None, lockfile: Path | None = None) -> RuntimeFingerprint:
-    import torch
+def capture_git_sha(repo_root: Path | None = None) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(repo_root) if repo_root else None,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=5,
+        )
+        sha = result.stdout.strip()
+    except Exception as exc:
+        raise RuntimeError("could not capture git SHA for training manifest") from exc
+    if not GIT_SHA_RE.match(sha):
+        raise RuntimeError(f"git rev-parse HEAD returned an invalid SHA: {sha!r}")
+    return sha
 
-    cuda_avail = torch.cuda.is_available()
-    return RuntimeFingerprint(
-        git_sha=_try_git_sha(repo_root),
-        lockfile_sha256=_sha256_file(lockfile) if (lockfile and lockfile.exists()) else "unknown",
-        python_version=sys.version.split()[0],
-        torch_version=torch.__version__,
-        cuda_version=getattr(torch.version, "cuda", None) if cuda_avail else None,
-        cuda_device_count=torch.cuda.device_count() if cuda_avail else 0,
-        cuda_device_name=torch.cuda.get_device_name(0) if cuda_avail else None,
-        cudnn_version=torch.backends.cudnn.version() if cuda_avail else None,
-        hostname=platform.node(),
-        platform=platform.platform(),
+
+def capture_lockfile_sha256(lockfile: Path | None = None) -> str | None:
+    if lockfile is None or not lockfile.exists():
+        return None
+    return sha256_file(lockfile)
+
+
+def capture_docker_image_sha(raw: str | None = None) -> str | None:
+    value = (raw or os.environ.get("WITTGENSTEIN_TRAINING_DOCKER_IMAGE_SHA") or "").strip()
+    return value or None
+
+
+def capture_hardware() -> TrainingRunHardware:
+    raw_node_count = os.environ.get("WITTGENSTEIN_TRAINING_NODE_COUNT", "1")
+    try:
+        node_count = int(raw_node_count)
+    except ValueError as exc:
+        raise RuntimeError(
+            f"WITTGENSTEIN_TRAINING_NODE_COUNT must be an integer, got {raw_node_count!r}"
+        ) from exc
+
+    try:
+        import torch
+
+        if torch.cuda.is_available():
+            return TrainingRunHardware(
+                gpuModel=torch.cuda.get_device_name(0),
+                gpuCount=torch.cuda.device_count(),
+                nodeCount=node_count,
+            )
+    except Exception:
+        pass
+
+    return TrainingRunHardware(
+        gpuModel=f"cpu:{platform.machine() or platform.processor() or 'unknown'}",
+        gpuCount=0,
+        nodeCount=node_count,
     )
 
 
@@ -170,89 +199,340 @@ def capture_dataset_fingerprint(
     files: list[Path],
     revision: str = "uncommitted",
     notes: str = "",
-    cache_per_file: bool = False,
-) -> DatasetFingerprint:
-    """SHA-256 over sorted (relative-path, file-sha256) pairs.
+    cache_per_file: bool = True,
+    root: Path | None = None,
+) -> TrainingRunDataset:
+    """SHA-256 over sorted (path, file-sha-or-size) pairs.
 
-    cache_per_file=False (default) means we hash file names + sizes only, which
-    is the cheap-but-coarser fingerprint suitable for development. Set True for
-    publish-quality fingerprints (slow on TB-scale datasets — prefer DVC's own
-    .dvc file SHA in that case).
+    `notes` is accepted for caller compatibility but intentionally not emitted:
+    the canonical manifest is strict and keeps prose outside the receipt.
+    `root`, when supplied, keeps the fingerprint independent of the checkout or
+    mount point that happened to hold the dataset.
+    `cache_per_file=False` is a development shortcut only; publishable training
+    receipts must use the default content-level hashing or a DVC-pinned source.
     """
+
+    del notes
     sorted_files = sorted(files, key=lambda p: str(p))
-    total_bytes = 0
-    sha_input = []
-    for p in sorted_files:
-        size = p.stat().st_size if p.exists() else 0
-        total_bytes += size
-        if cache_per_file:
-            sha_input.append((str(p), _sha256_file(p)))
-        else:
-            sha_input.append((str(p), str(size)))
-    root_sha = _sha256_bytes(json.dumps(sha_input, sort_keys=True).encode())
-    return DatasetFingerprint(
+    sha_input: list[tuple[str, str]] = []
+    for path in sorted_files:
+        if cache_per_file and not path.exists():
+            raise FileNotFoundError(f"cannot fingerprint missing dataset file: {path}")
+        size = path.stat().st_size if path.exists() else 0
+        digest = sha256_file(path) if cache_per_file and path.exists() else str(size)
+        manifest_path = path
+        if root is not None:
+            try:
+                manifest_path = path.relative_to(root)
+            except ValueError:
+                manifest_path = path
+        sha_input.append((manifest_path.as_posix(), digest))
+    return TrainingRunDataset(
+        dvcRev=revision,
         name=name,
-        root_sha256=root_sha,
-        file_count=len(sorted_files),
-        total_bytes=total_bytes,
-        revision=revision,
-        notes=notes,
+        sha256=sha256_bytes(json.dumps(sha_input, sort_keys=True).encode("utf-8")),
     )
 
 
-def capture_optimizer_checkpoint(
-    optimizer,
-    name: str | None = None,
-) -> OptimizerCheckpoint:
+def capture_optimizer_checkpoint(optimizer: Any, name: str | None = None) -> TrainingRunOptimizer:
     import io
     import torch
 
     buf = io.BytesIO()
     torch.save(optimizer.state_dict(), buf)
-    state_hash = _sha256_bytes(buf.getvalue())
-    pg = optimizer.param_groups[0]
-    return OptimizerCheckpoint(
+    param_group = optimizer.param_groups[0]
+    betas = param_group.get("betas", (0.0, 0.0))
+    return TrainingRunOptimizer(
         name=name or type(optimizer).__name__,
-        state_hash=state_hash,
-        lr=float(pg.get("lr", 0.0)),
-        weight_decay=float(pg.get("weight_decay", 0.0)),
-        betas=tuple(pg.get("betas", (0.0, 0.0))),
+        stateSha256=sha256_bytes(buf.getvalue()),
+        learningRate=float(param_group.get("lr", 0.0)),
+        weightDecay=float(param_group.get("weight_decay", 0.0)),
+        betas=(float(betas[0]), float(betas[1])),
+    )
+
+
+def synthetic_optimizer_checkpoint() -> TrainingRunOptimizer:
+    payload = b"wittgenstein stdlib training-manifest smoke has no optimizer state"
+    return TrainingRunOptimizer(
+        name="stdlib-smoke-none",
+        stateSha256=sha256_bytes(payload),
+        learningRate=0.0,
+        weightDecay=0.0,
+        betas=(0.0, 0.0),
     )
 
 
 def capture_training_checkpoint(
-    run_id: str,
-    step: int,
-    epoch: float,
-    wall_clock_s: float,
-    seed: int,
     weights_path: Path,
-) -> TrainingCheckpoint:
-    return TrainingCheckpoint(
-        run_id=run_id,
-        step=step,
-        epoch=epoch,
-        wall_clock_s=wall_clock_s,
-        seed=seed,
-        weights_path=str(weights_path),
-        weights_sha256=_sha256_file(weights_path) if weights_path.exists() else "pending-write",
+    weights_license: str,
+) -> TrainingRunCheckpoint:
+    return TrainingRunCheckpoint(
+        path=str(weights_path),
+        sha256=sha256_file(weights_path),
+        bytes=weights_path.stat().st_size,
+        weightsLicense=weights_license,
     )
 
 
-# ---------- Writer ----------
+def write_training_config_snapshot(path: Path, config: dict[str, Any]) -> TrainingRunConfigReference:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(config, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return TrainingRunConfigReference(path=str(path), sha256=sha256_file(path))
 
 
-def write_training_manifest(manifest: TrainingManifest, out_path: Path) -> None:
+def manifest_to_dict(manifest: TrainingRunManifest | dict[str, Any]) -> dict[str, Any]:
+    payload = asdict(manifest) if isinstance(manifest, TrainingRunManifest) else dict(manifest)
+    if payload.get("trainingConfig") is None:
+        payload.pop("trainingConfig", None)
+    return payload
+
+
+def assert_training_run_manifest_shape(manifest: TrainingRunManifest | dict[str, Any]) -> None:
+    payload = manifest_to_dict(manifest)
+    required = {
+        "schemaVersion",
+        "runId",
+        "subprogram",
+        "startedAt",
+        "finishedAt",
+        "harnessGitSha",
+        "trainingCodeGitSha",
+        "dockerImageSha",
+        "lockfileSha256",
+        "dataset",
+        "seed",
+        "stepCount",
+        "wallClockSec",
+        "hardware",
+        "optimizer",
+        "evalSnapshots",
+        "checkpoint",
+    }
+    optional = {"trainingConfig"}
+    _assert_keys(payload, required, optional, "manifest")
+    _require_equal(payload["schemaVersion"], TRAINING_RUN_MANIFEST_SCHEMA_VERSION, "schemaVersion")
+    _require_in(payload["subprogram"], SUBPROGRAMS, "subprogram")
+    _require_git_sha(payload["harnessGitSha"], "harnessGitSha")
+    _require_git_sha(payload["trainingCodeGitSha"], "trainingCodeGitSha")
+    if payload["dockerImageSha"] is not None:
+        if not re.match(r"^sha256:[a-f0-9]{64}$", str(payload["dockerImageSha"])):
+            raise ValueError("dockerImageSha must be null or sha256:<64 hex chars>")
+    if payload["lockfileSha256"] is not None:
+        _require_sha256(payload["lockfileSha256"], "lockfileSha256")
+    started = _parse_timestamp(payload["startedAt"], "startedAt")
+    finished_raw = payload["finishedAt"]
+    if finished_raw is not None:
+        finished = _parse_timestamp(finished_raw, "finishedAt")
+        if finished < started:
+            raise ValueError("finishedAt must be greater than or equal to startedAt")
+    if isinstance(payload["seed"], bool) or not isinstance(payload["seed"], int):
+        raise ValueError("seed must be an integer")
+    _require_nonnegative_int(payload["stepCount"], "stepCount")
+    _require_nonnegative_number(payload["wallClockSec"], "wallClockSec")
+    _validate_dataset(payload["dataset"])
+    _validate_hardware(payload["hardware"])
+    _validate_optimizer(payload["optimizer"])
+    _validate_checkpoint(payload["checkpoint"])
+    eval_snapshots = payload["evalSnapshots"]
+    if not isinstance(eval_snapshots, list):
+        raise ValueError("evalSnapshots must be a list")
+    for index, snapshot in enumerate(eval_snapshots):
+        _validate_eval_snapshot(snapshot, f"evalSnapshots[{index}]")
+    if "trainingConfig" in payload:
+        _validate_config_reference(payload["trainingConfig"], "trainingConfig")
+
+
+def write_training_run_manifest(manifest: TrainingRunManifest, out_path: Path) -> None:
+    assert_training_run_manifest_shape(manifest)
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    # Atomic write so partial files don't shadow good ones during a crash.
     tmp = out_path.with_suffix(out_path.suffix + f".tmp-{os.getpid()}-{int(time.time())}")
-    payload = json.dumps(asdict(manifest), indent=2, default=str)
-    tmp.write_text(payload)
+    tmp.write_text(json.dumps(manifest_to_dict(manifest), indent=2) + "\n", encoding="utf-8")
     tmp.replace(out_path)
 
 
+def write_training_manifest(manifest: TrainingRunManifest, out_path: Path) -> None:
+    """Backward-compatible writer name; writes the canonical run-manifest schema."""
+
+    write_training_run_manifest(manifest, out_path)
+
+
 def new_run_id(program: str) -> str:
-    """Deterministic-ish run-id: ISO timestamp + 8-char random hex."""
     ts = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
-    rand = _sha256_bytes(os.urandom(8))[:8]
+    rand = sha256_bytes(os.urandom(8))[:8]
     return f"{program}-{ts}-{rand}"
+
+
+def _assert_keys(
+    payload: dict[str, Any],
+    required: set[str],
+    optional: set[str],
+    label: str,
+) -> None:
+    actual = set(payload)
+    missing = required - actual
+    extra = actual - required - optional
+    if missing:
+        raise ValueError(f"{label} missing required keys: {sorted(missing)}")
+    if extra:
+        raise ValueError(f"{label} has unrecognized keys: {sorted(extra)}")
+
+
+def _require_equal(value: Any, expected: Any, label: str) -> None:
+    if value != expected:
+        raise ValueError(f"{label} must be {expected!r}; got {value!r}")
+
+
+def _require_in(value: Any, allowed: set[str], label: str) -> None:
+    if value not in allowed:
+        raise ValueError(f"{label} must be one of {sorted(allowed)}; got {value!r}")
+
+
+def _require_sha256(value: Any, label: str) -> None:
+    if not isinstance(value, str) or not SHA256_RE.match(value):
+        raise ValueError(f"{label} must be a 64-char lowercase sha256 hex string")
+
+
+def _require_git_sha(value: Any, label: str) -> None:
+    if not isinstance(value, str) or not GIT_SHA_RE.match(value):
+        raise ValueError(f"{label} must be a 40- or 64-char lowercase git sha")
+
+
+def _require_nonnegative_int(value: Any, label: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{label} must be a nonnegative integer")
+
+
+def _require_positive_int(value: Any, label: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{label} must be a positive integer")
+
+
+def _require_nonnegative_number(value: Any, label: str) -> None:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(float(value))
+        or value < 0
+    ):
+        raise ValueError(f"{label} must be a finite nonnegative number")
+
+
+def _require_finite_number(value: Any, label: str) -> None:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(float(value))
+    ):
+        raise ValueError(f"{label} must be a finite number")
+
+
+def _parse_timestamp(value: Any, label: str) -> datetime:
+    if not isinstance(value, str):
+        raise ValueError(f"{label} must be an ISO timestamp string")
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"{label} must be an ISO timestamp") from exc
+
+
+def _validate_dataset(payload: Any) -> None:
+    if not isinstance(payload, dict):
+        raise ValueError("dataset must be an object")
+    _assert_keys(payload, {"dvcRev", "name", "sha256"}, set(), "dataset")
+    if not payload["dvcRev"] or not payload["name"]:
+        raise ValueError("dataset.dvcRev and dataset.name must be nonempty")
+    _require_sha256(payload["sha256"], "dataset.sha256")
+
+
+def _validate_hardware(payload: Any) -> None:
+    if not isinstance(payload, dict):
+        raise ValueError("hardware must be an object")
+    _assert_keys(payload, {"gpuModel", "gpuCount", "nodeCount"}, set(), "hardware")
+    if not payload["gpuModel"]:
+        raise ValueError("hardware.gpuModel must be nonempty")
+    _require_nonnegative_int(payload["gpuCount"], "hardware.gpuCount")
+    _require_positive_int(payload["nodeCount"], "hardware.nodeCount")
+
+
+def _validate_optimizer(payload: Any) -> None:
+    if not isinstance(payload, dict):
+        raise ValueError("optimizer must be an object")
+    _assert_keys(
+        payload,
+        {"name", "stateSha256", "learningRate", "weightDecay", "betas"},
+        set(),
+        "optimizer",
+    )
+    if not payload["name"]:
+        raise ValueError("optimizer.name must be nonempty")
+    _require_sha256(payload["stateSha256"], "optimizer.stateSha256")
+    _require_nonnegative_number(payload["learningRate"], "optimizer.learningRate")
+    _require_nonnegative_number(payload["weightDecay"], "optimizer.weightDecay")
+    betas = payload["betas"]
+    if not isinstance(betas, (list, tuple)) or len(betas) != 2:
+        raise ValueError("optimizer.betas must be a two-number tuple/list")
+    _require_beta(betas[0], "optimizer.betas[0]")
+    _require_beta(betas[1], "optimizer.betas[1]")
+
+
+def _validate_checkpoint(payload: Any) -> None:
+    if not isinstance(payload, dict):
+        raise ValueError("checkpoint must be an object")
+    _assert_keys(payload, {"path", "sha256", "bytes", "weightsLicense"}, set(), "checkpoint")
+    if not payload["path"]:
+        raise ValueError("checkpoint.path must be nonempty")
+    _require_sha256(payload["sha256"], "checkpoint.sha256")
+    _require_positive_int(payload["bytes"], "checkpoint.bytes")
+    _require_in(payload["weightsLicense"], WEIGHTS_LICENSES, "checkpoint.weightsLicense")
+
+
+def _validate_eval_snapshot(payload: Any, label: str) -> None:
+    if not isinstance(payload, dict):
+        raise ValueError(f"{label} must be an object")
+    _assert_keys(payload, {"modality", "dataset", "step", "generatedAt", "metrics"}, set(), label)
+    _require_in(payload["modality"], MODALITIES, f"{label}.modality")
+    _validate_eval_dataset(payload["dataset"], f"{label}.dataset")
+    _require_nonnegative_int(payload["step"], f"{label}.step")
+    _parse_timestamp(payload["generatedAt"], f"{label}.generatedAt")
+    metrics = payload["metrics"]
+    if not isinstance(metrics, list) or not metrics:
+        raise ValueError(f"{label}.metrics must be a nonempty list")
+    for index, metric in enumerate(metrics):
+        _validate_eval_metric(metric, f"{label}.metrics[{index}]")
+
+
+def _validate_eval_dataset(payload: Any, label: str) -> None:
+    if not isinstance(payload, dict):
+        raise ValueError(f"{label} must be an object")
+    _assert_keys(payload, {"name", "split", "sha256"}, set(), label)
+    if not payload["name"] or not payload["split"]:
+        raise ValueError(f"{label}.name and {label}.split must be nonempty")
+    _require_sha256(payload["sha256"], f"{label}.sha256")
+
+
+def _validate_eval_metric(payload: Any, label: str) -> None:
+    if not isinstance(payload, dict):
+        raise ValueError(f"{label} must be an object")
+    _assert_keys(payload, {"name", "value"}, {"unit", "higherIsBetter"}, label)
+    if not payload["name"]:
+        raise ValueError(f"{label}.name must be nonempty")
+    _require_finite_number(payload["value"], f"{label}.value")
+    if "unit" in payload and (not isinstance(payload["unit"], str) or not payload["unit"]):
+        raise ValueError(f"{label}.unit must be a nonempty string when present")
+    if "higherIsBetter" in payload and not isinstance(payload["higherIsBetter"], bool):
+        raise ValueError(f"{label}.higherIsBetter must be boolean when present")
+
+
+def _validate_config_reference(payload: Any, label: str) -> None:
+    if not isinstance(payload, dict):
+        raise ValueError(f"{label} must be an object")
+    _assert_keys(payload, {"path", "sha256"}, set(), label)
+    if not payload["path"]:
+        raise ValueError(f"{label}.path must be nonempty")
+    _require_sha256(payload["sha256"], f"{label}.sha256")
+
+
+def _require_beta(value: Any, label: str) -> None:
+    _require_nonnegative_number(value, label)
+    if float(value) > 1:
+        raise ValueError(f"{label} must be between 0 and 1")

--- a/research/training/_shared/smoke_manifest.py
+++ b/research/training/_shared/smoke_manifest.py
@@ -1,0 +1,107 @@
+"""CPU-only smoke for the training-run manifest receipt.
+
+This does not train a model. It writes a tiny synthetic checkpoint and the
+canonical `witt.training.run-manifest/v0.1` receipt without importing torch,
+so CI can enforce the receipt floor before GPU training exists.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from .manifest import (
+    TRAINING_RUN_MANIFEST_SCHEMA_VERSION,
+    TrainingRunHardware,
+    TrainingRunManifest,
+    capture_dataset_fingerprint,
+    capture_docker_image_sha,
+    capture_git_sha,
+    capture_lockfile_sha256,
+    capture_training_checkpoint,
+    new_run_id,
+    synthetic_optimizer_checkpoint,
+    utc_now_iso,
+    write_training_config_snapshot,
+    write_training_run_manifest,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def build_smoke_manifest(out_root: Path, run_id: str | None = None) -> dict[str, Any]:
+    run_id = run_id or new_run_id("training-smoke")
+    run_dir = out_root / run_id
+    ckpt_dir = run_dir / "ckpts"
+    ckpt_dir.mkdir(parents=True, exist_ok=True)
+
+    dataset_marker = run_dir / "synthetic-dataset.txt"
+    dataset_marker.write_text("wittgenstein synthetic training manifest smoke\n", encoding="utf-8")
+    checkpoint_path = ckpt_dir / "final.synthetic"
+    checkpoint_path.write_bytes(b"wittgenstein synthetic checkpoint bytes\n")
+    config_ref = write_training_config_snapshot(
+        run_dir / "config.json",
+        {
+            "purpose": "stdlib training-manifest smoke",
+            "realTraining": False,
+            "subprogram": "tokenizer",
+        },
+    )
+
+    started_at = utc_now_iso()
+    manifest = TrainingRunManifest(
+        schemaVersion=TRAINING_RUN_MANIFEST_SCHEMA_VERSION,
+        runId=run_id,
+        subprogram="tokenizer",
+        startedAt=started_at,
+        finishedAt=utc_now_iso(),
+        harnessGitSha=capture_git_sha(REPO_ROOT),
+        trainingCodeGitSha=capture_git_sha(REPO_ROOT),
+        dockerImageSha=capture_docker_image_sha(),
+        lockfileSha256=capture_lockfile_sha256(REPO_ROOT / "research" / "training" / "requirements.txt"),
+        dataset=capture_dataset_fingerprint(
+            "synthetic-manifest-smoke",
+            [dataset_marker],
+            revision="synthetic-smoke",
+            cache_per_file=True,
+        ),
+        seed=0,
+        stepCount=0,
+        wallClockSec=0.0,
+        hardware=TrainingRunHardware(gpuModel="cpu:stdlib-smoke", gpuCount=0, nodeCount=1),
+        optimizer=synthetic_optimizer_checkpoint(),
+        evalSnapshots=[],
+        checkpoint=capture_training_checkpoint(checkpoint_path, weights_license="permissive"),
+        trainingConfig=config_ref,
+    )
+    manifest_path = run_dir / "manifest.json"
+    write_training_run_manifest(manifest, manifest_path)
+    return {
+        "runId": run_id,
+        "runDir": str(run_dir),
+        "manifestPath": str(manifest_path),
+        "checkpointPath": str(checkpoint_path),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--out-root",
+        type=Path,
+        default=REPO_ROOT / "artifacts" / "runs",
+        help="Output root for the synthetic run directory.",
+    )
+    parser.add_argument("--run-id", default=None, help="Optional deterministic run id for tests.")
+    args = parser.parse_args()
+
+    summary = build_smoke_manifest(args.out_root, run_id=args.run_id)
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/training/_shared/test_manifest.py
+++ b/research/training/_shared/test_manifest.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from .manifest import (
+    TRAINING_RUN_MANIFEST_SCHEMA_VERSION,
+    assert_training_run_manifest_shape,
+    capture_dataset_fingerprint,
+    sha256_file,
+)
+from .smoke_manifest import build_smoke_manifest
+
+
+class TrainingRunManifestSmokeTests(unittest.TestCase):
+    def test_stdlib_smoke_writes_canonical_manifest(self) -> None:
+        torch_was_loaded = "torch" in sys.modules
+        with tempfile.TemporaryDirectory() as tmp:
+            summary = build_smoke_manifest(Path(tmp), run_id="tokenizer-stdlib-smoke-test")
+            manifest_path = Path(summary["manifestPath"])
+            checkpoint_path = Path(summary["checkpointPath"])
+            payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+            checkpoint_sha256 = sha256_file(checkpoint_path)
+
+        assert_training_run_manifest_shape(payload)
+        self.assertEqual(payload["schemaVersion"], TRAINING_RUN_MANIFEST_SCHEMA_VERSION)
+        self.assertEqual(payload["subprogram"], "tokenizer")
+        self.assertEqual(payload["hardware"]["gpuModel"], "cpu:stdlib-smoke")
+        self.assertEqual(payload["hardware"]["gpuCount"], 0)
+        self.assertEqual(payload["checkpoint"]["weightsLicense"], "permissive")
+        self.assertEqual(payload["checkpoint"]["sha256"], checkpoint_sha256)
+        self.assertEqual(payload["optimizer"]["name"], "stdlib-smoke-none")
+        self.assertEqual(payload["evalSnapshots"], [])
+        self.assertIn("trainingConfig", payload)
+
+        if not torch_was_loaded:
+            self.assertNotIn("torch", sys.modules)
+
+    def test_rejects_legacy_training_manifest_shape(self) -> None:
+        with self.assertRaisesRegex(ValueError, "missing required keys"):
+            assert_training_run_manifest_shape(
+                {
+                    "schema_version": "witt.training/v0.1",
+                    "program": "tokenizer",
+                    "config": {},
+                }
+            )
+
+    def test_rejects_bool_where_schema_requires_numbers(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            summary = build_smoke_manifest(Path(tmp), run_id="tokenizer-stdlib-smoke-test")
+            payload = json.loads(Path(summary["manifestPath"]).read_text(encoding="utf-8"))
+
+        payload["hardware"]["gpuCount"] = False
+        with self.assertRaisesRegex(ValueError, "hardware.gpuCount"):
+            assert_training_run_manifest_shape(payload)
+
+    def test_dataset_fingerprint_can_ignore_mount_point(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root_a = Path(tmp) / "a" / "dataset"
+            root_b = Path(tmp) / "b" / "dataset"
+            for root in (root_a, root_b):
+                (root / "class").mkdir(parents=True)
+                (root / "class" / "sample.jpg").write_bytes(b"same-size")
+
+            fp_a = capture_dataset_fingerprint("dataset", [root_a / "class" / "sample.jpg"], root=root_a)
+            fp_b = capture_dataset_fingerprint("dataset", [root_b / "class" / "sample.jpg"], root=root_b)
+
+        self.assertEqual(fp_a.sha256, fp_b.sha256)
+
+    def test_dataset_content_fingerprint_rejects_missing_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = Path(tmp) / "missing.jpg"
+
+            with self.assertRaises(FileNotFoundError):
+                capture_dataset_fingerprint("dataset", [missing])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/research/training/adapter/README.md
+++ b/research/training/adapter/README.md
@@ -33,11 +33,11 @@ Architecture target (per research-program note):
 The adapter training script will need:
 
 1. **Frozen tokenizer checkpoint** — the result of `tokenizer/train.py`,
-   verified via the training manifest's `checkpoint.weights_sha256`.
+   verified via the training manifest's `checkpoint.sha256`.
 2. **Tokenized dataset cache** — every image in the training corpus
    tokenized once into `[H, W]` integer grids, persisted to disk for
-   quick reload. Cache is content-addressable by `image_sha256` and
-   `tokenizer_weights_sha256`.
+   quick reload. Cache is content-addressable by image SHA-256 and
+   tokenizer checkpoint SHA-256.
 3. **Visual Seed Code generator** — initial bootstrap: block-average
    pooling of the full grid to coarse k×k. Phase 2 may replace this
    with a learned compress step.
@@ -60,9 +60,9 @@ adapter/
 ```
 
 The receipt-first design (per #441) carries through — every adapter
-checkpoint's manifest pins the tokenizer SHA it was trained against,
-so adapter receipts are unambiguous about which tokenizer family they
-go with.
+checkpoint's manifest pins the tokenizer run id and checkpoint SHA-256 it was
+trained against, so adapter receipts are unambiguous about which tokenizer
+family they go with.
 
 ## Owning issues
 
@@ -80,8 +80,9 @@ go with.
 ## Receipt contract
 
 Every adapter training run emits a Wittgenstein manifest receipt under
-`research/training/_shared/runs/<run-id>/` mirroring the tokenizer's
-`TrainingManifest` shape (see `../_shared/manifest.py`). Additional
-adapter-specific fields go into the `config.tokenizer_pin` slot:
-the frozen tokenizer's `weights_sha256` and training run-id, so adapter
-receipts are unambiguous about which Phase-1.1 checkpoint they consume.
+`research/training/_shared/runs/<run-id>/` using the canonical
+`TrainingRunManifest` shape (see `../_shared/manifest.py`). Additional
+adapter-specific pins should live in the referenced training config, not as
+freeform top-level manifest fields: the frozen tokenizer's checkpoint SHA-256
+and training run-id must be enough to make adapter receipts unambiguous about
+which Phase-1.1 checkpoint they consume.

--- a/research/training/tokenizer/README.md
+++ b/research/training/tokenizer/README.md
@@ -32,7 +32,7 @@ Shared infrastructure (`research/training/_shared/`):
 
 ```
 _shared/
-├── manifest.py        # TrainingManifest emitter (Wittgenstein receipt spine)
+├── manifest.py        # TrainingRunManifest emitter (Wittgenstein receipt spine)
 ├── dataset.py         # ImageFolderDataset, SyntheticImageDataset, LlamaGen-canonical preproc
 └── _third_party/
     ├── README.md
@@ -63,15 +63,15 @@ must be true:
    exits 0, writes `final.pt` + `final.manifest.json`, and reports a clean
    acceptance summary.
 2. **Manifest spine is present** — every checkpoint being cited has a sibling
-   `*.manifest.json` with runtime, dataset, optimizer, checkpoint, and config
-   fields populated.
+   `*.manifest.json` with source provenance, dataset, hardware, optimizer,
+   checkpoint, and config-reference fields populated.
 3. **Dataset mode is explicit** — receipts clearly indicate whether the run
    used synthetic smoke data or a real dataset fingerprint; no ambiguous
    “training succeeded” wording across those two cases.
 4. **Metric degradation is observable** — if PSNR/SSIM, LPIPS, or rFID could
    not be computed because optional dependencies or runtime prerequisites were
-   missing, the receipt must say so in `eval.metrics.degraded` and
-   `eval.metrics.degradation_reasons`; silent metric omission is not acceptable.
+   missing, the run summary and eval receipt must say so explicitly; silent
+   metric omission is not acceptable.
 5. **No research blessing from smoke alone** — smoke proves loop integrity,
    manifest emission, and checkpoint I/O only. It does **not** count as model
    quality validation, tokenizer architecture approval, or dataset-license sign-off.
@@ -115,30 +115,36 @@ own-trained advantage is from D=32 vs D=8 + our license posture).
 
 ## Architecture choices vs LlamaGen baseline
 
-| Knob | LlamaGen `vq_ds16_c2i.pt` (audited) | Wittgenstein-native (this scaffold) | Why |
-|---|---|---|---|
-| Codebook K | 16384 | 16384 | Match audited baseline shape |
-| Embed dim D | 8 | **32** | Richer per-site latents for our learned MaskGIT adapter (LlamaGen's D=8 was intentionally low because their AR head carried semantic load — we don't have that constraint) |
-| Downsample p | 16 | 16 | Match audited baseline; 256² → 16×16 = 256 tokens |
-| Encoder ch_mult | [1,1,2,2,4] | [1,1,2,2,4] | Match |
-| Losses | L2 + LPIPS + PatchGAN + commit | Same | Match recipe |
-| Determinism class | structural-parity (Gate C) | structural-parity (planned) | Matches ADR-0015 precedent |
+| Knob              | LlamaGen `vq_ds16_c2i.pt` (audited) | Wittgenstein-native (this scaffold) | Why                                                                                                                                                                        |
+| ----------------- | ----------------------------------- | ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Codebook K        | 16384                               | 16384                               | Match audited baseline shape                                                                                                                                               |
+| Embed dim D       | 8                                   | **32**                              | Richer per-site latents for our learned MaskGIT adapter (LlamaGen's D=8 was intentionally low because their AR head carried semantic load — we don't have that constraint) |
+| Downsample p      | 16                                  | 16                                  | Match audited baseline; 256² → 16×16 = 256 tokens                                                                                                                          |
+| Encoder ch_mult   | [1,1,2,2,4]                         | [1,1,2,2,4]                         | Match                                                                                                                                                                      |
+| Losses            | L2 + LPIPS + PatchGAN + commit      | Same                                | Match recipe                                                                                                                                                               |
+| Determinism class | structural-parity (Gate C)          | structural-parity (planned)         | Matches ADR-0015 precedent                                                                                                                                                 |
 
 ## Receipt-first design (per #441)
 
-Every checkpoint emits a `TrainingManifest` capturing:
+Every checkpoint emits a `TrainingRunManifest` validated by
+`@wittgenstein/schemas`:
 
-- **runtime**: `git_sha`, `lockfile_sha256`, torch/CUDA/cudnn versions, hostname, A800 device name
-- **dataset**: `name`, `root_sha256` (over sorted file enumeration + sizes), `file_count`, `total_bytes`, `revision`
-- **optimizer**: `state_hash` (SHA-256 over state_dict bytes), `lr`, `weight_decay`, `betas`
-- **checkpoint**: `run_id`, `step`, `epoch`, `wall_clock_s`, `seed`, `weights_path`, `weights_sha256`
-- **eval**: `eval_set`, `eval_set_sha256`, `metrics` (filled by eval pass)
-- **config**: full hyperparameter dump (snapshot of TrainConfig)
+- **run identity**: `runId`, `subprogram`, `startedAt`, `finishedAt`
+- **source provenance**: `harnessGitSha`, `trainingCodeGitSha`, optional
+  `dockerImageSha`, `lockfileSha256`
+- **dataset**: `dvcRev`, `name`, `sha256`
+- **hardware**: `gpuModel`, `gpuCount`, `nodeCount`
+- **optimizer**: `stateSha256`, `learningRate`, `weightDecay`, `betas`
+- **checkpoint**: `path`, `sha256`, `bytes`, `weightsLicense`
+- **eval**: `evalSnapshots` filled by the eval pass; empty for smoke/no-eval
+  checkpoints
+- **config**: `trainingConfig` path + SHA-256, not a freeform top-level
+  hyperparameter blob
 
-This matches Wittgenstein's inference-side `RunManifest` shape so
-`wittgenstein replay` works equivalently for inference + training
-receipts. No silent fallbacks; the harness can verify any checkpoint
-back to the exact configuration and data slice that produced it.
+This keeps the Python training side aligned with the TypeScript schema that
+downstream decoder-family manifests consume. No silent fallbacks; the harness
+can verify any checkpoint back to the exact configuration and data slice that
+produced it.
 
 ## Owning issues
 
@@ -155,11 +161,12 @@ back to the exact configuration and data slice that produced it.
 - **PatchGAN discriminator** — discriminator architecture + warmup-aware
   GAN training loop. The losses.py module is already shaped for this.
 - **Eval pass (rFID / PSNR / SSIM / LPIPS / codebook usage on val 50k)** —
-  fills `manifest.eval.metrics` at every `eval_every` step.
+  fills `evalSnapshots` at every `eval_every` step.
 - **Resume-from-checkpoint** — `--resume <ckpt>` flag, restores model +
   optim + step counter, preserves run_id continuity.
-- **Aim/W&B tracker integration** — `manifest.experiment_uri` is the
-  hook; currently empty.
+- **Aim/W&B tracker integration** — tracker links belong in the training config
+  or an issue-owned tracker receipt; they are not freeform top-level manifest
+  fields.
 - **DVC dataset pin** — train script reads dataset SHA from a DVC
   `.dvc` file rather than the cheap file-enumeration fingerprint.
 - **FSDP2 sharding** — only needed if larger tokenizer variants are

--- a/research/training/tokenizer/smoke_test.py
+++ b/research/training/tokenizer/smoke_test.py
@@ -30,6 +30,7 @@ if str(_REPO_ROOT) not in sys.path:
 
 from research.training.tokenizer.config import smoke_config
 from research.training.tokenizer.train import train
+from research.training._shared.manifest import assert_training_run_manifest_shape
 
 
 def main() -> int:
@@ -53,6 +54,12 @@ def main() -> int:
     manifests = list((run_dir / "ckpts").glob("*.manifest.json"))
     if not manifests:
         print("[smoke] FAIL: no manifest written")
+        return 1
+    try:
+        manifest_payload = json.loads(sorted(manifests)[-1].read_text(encoding="utf-8"))
+        assert_training_run_manifest_shape(manifest_payload)
+    except Exception as exc:
+        print(f"[smoke] FAIL: manifest shape invalid: {exc}")
         return 1
     acceptance = summary.get("acceptance", {})
     if summary.get("final_step") != cfg.max_steps:

--- a/research/training/tokenizer/train.py
+++ b/research/training/tokenizer/train.py
@@ -44,20 +44,30 @@ for p in (_REPO_ROOT, _SHARED):
         sys.path.insert(0, str(p))
 
 from research.training._shared.manifest import (  # noqa: E402
-    EvalSnapshot,
-    TrainingManifest,
+    TRAINING_RUN_MANIFEST_SCHEMA_VERSION,
+    TrainingRunManifest,
     capture_dataset_fingerprint,
+    capture_docker_image_sha,
+    capture_git_sha,
+    capture_hardware,
+    capture_lockfile_sha256,
     capture_optimizer_checkpoint,
-    capture_runtime_fingerprint,
     capture_training_checkpoint,
     new_run_id,
-    write_training_manifest,
+    utc_now_iso,
+    write_training_config_snapshot,
+    write_training_run_manifest,
 )
 from research.training._shared.dataset import (  # noqa: E402
     ImageFolderDataset,
     SyntheticImageDataset,
 )
-from research.training.tokenizer.config import OptimConfig, TrainConfig, smoke_config  # noqa: E402
+from research.training.tokenizer.config import (  # noqa: E402
+    OptimConfig,
+    TrainConfig,
+    smoke_config,
+    to_dict as cfg_to_dict,
+)
 from research.training.tokenizer.losses import LossWeights, TokenizerLoss  # noqa: E402
 from research.training.tokenizer.model import (  # noqa: E402
     TokenizerConfig,
@@ -217,25 +227,31 @@ def train(cfg: TrainConfig) -> dict:
         (run_dir / "ckpts").mkdir(parents=True, exist_ok=True)
         print(f"[out] run_dir={run_dir}")
 
-    # ---- Capture once: runtime fingerprint + dataset fingerprint ----
+    # ---- Capture once: manifest invariants + dataset fingerprint ----
     if is_main(rank):
-        runtime_fp = capture_runtime_fingerprint(
-            repo_root=_REPO_ROOT,
-            lockfile=_REPO_ROOT / "research" / "training" / "requirements.txt",
+        started_at = utc_now_iso()
+        git_sha = capture_git_sha(_REPO_ROOT)
+        lockfile_sha = capture_lockfile_sha256(
+            _REPO_ROOT / "research" / "training" / "requirements.txt"
         )
+        docker_image_sha = capture_docker_image_sha()
+        hardware = capture_hardware()
+        config_ref = write_training_config_snapshot(run_dir / "config.json", cfg_to_dict(cfg))
         if cfg.smoke or not cfg.train_data_root:
             dataset_fp = capture_dataset_fingerprint(
                 "synthetic", files=[], revision="synthetic-smoke",
                 notes="SyntheticImageDataset; no on-disk files",
             )
         else:
-            file_list = train_ds.file_list_for_manifest()[:1000]  # sample for cheap fingerprint
+            train_data_root = Path(cfg.train_data_root)
+            file_list = train_ds.file_list_for_manifest()
             dataset_fp = capture_dataset_fingerprint(
-                Path(cfg.train_data_root).name,
+                train_data_root.name,
                 files=file_list,
                 revision="uncommitted",
-                notes=f"first 1000 files of {len(train_ds)}; full DVC pin pending #400",
-                cache_per_file=False,
+                notes=f"content fingerprint for {len(train_ds)} files; DVC pin pending #400",
+                cache_per_file=True,
+                root=train_data_root,
             )
 
     # ---- Train loop ----
@@ -320,7 +336,22 @@ def train(cfg: TrainConfig) -> dict:
 
         # Checkpoint
         if is_main(rank) and step > 0 and step % cfg.checkpoint_every == 0:
-            _write_checkpoint(run_dir, model, optim, cfg, step, t0, run_id, runtime_fp, dataset_fp)
+            _write_checkpoint(
+                run_dir,
+                model,
+                optim,
+                cfg,
+                step,
+                t0,
+                run_id,
+                started_at,
+                git_sha,
+                lockfile_sha,
+                docker_image_sha,
+                hardware,
+                dataset_fp,
+                config_ref,
+            )
 
         step += 1
 
@@ -328,7 +359,23 @@ def train(cfg: TrainConfig) -> dict:
 
     # ---- Final checkpoint + manifest ----
     if is_main(rank):
-        _write_checkpoint(run_dir, model, optim, cfg, step, t0, run_id, runtime_fp, dataset_fp, final=True)
+        _write_checkpoint(
+            run_dir,
+            model,
+            optim,
+            cfg,
+            step,
+            t0,
+            run_id,
+            started_at,
+            git_sha,
+            lockfile_sha,
+            docker_image_sha,
+            hardware,
+            dataset_fp,
+            config_ref,
+            final=True,
+        )
         final_ckpt = run_dir / "ckpts" / "final.pt"
         final_manifest = run_dir / "ckpts" / "final.manifest.json"
         summary["acceptance"]["final_checkpoint_written"] = final_ckpt.exists()
@@ -343,28 +390,48 @@ def train(cfg: TrainConfig) -> dict:
     return summary
 
 
-def _write_checkpoint(run_dir, model, optim, cfg, step, t0, run_id, runtime_fp, dataset_fp, final=False):
-    from research.training.tokenizer.config import to_dict as cfg_to_dict
+def _write_checkpoint(
+    run_dir,
+    model,
+    optim,
+    cfg,
+    step,
+    t0,
+    run_id,
+    started_at,
+    git_sha,
+    lockfile_sha,
+    docker_image_sha,
+    hardware,
+    dataset_fp,
+    config_ref,
+    final=False,
+):
     ckpt_path = run_dir / "ckpts" / (f"final.pt" if final else f"step_{step:08d}.pt")
     state = (model.module if hasattr(model, "module") else model).state_dict()
     torch.save({"model": state, "step": step}, ckpt_path)
-    manifest = TrainingManifest(
-        schema_version="witt.training/v0.1",
-        program="tokenizer",
-        family="wittgenstein-native-vqgan",
-        runtime=runtime_fp,
+    weights_license = "permissive" if cfg.smoke or not cfg.train_data_root else "research-only"
+    manifest = TrainingRunManifest(
+        schemaVersion=TRAINING_RUN_MANIFEST_SCHEMA_VERSION,
+        runId=run_id,
+        subprogram="tokenizer",
+        startedAt=started_at,
+        finishedAt=utc_now_iso(),
+        harnessGitSha=git_sha,
+        trainingCodeGitSha=git_sha,
+        dockerImageSha=docker_image_sha,
+        lockfileSha256=lockfile_sha,
         dataset=dataset_fp,
+        seed=cfg.seed,
+        stepCount=step,
+        wallClockSec=time.perf_counter() - t0,
+        hardware=hardware,
         optimizer=capture_optimizer_checkpoint(optim, name="AdamW"),
-        checkpoint=capture_training_checkpoint(
-            run_id=run_id, step=step, epoch=0.0,
-            wall_clock_s=time.perf_counter() - t0, seed=cfg.seed,
-            weights_path=ckpt_path,
-        ),
-        eval=EvalSnapshot(eval_set="not-yet-evaluated", eval_set_sha256="pending", metrics={}),
-        config=cfg_to_dict(cfg),
-        notes=("final checkpoint" if final else f"checkpoint at step {step}"),
+        evalSnapshots=[],
+        checkpoint=capture_training_checkpoint(ckpt_path, weights_license=weights_license),
+        trainingConfig=config_ref,
     )
-    write_training_manifest(manifest, run_dir / "ckpts" / (ckpt_path.stem + ".manifest.json"))
+    write_training_run_manifest(manifest, run_dir / "ckpts" / (ckpt_path.stem + ".manifest.json"))
 
 
 def _build_arg_parser() -> argparse.ArgumentParser:


### PR DESCRIPTION
Refs #441.

## Summary

This turns the actionable part of the #441 training-stack re-audit into code and enforceable receipts without approving expensive training:

- makes `packages/schemas/src/training-manifest.ts` the canonical training receipt contract for Python training loops as well as TS consumers;
- adds optimizer state SHA-256, finite wall-clock validation, and honest CPU smoke hardware (`gpuCount: 0`);
- replaces the Python-only `witt.training/v0.1` helper with a canonical `witt.training.run-manifest/v0.1` writer/validator;
- adds a stdlib-only `research.training._shared.smoke_manifest` plus unittest coverage that proves the receipt floor without importing torch;
- updates tokenizer training to emit the canonical manifest and makes tokenizer smoke validate the receipt shape;
- fixes the vendored LlamaGen codebook-usage accounting so the smoke path does not put mutable usage state into autograd/optimizer state;
- adds a dated closeout note for the #441 boundary and updates older docs so they do not imply a second or legacy manifest shape.

## Research / Decision Boundary

Sources re-checked for the closeout note on 2026-05-31:

- PyTorch FSDP2 `fully_shard`: https://docs.pytorch.org/docs/main/distributed.fsdp.fully_shard.html
- PyTorch `torchrun`: https://docs.pytorch.org/docs/main/elastic/run.html
- DeepSpeed ZeRO: https://deepspeed.readthedocs.io/en/stable/zero3.html
- DVC remote storage: https://doc.dvc.org/user-guide/data-management/remote-storage
- Hugging Face model cards: https://huggingface.co/docs/hub/en/model-cards

Decision kept narrow: plain PyTorch + `torchrun`/DDP remains the first executable training contract; FSDP2/DeepSpeed remain escalation paths for memory pressure, not receipt owners. This PR does not approve lab training, dataset publication, checkpoint publication, model quality claims, or broader third-party reuse.

## Verification

- `python3 -m compileall research/training`
- `python3 -m unittest discover -s research/training -p 'test_*.py' -v`
- `python3 -m research.training._shared.smoke_manifest --out-root /tmp/witt-training-smoke --run-id training-smoke-check-2`
- `pnpm --filter @wittgenstein/schemas test -- training-manifest.test.ts`
- `python3 -m research.training.tokenizer.smoke_test` (CPU, final_step=5, final checkpoint + manifest written)
- `pnpm lint:no-research-imports`
- `pnpm lint:deps`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `git diff --check HEAD~1..HEAD`

## Remaining Owner Scope

Leave #441 open until maintainers/model owners sign off on the broader Phase 1 training-stack boundary and until the remaining data/eval/training-owner issues have real evidence.
