### PR TITLE
feat(training): offline checkpoint integrity + recon + plot tooling

### DIFF
--- a/research/training/integrity_check.py
+++ b/research/training/integrity_check.py
@@ -1,0 +1,98 @@
+"""Post-training integrity audit for a tokenizer checkpoint.
+
+Read-only. Verifies a step_*.pt against its sibling manifest and itself:
+  - SHA256 of the .pt (recompute) vs a manifest digest field if one exists
+  - state_dict loads; param/tensor counts; scan EVERY float tensor for NaN/inf
+  - report training step recorded in ckpt vs manifest
+  - codebook embedding norm stats (sanity: not all-zero / not exploded)
+
+No repo imports -> runs anywhere with torch. Prints a report to stdout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+
+import torch
+
+
+def sha256(path: str, buf: int = 1 << 20) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(buf), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def find_digest(m: dict) -> tuple[str, str] | None:
+    keys = ("sha256", "sha", "digest", "checkpoint_sha256", "hash", "weights_sha256")
+    for k in keys:
+        if isinstance(m.get(k), str):
+            return (k, m[k])
+    for parent in ("checkpoint", "artifact", "receipt"):
+        sub = m.get(parent)
+        if isinstance(sub, dict):
+            for k in keys:
+                if isinstance(sub.get(k), str):
+                    return (f"{parent}.{k}", sub[k])
+    return None
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ckpt", required=True)
+    args = ap.parse_args()
+    ck = args.ckpt
+
+    print(f"[integ] ckpt={ck}")
+    print(f"[integ] size_bytes={os.path.getsize(ck)}")
+    digest = sha256(ck)
+    print(f"[integ] sha256={digest}")
+
+    # checkpoints are step_XXXX.pt with sibling step_XXXX.manifest.json
+    man = (ck[:-3] if ck.endswith(".pt") else ck) + ".manifest.json"
+    if os.path.exists(man):
+        with open(man) as f:
+            m = json.load(f)
+        print(f"[integ] manifest_keys={sorted(m.keys())}")
+        print(f"[integ] manifest_step={m.get('step')}")
+        found = find_digest(m)
+        if found:
+            match = found[1] == digest
+            print(f"[integ] manifest_digest[{found[0]}]={found[1]} MATCH={match}")
+        else:
+            print("[integ] manifest has NO stored digest -> byte-compare impossible (GAP to fix)")
+    else:
+        print(f"[integ] NO manifest at {man}")
+
+    ckpt = torch.load(ck, map_location="cpu", weights_only=True)
+    print(f"[integ] ckpt_top_keys={sorted(ckpt.keys())}")
+    print(f"[integ] step_in_ckpt={ckpt.get('step')}")
+
+    sd = ckpt["model"]
+    sd = {k[len('module.'):] if k.startswith('module.') else k: v for k, v in sd.items()}
+    tensors = [(k, v) for k, v in sd.items() if torch.is_tensor(v)]
+    n_params = sum(v.numel() for _, v in tensors)
+    bad = []
+    for k, v in tensors:
+        if v.is_floating_point() and (torch.isnan(v).any() or torch.isinf(v).any()):
+            bad.append(k)
+    print(f"[integ] tensors={len(tensors)} params={n_params:,}")
+    print(f"[integ] nan_or_inf_tensors={len(bad)} {bad[:8]}")
+
+    cb = next((sd[k] for k in sd if k.endswith('quantize.embedding.weight')), None)
+    if cb is not None:
+        norms = cb.float().norm(dim=1)
+        zero = int((norms == 0).sum())
+        print(f"[integ] codebook shape={tuple(cb.shape)} "
+              f"norm[min/mean/max]={norms.min():.4f}/{norms.mean():.4f}/{norms.max():.4f} "
+              f"zero_norm_rows={zero}")
+
+    print("[integ] DONE")
+
+
+if __name__ == "__main__":
+    main()

--- a/research/training/plot_training.py
+++ b/research/training/plot_training.py
@@ -1,0 +1,111 @@
+"""Plot training curves from a supervisor.log (offline, read-only).
+
+Parses the per-step log lines emitted by research.training.tokenizer.train and
+renders two figures + dumps the parsed series as JSON so every number on a plot
+is traceable to source.
+
+  python plot_training.py --log supervisor.log --out <dir>
+
+Line format parsed:
+  [step   33100/200000] lr=1.00e-04 l2=0.0506 lpips=0.1183 commit=-0.3594 \
+      total=-0.1906 codebook_usage=0.9724 | imgs/s=135.3 elapsed=13781.0s
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+
+LINE = re.compile(
+    r"\[step\s+(?P<step>\d+)/\d+\].*?"
+    r"l2=(?P<l2>[-\d.eE]+)\s+"
+    r"lpips=(?P<lpips>[-\d.eE]+)\s+"
+    r"commit=(?P<commit>[-\d.eE]+)\s+"
+    r"total=(?P<total>[-\d.eE]+)\s+"
+    r"codebook_usage=(?P<cb>[-\d.eE]+).*?"
+    r"imgs/s=(?P<ips>[-\d.eE]+)"
+)
+
+
+def parse(path: str) -> dict[str, list[float]]:
+    cols: dict[str, list[float]] = {k: [] for k in
+                                    ("step", "l2", "lpips", "commit", "total", "cb", "ips")}
+    with open(path) as f:
+        for ln in f:
+            m = LINE.search(ln)
+            if not m:
+                continue
+            for k in cols:
+                cols[k].append(float(m.group(k)))
+    return cols
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--log", required=True)
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+    os.makedirs(args.out, exist_ok=True)
+
+    c = parse(args.log)
+    n = len(c["step"])
+    if n == 0:
+        raise SystemExit("no step lines parsed — check log format")
+    print(f"[plot] parsed {n} step records, step {c['step'][0]:.0f}..{c['step'][-1]:.0f}")
+
+    with open(os.path.join(args.out, "training_series.json"), "w") as f:
+        json.dump(c, f)
+
+    # Figure 1: loss components
+    fig, ax = plt.subplots(figsize=(10, 6))
+    ax.plot(c["step"], c["l2"], label="l2 (recon MSE)", lw=1)
+    ax.plot(c["step"], c["lpips"], label="lpips (perceptual)", lw=1)
+    ax.plot(c["step"], c["commit"], label="commit (VQ)", lw=1)
+    ax.plot(c["step"], c["total"], label="total (incl. entropy term)", lw=1.4, color="k")
+    ax.axhline(0, color="grey", lw=0.5, ls="--")
+    ax.set_xlabel("step")
+    ax.set_ylabel("loss")
+    ax.set_title("Wittgenstein Phase-1.1 tokenizer — loss components (run 9f2c6a84, 54k steps)")
+    ax.legend()
+    ax.grid(alpha=0.3)
+    f1 = os.path.join(args.out, "loss_components.png")
+    fig.tight_layout()
+    fig.savefig(f1, dpi=120)
+    plt.close(fig)
+
+    # Figure 2: codebook usage trajectory
+    fig, ax = plt.subplots(figsize=(10, 4.5))
+    ax.plot(c["step"], [v * 100 for v in c["cb"]], color="tab:green", lw=1)
+    ax.set_ylim(0, 100)
+    ax.set_xlabel("step")
+    ax.set_ylabel("codebook usage (%)")
+    ax.set_title("Codebook usage trajectory (anti-collapse: entropy_loss_ratio=0.05)")
+    ax.grid(alpha=0.3)
+    f2 = os.path.join(args.out, "codebook_usage.png")
+    fig.tight_layout()
+    fig.savefig(f2, dpi=120)
+    plt.close(fig)
+
+    # Console summary (so claims are evidence-backed)
+    def at(step_target: float) -> int:
+        return min(range(n), key=lambda i: abs(c["step"][i] - step_target))
+
+    for s in (0, 1000, 8000, 22000, 44000, c["step"][-1]):
+        i = at(s)
+        print(f"[plot] step {c['step'][i]:6.0f}: l2={c['l2'][i]:.4f} "
+              f"lpips={c['lpips'][i]:.4f} commit={c['commit'][i]:.4f} "
+              f"total={c['total'][i]:.4f} cb={c['cb'][i]*100:.1f}% ips={c['ips'][i]:.1f}")
+    print(f"[plot] wrote {f1}")
+    print(f"[plot] wrote {f2}")
+    print("[plot] DONE")
+
+
+if __name__ == "__main__":
+    main()

--- a/research/training/recon_check.py
+++ b/research/training/recon_check.py
@@ -1,0 +1,121 @@
+"""Reconstruction spot-check for a trained tokenizer checkpoint.
+
+Loads a step_*.pt, infers (codebook_size, embed_dim) from the saved weights
+(so we never guess the config), encodes+decodes one real image, and writes
+before/after PNGs plus an L2/PSNR number. Validation only -- a checkpoint
+trained on research-only data is not publishable.
+
+Run:
+  CUDA_VISIBLE_DEVICES="" PYTHONPATH=. python research/training/recon_check.py \
+      --ckpt <path/to/step_XXXXXXXX.pt> \
+      --data <path/to/image/folder> \
+      --out  <output/dir>
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+
+import numpy as np
+import torch
+from PIL import Image
+
+
+def find_image(root: str) -> str:
+    for ext in ("*.jpg", "*.jpeg", "*.png"):
+        hits = glob.glob(os.path.join(root, "**", ext), recursive=True)
+        if hits:
+            return sorted(hits)[0]
+    raise FileNotFoundError(f"no images under {root}")
+
+
+def load_image(path: str, size: int) -> torch.Tensor:
+    """Center-crop to square, resize to `size`, normalize to [-1, 1] (LlamaGen)."""
+    img = Image.open(path).convert("RGB")
+    w, h = img.size
+    s = min(w, h)
+    img = img.crop(((w - s) // 2, (h - s) // 2, (w - s) // 2 + s, (h - s) // 2 + s))
+    img = img.resize((size, size), Image.BICUBIC)
+    t = torch.from_numpy(np.asarray(img, dtype="float32")).permute(2, 0, 1) / 255.0
+    return (t * 2.0 - 1.0).unsqueeze(0)  # [1,3,H,W] in [-1,1]
+
+
+def to_png(t: torch.Tensor, path: str) -> None:
+    """t: [1,3,H,W] or [3,H,W] in [-1,1] -> uint8 PNG."""
+    x = t.detach().float().cpu()
+    if x.dim() == 4:
+        x = x[0]
+    arr = ((x.clamp(-1, 1) + 1.0) * 127.5).round().byte().permute(1, 2, 0).numpy()
+    Image.fromarray(arr).save(path)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ckpt", required=True)
+    ap.add_argument("--data", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--size", type=int, default=256)
+    args = ap.parse_args()
+
+    os.makedirs(args.out, exist_ok=True)
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    ckpt = torch.load(args.ckpt, map_location="cpu", weights_only=True)
+    step = int(ckpt.get("step", -1))
+    sd = ckpt["model"]
+    sd = {k[len("module."):] if k.startswith("module.") else k: v for k, v in sd.items()}
+
+    cb_key = next(
+        (k for k in sd if k.endswith("quantize.embedding.weight")
+         or k.endswith("codebook.weight")
+         or (k.endswith("embedding.weight") and sd[k].dim() == 2 and sd[k].shape[0] >= 1024)),
+        None,
+    )
+    if cb_key is None:
+        raise RuntimeError(f"could not find codebook weight; keys sample: {list(sd)[:8]}")
+    K, D = int(sd[cb_key].shape[0]), int(sd[cb_key].shape[1])
+    print(f"[recon] ckpt={args.ckpt} step={step} codebook K={K} D={D} (key={cb_key})")
+
+    from research.training.tokenizer.model import TokenizerConfig, build_tokenizer
+
+    cfg = TokenizerConfig(codebook_size=K, codebook_embed_dim=D)
+    model = build_tokenizer(cfg)
+    missing, unexpected = model.load_state_dict(sd, strict=False)
+    print(f"[recon] load_state_dict missing={len(missing)} unexpected={len(unexpected)}")
+    if missing:
+        print(f"[recon]   missing sample: {missing[:6]}")
+    if unexpected:
+        print(f"[recon]   unexpected sample: {unexpected[:6]}")
+    model.eval().to(device)
+
+    img_path = find_image(args.data)
+    x = load_image(img_path, args.size).to(device)
+    print(f"[recon] image={img_path} shape={tuple(x.shape)}")
+
+    with torch.no_grad():
+        try:
+            quant, _, _ = model.encode(x)
+            rec = model.decode(quant)
+            mode = "encode/decode"
+        except Exception as e:
+            print(f"[recon] encode/decode path failed ({e!r}); using forward()")
+            out = model(x)
+            rec = out[0] if isinstance(out, (tuple, list)) else out
+            mode = "forward"
+
+    l2 = torch.mean((x - rec) ** 2).item()
+    psnr = 10.0 * torch.log10(torch.tensor(4.0 / max(l2, 1e-12))).item()  # data range 2
+    before = os.path.join(args.out, f"step{step:08d}_before.png")
+    after = os.path.join(args.out, f"step{step:08d}_after.png")
+    to_png(x, before)
+    to_png(rec, after)
+    print(f"[recon] mode={mode} L2(MSE)={l2:.5f} PSNR={psnr:.2f}dB")
+    print(f"[recon] wrote {before}")
+    print(f"[recon] wrote {after}")
+    print("[recon] DONE")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Three small, read-only, dependency-light scripts for **auditing a tokenizer training run after the fact**. They formalize the post-run verification I used to audit a Phase-1.1 run; all inputs are CLI args (no cluster paths, no repo-internal assumptions beyond the existing tokenizer model factory).

| Script | Purpose |
|---|---|
| `integrity_check.py` | Recompute checkpoint SHA256, **byte-compare against the sibling manifest's `weights_sha256`**, scan every float tensor for NaN/inf, report codebook row-norm stats (dead-code detection). |
| `recon_check.py` | Load a `step_*.pt` (self-infers K/D from the codebook weight, `load_state_dict(strict=False)`), encode+decode one image, write before/after PNGs + report L2/PSNR. |
| `plot_training.py` | Parse a training stdout log into loss-component and codebook-usage plots plus a traceable `training_series.json`. |

## Why

A checkpoint + manifest is only trustworthy if you can independently re-verify it. These give a reviewer (or a future run) a one-command way to confirm a checkpoint is intact, loads cleanly, has a healthy codebook, and matches its receipt — exactly the checks that should precede any "this run is good" claim.

## Receipts / evidence

These were run for real against a Phase-1.1 validation checkpoint:
- `integrity_check.py` → SHA recomputed two independent ways (this script + coreutil `sha256sum`) matched each other **and** the manifest's `weights_sha256` byte-for-byte; 0 NaN/inf across 344 tensors; codebook 16384×32, 0 dead rows.
- `recon_check.py` → clean `load_state_dict` (missing=0 unexpected=0), produced before/after PNGs and an L2/PSNR number consistent with the training log.
- `plot_training.py` → parsed 1100 step records into two PNGs + series JSON.

## Boundaries / scope

- Python-only, all under `research/training/`. No `packages/` or publish surface touched.
- Imports only `torch` / `numpy` / `PIL` / `matplotlib` + the existing `research.training.tokenizer.model` factory (`build_tokenizer`, `TokenizerConfig` — both present on `main`).
- **Read-only**: none of these mutate checkpoints, manifests, or training state.
- No checkpoint or dataset is added to the repo (training artifacts stay out; the audited checkpoint was research-only data and is not published).

## Test plan

- [x] `python -m py_compile` on all three (clean).
- [x] All three executed against a real checkpoint/log (outputs above).
- [ ] CI: `typos` + `actionlint` + Node/Python verify under the existing workflow.
- [ ] Reviewer note: CI's `compileall` covers `polyglot-mini/` only, not `research/training/` — these were compiled locally instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
