### PR TITLE
chore: materialize benchmark and sandbox debt

### DIFF
--- a/benchmarks/tools/README.md
+++ b/benchmarks/tools/README.md
@@ -1,10 +1,13 @@
 # benchmarks/tools/
 
-Phase-4 quality-metric runners (per `docs/roadmap.md` Phase 4). Today every entrypoint here is a typed Python skeleton that raises `NotImplementedError` — landing the contract first so that wiring CLIP / Whisper / discriminative classifiers can happen one PR at a time without rediscovering the file layout.
+Phase-4 quality-metric runners (per `docs/roadmap.md` Phase 4). Model-backed metric
+runners still land one PR at a time; implemented runners write score receipts or
+charts, while unimplemented runners raise `NotImplementedError` instead of silently
+passing.
 
 ## Contract
 
-Every runner is invoked as:
+Per-artifact metric runners are invoked as:
 
 ```bash
 python benchmarks/tools/<runner>.py \
@@ -17,9 +20,19 @@ python benchmarks/tools/<runner>.py \
 - `--manifest` — path to the run manifest at `artifacts/runs/<run-id>/manifest.json` (the runner inspects modality / route / seed for context).
 - `--out` — path to write a structured **score receipt** JSON. If the runner is not yet implemented it raises `NotImplementedError` and writes nothing; the caller can detect this from the missing file and fall back to the structural smoke proxy.
 
+The aggregate chart runner is invoked as:
+
+```bash
+python benchmarks/tools/chart.py \
+  --receipts-dir artifacts/benchmarks/<tag> \
+  --tag <tag> \
+  --out artifacts/benchmarks/<tag>.png
+```
+
 ## Score receipt shape
 
-When a runner is implemented, the receipt JSON has this shape (tighter typing TBD when the first real runner lands):
+Implemented runners write receipt JSON in the shared shape enforced by
+`score_receipt.py`:
 
 ```json
 {
@@ -43,7 +56,10 @@ When a runner is implemented, the receipt JSON has this shape (tighter typing TB
 }
 ```
 
-The shape is **not yet a zod-validated boundary** — it solidifies when the first runner lands and the actual data shape is known.
+This is now a code boundary for benchmark tools: `score_receipt.py` validates the common
+fields (`tool`, `version`, `metric`, `model`, `inputs`, `generatedAt`) before downstream
+tools consume a receipt. A future TypeScript / Zod mirror can land when score receipts
+become part of the public schema package.
 
 ## Runners
 
@@ -52,18 +68,22 @@ The shape is **not yet a zod-validated boundary** — it solidifies when the fir
 | `clipscore.py`  | image          | CLIPScore (image-text cosine)                                  | 🔴 Stub |
 | `wer.py`        | audio (speech) | Whisper WER                                                    | 🔴 Stub |
 | `disc_score.py` | sensor         | discriminative-score classifier                                | 🔴 Stub |
-| `chart.py`      | all            | aggregate score chart from `artifacts/benchmarks/<tag>/*.json` | 🔴 Stub |
+| `chart.py`      | all            | aggregate score chart from `artifacts/benchmarks/<tag>/*.json` | ✅ PNG chart |
 
 ## Why scaffolding-only first
 
 Per docs/roadmap.md Phase 4 plan: the metric runners land at v0.4. Without scaffolding, the first contributor to wire CLIP has to discover the file layout, dependency choice, manifest contract, and CI integration from scratch. With scaffolding, that contributor only has to fill in the model call.
 
-Each stub:
+Each unimplemented runner:
 
 - Validates argparse inputs.
 - Reads the run manifest and asserts the modality matches what the runner expects.
 - Raises `NotImplementedError` with a one-line "wire X here" message.
 - A test under `benchmarks/tools/test_*` asserts the `NotImplementedError` fires (so that "still a stub" is itself a checked invariant — silent success here would be the worst failure mode).
+
+`chart.py` is implemented now: it reads score receipts, validates the common
+receipt shape through `score_receipt.py`, and writes a matplotlib PNG with one panel per
+raw metric unit. Values are intentionally not normalized across metrics.
 
 ## Out of scope
 

--- a/benchmarks/tools/chart.py
+++ b/benchmarks/tools/chart.py
@@ -1,47 +1,94 @@
 #!/usr/bin/env python3
-"""Aggregate score chart generator (Phase 4 stub).
+"""Aggregate score chart generator.
 
 Reads a directory of score-receipt JSON files (produced by clipscore /
 wer / disc_score) and writes a single chart summarizing the aggregate
-quality picture for a release tag. Today this is a typed skeleton that
-raises NotImplementedError so the contract is locked before a chart
-library and aggregation rule are committed to.
+quality picture for a release tag.
 
 Per docs/roadmap.md Phase 4: "Chart generator producing
 artifacts/benchmarks/<tag>.png".
-
-To implement:
-    1. Pick a chart library (matplotlib, since polyglot-mini already
-       depends on it; no new dependency).
-    2. Decide aggregation: per-modality scatter, per-runner box, or
-       single multi-panel figure. Pick one.
-    3. Replace the NotImplementedError with the read + render pass.
-    4. Write the PNG to args.out.
-    5. Drop the test that asserts NotImplementedError fires.
 
 See benchmarks/tools/README.md for the full contract.
 """
 from __future__ import annotations
 
 import argparse
-import json
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
+import matplotlib
 
-def _read_score_receipts(receipts_dir: Path) -> list[dict]:
-    if not receipts_dir.is_dir():
-        raise FileNotFoundError(f"Score-receipts directory not found: {receipts_dir}")
-    receipts: list[dict] = []
-    for path in sorted(receipts_dir.glob("*.json")):
-        receipts.append(json.loads(path.read_text()))
-    return receipts
+matplotlib.use("Agg")
+from matplotlib import pyplot as plt  # noqa: E402
+
+from score_receipt import ScoreReceipt, load_score_receipts  # noqa: E402
+
+
+def _render_chart(receipts: list[ScoreReceipt], out: Path, tag: str) -> None:
+    grouped: dict[tuple[str, str], list[ScoreReceipt]] = {}
+    for receipt in receipts:
+        grouped.setdefault((receipt.metric.name, receipt.metric.unit), []).append(
+            receipt
+        )
+
+    panel_count = len(grouped)
+    max_rows = max(len(group) for group in grouped.values())
+    height = max(4.0, panel_count * 2.6 + max_rows * 0.24)
+    fig, axes = plt.subplots(panel_count, 1, figsize=(10, height), squeeze=False)
+    palette = {
+        "clipscore": "#3563E9",
+        "wer": "#D64A3A",
+        "disc_score": "#168A5B",
+    }
+
+    for axis, ((metric_name, unit), metric_points) in zip(axes.flat, grouped.items()):
+        ordered = sorted(
+            metric_points,
+            key=lambda receipt: (receipt.tool, receipt.chart_label),
+        )
+        labels = [f"{receipt.tool}: {receipt.chart_label}" for receipt in ordered]
+        values = [receipt.metric.value for receipt in ordered]
+        colors = [palette.get(receipt.tool, "#6B7280") for receipt in ordered]
+        y_positions = range(len(ordered))
+
+        axis.barh(y_positions, values, color=colors)
+        axis.set_yticks(list(y_positions), labels=labels)
+        axis.invert_yaxis()
+        axis.set_title(metric_name)
+        axis.set_xlabel(unit or "score")
+        axis.grid(axis="x", alpha=0.24)
+        axis.spines["top"].set_visible(False)
+        axis.spines["right"].set_visible(False)
+
+        if values:
+            max_value = max(values)
+            pad = max(abs(max_value) * 0.02, 0.01)
+            axis.set_xlim(right=max_value + max(abs(max_value), 1.0) * 0.16)
+            for index, value in enumerate(values):
+                axis.text(value + pad, index, f"{value:.3g}", va="center", fontsize=9)
+
+    generated_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    fig.suptitle(f"Wittgenstein benchmark scores - {tag}", fontsize=14, fontweight="bold")
+    fig.text(
+        0.01,
+        0.01,
+        f"Generated {generated_at} from {len(receipts)} score receipt(s). "
+        "Raw metric units are not normalized.",
+        fontsize=8,
+        color="#4B5563",
+    )
+    fig.tight_layout(rect=(0, 0.04, 1, 0.95))
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out, dpi=160)
+    plt.close(fig)
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="chart",
-        description="Aggregate score chart generator (Phase 4 stub).",
+        description="Aggregate score chart generator.",
     )
     parser.add_argument(
         "--receipts-dir",
@@ -64,17 +111,13 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    receipts = _read_score_receipts(args.receipts_dir)
+    receipts = load_score_receipts(args.receipts_dir)
     if not receipts:
         print(f"chart: no score receipts found in {args.receipts_dir}", file=sys.stderr)
         return 1
 
-    raise NotImplementedError(
-        "chart: chart rendering is not yet implemented. "
-        "Pick a chart shape (per-modality scatter / per-runner box / multi-panel) "
-        "and replace this stub with matplotlib calls. "
-        "See benchmarks/tools/README.md."
-    )
+    _render_chart(receipts, args.out, args.tag)
+    return 0
 
 
 if __name__ == "__main__":

--- a/benchmarks/tools/score_receipt.py
+++ b/benchmarks/tools/score_receipt.py
@@ -1,0 +1,115 @@
+"""Shared score-receipt contract for benchmark tools."""
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+JsonObject = dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ScoreMetric:
+    name: str
+    value: float
+    unit: str
+
+
+@dataclass(frozen=True)
+class ScoreModel:
+    id: str
+    deterministic: bool
+
+
+@dataclass(frozen=True)
+class ScoreInputs:
+    artifact: str
+    manifest: str
+    prompt: str | None
+    raw: JsonObject
+
+
+@dataclass(frozen=True)
+class ScoreReceipt:
+    path: Path
+    tool: str
+    version: str
+    metric: ScoreMetric
+    model: ScoreModel
+    inputs: ScoreInputs
+    generated_at: str
+    raw: JsonObject
+
+    @property
+    def chart_label(self) -> str:
+        return Path(self.inputs.artifact).stem or self.path.stem
+
+
+def load_score_receipts(receipts_dir: Path) -> list[ScoreReceipt]:
+    if not receipts_dir.is_dir():
+        raise FileNotFoundError(f"Score-receipts directory not found: {receipts_dir}")
+
+    receipts: list[ScoreReceipt] = []
+    for path in sorted(receipts_dir.glob("*.json")):
+        payload = json.loads(path.read_text())
+        receipts.append(parse_score_receipt(path, payload))
+    return receipts
+
+
+def parse_score_receipt(path: Path, payload: Any) -> ScoreReceipt:
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path}: score receipt must be a JSON object")
+
+    metric = _required_object(path, payload, "metric")
+    model = _required_object(path, payload, "model")
+    inputs = _required_object(path, payload, "inputs")
+    raw_value = metric.get("value")
+    if not isinstance(raw_value, (int, float)) or not math.isfinite(raw_value):
+        raise ValueError(f"{path}: receipt.metric.value must be a finite number")
+
+    prompt = inputs.get("prompt")
+    if prompt is not None and not isinstance(prompt, str):
+        raise ValueError(f"{path}: receipt.inputs.prompt must be a string when present")
+
+    deterministic = model.get("deterministic")
+    if not isinstance(deterministic, bool):
+        raise ValueError(f"{path}: receipt.model.deterministic must be a boolean")
+
+    return ScoreReceipt(
+        path=path,
+        tool=_required_string(path, payload, "tool"),
+        version=_required_string(path, payload, "version"),
+        metric=ScoreMetric(
+            name=_required_string(path, metric, "name"),
+            value=float(raw_value),
+            unit=_required_string(path, metric, "unit"),
+        ),
+        model=ScoreModel(
+            id=_required_string(path, model, "id"),
+            deterministic=deterministic,
+        ),
+        inputs=ScoreInputs(
+            artifact=_required_string(path, inputs, "artifact"),
+            manifest=_required_string(path, inputs, "manifest"),
+            prompt=prompt,
+            raw=inputs,
+        ),
+        generated_at=_required_string(path, payload, "generatedAt"),
+        raw=payload,
+    )
+
+
+def _required_object(path: Path, payload: JsonObject, key: str) -> JsonObject:
+    value = payload.get(key)
+    if not isinstance(value, dict):
+        raise ValueError(f"{path}: receipt.{key} must be an object")
+    return value
+
+
+def _required_string(path: Path, payload: JsonObject, key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{path}: receipt.{key} must be a non-empty string")
+    return value

--- a/benchmarks/tools/test_stubs.py
+++ b/benchmarks/tools/test_stubs.py
@@ -1,8 +1,7 @@
-"""Asserts every Phase 4 runner stub raises NotImplementedError.
+"""Checks Phase 4 benchmark tool behavior.
 
-Drop the relevant block (and add real coverage) when each runner gets
-its real implementation. Until then, "this is a stub" is itself an
-invariant — silent success here would be the worst failure mode.
+Unimplemented metric runners still raise NotImplementedError. Implemented
+tools get real output coverage here.
 
 Run with:
     python -m unittest discover -s benchmarks/tools -p 'test_*.py' -v
@@ -22,6 +21,7 @@ sys.path.insert(0, str(THIS_DIR))
 import chart  # noqa: E402
 import clipscore  # noqa: E402
 import disc_score  # noqa: E402
+import score_receipt  # noqa: E402
 import wer  # noqa: E402
 
 
@@ -37,7 +37,22 @@ def _write_manifest(path: Path, codec: str, route: str | None = None) -> None:
     _write_dummy(path, json.dumps(payload))
 
 
-class StubsRaiseNotImplementedTests(unittest.TestCase):
+def _receipt(tool: str, metric_name: str, value: float, unit: str, artifact: str) -> dict:
+    return {
+        "tool": tool,
+        "version": "0.0.1",
+        "metric": {"name": metric_name, "value": value, "unit": unit},
+        "model": {"id": "local/test-model", "deterministic": True},
+        "inputs": {
+            "artifact": artifact,
+            "manifest": "artifacts/runs/example/manifest.json",
+            "prompt": "test prompt",
+        },
+        "generatedAt": "2026-05-31T00:00:00Z",
+    }
+
+
+class BenchmarkToolTests(unittest.TestCase):
     def setUp(self) -> None:
         self.tmp = tempfile.mkdtemp(prefix="benchmarks-tools-stubs-")
 
@@ -55,7 +70,14 @@ class StubsRaiseNotImplementedTests(unittest.TestCase):
         _write_manifest(manifest, codec="image")
         with self.assertRaises(NotImplementedError):
             clipscore.main(
-                ["--artifact", str(artifact), "--manifest", str(manifest), "--out", str(out)]
+                [
+                    "--artifact",
+                    str(artifact),
+                    "--manifest",
+                    str(manifest),
+                    "--out",
+                    str(out),
+                ]
             )
 
     def test_wer_stub_raises(self) -> None:
@@ -66,7 +88,14 @@ class StubsRaiseNotImplementedTests(unittest.TestCase):
         _write_manifest(manifest, codec="audio", route="speech")
         with self.assertRaises(NotImplementedError):
             wer.main(
-                ["--artifact", str(artifact), "--manifest", str(manifest), "--out", str(out)]
+                [
+                    "--artifact",
+                    str(artifact),
+                    "--manifest",
+                    str(manifest),
+                    "--out",
+                    str(out),
+                ]
             )
 
     def test_disc_score_stub_raises(self) -> None:
@@ -77,18 +106,84 @@ class StubsRaiseNotImplementedTests(unittest.TestCase):
         _write_manifest(manifest, codec="sensor")
         with self.assertRaises(NotImplementedError):
             disc_score.main(
-                ["--artifact", str(artifact), "--manifest", str(manifest), "--out", str(out)]
+                [
+                    "--artifact",
+                    str(artifact),
+                    "--manifest",
+                    str(manifest),
+                    "--out",
+                    str(out),
+                ]
             )
 
-    def test_chart_stub_raises(self) -> None:
+    def test_chart_writes_png(self) -> None:
         receipts_dir = Path(self.tmp, "receipts")
         receipts_dir.mkdir()
-        _write_dummy(receipts_dir / "one.json", json.dumps({"tool": "clipscore"}))
+        _write_dummy(
+            receipts_dir / "clip.json",
+            json.dumps(
+                _receipt(
+                    "clipscore",
+                    "CLIPScore",
+                    0.832,
+                    "cosine",
+                    "artifacts/runs/example/image.png",
+                )
+            ),
+        )
+        _write_dummy(
+            receipts_dir / "wer.json",
+            json.dumps(
+                _receipt(
+                    "wer",
+                    "WER",
+                    0.071,
+                    "ratio",
+                    "artifacts/runs/example/speech.wav",
+                )
+            ),
+        )
         out = Path(self.tmp, "chart.png")
-        with self.assertRaises(NotImplementedError):
-            chart.main(
-                ["--receipts-dir", str(receipts_dir), "--out", str(out)]
-            )
+        status = chart.main(
+            [
+                "--receipts-dir",
+                str(receipts_dir),
+                "--out",
+                str(out),
+                "--tag",
+                "test-tag",
+            ]
+        )
+        self.assertEqual(status, 0)
+        self.assertTrue(out.exists())
+        self.assertEqual(out.read_bytes()[:8], b"\x89PNG\r\n\x1a\n")
+
+    def test_chart_rejects_invalid_receipt_shape(self) -> None:
+        receipts_dir = Path(self.tmp, "receipts")
+        receipts_dir.mkdir()
+        _write_dummy(receipts_dir / "broken.json", json.dumps({"tool": "clipscore"}))
+        out = Path(self.tmp, "chart.png")
+        with self.assertRaises(ValueError):
+            chart.main(["--receipts-dir", str(receipts_dir), "--out", str(out)])
+
+    def test_score_receipt_contract_parses_full_shape(self) -> None:
+        path = Path(self.tmp, "score.json")
+        receipt = score_receipt.parse_score_receipt(
+            path,
+            _receipt("clipscore", "CLIPScore", 0.832, "cosine", "image.png"),
+        )
+        self.assertEqual(receipt.tool, "clipscore")
+        self.assertEqual(receipt.version, "0.0.1")
+        self.assertEqual(receipt.metric.name, "CLIPScore")
+        self.assertEqual(receipt.metric.value, 0.832)
+        self.assertEqual(receipt.model.id, "local/test-model")
+        self.assertEqual(receipt.inputs.manifest, "artifacts/runs/example/manifest.json")
+        self.assertEqual(receipt.chart_label, "image")
+
+    def test_score_receipt_rejects_non_finite_metric(self) -> None:
+        payload = _receipt("clipscore", "CLIPScore", float("nan"), "cosine", "image.png")
+        with self.assertRaises(ValueError):
+            score_receipt.parse_score_receipt(Path(self.tmp, "score.json"), payload)
 
 
 if __name__ == "__main__":

--- a/docs/adrs/0016-untrusted-code-execution-boundary.md
+++ b/docs/adrs/0016-untrusted-code-execution-boundary.md
@@ -24,7 +24,7 @@ Wittgenstein executes code that a language model emits in two places today:
 
 The 2026-05-03 staff audit (#103, §3.4) flagged that the line between "research-grade subprocess sandbox" and "production-grade code-execution boundary" needed an ADR so future contributors and downstream operators have a clear rule, not an implicit one.
 
-`packages/sandbox/` exists as a TypeScript package whose `execProgram` currently throws on call (a generic `Error` carrying an explicit `"not implemented"` message; a typed `NotImplementedError` class is an open follow-up nicety, but the load-bearing contract is the throw, not the class) — it is the **reserved boundary** for the production path. ADR-0016 ratifies that reservation rather than implementing the production sandbox itself; production implementation is a separate engineering line whose entry condition is named below.
+`packages/sandbox/` exists as a TypeScript package whose `execProgram` currently throws on call with a typed `NotImplementedError` carrying `code = "SANDBOX_NOT_IMPLEMENTED"` and `details.kind = "production_sandbox_not_implemented"` — it is the **reserved boundary** for the production path. ADR-0016 ratifies that reservation rather than implementing the production sandbox itself; production implementation is a separate engineering line whose entry condition is named below.
 
 ## Decision
 
@@ -63,7 +63,7 @@ The 2026-05-03 staff audit (#103, §3.4) flagged that the line between "research
 
 - `SECURITY.md` cites this ADR as the load-bearing doctrine for the research / production boundary; the existing prose is preserved as the inline summary.
 - `docs/engineering-discipline.md` carries a short inline paragraph in §"Robustness: Never Hide Errors" naming this boundary as a non-silent-fallback case, citing ADR-0016.
-- `packages/sandbox/README.md` already exists; a focused follow-up will tighten its `execProgram` contract description and add an ADR-0016 cite (it currently uses `NotImplementedError`-style wording that predates this ADR).
+- `packages/sandbox/README.md` describes the typed `execProgram` hard-failure contract and cites ADR-0016.
 - Painter-path callers in `polyglot-mini` continue to work as today; nothing in the research-grade path changes.
 - Future engineering work on the production sandbox lands inside `packages/sandbox/` against one of the named mechanisms in §Decision 2; the choice of mechanism + its threat-model coverage is its own engineering-lane PR (Brief / RFC / ADR amendment / exec plan / code).
 - **Kill criterion:** if a production deployment is attempted before `@wittgenstein/sandbox` is implemented, this ADR's hard-error contract (§Decision 4) trips. That failure is the signal to land the production sandbox, not to weaken the boundary. Reopening this ADR to allow the research-grade subprocess sandbox in production requires explicit doctrine reversal, not a quiet workaround.

--- a/docs/benchmark-standards.md
+++ b/docs/benchmark-standards.md
@@ -212,6 +212,19 @@ MOONSHOT_API_KEY=sk-... pnpm benchmark --live
 Results write to `artifacts/benchmarks/latest.json`. Each result embeds the run ID so
 the full `RunManifest` in `artifacts/runs/<id>/manifest.json` can be inspected.
 
+When score receipts exist for a release tag, render the aggregate chart with:
+
+```bash
+python benchmarks/tools/chart.py \
+  --receipts-dir artifacts/benchmarks/<tag> \
+  --tag <tag> \
+  --out artifacts/benchmarks/<tag>.png
+```
+
+Benchmark score receipts are validated by `benchmarks/tools/score_receipt.py` before the
+chart runner consumes them. This keeps the receipt contract in code while the model-backed
+metric runners are still landing one at a time.
+
 ---
 
 ## Benchmark Cadence

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -101,7 +101,7 @@ Move benchmarks from "structural smoke proxy" to "standard metrics alongside the
 - [ ] Whisper WER runner for TTS (`benchmarks/tools/wer.py`)
 - [ ] Discriminative-score classifier for sensor
 - [ ] 10 prompts per modality; results committed per release tag
-- [ ] Chart generator producing `artifacts/benchmarks/<tag>.png`
+- [x] Chart generator producing `artifacts/benchmarks/<tag>.png`
 
 ## Phase 5 — Distribution
 

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -4,24 +4,25 @@ Reserved execution boundary for untrusted or capability-scoped programs.
 
 ## Why it exists
 
-The scaffold does not need a real sandbox today, but the repo reserves a stable package and API for future codecs that may need to execute generated Python, DSP snippets, or other untrusted code behind an explicit boundary.
+The scaffold does not need a real production sandbox today, but the repo reserves a
+stable package and API for future codecs that may need to execute generated Python, DSP
+snippets, or other untrusted code behind an explicit boundary.
 
 ## Stability Promise
 
 - `execProgram()` is the public seam.
-- The current implementation throws a `NotImplementedError`-style failure on purpose.
+- The current implementation throws a typed `NotImplementedError` on purpose.
+- The error carries `code = "SANDBOX_NOT_IMPLEMENTED"` and
+  `details.kind = "production_sandbox_not_implemented"` so callers can write manifest
+  failures without string parsing.
 - Future versions may swap the backend implementation without changing the call shape.
 
-Reserved boundary for untrusted-code execution.
+## ADR-0016 contract
 
-## Why this package exists today
+ADR-0016 locks this package as the production-path entrypoint for untrusted-code
+execution. Until a production backend lands, callers must propagate the typed hard
+failure and must not fall back to the research-grade `polyglot-mini` subprocess sandbox.
 
-No current codec needs to run arbitrary user/LLM-emitted code. But future codec routes (Python-backed DSP for audio, LLM-emitted drawing programs, symbolic-music synthesis) will. This package reserves the interface now so those routes have a single, reviewed place to integrate.
-
-## Stability guarantee
-
-The `execProgram(code, options): Promise<ExecResult>` signature is stable. Implementations may be swapped (subprocess, Deno permissions, Firecracker, etc.) without changing the contract.
-
-## Not implemented
-
-Calling `execProgram` throws. A real implementation must enforce timeout, memory cap, network isolation, and filesystem scope.
+A real implementation must enforce timeout, memory cap, network isolation, and filesystem
+scope against one of the ADR-named mechanisms (`nsjail`, `bubblewrap`, Pyodide/WASM, or a
+documented peer mechanism).

--- a/packages/sandbox/src/exec.ts
+++ b/packages/sandbox/src/exec.ts
@@ -14,6 +14,42 @@ export interface ExecResult {
   timedOut: boolean;
 }
 
+export interface SandboxErrorOptions {
+  cause?: unknown;
+  details?: Record<string, unknown>;
+}
+
+export class SandboxError extends Error {
+  public readonly code: string;
+  public readonly details: Record<string, unknown> | undefined;
+
+  public constructor(
+    code: string,
+    message: string,
+    options: SandboxErrorOptions = {},
+  ) {
+    super(message, { cause: options.cause });
+    this.name = "SandboxError";
+    this.code = code;
+    this.details = options.details;
+  }
+}
+
+export class NotImplementedError extends SandboxError {
+  public constructor(scope: string, options: SandboxErrorOptions = {}) {
+    const details = {
+      kind: "production_sandbox_not_implemented",
+      adr: "ADR-0016",
+      ...options.details,
+    };
+    super("SANDBOX_NOT_IMPLEMENTED", `NotImplementedError(${scope})`, {
+      cause: options.cause,
+      details,
+    });
+    this.name = "NotImplementedError";
+  }
+}
+
 /**
  * Reserved boundary for untrusted code execution (e.g. Python-backed audio DSP,
  * LLM-emitted drawing programs). Not implemented in scaffold — callers must
@@ -23,7 +59,11 @@ export async function execProgram(
   _code: string,
   _options: ExecOptions,
 ): Promise<ExecResult> {
-  throw new Error(
-    "execProgram: not implemented. This is a reserved sandbox boundary; see packages/sandbox/README.md.",
-  );
+  throw new NotImplementedError("execProgram", {
+    details: {
+      package: "@wittgenstein/sandbox",
+      reservedBoundary: "untrusted-code-execution",
+      mechanism: "none",
+    },
+  });
 }

--- a/packages/sandbox/test/exec.test.ts
+++ b/packages/sandbox/test/exec.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { execProgram } from "../src/index.js";
+import { execProgram, NotImplementedError } from "../src/index.js";
 
 describe("@wittgenstein/sandbox", () => {
   it("preserves the reserved execution seam", async () => {
@@ -7,6 +7,25 @@ describe("@wittgenstein/sandbox", () => {
       execProgram("print('hi')", {
         timeoutMs: 10,
       }),
-    ).rejects.toThrow("not implemented");
+    ).rejects.toBeInstanceOf(NotImplementedError);
+  });
+
+  it("throws a structured production-sandbox-not-implemented error", async () => {
+    await expect(
+      execProgram("print('hi')", {
+        timeoutMs: 10,
+      }),
+    ).rejects.toMatchObject({
+      name: "NotImplementedError",
+      code: "SANDBOX_NOT_IMPLEMENTED",
+      message: "NotImplementedError(execProgram)",
+      details: {
+        kind: "production_sandbox_not_implemented",
+        adr: "ADR-0016",
+        package: "@wittgenstein/sandbox",
+        reservedBoundary: "untrusted-code-execution",
+        mechanism: "none",
+      },
+    });
   });
 });


### PR DESCRIPTION
## Summary
- implement the Phase 4 benchmark chart runner and mark the roadmap item complete
- add a shared Python score-receipt contract used by the chart runner and tests
- replace the sandbox reserved-boundary generic throw with a typed ADR-0016 NotImplementedError

## Verification
- python3 -m unittest discover -s benchmarks/tools -p 'test_*.py' -v
- python3 -m py_compile benchmarks/tools/chart.py benchmarks/tools/score_receipt.py benchmarks/tools/test_stubs.py
- pnpm --filter @wittgenstein/sandbox test
- pnpm --filter @wittgenstein/sandbox typecheck
- pnpm --filter @wittgenstein/sandbox lint
- git diff --check