### PR TITLE
fix(cli): close replay and reviewdog debt

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -48,7 +48,7 @@ jobs:
           filter_mode: added
           level: warning
           fail_level: none
-          markdownlint_flags: "README.md CONTRIBUTING.md CHANGELOG.md PROMPT.md docs/THESIS.md docs/architecture.md docs/hard-constraints.md docs/implementation-status.md docs/quickstart.md docs/reproducibility.md docs/codecs/*.md"
+          markdownlint_flags: "--config .markdownlint-cli2.yaml --configPointer /config README.md CONTRIBUTING.md CHANGELOG.md PROMPT.md docs/THESIS.md docs/architecture.md docs/hard-constraints.md docs/implementation-status.md docs/quickstart.md docs/reproducibility.md docs/codecs/*.md"
 
   eslint:
     name: ESLint review comments

--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ text-first LLM
   → real artifact + manifest receipt
 ```
 
-| Modality  | LLM-facing code layer                                                | Local execution layer                                               | Artifact               |
-| --------- | -------------------------------------------------------------------- | ------------------------------------------------------------------- | ---------------------- |
-| 🖼️ Image  | Visual Seed Code (primary) + optional `Semantic IR`                  | Seed expander → frozen VQ decoder¹                                  | PNG                    |
-| 🔊 Audio  | Route-specific audio code (speech / soundscape / music)              | Procedural synth (default) + opt-in Kokoro speech                   | WAV                    |
-| 📡 Sensor | Operator program (with `patchGrammar` for local-context composition) | Deterministic signal expansion                                      | CSV + interactive HTML |
-| 🎞️ Video  | Composition spec                                                     | HyperFrames-shaped local render (HTML default, MP4 opt-in)          | MP4 / HTML             |
+| Modality  | LLM-facing code layer                                                | Local execution layer                                      | Artifact               |
+| --------- | -------------------------------------------------------------------- | ---------------------------------------------------------- | ---------------------- |
+| 🖼️ Image  | Visual Seed Code (primary) + optional `Semantic IR`                  | Seed expander → frozen VQ decoder¹                         | PNG                    |
+| 🔊 Audio  | Route-specific audio code (speech / soundscape / music)              | Procedural synth (default) + opt-in Kokoro speech          | WAV                    |
+| 📡 Sensor | Operator program (with `patchGrammar` for local-context composition) | Deterministic signal expansion                             | CSV + interactive HTML |
+| 🎞️ Video  | Composition spec                                                     | HyperFrames-shaped local render (HTML default, MP4 opt-in) | MP4 / HTML             |
 
 Image, audio, sensor, and video HTML produce real artifacts today; video MP4 is an opt-in local-render path requiring Chrome/Chromium + FFmpeg. Per-modality maturity is in [`docs/implementation-status.md`](docs/implementation-status.md); the full five-layer mapping is in the [Architecture](#architecture-five-layers) section below; the [30-second sensor quickstart](#quickstart-30-seconds-no-api-key) is the smallest no-API-key proof.
 
@@ -370,17 +370,17 @@ not neural text-to-video generation.
 
 This is the shortest “what can I actually get out today?” view. For deeper component-by-component detail, keep using `docs/implementation-status.md`.
 
-| Modality | Default artifact | Opt-in artifact | Notes |
-| --- | --- | --- | --- |
-| Image (TS) | PNG (placeholder-class) | PNG (reference decode when weights present) | Scene + seed/semantic receipts ship; frozen decoder bridge not yet wired for LlamaGen/SEED |
-| Image (polyglot-mini) | PNG | — | Research-grade code-as-painter and MLP fallback painter ship |
-| Audio (TS) | WAV | — | Speech + soundscape + music ship |
-| Sensor (TS) | JSON / HTML / PNG | — | Loupe dashboard ships |
-| Video (TS) | HyperFrames-shaped HTML | MP4 (local) | MP4 requires local Chrome/Chromium + FFmpeg and enabling `WITTGENSTEIN_HYPERFRAMES_RENDER=1` |
+| Modality              | Default artifact        | Opt-in artifact                             | Notes                                                                                        |
+| --------------------- | ----------------------- | ------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Image (TS)            | PNG (placeholder-class) | PNG (reference decode when weights present) | Scene + seed/semantic receipts ship; frozen decoder bridge not yet wired for LlamaGen/SEED   |
+| Image (polyglot-mini) | PNG                     | —                                           | Research-grade code-as-painter and MLP fallback painter ship                                 |
+| Audio (TS)            | WAV                     | —                                           | Speech + soundscape + music ship                                                             |
+| Sensor (TS)           | JSON / HTML / PNG       | —                                           | Loupe dashboard ships                                                                        |
+| Video (TS)            | HyperFrames-shaped HTML | MP4 (local)                                 | MP4 requires local Chrome/Chromium + FFmpeg and enabling `WITTGENSTEIN_HYPERFRAMES_RENDER=1` |
 
 **What's next.** Doctrine is locked; the active workstream is the Codec Protocol v2 port
 across all modalities, sequenced in [`docs/exec-plans/active/codec-v2-port.md`](docs/exec-plans/active/codec-v2-port.md)
-(`M0` and `M1A` are landed; `M2 audio` is next; `M1B image depth` is tracked separately).
+(`M0`, `M1A`, `M2 audio`, and `M3 sensor` are landed; `M1B image depth` is tracked separately).
 
 Roadmap: [`docs/roadmap.md`](docs/roadmap.md). Changelog: [`CHANGELOG.md`](CHANGELOG.md).
 Security: [`SECURITY.md`](SECURITY.md).
@@ -396,7 +396,7 @@ is visible, but **do not depend on them in production** until the status matrix 
 | Surface                                       | State             | What works today                                                                      | What's missing                                                                 |
 | --------------------------------------------- | ----------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
 | TS `codec-image` adapter + decoder            | ⚠️ Partial        | Scene JSON, placeholder latents, MLP loader, `renderSky` / `renderTerrain` primitives | Frozen VQ decoder bridge (LlamaGen / SEED); trained adapter weights            |
-| TS `codec-video`                              | ⚠️ Partial        | Schema, HTML renderer, opt-in repo-owned MP4 renderer                                  | M5b video metrics / richer composition features                                |
+| TS `codec-video`                              | ⚠️ Partial        | Schema, HTML renderer, opt-in repo-owned MP4 renderer                                 | M5b video metrics / richer composition features                                |
 | Benchmark quality scores                      | ⚠️ Proxy          | Structural smoke checks, cost/latency timing                                          | CLIPScore, Whisper WER, UTMOS, discriminative score runners                    |
 | `polyglot-mini` image code-as-painter sandbox | ⚠️ Research-grade | `subprocess` with 20 s timeout + safe globals                                         | Kernel-level isolation for multi-tenant use (see [`SECURITY.md`](SECURITY.md)) |
 

--- a/README.md
+++ b/README.md
@@ -370,13 +370,13 @@ not neural text-to-video generation.
 
 This is the shortest “what can I actually get out today?” view. For deeper component-by-component detail, keep using `docs/implementation-status.md`.
 
-| Modality              | Default artifact        | Opt-in artifact                             | Notes                                                                                        |
-| --------------------- | ----------------------- | ------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| Image (TS)            | PNG (placeholder-class) | PNG (reference decode when weights present) | Scene + seed/semantic receipts ship; frozen decoder bridge not yet wired for LlamaGen/SEED   |
-| Image (polyglot-mini) | PNG                     | —                                           | Research-grade code-as-painter and MLP fallback painter ship                                 |
-| Audio (TS)            | WAV                     | —                                           | Speech + soundscape + music ship                                                             |
-| Sensor (TS)           | JSON / HTML / PNG       | —                                           | Loupe dashboard ships                                                                        |
-| Video (TS)            | HyperFrames-shaped HTML | MP4 (local)                                 | MP4 requires local Chrome/Chromium + FFmpeg and enabling `WITTGENSTEIN_HYPERFRAMES_RENDER=1` |
+| Modality              | Default artifact            | Opt-in artifact                             | Notes                                                                                        |
+| --------------------- | --------------------------- | ------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Image (TS)            | PNG (placeholder-class)     | PNG (reference decode when weights present) | Scene + seed/semantic receipts ship; frozen decoder bridge not yet wired for LlamaGen/SEED   |
+| Image (polyglot-mini) | PNG                         | —                                           | Research-grade code-as-painter and MLP fallback painter ship                                 |
+| Audio (TS)            | WAV                         | —                                           | Speech + soundscape + music ship                                                             |
+| Sensor (TS)           | HTML / JSON (+ CSV sidecar) | —                                           | Loupe dashboard ships                                                                        |
+| Video (TS)            | HyperFrames-shaped HTML     | MP4 (local)                                 | MP4 requires local Chrome/Chromium + FFmpeg and enabling `WITTGENSTEIN_HYPERFRAMES_RENDER=1` |
 
 **What's next.** Doctrine is locked; the active workstream is the Codec Protocol v2 port
 across all modalities, sequenced in [`docs/exec-plans/active/codec-v2-port.md`](docs/exec-plans/active/codec-v2-port.md)

--- a/apps/site/src/sections/HumanReadabilitySection.tsx
+++ b/apps/site/src/sections/HumanReadabilitySection.tsx
@@ -50,7 +50,8 @@ export default function HumanReadabilitySection() {
           >
             <span className="text-[hsl(var(--coral))]">User prompt</span>
             {"\n    →  schema preamble + "}
-            <span className="text-[hsl(var(--coral))]">Visual Seed Code (VSC)</span>-bearing image contract
+            <span className="text-[hsl(var(--coral))]">Visual Seed Code (VSC)</span>-bearing image
+            contract
             {"\n          →  "}
             <span className="text-[hsl(var(--coral))]">LLM</span>
             {" (planner)"}

--- a/packages/cli/src/commands/replay.ts
+++ b/packages/cli/src/commands/replay.ts
@@ -24,7 +24,6 @@ import type { Command } from "commander";
 import {
   RunManifestSchema,
   WittgensteinRequestSchema,
-  type RunManifest,
   type WittgensteinRequest,
 } from "@wittgenstein/schemas";
 import { Wittgenstein } from "@wittgenstein/core";
@@ -40,11 +39,19 @@ const REPLAY_SUPPORTED_ROUTES: ReadonlySet<string> = new Set([
   "asciipng-local",
 ]);
 
-function manifestReplayKey(manifest: RunManifest): string {
-  if (manifest.codec === "sensor") return "sensor";
-  if (manifest.codec === "svg") return "svg-local"; // svg-local is the deterministic path
-  if (manifest.codec === "asciipng") return "asciipng-local";
-  return manifest.codec;
+function requestReplayKey(request: WittgensteinRequest): string {
+  if (request.modality === "sensor") return "sensor";
+  if (request.modality === "svg") return `svg-${request.source}`;
+  if (request.modality === "asciipng") return `asciipng-${request.source}`;
+  return request.modality;
+}
+
+function writeStructuredError(payload: Record<string, unknown>): void {
+  console.error(JSON.stringify({ ok: false, ...payload }, null, 2));
+}
+
+function errorCause(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 export function registerReplayCommand(program: Command): void {
@@ -62,18 +69,11 @@ export function registerReplayCommand(program: Command): void {
       try {
         manifestJson = await readFile(absPath, "utf8");
       } catch (error) {
-        console.error(
-          JSON.stringify(
-            {
-              ok: false,
-              code: "MANIFEST_READ_FAILED",
-              message: `Could not read manifest at ${absPath}`,
-              cause: error instanceof Error ? error.message : String(error),
-            },
-            null,
-            2,
-          ),
-        );
+        writeStructuredError({
+          code: "MANIFEST_READ_FAILED",
+          message: `Could not read manifest at ${absPath}`,
+          cause: errorCause(error),
+        });
         process.exitCode = 1;
         return;
       }
@@ -82,124 +82,118 @@ export function registerReplayCommand(program: Command): void {
       try {
         parsedManifest = JSON.parse(manifestJson);
       } catch (error) {
-        console.error(
-          JSON.stringify(
-            {
-              ok: false,
-              code: "MANIFEST_INVALID_JSON",
-              message: `Manifest at ${absPath} is not valid JSON.`,
-              cause: error instanceof Error ? error.message : String(error),
-            },
-            null,
-            2,
-          ),
-        );
+        writeStructuredError({
+          code: "MANIFEST_INVALID_JSON",
+          message: `Manifest at ${absPath} is not valid JSON.`,
+          cause: errorCause(error),
+        });
         process.exitCode = 1;
         return;
       }
 
       const validation = RunManifestSchema.safeParse(parsedManifest);
       if (!validation.success) {
-        console.error(
-          JSON.stringify(
-            {
-              ok: false,
-              code: "MANIFEST_SCHEMA_INVALID",
-              message: "Manifest does not match RunManifestSchema.",
-              issues: validation.error.issues,
-            },
-            null,
-            2,
-          ),
-        );
+        writeStructuredError({
+          code: "MANIFEST_SCHEMA_INVALID",
+          message: "Manifest does not match RunManifestSchema.",
+          issues: validation.error.issues,
+        });
         process.exitCode = 1;
         return;
       }
       const manifest = validation.data;
 
-      const replayKey = manifestReplayKey(manifest);
-      if (!REPLAY_SUPPORTED_ROUTES.has(replayKey)) {
-        console.error(
-          JSON.stringify(
-            {
-              ok: false,
-              code: "REPLAY_UNSUPPORTED_ROUTE",
-              message: `Replay is not yet wired for codec '${manifest.codec}'. Currently supported: sensor, svg (local), asciipng (local). Image / audio / video pending M1B / M2-cross-platform / M4 — see issue #384.`,
-              codec: manifest.codec,
-            },
-            null,
-            2,
-          ),
-        );
-        process.exitCode = 1;
-        return;
-      }
-
       if (manifest.request === undefined) {
-        console.error(
-          JSON.stringify(
-            {
-              ok: false,
-              code: "MANIFEST_MISSING_REQUEST",
-              message:
-                "Manifest predates the `request` field added for replay. Re-run the original command to produce a replay-compatible manifest (Issue #384).",
-            },
-            null,
-            2,
-          ),
-        );
+        writeStructuredError({
+          code: "MANIFEST_MISSING_REQUEST",
+          message:
+            "Manifest predates the `request` field added for replay. Re-run the original command to produce a replay-compatible manifest (Issue #384).",
+        });
         process.exitCode = 1;
         return;
       }
 
       const requestValidation = WittgensteinRequestSchema.safeParse(manifest.request);
       if (!requestValidation.success) {
-        console.error(
-          JSON.stringify(
-            {
-              ok: false,
-              code: "MANIFEST_REQUEST_INVALID",
-              message:
-                "Recorded request does not match WittgensteinRequestSchema; cannot replay.",
-              issues: requestValidation.error.issues,
-            },
-            null,
-            2,
-          ),
-        );
+        writeStructuredError({
+          code: "MANIFEST_REQUEST_INVALID",
+          message: "Recorded request does not match WittgensteinRequestSchema; cannot replay.",
+          issues: requestValidation.error.issues,
+        });
         process.exitCode = 1;
         return;
       }
       const request: WittgensteinRequest = requestValidation.data;
 
-      if (manifest.artifactSha256 === null) {
-        console.error(
-          JSON.stringify(
-            {
-              ok: false,
-              code: "MANIFEST_NO_BASELINE_HASH",
-              message:
-                "Original manifest has no artifactSha256 to compare against (likely a failed run). Nothing to verify.",
-            },
-            null,
-            2,
-          ),
-        );
+      if (request.modality !== manifest.codec) {
+        writeStructuredError({
+          code: "MANIFEST_REQUEST_CODEC_MISMATCH",
+          message:
+            "Manifest codec does not match the recorded request modality; refusing to replay an ambiguous run.",
+          codec: manifest.codec,
+          requestModality: request.modality,
+        });
         process.exitCode = 1;
         return;
       }
 
-      const harness = await Wittgenstein.bootstrap({
-        cwd: workspaceRoot,
-        ...(options.config ? { configPath: options.config } : {}),
-      });
+      const replayKey = requestReplayKey(request);
+      if (!REPLAY_SUPPORTED_ROUTES.has(replayKey)) {
+        writeStructuredError({
+          code: "REPLAY_UNSUPPORTED_ROUTE",
+          message: `Replay is not yet wired for route '${replayKey}'. Currently supported: sensor, svg (local), asciipng (local). Image / audio / video pending M1B / M2-cross-platform / M4 — see issue #384.`,
+          codec: manifest.codec,
+          route: replayKey,
+        });
+        process.exitCode = 1;
+        return;
+      }
 
-      const outcome = await harness.run(request, {
-        command: "replay",
-        args: [absPath],
-        cwd: workspaceRoot,
-        dryRun: true,
-      });
+      if (manifest.artifactSha256 === null) {
+        writeStructuredError({
+          code: "MANIFEST_NO_BASELINE_HASH",
+          message:
+            "Original manifest has no artifactSha256 to compare against (likely a failed run). Nothing to verify.",
+        });
+        process.exitCode = 1;
+        return;
+      }
+
+      let outcome: Awaited<ReturnType<Wittgenstein["run"]>>;
+      try {
+        const harness = await Wittgenstein.bootstrap({
+          cwd: workspaceRoot,
+          ...(options.config ? { configPath: options.config } : {}),
+        });
+
+        outcome = await harness.run(request, {
+          command: "replay",
+          args: [absPath],
+          cwd: workspaceRoot,
+          dryRun: true,
+        });
+      } catch (error) {
+        writeStructuredError({
+          code: "REPLAY_EXECUTION_FAILED",
+          message: "Replay execution failed before a comparable manifest was produced.",
+          cause: errorCause(error),
+        });
+        process.exitCode = 1;
+        return;
+      }
+
+      if (outcome.error !== null || !outcome.manifest.ok) {
+        writeStructuredError({
+          code: "REPLAY_EXECUTION_FAILED",
+          message: "Replay execution produced a failed manifest; cannot compare artifact hashes.",
+          replayRunId: outcome.manifest.runId,
+          replayRunDir: outcome.runDir,
+          cause: outcome.error?.message ?? "Unknown replay failure.",
+          error: outcome.error,
+        });
+        process.exitCode = 1;
+        return;
+      }
 
       const replayedHash = outcome.manifest.artifactSha256;
       const baselineHash = manifest.artifactSha256;

--- a/packages/cli/test/replay.test.ts
+++ b/packages/cli/test/replay.test.ts
@@ -196,9 +196,10 @@ describe("@wittgenstein/cli replay (Issue #384)", () => {
       request: { modality: "svg", prompt: "prompt", source: "local" },
     });
 
+    const missingConfigPath = join(workDir, "wittgenstein-missing-config.toml");
     const replay = spawnSync(
       process.execPath,
-      [cliBin, "replay", fakeManifestPath, "--config", "/tmp/wittgenstein-missing-config.toml"],
+      [cliBin, "replay", fakeManifestPath, "--config", missingConfigPath],
       {
         cwd: packageRoot,
         encoding: "utf8",
@@ -209,6 +210,27 @@ describe("@wittgenstein/cli replay (Issue #384)", () => {
     expect(errOutput.code).toBe("REPLAY_EXECUTION_FAILED");
     expect(errOutput.cause).toContain("wittgenstein-missing-config.toml");
   });
+
+  it("reports invalid recorded requests before replay execution", async () => {
+    const fakeManifestPath = await writeManifest("fake-invalid-request", {
+      codec: "svg",
+      command: "wittgenstein svg",
+      artifactPath: "/tmp/out.svg",
+      rawRequest: { modality: "svg", prompt: "" },
+    });
+
+    const replay = spawnSync(process.execPath, [cliBin, "replay", fakeManifestPath], {
+      cwd: packageRoot,
+      encoding: "utf8",
+    });
+    expect(replay.status).toBe(1);
+    const errOutput = JSON.parse(replay.stderr) as {
+      code: string;
+      issues: Array<{ path: Array<string | number> }>;
+    };
+    expect(errOutput.code).toBe("MANIFEST_REQUEST_INVALID");
+    expect(errOutput.issues.some((issue) => issue.path.includes("prompt"))).toBe(true);
+  });
 });
 
 type ManifestFixtureOptions = {
@@ -217,6 +239,7 @@ type ManifestFixtureOptions = {
   route?: string;
   artifactPath: string;
   request?: WittgensteinRequest;
+  rawRequest?: unknown;
 };
 
 async function writeManifest(
@@ -247,7 +270,7 @@ async function writeManifest(
     promptExpanded: "prompt",
     llmOutputRaw: "{}",
     llmOutputParsed: {},
-    request: options.request,
+    request: options.rawRequest ?? options.request,
     artifactPath: options.artifactPath,
     artifactSha256: "deadbeef",
     startedAt: new Date().toISOString(),

--- a/packages/cli/test/replay.test.ts
+++ b/packages/cli/test/replay.test.ts
@@ -1,13 +1,12 @@
 /**
  * End-to-end smoke test for `wittgenstein replay <manifest-path>` (#384).
  *
- * Runs sensor --dry-run twice via the CLI; the second run is `replay`
+ * Runs svg --source local via the CLI; the second run is `replay`
  * against the first run's manifest. Asserts byte-parity through the
  * exit code + structured stdout.
  *
- * Why sensor: the sensor codec is fully deterministic (no LLM call, no
- * platform-divergence concerns like #374 image PNG). It is the canonical
- * route for proving the reproducibility claim today.
+ * Why svg-local and not sensor: sensor dashboards still carry an output-path
+ * user hint, while svg-local emits pure deterministic SVG.
  */
 import { spawnSync } from "node:child_process";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
@@ -15,6 +14,7 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { RunManifest, WittgensteinRequest } from "@wittgenstein/schemas";
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const cliBin = resolve(packageRoot, "bin", "wittgenstein.js");
@@ -95,42 +95,12 @@ describe("@wittgenstein/cli replay (Issue #384)", () => {
   });
 
   it("refuses replay for the image codec with a clear error", async () => {
-    // Build a fake manifest with codec: image; replay should refuse.
-    const fakeManifestDir = join(workDir, "fake-image");
-    await mkdtemp(join(tmpdir(), "noop-")); // ensure tmpdir works
-    const { mkdir, writeFile } = await import("node:fs/promises");
-    await mkdir(fakeManifestDir, { recursive: true });
-    const fakeManifestPath = join(fakeManifestDir, "manifest.json");
-    await writeFile(
-      fakeManifestPath,
-      JSON.stringify({
-        runId: "fake-image-run",
-        gitSha: "abc",
-        lockfileHash: "def",
-        nodeVersion: process.version,
-        wittgensteinVersion: "0.0.0",
-        command: "wittgenstein image",
-        args: ["prompt"],
-        seed: 7,
-        codec: "image",
-        license: { weightsRestriction: "permissive" },
-        llmProvider: "anthropic",
-        llmModel: "claude-opus-4-7",
-        llmTokens: { input: 1, output: 2 },
-        costUsd: 0,
-        promptRaw: "prompt",
-        promptExpanded: "prompt",
-        llmOutputRaw: "{}",
-        llmOutputParsed: {},
-        request: { modality: "image", prompt: "prompt" },
-        artifactPath: "/tmp/out.png",
-        artifactSha256: "deadbeef",
-        startedAt: new Date().toISOString(),
-        durationMs: 10,
-        ok: true,
-      }),
-      "utf8",
-    );
+    const fakeManifestPath = await writeManifest("fake-image", {
+      codec: "image",
+      command: "wittgenstein image",
+      artifactPath: "/tmp/out.png",
+      request: { modality: "image", prompt: "prompt" },
+    });
 
     const replay = spawnSync(process.execPath, [cliBin, "replay", fakeManifestPath], {
       cwd: packageRoot,
@@ -142,41 +112,13 @@ describe("@wittgenstein/cli replay (Issue #384)", () => {
   });
 
   it("refuses replay on a manifest missing the request field", async () => {
-    const fakeManifestDir = join(workDir, "fake-no-request");
-    const { mkdir, writeFile } = await import("node:fs/promises");
-    await mkdir(fakeManifestDir, { recursive: true });
-    const fakeManifestPath = join(fakeManifestDir, "manifest.json");
-    await writeFile(
-      fakeManifestPath,
-      JSON.stringify({
-        runId: "fake-sensor-run",
-        gitSha: "abc",
-        lockfileHash: "def",
-        nodeVersion: process.version,
-        wittgensteinVersion: "0.0.0",
-        command: "wittgenstein sensor",
-        args: ["prompt"],
-        seed: 7,
-        codec: "sensor",
-        route: "ecg",
-        license: { weightsRestriction: "permissive" },
-        llmProvider: "anthropic",
-        llmModel: "claude-opus-4-7",
-        llmTokens: { input: 0, output: 0 },
-        costUsd: 0,
-        promptRaw: "prompt",
-        promptExpanded: "prompt",
-        llmOutputRaw: "{}",
-        llmOutputParsed: {},
-        // intentionally no `request` field — pre-replay-era manifest
-        artifactPath: "/tmp/out.json",
-        artifactSha256: "deadbeef",
-        startedAt: new Date().toISOString(),
-        durationMs: 10,
-        ok: true,
-      }),
-      "utf8",
-    );
+    const fakeManifestPath = await writeManifest("fake-no-request", {
+      codec: "sensor",
+      command: "wittgenstein sensor",
+      route: "ecg",
+      artifactPath: "/tmp/out.json",
+      request: undefined,
+    });
 
     const replay = spawnSync(process.execPath, [cliBin, "replay", fakeManifestPath], {
       cwd: packageRoot,
@@ -186,4 +128,132 @@ describe("@wittgenstein/cli replay (Issue #384)", () => {
     const errOutput = JSON.parse(replay.stderr) as { code: string };
     expect(errOutput.code).toBe("MANIFEST_MISSING_REQUEST");
   });
+
+  it("refuses non-local svg manifests based on the recorded request", async () => {
+    const fakeManifestPath = await writeManifest("fake-svg-engine", {
+      codec: "svg",
+      command: "wittgenstein svg",
+      artifactPath: "/tmp/out.svg",
+      request: { modality: "svg", prompt: "prompt", source: "engine" },
+    });
+
+    const replay = spawnSync(process.execPath, [cliBin, "replay", fakeManifestPath], {
+      cwd: packageRoot,
+      encoding: "utf8",
+    });
+    expect(replay.status).toBe(1);
+    const errOutput = JSON.parse(replay.stderr) as { code: string; route: string };
+    expect(errOutput.code).toBe("REPLAY_UNSUPPORTED_ROUTE");
+    expect(errOutput.route).toBe("svg-engine");
+  });
+
+  it("refuses non-local asciipng manifests based on the recorded request", async () => {
+    const fakeManifestPath = await writeManifest("fake-asciipng-minimax", {
+      codec: "asciipng",
+      command: "wittgenstein asciipng",
+      artifactPath: "/tmp/out.png",
+      request: { modality: "asciipng", prompt: "prompt", source: "minimax" },
+    });
+
+    const replay = spawnSync(process.execPath, [cliBin, "replay", fakeManifestPath], {
+      cwd: packageRoot,
+      encoding: "utf8",
+    });
+    expect(replay.status).toBe(1);
+    const errOutput = JSON.parse(replay.stderr) as { code: string; route: string };
+    expect(errOutput.code).toBe("REPLAY_UNSUPPORTED_ROUTE");
+    expect(errOutput.route).toBe("asciipng-minimax");
+  });
+
+  it("refuses manifests whose codec disagrees with the recorded request", async () => {
+    const fakeManifestPath = await writeManifest("fake-codec-request-mismatch", {
+      codec: "svg",
+      command: "wittgenstein svg",
+      artifactPath: "/tmp/out.svg",
+      request: { modality: "sensor", prompt: "prompt", signal: "ecg" },
+    });
+
+    const replay = spawnSync(process.execPath, [cliBin, "replay", fakeManifestPath], {
+      cwd: packageRoot,
+      encoding: "utf8",
+    });
+    expect(replay.status).toBe(1);
+    const errOutput = JSON.parse(replay.stderr) as {
+      code: string;
+      codec: string;
+      requestModality: string;
+    };
+    expect(errOutput.code).toBe("MANIFEST_REQUEST_CODEC_MISMATCH");
+    expect(errOutput.codec).toBe("svg");
+    expect(errOutput.requestModality).toBe("sensor");
+  });
+
+  it("reports replay bootstrap failures as structured errors", async () => {
+    const fakeManifestPath = await writeManifest("fake-bad-config", {
+      codec: "svg",
+      command: "wittgenstein svg",
+      artifactPath: "/tmp/out.svg",
+      request: { modality: "svg", prompt: "prompt", source: "local" },
+    });
+
+    const replay = spawnSync(
+      process.execPath,
+      [cliBin, "replay", fakeManifestPath, "--config", "/tmp/wittgenstein-missing-config.toml"],
+      {
+        cwd: packageRoot,
+        encoding: "utf8",
+      },
+    );
+    expect(replay.status).toBe(1);
+    const errOutput = JSON.parse(replay.stderr) as { code: string; cause: string };
+    expect(errOutput.code).toBe("REPLAY_EXECUTION_FAILED");
+    expect(errOutput.cause).toContain("wittgenstein-missing-config.toml");
+  });
 });
+
+type ManifestFixtureOptions = {
+  codec: string;
+  command: string;
+  route?: string;
+  artifactPath: string;
+  request?: WittgensteinRequest;
+};
+
+async function writeManifest(
+  directoryName: string,
+  options: ManifestFixtureOptions,
+): Promise<string> {
+  const fakeManifestDir = join(workDir, directoryName);
+  const { mkdir, writeFile } = await import("node:fs/promises");
+  await mkdir(fakeManifestDir, { recursive: true });
+  const fakeManifestPath = join(fakeManifestDir, "manifest.json");
+  const manifest: RunManifest = {
+    runId: `${directoryName}-run`,
+    gitSha: "abc",
+    lockfileHash: "def",
+    nodeVersion: process.version,
+    wittgensteinVersion: "0.0.0",
+    command: options.command,
+    args: ["prompt"],
+    seed: 7,
+    codec: options.codec,
+    route: options.route,
+    license: { weightsRestriction: "permissive" },
+    llmProvider: "anthropic",
+    llmModel: "claude-opus-4-7",
+    llmTokens: { input: 0, output: 0 },
+    costUsd: 0,
+    promptRaw: "prompt",
+    promptExpanded: "prompt",
+    llmOutputRaw: "{}",
+    llmOutputParsed: {},
+    request: options.request,
+    artifactPath: options.artifactPath,
+    artifactSha256: "deadbeef",
+    startedAt: new Date().toISOString(),
+    durationMs: 10,
+    ok: true,
+  };
+  await writeFile(fakeManifestPath, JSON.stringify(manifest), "utf8");
+  return fakeManifestPath;
+}

--- a/packages/codec-asciipng/test/codec.test.ts
+++ b/packages/codec-asciipng/test/codec.test.ts
@@ -21,8 +21,9 @@ describe("@wittgenstein/codec-asciipng", () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error.code).toBe("ASCIIPNG_SCHEMA_INVALID");
-    const issues = (result.error.details as { issues: ReadonlyArray<{ path: ReadonlyArray<string | number> }> })
-      .issues;
+    const issues = (
+      result.error.details as { issues: ReadonlyArray<{ path: ReadonlyArray<string | number> }> }
+    ).issues;
     expect(issues.some((issue) => issue.path.includes("columns"))).toBe(true);
   });
 

--- a/packages/codec-image/src/decoders/llamagen/README.md
+++ b/packages/codec-image/src/decoders/llamagen/README.md
@@ -26,7 +26,7 @@ shared [`../weights.ts`](../weights.ts) cache + sha256 resolver and the
   via `torch.onnx.export` per the audit script
   `m1b-work/scripts/gate_d_onnx_export.py`. Encoder is intentionally
   not in the shipped file — the bridge contract is `decode(codes) →
-  raster`; encoders are offline tooling for adapter training only.
+raster`; encoders are offline tooling for adapter training only.
 - **Audit provenance** — Gates A+B in
   [`docs/research/2026-05-13-audit-vqgan-class.md`](../../../../../docs/research/2026-05-13-audit-vqgan-class.md);
   Gates C+D in
@@ -34,17 +34,17 @@ shared [`../weights.ts`](../weights.ts) cache + sha256 resolver and the
 
 ## Capabilities the bridge advertises
 
-| Field | Value | Source |
-|---|---|---|
-| `family` | `"llamagen"` | manifest |
-| `decoderId` | `"llamagen-frozen-vq-v0"` | locked constant in `../llamagen.ts` |
-| `supportedShapes` | `[{ shape: "2D", tokenGrid: [16, 16], outputPixels: [256, 256] }]` | Gate D `latent_grid` + `image_size` |
-| `codebook` | `"vq_ds16_c2i"` | upstream tokenizer artifact name |
-| `codebookVersion` | `"FoundationVision/LlamaGen@81e41139"` | manifest `repoId@revision` shortening |
-| `determinismClass` | `"structural-parity"` | Gate C verdict (ADR-0015 cross-platform precedent) |
-| `runtimeTier` | `"node-onnx-cpu"` | canonical M-phase tier per `docs/hard-constraints.md` |
-| `codeLicense` | `"MIT"` | manifest |
-| `weightsLicense` | `"permissive"` | manifest |
+| Field              | Value                                                              | Source                                                |
+| ------------------ | ------------------------------------------------------------------ | ----------------------------------------------------- |
+| `family`           | `"llamagen"`                                                       | manifest                                              |
+| `decoderId`        | `"llamagen-frozen-vq-v0"`                                          | locked constant in `../llamagen.ts`                   |
+| `supportedShapes`  | `[{ shape: "2D", tokenGrid: [16, 16], outputPixels: [256, 256] }]` | Gate D `latent_grid` + `image_size`                   |
+| `codebook`         | `"vq_ds16_c2i"`                                                    | upstream tokenizer artifact name                      |
+| `codebookVersion`  | `"FoundationVision/LlamaGen@81e41139"`                             | manifest `repoId@revision` shortening                 |
+| `determinismClass` | `"structural-parity"`                                              | Gate C verdict (ADR-0015 cross-platform precedent)    |
+| `runtimeTier`      | `"node-onnx-cpu"`                                                  | canonical M-phase tier per `docs/hard-constraints.md` |
+| `codeLicense`      | `"MIT"`                                                            | manifest                                              |
+| `weightsLicense`   | `"permissive"`                                                     | manifest                                              |
 
 ## ONNX hosting — pending
 

--- a/packages/codec-sensor/test/codec.test.ts
+++ b/packages/codec-sensor/test/codec.test.ts
@@ -376,8 +376,9 @@ describe("@wittgenstein/codec-sensor structured error paths", () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error.code).toBe("SENSOR_SCHEMA_INVALID");
-    const issues = (result.error.details as { issues: ReadonlyArray<{ path: ReadonlyArray<string | number> }> })
-      .issues;
+    const issues = (
+      result.error.details as { issues: ReadonlyArray<{ path: ReadonlyArray<string | number> }> }
+    ).issues;
     expect(issues.length).toBeGreaterThan(0);
     expect(issues.some((issue) => issue.path.includes("signal"))).toBe(true);
   });
@@ -420,8 +421,9 @@ describe("@wittgenstein/codec-sensor structured error paths", () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error.code).toBe("SENSOR_SCHEMA_INVALID");
-    const issues = (result.error.details as { issues: ReadonlyArray<{ path: ReadonlyArray<string | number> }> })
-      .issues;
+    const issues = (
+      result.error.details as { issues: ReadonlyArray<{ path: ReadonlyArray<string | number> }> }
+    ).issues;
     expect(issues.some((issue) => issue.path.includes("operators"))).toBe(true);
   });
 });

--- a/packages/sandbox/src/exec.ts
+++ b/packages/sandbox/src/exec.ts
@@ -23,11 +23,7 @@ export class SandboxError extends Error {
   public readonly code: string;
   public readonly details: Record<string, unknown> | undefined;
 
-  public constructor(
-    code: string,
-    message: string,
-    options: SandboxErrorOptions = {},
-  ) {
+  public constructor(code: string, message: string, options: SandboxErrorOptions = {}) {
     super(message, { cause: options.cause });
     this.name = "SandboxError";
     this.code = code;
@@ -55,10 +51,7 @@ export class NotImplementedError extends SandboxError {
  * LLM-emitted drawing programs). Not implemented in scaffold — callers must
  * handle NotImplementedError.
  */
-export async function execProgram(
-  _code: string,
-  _options: ExecOptions,
-): Promise<ExecResult> {
+export async function execProgram(_code: string, _options: ExecOptions): Promise<ExecResult> {
   throw new NotImplementedError("execProgram", {
     details: {
       package: "@wittgenstein/sandbox",


### PR DESCRIPTION
## What changed
- Make `wittgenstein replay` derive replay support from the validated recorded request, so `svg`/`asciipng` live routes are refused instead of being treated as local replayable runs.
- Normalize replay bootstrap/run failures into structured stderr errors rather than leaking uncaught exceptions or degrading into hash-mismatch comparisons.
- Point reviewdog markdownlint at the existing `.markdownlint-cli2.yaml` config so disabled legacy rules like MD013 stop producing review noise.
- Close small historical reviewdog/CodeRabbit leftovers: stale README M2/M3 status, stale replay test header, and touched-file Prettier suggestions.

## Why
This closes non-training historical review debt already merged to `main`; it intentionally avoids the currently open training PRs (#569-#572) and does not change training code or M1B training behavior. README changes in this PR are factual drift correction against landed behavior, not new doctrine.

## Validation
- `pnpm typecheck`
- `pnpm test`
- `pnpm lint`
- `pnpm --filter @wittgenstein/cli test -- replay.test.ts`
- `pnpm --filter @wittgenstein/cli lint && pnpm --filter @wittgenstein/cli typecheck`
- `pnpm --filter @wittgenstein/sandbox test && pnpm --filter @wittgenstein/codec-asciipng test && pnpm --filter @wittgenstein/codec-sensor test`
- `pnpm format:check:maintained`
- `pnpm dlx markdownlint-cli@0.41.0 --config .markdownlint-cli2.yaml --configPointer /config README.md CONTRIBUTING.md CHANGELOG.md PROMPT.md docs/THESIS.md docs/architecture.md docs/hard-constraints.md docs/implementation-status.md docs/quickstart.md docs/reproducibility.md docs/codecs/*.md`
- `git diff --check`

## Remaining risks
- This keeps replay support narrow: only `sensor`, `svg-local`, and `asciipng-local` remain supported. Image/audio/video and live LLM replay are still intentionally refused.
