### PR TITLE
feat(training): gloo/CPU DDP fallback — multi-process GAN path now testable

### DIFF
--- a/research/training/tokenizer/test_gan_ddp_smoke.py
+++ b/research/training/tokenizer/test_gan_ddp_smoke.py
@@ -1,0 +1,91 @@
+"""Multi-process (DDP) smoke test for GAN-enabled tokenizer training, on CPU.
+
+Single-process `test_gan_smoke.py` exercises the loss/optimizer wiring but NOT
+the distributed path. This launches 2 ranks via torchrun so the gloo/CPU DDP
+fallback, the dual-DDP wrap (generator + discriminator), and the two-optimizer
+step are actually executed together — the interaction flagged as "untested
+locally" when the GAN code first landed (#572).
+
+Run:  python -m torch.distributed.run --nproc-per-node 2 --master-port 29555 \
+          -m research.training.tokenizer.test_gan_ddp_smoke
+Exit 0 on all ranks = pass. Rank 0 asserts the checkpoint + manifest; non-zero
+ranks just need to complete train() without raising.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import torch
+
+_HERE = Path(__file__).resolve().parent
+_REPO_ROOT = _HERE.parent.parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from research.training.tokenizer.config import OptimConfig, TrainConfig  # noqa: E402
+from research.training.tokenizer.model import TokenizerConfig  # noqa: E402
+from research.training.tokenizer.train import train, init_distributed, is_main  # noqa: E402
+
+
+def _ddp_gan_config(out_root: str) -> TrainConfig:
+    cfg = TrainConfig()
+    cfg.tokenizer = TokenizerConfig(codebook_size=256, codebook_embed_dim=16, image_size=64)
+    cfg.image_size = 64
+    cfg.batch_size_per_gpu = 2
+    cfg.max_steps = 4
+    cfg.log_every = 1
+    cfg.eval_every = 999_999
+    cfg.checkpoint_every = 999_999
+    cfg.num_workers = 0
+    cfg.smoke = True
+    cfg.lpips_enabled = False
+    cfg.gan_enabled = True
+    cfg.gan_on_step = 1
+    cfg.disc_base_channels = 16
+    cfg.disc_n_layers = 2
+    cfg.optim = OptimConfig(lr=1e-4)
+    cfg.optim.warmup_steps = 1
+    cfg.out_root = out_root
+    cfg.train_data_root = ""
+    return cfg
+
+
+def main() -> int:
+    torch.manual_seed(0)
+    # Peek at the world size init_distributed will see (without consuming it).
+    expected_world = int(os.environ.get("WORLD_SIZE", "1"))
+
+    # Each rank writes under the SAME shared out_root so the run_dir broadcast
+    # (rank 0 invents run_id) resolves to one place all ranks can see.
+    shared_out = os.environ.get("WITT_DDP_TEST_OUT")
+    if not shared_out:
+        shared_out = tempfile.mkdtemp(prefix="witt_ddp_")
+        os.environ["WITT_DDP_TEST_OUT"] = shared_out
+
+    cfg = _ddp_gan_config(shared_out)
+    summary = train(cfg)
+
+    # Only rank 0 owns the checkpoint/manifest assertions.
+    rank = int(os.environ.get("RANK", "0"))
+    if rank == 0:
+        assert summary["final_step"] == 4, f"steps={summary['final_step']}"
+        comps = summary.get("final_components", {})
+        assert "d_loss" in comps, f"no d_loss; components={list(comps)}"
+        final_ckpt = Path(summary["run_dir"]) / "ckpts" / "final.pt"
+        assert final_ckpt.exists(), f"no checkpoint at {final_ckpt}"
+        payload = torch.load(final_ckpt, map_location="cpu", weights_only=True)
+        assert "discriminator" in payload, f"checkpoint keys={list(payload)}"
+        print(f"[ddp-gan-smoke] world={expected_world} rank=0 steps={summary['final_step']} "
+              f"d_loss={comps['d_loss']:.4f} gan_g={comps.get('gan_g', float('nan')):.4f}")
+        print("[ddp-gan-smoke] PASS")
+    else:
+        print(f"[ddp-gan-smoke] world={expected_world} rank={rank} completed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/training/tokenizer/train.py
+++ b/research/training/tokenizer/train.py
@@ -102,12 +102,18 @@ def init_distributed() -> tuple[int, int, int, torch.device]:
     Falls back to single-process if torchrun env vars are absent (smoke).
     """
     if "RANK" in os.environ and "WORLD_SIZE" in os.environ:
-        dist.init_process_group(backend="nccl")
+        # nccl is GPU-only; fall back to gloo when CUDA is absent so the
+        # multi-process DDP path is runnable (and testable) on CPU too.
+        use_cuda = torch.cuda.is_available()
+        dist.init_process_group(backend="nccl" if use_cuda else "gloo")
         rank = dist.get_rank()
         world = dist.get_world_size()
-        local = int(os.environ["LOCAL_RANK"])
-        torch.cuda.set_device(local)
-        device = torch.device("cuda", local)
+        local = int(os.environ.get("LOCAL_RANK", 0))
+        if use_cuda:
+            torch.cuda.set_device(local)
+            device = torch.device("cuda", local)
+        else:
+            device = torch.device("cpu")
         return rank, world, local, device
     if torch.cuda.is_available():
         return 0, 1, 0, torch.device("cuda", 0)
@@ -116,6 +122,18 @@ def init_distributed() -> tuple[int, int, int, torch.device]:
 
 def is_main(rank: int) -> bool:
     return rank == 0
+
+
+def _ddp_wrap(module, device, local_rank, **kwargs):
+    """DDP-wrap a module with device-correct kwargs.
+
+    On CUDA, DDP pins to a device via device_ids/output_device; on CPU
+    (gloo backend) those MUST be omitted/None or DDP raises. Centralizes the
+    branch so the generator and discriminator wrap identically.
+    """
+    if device.type == "cuda":
+        return DDP(module, device_ids=[local_rank], output_device=local_rank, **kwargs)
+    return DDP(module, **kwargs)
 
 
 def cleanup_distributed():
@@ -199,7 +217,7 @@ def train(cfg: TrainConfig) -> dict:
         )
 
     if world > 1:
-        model = DDP(model, device_ids=[local_rank], output_device=local_rank, find_unused_parameters=False)
+        model = _ddp_wrap(model, device, local_rank, find_unused_parameters=False)
 
     # ---- Loss ----
     lpips_mod = None
@@ -230,7 +248,7 @@ def train(cfg: TrainConfig) -> dict:
             betas=(cfg.optim.beta1, cfg.optim.beta2),
         )
         discriminator = (
-            DDP(disc_core, device_ids=[local_rank], output_device=local_rank)
+            _ddp_wrap(disc_core, device, local_rank)
             if world > 1
             else disc_core
         )


### PR DESCRIPTION
## What

Makes the distributed training path **CPU-runnable** so the multi-process DDP + GAN interaction can actually be tested — closing the "DDP path untested locally" caveat from #572.

- `init_distributed`: choose `nccl` when CUDA is available, else `gloo`; set `device=cpu` and default `LOCAL_RANK=0` in the CPU case (previously hardcoded `nccl` + unconditional `torch.cuda.set_device`, so the distributed branch required GPUs).
- `_ddp_wrap` helper: omits `device_ids`/`output_device` on CPU (DDP requires them unset for gloo) and applies them on CUDA. Both the generator and the discriminator wrap through it, so they behave identically.
- `test_gan_ddp_smoke.py`: launches **2 ranks** via `torch.distributed.run` and asserts the GAN+eval run completes on both ranks with a discriminator-bearing checkpoint.

## Why

#572 wired a PatchGAN discriminator with its own optimizer and a second DDP wrap, but that two-optimizer dual-DDP step had only ever run single-process/CPU — the genuinely risky interaction (two DDP modules, generator backward touching the discriminator, separate D backward) was unexercised. nccl is GPU-only, so it couldn't be tested without a cluster. gloo fallback fixes that.

## Receipts / evidence (local; CI does not compile `research/training/`)

- **2-process CPU DDP run** (`python -m torch.distributed.run --nproc-per-node 2 -m research.training.tokenizer.test_gan_ddp_smoke`): `[init] rank=0 world=2 device=cpu` + `rank=1 world=2 device=cpu`; PatchGAN discriminator built; rank 0 `PASS`, rank 1 `completed`; **exit 0, no NCCL error**.
- **Single-process `test_gan_smoke` still passes** (exit 0) — no regression.
- `py_compile` clean on both changed/added files.

## Boundaries / scope

- Python-only, `research/training/tokenizer/`. No publish surface, no deps.
- gloo/CPU is for **testability and GPU-less portability**; production multi-GPU still uses nccl (unchanged when CUDA present).
- Real multi-GPU cluster validation of GAN-on training is still worthwhile, but the DDP *logic* is now exercised.

## Test plan

- [x] 2-rank CPU DDP GAN smoke (world=2, both ranks complete, exit 0).
- [x] single-process GAN smoke (no regression).
- [x] `py_compile` both files.
- [ ] Reviewer: real multi-GPU `--gan` run on a cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
