### PR TITLE
feat(training): add experiment tracking receipts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,10 @@ artifacts/m1b-audit/*
 !artifacts/m1b-audit/.gitkeep
 !artifacts/m1b-audit/README.md
 
+# Local CPU/GPU training smoke outputs; receipts/checkpoints are committed only
+# when deliberately copied into an artifact bundle.
+research/training/_shared/runs/
+
 # Local image-adapter training outputs (keep raw data private / large)
 data/image_adapter/train/*.jsonl
 data/image_adapter/artifacts/

--- a/docs/contributing/training-setup.md
+++ b/docs/contributing/training-setup.md
@@ -61,12 +61,14 @@ artifact bundle. It records:
 - Per-eval-step metric snapshots
 - Checkpoint path, SHA-256, byte size, and weights license
 
-Do not put a freeform hyperparameter blob inside the receipt. Training
-configuration stays in the training program's own config file; the receipt
-may point at that file with a path and SHA-256. The same receipt can be
-mirrored to Aim (local) and W&B (when a project key is set via
-`WANDB_PROJECT`). Aim is the default because the manifest spine is the
-canonical record and Aim stays local + offline-friendly.
+Do not put a freeform hyperparameter blob or tracker block inside the receipt.
+Training configuration stays in the training program's own config file; the
+receipt may point at that file with a path and SHA-256. Experiment tracker
+linkage is a sibling `witt.training.experiment/v0.1` receipt, with a local JSONL
+implementation used by CPU smoke tests. See
+[training experiment tracking](../training/experiment-tracking.md) for the
+contract and the #399 boundary between repo-side receipts and the still-external
+shared Aim deployment.
 
 The three manifest surfaces are intentionally separate:
 

--- a/docs/research/2026-05-31-training-stack-re-audit-closeout.md
+++ b/docs/research/2026-05-31-training-stack-re-audit-closeout.md
@@ -47,6 +47,10 @@ expensive training run. The durable boundary is:
   The Python helper now mirrors it, including optimizer state SHA-256,
   checkpoint byte/SHA/license fields, dataset SHA, hardware, and config
   reference.
+- **Tracker contract:** experiment tracker linkage is a sibling
+  `witt.training.experiment/v0.1` receipt, not a top-level freeform field in
+  `TrainingRunManifest`. The local JSONL tracker is only the executable smoke
+  floor; #399 still owns shared Aim deployment evidence.
 - **CPU smoke honesty:** schema hardware now permits `gpuCount: 0`. CPU-only
   smoke receipts should say they are CPU receipts instead of inventing a GPU.
 - **Reuse strategy:** LlamaGen tokenizer reuse remains limited to the audited
@@ -63,9 +67,11 @@ The following is safe to merge before lab compute:
 
 - stdlib-only `research.training._shared.smoke_manifest`;
 - `research.training._shared.test_manifest`;
+- `research.training._shared.test_experiment_tracking`;
 - canonical Python manifest writer updates;
-- schema tests for optimizer receipts and CPU-only smoke;
-- tokenizer smoke validation that fails if the emitted manifest shape drifts.
+- schema tests for optimizer receipts, experiment receipts, and CPU-only smoke;
+- tokenizer smoke validation that fails if the emitted manifest or experiment
+  receipt shape drifts.
 
 These changes are receipt-floor work. They do not claim model quality, dataset
 readiness, or checkpoint publishability.

--- a/docs/training/experiment-tracking.md
+++ b/docs/training/experiment-tracking.md
@@ -1,0 +1,74 @@
+# Training experiment tracking
+
+This is the repository-side tracking contract for Phase 1 training runs. It
+does not deploy the shared Aim service requested by
+[#399](https://github.com/p-to-q/wittgenstein/issues/399); that still needs a
+lab-owned endpoint, credentials, and contributor-access validation.
+
+## Receipt model
+
+`TrainingRunManifest` stays the canonical checkpoint receipt and remains
+strict. Do not add a freeform top-level `experiment` block to it. Tracker
+linkage lives next to the run as a sibling receipt:
+
+- `config.json` contains an `experimentTracking` reference with tracker name,
+  run id, receipt path, metrics-log path, and URI.
+- `experiment-metrics.jsonl` contains append-only params and metrics records.
+- `experiment.json` is the final `witt.training.experiment/v0.1` receipt. It
+  records the tracker, metrics-log SHA-256/byte count, training run id, and the
+  final training-manifest/checkpoint hashes when the run finishes.
+
+This keeps the checkpoint receipt stable while allowing Aim, W&B, MLflow, or
+the local JSONL floor to point back to the same training run.
+
+## Local JSONL floor
+
+`research.training._shared.experiment_tracking.JsonlExperimentTracker` is the
+stdlib implementation used by CPU smoke tests and offline training runs. It is
+not a replacement for a shared tracking service; it is the minimum executable
+receipt floor so CI can prove that every tokenizer smoke run emits tracker
+evidence without requiring a network service.
+
+Tokenizer smoke runs now write:
+
+```text
+research/training/_shared/runs/smoke/<run-id>/config.json
+research/training/_shared/runs/smoke/<run-id>/experiment-metrics.jsonl
+research/training/_shared/runs/smoke/<run-id>/experiment.json
+research/training/_shared/runs/smoke/<run-id>/ckpts/final.manifest.json
+research/training/_shared/runs/smoke/<run-id>/ckpts/final.pt
+```
+
+The generated `research/training/_shared/runs/` tree is ignored by git.
+
+## External trackers
+
+External tracker adapters should emit the same `experiment.json` receipt. The
+schema already accepts `aim`, `wandb`, and `mlflow` tracker ids, but a tracker
+adapter is not complete until it writes:
+
+- the tracker URI and remote run id;
+- the metrics-log or exported event-log digest;
+- the matching final `TrainingRunManifest` reference;
+- enough setup docs for a contributor to view the run from a fresh checkout.
+
+Aim remains the intended lab default for #399, but the repo contract does not
+claim that a shared Aim endpoint exists. Before closing #399, validate the
+current Aim deployment instructions, endpoint access, retention policy, and
+sample tokenizer run against the lab environment.
+
+## Verification
+
+Run the receipt-floor checks locally:
+
+```bash
+python3 -m unittest research.training._shared.test_manifest \
+  research.training._shared.test_experiment_tracking
+python3 -m research.training._shared.smoke_manifest
+python3 -m research.training.tokenizer.smoke_test
+pnpm --filter @wittgenstein/schemas test -- training
+```
+
+These checks prove schema and smoke-run receipt shape only. They do not prove
+ImageNet/CC12M data availability, lab GPU performance, model quality, or shared
+tracker access.

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -3,6 +3,7 @@ export * from "./config.js";
 export * from "./modality.js";
 export * from "./manifest.js";
 export * from "./training-manifest.js";
+export * from "./training-experiment.js";
 export * from "./trackers.js";
 export * as codecV2 from "./codec/v2/index.js";
 export * as llm from "./llm/index.js";

--- a/packages/schemas/src/training-experiment.ts
+++ b/packages/schemas/src/training-experiment.ts
@@ -1,0 +1,74 @@
+import { z } from "zod";
+import { TrainingRunManifestReferenceSchema } from "./training-manifest.js";
+
+const Sha256Schema = z.string().regex(/^[a-f0-9]{64}$/);
+const TimestampSchema = z.string().datetime({ offset: true });
+
+export const TrainingExperimentReceiptSchemaVersion = "witt.training.experiment/v0.1" as const;
+
+export const TrainingExperimentTrackerSchema = z.enum(["aim", "wandb", "mlflow", "jsonl"]);
+
+export const TrainingExperimentMetricLogSchema = z
+  .object({
+    path: z.string().min(1),
+    sha256: Sha256Schema,
+    bytes: z.number().int().nonnegative(),
+  })
+  .strict();
+
+export const TrainingExperimentConfigReferenceSchema = z
+  .object({
+    tracker: TrainingExperimentTrackerSchema,
+    uri: z.string().url(),
+    runId: z.string().min(1),
+    trainingRunId: z.string().min(1),
+    receiptPath: z.string().min(1),
+    metricsLogPath: z.string().min(1),
+  })
+  .strict();
+
+export const TrainingExperimentReceiptSchema = z
+  .object({
+    schemaVersion: z.literal(TrainingExperimentReceiptSchemaVersion),
+    tracker: TrainingExperimentTrackerSchema,
+    uri: z.string().url(),
+    runId: z.string().min(1),
+    trainingRunId: z.string().min(1),
+    startedAt: TimestampSchema,
+    finishedAt: TimestampSchema.nullable(),
+    metricsLog: TrainingExperimentMetricLogSchema,
+    manifest: TrainingRunManifestReferenceSchema.optional(),
+  })
+  .strict()
+  .superRefine((receipt, ctx) => {
+    if (receipt.finishedAt === null) {
+      return;
+    }
+
+    if (Date.parse(receipt.finishedAt) < Date.parse(receipt.startedAt)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["finishedAt"],
+        message: "finishedAt must be greater than or equal to startedAt.",
+      });
+    }
+  });
+
+export const TrainingExperimentReferenceSchema = z
+  .object({
+    tracker: TrainingExperimentTrackerSchema,
+    uri: z.string().url(),
+    runId: z.string().min(1),
+    receiptPath: z.string().min(1),
+    receiptSha256: Sha256Schema,
+    metricsSha256: Sha256Schema,
+  })
+  .strict();
+
+export type TrainingExperimentTracker = z.infer<typeof TrainingExperimentTrackerSchema>;
+export type TrainingExperimentMetricLog = z.infer<typeof TrainingExperimentMetricLogSchema>;
+export type TrainingExperimentConfigReference = z.infer<
+  typeof TrainingExperimentConfigReferenceSchema
+>;
+export type TrainingExperimentReceipt = z.infer<typeof TrainingExperimentReceiptSchema>;
+export type TrainingExperimentReference = z.infer<typeof TrainingExperimentReferenceSchema>;

--- a/packages/schemas/test/fixtures/training-experiment-receipt.json
+++ b/packages/schemas/test/fixtures/training-experiment-receipt.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": "witt.training.experiment/v0.1",
+  "tracker": "jsonl",
+  "uri": "file:///tmp/wittgenstein/runs/tokenizer-20260531T210000Z-a1b2c3d4/experiment-metrics.jsonl",
+  "runId": "jsonl-tokenizer-20260531T210000Z-a1b2c3d4",
+  "trainingRunId": "tokenizer-20260531T210000Z-a1b2c3d4",
+  "startedAt": "2026-05-31T21:00:00Z",
+  "finishedAt": "2026-05-31T21:03:15Z",
+  "metricsLog": {
+    "path": "research/training/_shared/runs/tokenizer-20260531T210000Z-a1b2c3d4/experiment-metrics.jsonl",
+    "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "bytes": 8192
+  },
+  "manifest": {
+    "runId": "tokenizer-20260531T210000Z-a1b2c3d4",
+    "manifestPath": "research/training/_shared/runs/tokenizer-20260531T210000Z-a1b2c3d4/ckpts/final.manifest.json",
+    "manifestSha256": "8888888888888888888888888888888888888888888888888888888888888888",
+    "checkpointSha256": "7777777777777777777777777777777777777777777777777777777777777777"
+  }
+}

--- a/packages/schemas/test/training-experiment.test.ts
+++ b/packages/schemas/test/training-experiment.test.ts
@@ -1,0 +1,112 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  TrainingExperimentConfigReferenceSchema,
+  TrainingExperimentReceiptSchema,
+  TrainingExperimentReceiptSchemaVersion,
+  TrainingExperimentReferenceSchema,
+  type TrainingExperimentReceipt,
+} from "../src/index.js";
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const fixturePath = join(testDir, "fixtures", "training-experiment-receipt.json");
+
+describe("TrainingExperimentReceiptSchema", () => {
+  it("round-trips the stdlib JSONL tracker receipt shape", () => {
+    const fixture = readTrainingExperimentFixture();
+
+    const parsed = TrainingExperimentReceiptSchema.parse(fixture);
+
+    expect(parsed).toEqual(fixture);
+    expect(parsed.schemaVersion).toBe(TrainingExperimentReceiptSchemaVersion);
+    expect(parsed.tracker).toBe("jsonl");
+    expect(parsed.manifest?.manifestSha256).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("accepts external tracker URI schemes without putting them in the training manifest", () => {
+    const fixture = readTrainingExperimentFixture();
+
+    for (const [tracker, uri] of [
+      ["aim", "aim://wittgenstein/tokenizer-20260531T210000Z-a1b2c3d4"],
+      ["wandb", "https://wandb.ai/wittgenstein/training/runs/a1b2c3d4"],
+      ["mlflow", "http://mlflow.internal/#/experiments/1/runs/a1b2c3d4"],
+    ] as const) {
+      expect(
+        TrainingExperimentReceiptSchema.parse({
+          ...fixture,
+          tracker,
+          uri,
+          runId: `${tracker}-a1b2c3d4`,
+        }).tracker,
+      ).toBe(tracker);
+    }
+  });
+
+  it("rejects impossible tracker windows", () => {
+    const fixture = readTrainingExperimentFixture();
+
+    const parsed = TrainingExperimentReceiptSchema.safeParse({
+      ...fixture,
+      finishedAt: "2026-05-31T20:59:59Z",
+    });
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error?.issues.map((issue) => issue.path.join("."))).toContain("finishedAt");
+  });
+
+  it("validates the pre-finish reference that training configs can embed", () => {
+    const fixture = readTrainingExperimentFixture();
+
+    expect(
+      TrainingExperimentConfigReferenceSchema.parse({
+        tracker: fixture.tracker,
+        uri: fixture.uri,
+        runId: fixture.runId,
+        trainingRunId: fixture.trainingRunId,
+        receiptPath:
+          "research/training/_shared/runs/tokenizer-20260531T210000Z-a1b2c3d4/experiment.json",
+        metricsLogPath:
+          "research/training/_shared/runs/tokenizer-20260531T210000Z-a1b2c3d4/experiment-metrics.jsonl",
+      }),
+    ).toEqual({
+      tracker: fixture.tracker,
+      uri: fixture.uri,
+      runId: fixture.runId,
+      trainingRunId: fixture.trainingRunId,
+      receiptPath:
+        "research/training/_shared/runs/tokenizer-20260531T210000Z-a1b2c3d4/experiment.json",
+      metricsLogPath:
+        "research/training/_shared/runs/tokenizer-20260531T210000Z-a1b2c3d4/experiment-metrics.jsonl",
+    });
+  });
+
+  it("validates a compact post-run reference suitable for artifact indexes", () => {
+    const fixture = readTrainingExperimentFixture();
+
+    expect(
+      TrainingExperimentReferenceSchema.parse({
+        tracker: fixture.tracker,
+        uri: fixture.uri,
+        runId: fixture.runId,
+        receiptPath:
+          "research/training/_shared/runs/tokenizer-20260531T210000Z-a1b2c3d4/experiment.json",
+        receiptSha256: "9999999999999999999999999999999999999999999999999999999999999999",
+        metricsSha256: fixture.metricsLog.sha256,
+      }),
+    ).toEqual({
+      tracker: fixture.tracker,
+      uri: fixture.uri,
+      runId: fixture.runId,
+      receiptPath:
+        "research/training/_shared/runs/tokenizer-20260531T210000Z-a1b2c3d4/experiment.json",
+      receiptSha256: "9999999999999999999999999999999999999999999999999999999999999999",
+      metricsSha256: fixture.metricsLog.sha256,
+    });
+  });
+});
+
+function readTrainingExperimentFixture(): TrainingExperimentReceipt {
+  return JSON.parse(readFileSync(fixturePath, "utf8")) as TrainingExperimentReceipt;
+}

--- a/packages/schemas/test/training-manifest.test.ts
+++ b/packages/schemas/test/training-manifest.test.ts
@@ -68,6 +68,29 @@ describe("TrainingRunManifestSchema", () => {
     );
   });
 
+  it("rejects tracker linkage as a freeform top-level manifest field", () => {
+    const fixture = readTrainingManifestFixture();
+
+    const parsed = TrainingRunManifestSchema.safeParse({
+      ...fixture,
+      experiment: {
+        tracker: "aim",
+        uri: "aim://wittgenstein/tokenizer-a1b2c3d4",
+        runId: "a1b2c3d4",
+      },
+    });
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error?.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "unrecognized_keys",
+          keys: ["experiment"],
+        }),
+      ]),
+    );
+  });
+
   it("rejects impossible run windows", () => {
     const fixture = readTrainingManifestFixture();
 

--- a/research/training/README.md
+++ b/research/training/README.md
@@ -23,6 +23,7 @@ See the operating doctrine:
 
 - [docs/research/2026-05-13-wittgenstein-research-program.md](../../docs/research/2026-05-13-wittgenstein-research-program.md) — three-track framing (engineering / research / hacker)
 - [docs/research/2026-05-13-delivery-and-componentization.md](../../docs/research/2026-05-13-delivery-and-componentization.md) — tier doctrine + why training stays outside the publish surface
+- [docs/training/experiment-tracking.md](../../docs/training/experiment-tracking.md) — #399 tracker receipt contract and shared-Aim boundary
 - [docs/research/2026-05-13-m1b-prep-research.md](../../docs/research/2026-05-13-m1b-prep-research.md) — Phase-0 literature floor (LlamaGen, Open-MAGVIT2, TiTok, VAR)
 - [docs/research/2026-05-31-training-stack-re-audit-closeout.md](../../docs/research/2026-05-31-training-stack-re-audit-closeout.md) — #441 closeout: schema-aligned receipt floor + GPU wait lines
 - [docs/research/2026-05-27-pre-training-readiness.md](../../docs/research/2026-05-27-pre-training-readiness.md) — engineering-readiness audit run right before specialist kickoff (Tier-0 self-check, latent bugs found + fixed, open handoff issues)
@@ -85,20 +86,28 @@ checkpoint by pointing `assets.trainingProvenance` at the training receipt.
 The inference-time `RunManifest` remains a separate receipt for a concrete
 artifact-producing CLI call that may load the blessed decoder.
 
+Experiment tracking is also separate from the training manifest. The local JSONL
+tracker writes `experiment-metrics.jsonl` plus a
+`witt.training.experiment/v0.1` sibling receipt, and `config.json` carries only a
+small `experimentTracking` reference. Shared Aim deployment remains #399's
+external lab-work item.
+
 ## Receipt smoke
 
 The shared manifest spine has a CPU-only smoke that writes a synthetic
-checkpoint plus `manifest.json` without importing torch or touching real
-datasets:
+checkpoint plus `manifest.json`, `experiment.json`, and
+`experiment-metrics.jsonl` without importing torch or touching real datasets:
 
 ```bash
 python3 -m research.training._shared.smoke_manifest
-python3 -m unittest research.training._shared.test_manifest
+python3 -m unittest research.training._shared.test_manifest \
+  research.training._shared.test_experiment_tracking
 ```
 
 This is the receipt floor for #435 / #441. It does not claim that tokenizer,
 adapter, or LLM-head training has run; it only proves that future training
-programs can emit the required manifest shape before GPU work starts.
+programs can emit the required manifest and tracker-receipt shape before GPU
+work starts.
 
 ## M1B audit receipts
 

--- a/research/training/_shared/experiment_tracking.py
+++ b/research/training/_shared/experiment_tracking.py
@@ -1,0 +1,215 @@
+"""Experiment-tracker receipts for training runs.
+
+The canonical TrainingRunManifest remains strict and does not carry a
+freeform `experiment` block. Tracker linkage lives in this sibling receipt so
+Aim/W&B/MLflow can be added without changing the checkpoint receipt shape.
+
+The `jsonl` tracker is the stdlib floor: it gives CI and CPU smoke tests a
+real metrics log and receipt without requiring an Aim server.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from .manifest import SHA256_RE, sha256_file, utc_now_iso
+
+
+TRAINING_EXPERIMENT_RECEIPT_SCHEMA_VERSION = "witt.training.experiment/v0.1"
+TRACKERS = {"aim", "wandb", "mlflow", "jsonl"}
+
+
+@dataclass(frozen=True)
+class TrainingExperimentMetricLog:
+    path: str
+    sha256: str
+    bytes: int
+
+
+@dataclass(frozen=True)
+class TrainingExperimentManifestReference:
+    runId: str
+    manifestPath: str
+    manifestSha256: str
+    checkpointSha256: str
+
+
+@dataclass(frozen=True)
+class TrainingExperimentReceipt:
+    schemaVersion: str
+    tracker: str
+    uri: str
+    runId: str
+    trainingRunId: str
+    startedAt: str
+    finishedAt: str | None
+    metricsLog: TrainingExperimentMetricLog
+    manifest: TrainingExperimentManifestReference | None = None
+
+
+class JsonlExperimentTracker:
+    """Small local tracker used by smoke tests and offline training runs."""
+
+    def __init__(self, run_dir: Path, training_run_id: str):
+        self.run_dir = run_dir
+        self.training_run_id = training_run_id
+        self.run_id = f"jsonl-{training_run_id}"
+        self.started_at = utc_now_iso()
+        self.metrics_path = run_dir / "experiment-metrics.jsonl"
+        self.receipt_path = run_dir / "experiment.json"
+        run_dir.mkdir(parents=True, exist_ok=True)
+        self.metrics_path.touch(exist_ok=True)
+        self.write_receipt()
+
+    def config_reference(self) -> dict[str, str]:
+        return {
+            "tracker": "jsonl",
+            "runId": self.run_id,
+            "trainingRunId": self.training_run_id,
+            "receiptPath": str(self.receipt_path),
+            "metricsLogPath": str(self.metrics_path),
+            "uri": self.metrics_path.resolve().as_uri(),
+        }
+
+    def log_params(self, params: dict[str, Any]) -> None:
+        self._append({"type": "params", "at": utc_now_iso(), "params": params})
+
+    def log_metrics(self, step: int, metrics: dict[str, Any]) -> None:
+        self._append({"type": "metrics", "at": utc_now_iso(), "step": step, "metrics": metrics})
+
+    def finish(self, manifest: TrainingExperimentManifestReference | None = None) -> None:
+        self.write_receipt(finished_at=utc_now_iso(), manifest=manifest)
+
+    def write_receipt(
+        self,
+        *,
+        finished_at: str | None = None,
+        manifest: TrainingExperimentManifestReference | None = None,
+    ) -> None:
+        metrics = TrainingExperimentMetricLog(
+            path=str(self.metrics_path),
+            sha256=sha256_file(self.metrics_path),
+            bytes=self.metrics_path.stat().st_size,
+        )
+        receipt = TrainingExperimentReceipt(
+            schemaVersion=TRAINING_EXPERIMENT_RECEIPT_SCHEMA_VERSION,
+            tracker="jsonl",
+            uri=self.metrics_path.resolve().as_uri(),
+            runId=self.run_id,
+            trainingRunId=self.training_run_id,
+            startedAt=self.started_at,
+            finishedAt=finished_at,
+            metricsLog=metrics,
+            manifest=manifest,
+        )
+        assert_training_experiment_receipt_shape(receipt)
+        payload = experiment_receipt_to_dict(receipt)
+        self.receipt_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+    def _append(self, payload: dict[str, Any]) -> None:
+        with self.metrics_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, sort_keys=True) + "\n")
+
+
+def experiment_receipt_to_dict(
+    receipt: TrainingExperimentReceipt | dict[str, Any],
+) -> dict[str, Any]:
+    payload = asdict(receipt) if isinstance(receipt, TrainingExperimentReceipt) else dict(receipt)
+    if payload.get("manifest") is None:
+        payload.pop("manifest", None)
+    return payload
+
+
+def assert_training_experiment_receipt_shape(receipt: TrainingExperimentReceipt | dict[str, Any]) -> None:
+    payload = experiment_receipt_to_dict(receipt)
+    required = {
+        "schemaVersion",
+        "tracker",
+        "uri",
+        "runId",
+        "trainingRunId",
+        "startedAt",
+        "finishedAt",
+        "metricsLog",
+    }
+    optional = {"manifest"}
+    _assert_keys(payload, required, optional, "experiment")
+    if payload["schemaVersion"] != TRAINING_EXPERIMENT_RECEIPT_SCHEMA_VERSION:
+        raise ValueError("schemaVersion must be witt.training.experiment/v0.1")
+    if payload["tracker"] not in TRACKERS:
+        raise ValueError(f"tracker must be one of {sorted(TRACKERS)}")
+    if "://" not in payload["uri"]:
+        raise ValueError("uri must be an absolute URL")
+    for key in ("runId", "trainingRunId", "startedAt"):
+        if not isinstance(payload[key], str) or not payload[key]:
+            raise ValueError(f"{key} must be a nonempty string")
+    started_at = _parse_iso_timestamp(payload["startedAt"], "startedAt")
+    if payload["finishedAt"] is not None and not isinstance(payload["finishedAt"], str):
+        raise ValueError("finishedAt must be null or an ISO timestamp string")
+    if payload["finishedAt"] is not None:
+        finished_at = _parse_iso_timestamp(payload["finishedAt"], "finishedAt")
+        if finished_at < started_at:
+            raise ValueError("finishedAt must be greater than or equal to startedAt")
+    _validate_metric_log(payload["metricsLog"])
+    if "manifest" in payload:
+        _validate_manifest_reference(payload["manifest"])
+
+
+def _assert_keys(
+    payload: dict[str, Any],
+    required: set[str],
+    optional: set[str],
+    label: str,
+) -> None:
+    actual = set(payload)
+    missing = required - actual
+    extra = actual - required - optional
+    if missing:
+        raise ValueError(f"{label} missing required keys: {sorted(missing)}")
+    if extra:
+        raise ValueError(f"{label} has unrecognized keys: {sorted(extra)}")
+
+
+def _validate_metric_log(payload: Any) -> None:
+    if not isinstance(payload, dict):
+        raise ValueError("metricsLog must be an object")
+    _assert_keys(payload, {"path", "sha256", "bytes"}, set(), "metricsLog")
+    if not payload["path"]:
+        raise ValueError("metricsLog.path must be nonempty")
+    _require_sha256(payload["sha256"], "metricsLog.sha256")
+    if isinstance(payload["bytes"], bool) or not isinstance(payload["bytes"], int) or payload["bytes"] < 0:
+        raise ValueError("metricsLog.bytes must be a nonnegative integer")
+
+
+def _validate_manifest_reference(payload: Any) -> None:
+    if not isinstance(payload, dict):
+        raise ValueError("manifest must be an object")
+    _assert_keys(
+        payload,
+        {"runId", "manifestPath", "manifestSha256", "checkpointSha256"},
+        set(),
+        "manifest",
+    )
+    if not payload["runId"] or not payload["manifestPath"]:
+        raise ValueError("manifest.runId and manifest.manifestPath must be nonempty")
+    _require_sha256(payload["manifestSha256"], "manifest.manifestSha256")
+    _require_sha256(payload["checkpointSha256"], "manifest.checkpointSha256")
+
+
+def _parse_iso_timestamp(value: str, label: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"{label} must be an ISO timestamp string") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"{label} must include a timezone offset")
+    return parsed
+
+
+def _require_sha256(value: Any, label: str) -> None:
+    if not isinstance(value, str) or not SHA256_RE.match(value):
+        raise ValueError(f"{label} must be a 64-char lowercase sha256 hex string")

--- a/research/training/_shared/smoke_manifest.py
+++ b/research/training/_shared/smoke_manifest.py
@@ -12,6 +12,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+from .experiment_tracking import JsonlExperimentTracker, TrainingExperimentManifestReference
 from .manifest import (
     TRAINING_RUN_MANIFEST_SCHEMA_VERSION,
     TrainingRunHardware,
@@ -22,6 +23,7 @@ from .manifest import (
     capture_lockfile_sha256,
     capture_training_checkpoint,
     new_run_id,
+    sha256_file,
     synthetic_optimizer_checkpoint,
     utc_now_iso,
     write_training_config_snapshot,
@@ -42,12 +44,16 @@ def build_smoke_manifest(out_root: Path, run_id: str | None = None) -> dict[str,
     dataset_marker.write_text("wittgenstein synthetic training manifest smoke\n", encoding="utf-8")
     checkpoint_path = ckpt_dir / "final.synthetic"
     checkpoint_path.write_bytes(b"wittgenstein synthetic checkpoint bytes\n")
+    tracker = JsonlExperimentTracker(run_dir, run_id)
+    tracker.log_params({"purpose": "stdlib training-manifest smoke", "subprogram": "tokenizer"})
+    tracker.log_metrics(0, {"loss": 0.0, "wallClockSec": 0.0})
     config_ref = write_training_config_snapshot(
         run_dir / "config.json",
         {
             "purpose": "stdlib training-manifest smoke",
             "realTraining": False,
             "subprogram": "tokenizer",
+            "experimentTracking": tracker.config_reference(),
         },
     )
 
@@ -79,11 +85,21 @@ def build_smoke_manifest(out_root: Path, run_id: str | None = None) -> dict[str,
     )
     manifest_path = run_dir / "manifest.json"
     write_training_run_manifest(manifest, manifest_path)
+    tracker.finish(
+        TrainingExperimentManifestReference(
+            runId=run_id,
+            manifestPath=str(manifest_path),
+            manifestSha256=sha256_file(manifest_path),
+            checkpointSha256=sha256_file(checkpoint_path),
+        )
+    )
     return {
         "runId": run_id,
         "runDir": str(run_dir),
         "manifestPath": str(manifest_path),
         "checkpointPath": str(checkpoint_path),
+        "experimentReceiptPath": str(tracker.receipt_path),
+        "experimentMetricsPath": str(tracker.metrics_path),
     }
 
 

--- a/research/training/_shared/test_experiment_tracking.py
+++ b/research/training/_shared/test_experiment_tracking.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from .experiment_tracking import (
+    JsonlExperimentTracker,
+    TrainingExperimentManifestReference,
+    assert_training_experiment_receipt_shape,
+)
+from .manifest import sha256_file
+
+
+class TrainingExperimentReceiptTests(unittest.TestCase):
+    def test_jsonl_tracker_writes_receipt_without_torch(self) -> None:
+        torch_was_loaded = "torch" in sys.modules
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = Path(tmp) / "run"
+            tracker = JsonlExperimentTracker(run_dir, "tokenizer-stdlib-smoke-test")
+            config_reference = tracker.config_reference()
+            tracker.log_params({"subprogram": "tokenizer", "smoke": True})
+            tracker.log_metrics(0, {"loss": 0.0, "lr": 0.0})
+            manifest_path = run_dir / "manifest.json"
+            checkpoint_path = run_dir / "ckpts" / "final.synthetic"
+            checkpoint_path.parent.mkdir(parents=True)
+            manifest_path.write_text("{}\n", encoding="utf-8")
+            checkpoint_path.write_bytes(b"checkpoint")
+            tracker.finish(
+                TrainingExperimentManifestReference(
+                    runId="tokenizer-stdlib-smoke-test",
+                    manifestPath=str(manifest_path),
+                    manifestSha256=sha256_file(manifest_path),
+                    checkpointSha256=sha256_file(checkpoint_path),
+                )
+            )
+
+            payload = json.loads(tracker.receipt_path.read_text(encoding="utf-8"))
+            metrics_lines = tracker.metrics_path.read_text(encoding="utf-8").splitlines()
+
+        assert_training_experiment_receipt_shape(payload)
+        self.assertEqual(payload["schemaVersion"], "witt.training.experiment/v0.1")
+        self.assertEqual(payload["tracker"], "jsonl")
+        self.assertEqual(payload["trainingRunId"], "tokenizer-stdlib-smoke-test")
+        self.assertEqual(len(metrics_lines), 2)
+        self.assertIn("manifest", payload)
+        self.assertEqual(payload["metricsLog"]["bytes"], len("\n".join(metrics_lines).encode("utf-8")) + 1)
+        self.assertEqual(config_reference["trainingRunId"], "tokenizer-stdlib-smoke-test")
+        self.assertTrue(config_reference["metricsLogPath"].endswith("experiment-metrics.jsonl"))
+
+        if not torch_was_loaded:
+            self.assertNotIn("torch", sys.modules)
+
+    def test_rejects_freeform_experiment_receipt_fields(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unrecognized keys"):
+            assert_training_experiment_receipt_shape(
+                {
+                    "schemaVersion": "witt.training.experiment/v0.1",
+                    "tracker": "jsonl",
+                    "uri": "file:///tmp/metrics.jsonl",
+                    "runId": "jsonl-run",
+                    "trainingRunId": "training-run",
+                    "startedAt": "2026-05-31T00:00:00Z",
+                    "finishedAt": None,
+                    "metricsLog": {
+                        "path": "metrics.jsonl",
+                        "sha256": "0" * 64,
+                        "bytes": 0,
+                    },
+                    "hparams": {},
+                }
+            )
+
+    def test_rejects_impossible_tracker_windows(self) -> None:
+        with self.assertRaisesRegex(ValueError, "finishedAt must be greater than or equal"):
+            assert_training_experiment_receipt_shape(
+                {
+                    "schemaVersion": "witt.training.experiment/v0.1",
+                    "tracker": "jsonl",
+                    "uri": "file:///tmp/metrics.jsonl",
+                    "runId": "jsonl-run",
+                    "trainingRunId": "training-run",
+                    "startedAt": "2026-05-31T00:00:00Z",
+                    "finishedAt": "2026-05-30T23:59:59Z",
+                    "metricsLog": {
+                        "path": "metrics.jsonl",
+                        "sha256": "0" * 64,
+                        "bytes": 0,
+                    },
+                }
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/research/training/tokenizer/smoke_test.py
+++ b/research/training/tokenizer/smoke_test.py
@@ -30,6 +30,7 @@ if str(_REPO_ROOT) not in sys.path:
 
 from research.training.tokenizer.config import smoke_config
 from research.training.tokenizer.train import train
+from research.training._shared.experiment_tracking import assert_training_experiment_receipt_shape
 from research.training._shared.manifest import assert_training_run_manifest_shape
 
 
@@ -61,6 +62,24 @@ def main() -> int:
     except Exception as exc:
         print(f"[smoke] FAIL: manifest shape invalid: {exc}")
         return 1
+    experiment_receipt_path = run_dir / "experiment.json"
+    experiment_metrics_path = run_dir / "experiment-metrics.jsonl"
+    if not experiment_receipt_path.exists():
+        print("[smoke] FAIL: experiment receipt missing")
+        return 1
+    if not experiment_metrics_path.exists():
+        print("[smoke] FAIL: experiment metrics log missing")
+        return 1
+    try:
+        experiment_payload = json.loads(experiment_receipt_path.read_text(encoding="utf-8"))
+        assert_training_experiment_receipt_shape(experiment_payload)
+    except Exception as exc:
+        print(f"[smoke] FAIL: experiment receipt shape invalid: {exc}")
+        return 1
+    metrics_lines = experiment_metrics_path.read_text(encoding="utf-8").splitlines()
+    if not metrics_lines:
+        print("[smoke] FAIL: experiment metrics log is empty")
+        return 1
     acceptance = summary.get("acceptance", {})
     if summary.get("final_step") != cfg.max_steps:
         print(
@@ -72,6 +91,12 @@ def main() -> int:
         return 1
     if acceptance.get("final_checkpoint_written") is not True:
         print("[smoke] FAIL: final checkpoint missing from acceptance summary")
+        return 1
+    if acceptance.get("experiment_receipt_written") is not True:
+        print("[smoke] FAIL: experiment receipt missing from acceptance summary")
+        return 1
+    if acceptance.get("experiment_metrics_written") is not True:
+        print("[smoke] FAIL: experiment metrics missing from acceptance summary")
         return 1
     if acceptance.get("used_synthetic_data") is not True:
         print("[smoke] FAIL: smoke run did not report synthetic dataset usage")

--- a/research/training/tokenizer/train.py
+++ b/research/training/tokenizer/train.py
@@ -43,6 +43,10 @@ for p in (_REPO_ROOT, _SHARED):
     if str(p) not in sys.path:
         sys.path.insert(0, str(p))
 
+from research.training._shared.experiment_tracking import (  # noqa: E402
+    JsonlExperimentTracker,
+    TrainingExperimentManifestReference,
+)
 from research.training._shared.manifest import (  # noqa: E402
     TRAINING_RUN_MANIFEST_SCHEMA_VERSION,
     TrainingRunManifest,
@@ -54,6 +58,7 @@ from research.training._shared.manifest import (  # noqa: E402
     capture_optimizer_checkpoint,
     capture_training_checkpoint,
     new_run_id,
+    sha256_file,
     utc_now_iso,
     write_training_config_snapshot,
     write_training_run_manifest,
@@ -236,7 +241,11 @@ def train(cfg: TrainConfig) -> dict:
         )
         docker_image_sha = capture_docker_image_sha()
         hardware = capture_hardware()
-        config_ref = write_training_config_snapshot(run_dir / "config.json", cfg_to_dict(cfg))
+        experiment_tracker = JsonlExperimentTracker(run_dir, run_id)
+        experiment_tracker.log_params({"subprogram": "tokenizer", "config": cfg_to_dict(cfg)})
+        config_payload = cfg_to_dict(cfg)
+        config_payload["experimentTracking"] = experiment_tracker.config_reference()
+        config_ref = write_training_config_snapshot(run_dir / "config.json", config_payload)
         if cfg.smoke or not cfg.train_data_root:
             dataset_fp = capture_dataset_fingerprint(
                 "synthetic", files=[], revision="synthetic-smoke",
@@ -333,6 +342,14 @@ def train(cfg: TrainConfig) -> dict:
             )
             last_log_t = time.perf_counter()
             summary["final_components"] = components
+            experiment_tracker.log_metrics(
+                step,
+                {
+                    "lr": lr,
+                    "imgsPerSec": ips,
+                    **components,
+                },
+            )
 
         # Checkpoint
         if is_main(rank) and step > 0 and step % cfg.checkpoint_every == 0:
@@ -359,7 +376,7 @@ def train(cfg: TrainConfig) -> dict:
 
     # ---- Final checkpoint + manifest ----
     if is_main(rank):
-        _write_checkpoint(
+        final_manifest_path = _write_checkpoint(
             run_dir,
             model,
             optim,
@@ -378,8 +395,20 @@ def train(cfg: TrainConfig) -> dict:
         )
         final_ckpt = run_dir / "ckpts" / "final.pt"
         final_manifest = run_dir / "ckpts" / "final.manifest.json"
+        experiment_tracker.finish(
+            TrainingExperimentManifestReference(
+                runId=run_id,
+                manifestPath=str(final_manifest_path),
+                manifestSha256=sha256_file(final_manifest_path),
+                checkpointSha256=sha256_file(final_ckpt),
+            )
+        )
         summary["acceptance"]["final_checkpoint_written"] = final_ckpt.exists()
         summary["acceptance"]["manifest_written"] = final_manifest.exists()
+        summary["acceptance"]["experiment_receipt_written"] = (run_dir / "experiment.json").exists()
+        summary["acceptance"]["experiment_metrics_written"] = (
+            run_dir / "experiment-metrics.jsonl"
+        ).exists()
         summary["acceptance"]["dataset_corrupt_count"] = int(
             getattr(train_ds, "corrupt_count", 0)
         )
@@ -431,7 +460,9 @@ def _write_checkpoint(
         checkpoint=capture_training_checkpoint(ckpt_path, weights_license=weights_license),
         trainingConfig=config_ref,
     )
-    write_training_run_manifest(manifest, run_dir / "ckpts" / (ckpt_path.stem + ".manifest.json"))
+    manifest_path = run_dir / "ckpts" / (ckpt_path.stem + ".manifest.json")
+    write_training_run_manifest(manifest, manifest_path)
+    return manifest_path
 
 
 def _build_arg_parser() -> argparse.ArgumentParser:


### PR DESCRIPTION
## Summary
- add `TrainingExperimentReceiptSchema` / config-reference schemas for tracker receipts outside `TrainingRunManifest`
- add a stdlib JSONL experiment tracker and wire shared/tokenizer smokes to emit `experiment.json` + `experiment-metrics.jsonl`
- document the #399 boundary: repo-side receipt floor is implemented, shared Aim deployment/access remains external evidence

## Validation
- `pnpm install --frozen-lockfile --offline`
- `pnpm exec prettier --check packages/schemas/src/training-experiment.ts packages/schemas/src/index.ts packages/schemas/test/training-experiment.test.ts packages/schemas/test/training-manifest.test.ts packages/schemas/test/fixtures/training-experiment-receipt.json docs/training/experiment-tracking.md docs/contributing/training-setup.md research/training/README.md docs/research/2026-05-31-training-stack-re-audit-closeout.md`
- `pnpm format:check`
- `pnpm --filter @wittgenstein/schemas test -- training`
- `pnpm --filter @wittgenstein/schemas typecheck`
- `pnpm --filter @wittgenstein/schemas lint`
- `python3 -m unittest research.training._shared.test_manifest research.training._shared.test_experiment_tracking`
- `python3 -m compileall research/training/_shared research/training/tokenizer`
- `python3 -m research.training._shared.smoke_manifest --run-id experiment-tracking-smoke-399-final`
- generated `manifest.json` + `experiment.json` parsed with `@wittgenstein/schemas` via `node --import tsx`
- `python3 -m research.training.tokenizer.smoke_test`
- tokenizer smoke `final.manifest.json` + `experiment.json` parsed with `@wittgenstein/schemas` via `node --import tsx`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm lint:deps`
- `pnpm lint:publish-surface`
- `pnpm test`
- `pnpm test:golden`
- `pnpm reviewer-bench`

## Issue
Refs #399. This intentionally does not close #399 because the shared Aim service, credentials, retention/access docs, and contributor-visible deployed run still require lab/ops evidence outside this repository change.