### PR TITLE
fix(training): honest training receipts — real LPIPS, truthful gan_enabled, git_sha fallback

### DIFF
--- a/research/training/_shared/eval.py
+++ b/research/training/_shared/eval.py
@@ -61,7 +61,7 @@ def evaluate_tokenizer_reconstruction(
     device: torch.device,
     cfg: TokenizerEvalConfig | None = None,
 ) -> dict[str, Any]:
-    """Run reconstruction eval; returns metrics for a TrainingRunEvalSnapshot.
+    """Run reconstruction eval; returns metric dict for manifest.eval.metrics.
 
     Caller is responsible for setting `model.eval()` (we don't toggle here
     so the caller's state stays explicit).
@@ -83,6 +83,8 @@ def evaluate_tokenizer_reconstruction(
             degradation_reasons.append("torchmetrics-missing:psnr-ssim")
 
     lpips_metric = None
+    lpips_sum = 0.0      # batch-size-weighted running sum for an exact streaming mean
+    lpips_count = 0
     if cfg.compute_lpips:
         try:
             import lpips
@@ -129,8 +131,12 @@ def evaluate_tokenizer_reconstruction(
                 ssim_metric.update(rec_u8.float(), img_u8.float())
 
         if lpips_metric is not None:
-            # LPIPS expects [-1, 1] which is what we have
-            _ = lpips_metric(recon, img).mean()  # streaming mean accumulated below
+            # LPIPS expects [-1, 1], which is what we have. Accumulate a
+            # batch-size-weighted running SUM so the final mean is exact even
+            # when the last batch is short (a plain mean-of-batch-means is not).
+            per_image = lpips_metric(recon, img)  # shape [N,1,1,1]
+            lpips_sum += float(per_image.sum().detach().cpu())
+            lpips_count += img.shape[0]
 
         if rfid_tmpdir is not None:
             from PIL import Image
@@ -172,10 +178,12 @@ def evaluate_tokenizer_reconstruction(
         metrics["psnr"] = float(psnr_metric.compute().cpu())
     if ssim_metric is not None:
         metrics["ssim"] = float(ssim_metric.compute().cpu())
-    if lpips_metric is not None:
-        # Re-run for accurate streaming mean (the .mean() above wasn't accumulated cleanly).
-        # For a careful audit, a follow-up should accumulate per-sample LPIPS in a running tensor.
-        metrics["lpips_note"] = "per-sample accumulation TBD; current eval uses streaming approx"
+    if lpips_metric is not None and lpips_count > 0:
+        # Exact dataset-mean LPIPS = sum(per-image LPIPS) / n_images.
+        metrics["lpips"] = lpips_sum / lpips_count
+    elif lpips_metric is not None:
+        metrics["lpips_error"] = "no images evaluated"
+        degradation_reasons.append("lpips-no-images")
 
     if rfid_tmpdir is not None:
         try:

--- a/research/training/_shared/manifest.py
+++ b/research/training/_shared/manifest.py
@@ -138,6 +138,15 @@ def sha256_bytes(data: bytes) -> str:
 
 
 def capture_git_sha(repo_root: Path | None = None) -> str:
+    # Deployments that copy the source WITHOUT a .git dir (e.g. an ephemeral
+    # cluster run that rsyncs only the tree) can't read the revision from git.
+    # Honor WITT_GIT_SHA first so the launcher can inject the source revision;
+    # it must still be a valid 40-hex SHA so the manifest stays trustworthy.
+    env_sha = os.environ.get("WITT_GIT_SHA", "").strip()
+    if env_sha:
+        if not GIT_SHA_RE.match(env_sha):
+            raise RuntimeError(f"WITT_GIT_SHA is not a valid git SHA: {env_sha!r}")
+        return env_sha
     try:
         result = subprocess.run(
             ["git", "rev-parse", "HEAD"],

--- a/research/training/tokenizer/config.py
+++ b/research/training/tokenizer/config.py
@@ -58,7 +58,12 @@ class TrainConfig:
 
     # GAN
     gan_on_step: int = 20_000    # warmup recon-only first, then add GAN
-    gan_enabled: bool = True     # set False for smoke
+    # No PatchGAN discriminator is wired yet (train.py instantiates the loss with
+    # discriminator=None; losses.py only applies the GAN term when one is present).
+    # Default False so the training manifest does NOT record gan_enabled=True for a
+    # run where no adversarial training actually happened. Flip to True only once a
+    # discriminator is wired — until then it is a no-op that misleads the receipt.
+    gan_enabled: bool = False
 
     # Losses
     lpips_enabled: bool = True


### PR DESCRIPTION
## What

Three small, independent fixes that keep the training **receipts honest** — each closes a gap where the manifest or eval recorded (or dropped) something that didn't match what actually ran. Surfaced while auditing a real 6h Phase-1.1 tokenizer validation run.

| Commit | Gap | Fix |
|---|---|---|
| `fix(training): emit real LPIPS …` | `_shared/eval.py` computed per-batch LPIPS into `_` and the final block only set a *note string* — `metrics["lpips"]` was **never populated** despite `compute_lpips=True` (silent metric drop). | Accumulate a batch-size-weighted running sum → emit the exact dataset-mean `metrics["lpips"]`. |
| `fix(training): default gan_enabled=False …` | `config.gan_enabled` defaulted `True`, but no PatchGAN discriminator is wired (`train.py` passes `discriminator=None`; `losses.py` only applies the GAN term when one is present). A reconstruction-only run therefore recorded `gan_enabled=True` — the receipt **overstated** what trained. | Default `False`; flip to `True` only once a discriminator exists. No behaviour change to the loss (already inert), only to what the manifest records. |
| `feat(training): WITT_GIT_SHA fallback …` | `capture_git_sha()` raises when the tree has no `.git` (ephemeral runs that rsync only the source), which **blocks manifest emission** on those hosts. | Honor a `WITT_GIT_SHA` env var first so the launcher can inject the source revision. Still validated against the 40-hex regex; normal checkouts unaffected. |

## Receipts / evidence

- **LPIPS**: a real run's eval would return only `lpips_note` and no number; after this change `metrics["lpips"]` is a float. Diff is a surgical 3-hunk change (running sum + emit), nothing else in `eval.py` touched.
- **gan_enabled**: a real validation run's manifest recorded `config.gan_enabled: true` while the run was provably reconstruction-only (no discriminator in the graph). The flag now records the truth.
- **WITT_GIT_SHA**: a real cluster run's manifest needed a source SHA but the rsync'd tree had no `.git`. Verified the three code paths in isolation: env SHA honored, invalid env SHA rejected, git path used when env unset.

## Boundaries / scope

- Python-only, all under `research/training/`. No `packages/` or publish surface touched.
- No new dependencies. No checkpoint or dataset is added (training artifacts stay out of the repo).
- The `gan_enabled` change is **not** a GAN implementation — wiring a PatchGAN discriminator is separate follow-up work.
- `WITT_GIT_SHA` is opt-in; absent it, behaviour is unchanged.
- This is a research-only validation run's findings; **no checkpoint is published** (LLaVA-Pretrain license is research-only).

## Test plan

- [x] `python -m py_compile` on all three changed files (clean).
- [x] `capture_git_sha` env-fallback logic unit-checked in isolation (honor / reject-bad / git-fallthrough).
- [ ] CI: Python `compileall` + `unittest` under the existing workflow.
- [ ] Reviewer to confirm `metrics["lpips"]` appears in an eval run (requires `lpips` installed; not in floor reqs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
