### PR TITLE
fix(cli): reject malformed seed values

### DIFF
--- a/packages/cli/src/commands/asciipng.ts
+++ b/packages/cli/src/commands/asciipng.ts
@@ -1,5 +1,10 @@
 import type { Command } from "commander";
-import { runCodecCommand, parseOptionalSeed, type CommandRuntimeOptions } from "./shared.js";
+import {
+  runCodecCommand,
+  parseOptionalSeed,
+  parseSeedOption,
+  type CommandRuntimeOptions,
+} from "./shared.js";
 import { ensureMinimaxApiKeyInteractive } from "./minimax-key.js";
 
 export interface AsciipngCommandOptions extends CommandRuntimeOptions {
@@ -18,7 +23,7 @@ export function registerAsciipngCommand(program: Command): void {
       "PNG from a character grid: local (no API) or Minimax text-only API + deterministic post-process (not raw image bytes).",
     )
     .option("--out <path>", "output path (default under artifacts/runs/…)")
-    .option("--seed <number>", "seed")
+    .option("--seed <number>", "seed", parseSeedOption)
     .option("--columns <n>", "grid width in characters", "60")
     .option("--rows <n>", "grid height in characters", "30")
     .option("--cell <n>", "pixel size per character cell", "4")
@@ -27,7 +32,10 @@ export function registerAsciipngCommand(program: Command): void {
       "local: deterministic pseudo-glyph; minimax: call text chat, normalize lines, rasterize",
       "local",
     )
-    .option("--minimax-model <id>", "Minimax chat model id (default env WITTGENSTEIN_MINIMAX_MODEL or abab6.5s-chat-h)")
+    .option(
+      "--minimax-model <id>",
+      "Minimax chat model id (default env WITTGENSTEIN_MINIMAX_MODEL or abab6.5s-chat-h)",
+    )
     .option(
       "--dry-run",
       "skip Minimax HTTP when source=minimax (use local grid from prompt only); otherwise ignored for local",

--- a/packages/cli/src/commands/audio.ts
+++ b/packages/cli/src/commands/audio.ts
@@ -1,5 +1,10 @@
 import type { Command } from "commander";
-import { runCodecCommand, parseOptionalSeed, type CommandRuntimeOptions } from "./shared.js";
+import {
+  runCodecCommand,
+  parseOptionalSeed,
+  parseSeedOption,
+  type CommandRuntimeOptions,
+} from "./shared.js";
 
 export function registerAudioCommand(program: Command): void {
   program
@@ -10,7 +15,7 @@ export function registerAudioCommand(program: Command): void {
     .option("--ambient <ambient>", "auto | silence | rain | wind | city | forest | electronic")
     .option("--duration-sec <number>", "requested duration in seconds")
     .option("--out <path>", "output path")
-    .option("--seed <number>", "seed")
+    .option("--seed <number>", "seed", parseSeedOption)
     .option("--dry-run", "skip the remote model call and exercise the manifest spine")
     .option("--config <path>", "config path")
     .action(

--- a/packages/cli/src/commands/image.ts
+++ b/packages/cli/src/commands/image.ts
@@ -1,6 +1,11 @@
 import type { Command } from "commander";
 import type { RunManifest } from "@wittgenstein/schemas";
-import { runCodecCommand, parseOptionalSeed, type CommandRuntimeOptions } from "./shared.js";
+import {
+  runCodecCommand,
+  parseOptionalSeed,
+  parseSeedOption,
+  type CommandRuntimeOptions,
+} from "./shared.js";
 
 interface ImageCommandOptions extends CommandRuntimeOptions {
   showImageCode?: boolean;
@@ -15,7 +20,7 @@ export function registerImageCommand(program: Command): void {
     .argument("<prompt>", "user prompt")
     .description("Run the image codec")
     .option("--out <path>", "output path")
-    .option("--seed <number>", "seed")
+    .option("--seed <number>", "seed", parseSeedOption)
     .option("--dry-run", "skip the remote model call and exercise the manifest spine")
     .option("--show-image-code", "print the imageCode receipt that records the fired VSC path")
     .option("--show-semantic", "print the emitted/effective Semantic IR for inspection")

--- a/packages/cli/src/commands/sensor.ts
+++ b/packages/cli/src/commands/sensor.ts
@@ -1,5 +1,10 @@
 import type { Command } from "commander";
-import { runCodecCommand, parseOptionalSeed, type CommandRuntimeOptions } from "./shared.js";
+import {
+  runCodecCommand,
+  parseOptionalSeed,
+  parseSeedOption,
+  type CommandRuntimeOptions,
+} from "./shared.js";
 
 export function registerSensorCommand(program: Command): void {
   program
@@ -10,7 +15,7 @@ export function registerSensorCommand(program: Command): void {
     .option("--sample-rate-hz <number>", "requested sample rate")
     .option("--duration-sec <number>", "requested duration in seconds")
     .option("--out <path>", "output path")
-    .option("--seed <number>", "seed")
+    .option("--seed <number>", "seed", parseSeedOption)
     .option("--dry-run", "skip the remote model call and exercise the manifest spine")
     .option("--config <path>", "config path")
     .action(
@@ -32,9 +37,7 @@ export function registerSensorCommand(program: Command): void {
             sampleRateHz: options.sampleRateHz
               ? Number.parseFloat(options.sampleRateHz)
               : undefined,
-            durationSec: options.durationSec
-              ? Number.parseFloat(options.durationSec)
-              : undefined,
+            durationSec: options.durationSec ? Number.parseFloat(options.durationSec) : undefined,
           },
           "wittgenstein sensor",
           process.argv.slice(2),

--- a/packages/cli/src/commands/shared.ts
+++ b/packages/cli/src/commands/shared.ts
@@ -1,11 +1,12 @@
 import { existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
+import { InvalidArgumentError } from "commander";
 import type { RunManifest, WittgensteinRequest } from "@wittgenstein/schemas";
 import { Wittgenstein } from "@wittgenstein/core";
 
 export interface CommandRuntimeOptions {
   out?: string;
-  seed?: string;
+  seed?: number;
   dryRun?: boolean;
   config?: string;
   allowResearchWeights?: boolean;
@@ -70,12 +71,25 @@ export async function runCodecCommand(
   }
 }
 
-export function parseOptionalSeed(seed: string | undefined): number | null | undefined {
+export function parseSeedOption(seed: string): number {
+  if (!/^-?\d+$/.test(seed)) {
+    throw new InvalidArgumentError("Seed must be an integer.");
+  }
+
+  const parsed = Number(seed);
+  if (!Number.isSafeInteger(parsed)) {
+    throw new InvalidArgumentError("Seed must be a safe integer.");
+  }
+
+  return parsed;
+}
+
+export function parseOptionalSeed(seed: number | undefined): number | null | undefined {
   if (seed === undefined) {
     return undefined;
   }
 
-  return Number.parseInt(seed, 10);
+  return seed;
 }
 
 export function resolveExecutionRoot(): string {

--- a/packages/cli/src/commands/svg.ts
+++ b/packages/cli/src/commands/svg.ts
@@ -1,5 +1,10 @@
 import type { Command } from "commander";
-import { runCodecCommand, parseOptionalSeed, type CommandRuntimeOptions } from "./shared.js";
+import {
+  runCodecCommand,
+  parseOptionalSeed,
+  parseSeedOption,
+  type CommandRuntimeOptions,
+} from "./shared.js";
 
 export interface SvgCommandOptions extends CommandRuntimeOptions {
   source?: string;
@@ -13,7 +18,7 @@ export function registerSvgCommand(program: Command): void {
       "Run the SVG codec: `engine` calls the grammar engine HTTP; `local` emits deterministic vector art from the prompt (no text, black background).",
     )
     .option("--out <path>", "output path")
-    .option("--seed <number>", "seed")
+    .option("--seed <number>", "seed", parseSeedOption)
     .option("--source <engine|local>", "svg generation source", "engine")
     .option("--dry-run", "skip remote model / engine calls and exercise the manifest spine")
     .option("--config <path>", "config path")

--- a/packages/cli/src/commands/tts.ts
+++ b/packages/cli/src/commands/tts.ts
@@ -1,5 +1,10 @@
 import type { Command } from "commander";
-import { runCodecCommand, parseOptionalSeed, type CommandRuntimeOptions } from "./shared.js";
+import {
+  runCodecCommand,
+  parseOptionalSeed,
+  parseSeedOption,
+  type CommandRuntimeOptions,
+} from "./shared.js";
 
 export function registerTtsCommand(program: Command): void {
   program
@@ -9,7 +14,7 @@ export function registerTtsCommand(program: Command): void {
     .option("--ambient <ambient>", "auto | silence | rain | wind | city | forest | electronic")
     .option("--duration-sec <number>", "requested duration in seconds")
     .option("--out <path>", "output path")
-    .option("--seed <number>", "seed")
+    .option("--seed <number>", "seed", parseSeedOption)
     .option("--dry-run", "skip the remote model call and exercise the manifest spine")
     .option("--config <path>", "config path")
     .action(
@@ -28,9 +33,7 @@ export function registerTtsCommand(program: Command): void {
             seed: parseOptionalSeed(options.seed),
             route: "speech",
             ambient: options.ambient,
-            durationSec: options.durationSec
-              ? Number.parseFloat(options.durationSec)
-              : undefined,
+            durationSec: options.durationSec ? Number.parseFloat(options.durationSec) : undefined,
           },
           "wittgenstein tts",
           process.argv.slice(2),

--- a/packages/cli/src/commands/video.ts
+++ b/packages/cli/src/commands/video.ts
@@ -4,6 +4,7 @@ import type { Command } from "commander";
 import {
   runCodecCommand,
   parseOptionalSeed,
+  parseSeedOption,
   resolveExecutionRoot,
   type CommandRuntimeOptions,
 } from "./shared.js";
@@ -26,8 +27,13 @@ export function registerVideoCommand(program: Command): void {
     )
     .option("--duration-sec <number>", "requested duration in seconds")
     .option("--out <path>", "output path")
-    .option("--seed <number>", "seed")
-    .option("--svg <path>", "SVG file as one slide (repeatable); bypasses LLM when set", collectSvgPath, [])
+    .option("--seed <number>", "seed", parseSeedOption)
+    .option(
+      "--svg <path>",
+      "SVG file as one slide (repeatable); bypasses LLM when set",
+      collectSvgPath,
+      [],
+    )
     .option("--dry-run", "skip the remote model call and exercise the manifest spine")
     .option("--config <path>", "config path")
     .action(async (prompt: string, options: VideoCommandOptions) => {

--- a/packages/cli/test/bin.test.ts
+++ b/packages/cli/test/bin.test.ts
@@ -16,4 +16,21 @@ describe("@wittgenstein/cli bin", () => {
     expect(result.stdout.trim()).toBe("0.1.0");
     expect(result.stderr).toBe("");
   });
+
+  it("rejects malformed seed values before running a codec", () => {
+    const result = spawnSync(
+      process.execPath,
+      ["./bin/wittgenstein.js", "sensor", "stable ECG trace", "--dry-run", "--seed", "12abc"],
+      {
+        cwd: packageRoot,
+        encoding: "utf8",
+      },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain(
+      "error: option '--seed <number>' argument '12abc' is invalid. Seed must be an integer.",
+    );
+  });
 });

--- a/packages/cli/test/shared.test.ts
+++ b/packages/cli/test/shared.test.ts
@@ -1,35 +1,43 @@
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
-import { parseOptionalSeed, resolveExecutionRoot } from "../src/commands/shared.js";
+import {
+  parseOptionalSeed,
+  parseSeedOption,
+  resolveExecutionRoot,
+} from "../src/commands/shared.js";
 
 describe("parseOptionalSeed", () => {
   it("returns undefined when no seed is provided (caller should fall through to default)", () => {
     expect(parseOptionalSeed(undefined)).toBeUndefined();
   });
 
+  it("passes through parsed integer seeds", () => {
+    expect(parseOptionalSeed(0)).toBe(0);
+    expect(parseOptionalSeed(42)).toBe(42);
+  });
+});
+
+describe("parseSeedOption", () => {
   it("parses '0' as the integer zero (NOT a missing value)", () => {
-    expect(parseOptionalSeed("0")).toBe(0);
+    expect(parseSeedOption("0")).toBe(0);
   });
 
   it("parses positive integers", () => {
-    expect(parseOptionalSeed("7")).toBe(7);
-    expect(parseOptionalSeed("42")).toBe(42);
+    expect(parseSeedOption("7")).toBe(7);
+    expect(parseSeedOption("42")).toBe(42);
   });
 
-  it("parses leading-numeric strings as the parseInt prefix", () => {
-    // parseInt("123abc", 10) → 123 — not ideal but the documented behavior
-    // of the existing implementation. If the contract changes (e.g. reject
-    // garbage), update this test alongside the change.
-    expect(parseOptionalSeed("123abc")).toBe(123);
+  it("rejects leading-numeric strings instead of truncating to the parseInt prefix", () => {
+    expect(() => parseSeedOption("123abc")).toThrow("Seed must be an integer.");
   });
 
-  it("returns NaN for non-numeric strings (not undefined; the caller can detect)", () => {
-    // The function returns undefined ONLY for undefined input. A bad seed
-    // string surfaces as NaN so the caller can choose to error rather
-    // than silently resolve to the default.
-    const result = parseOptionalSeed("not-a-number");
-    expect(Number.isNaN(result)).toBe(true);
+  it("rejects non-numeric strings before they can serialize to null in manifests", () => {
+    expect(() => parseSeedOption("not-a-number")).toThrow("Seed must be an integer.");
+  });
+
+  it("rejects numbers outside JavaScript's safe integer range", () => {
+    expect(() => parseSeedOption("9007199254740992")).toThrow("Seed must be a safe integer.");
   });
 });
 


### PR DESCRIPTION
## Summary
- add a shared Commander parser for `--seed` that only accepts safe integer values
- wire the parser across image/audio/tts/video/sensor/svg/asciipng commands
- replace the old parseInt-prefix behavior so values like `12abc` and `not-a-number` fail before reaching the harness or manifest spine
- add helper and bin-level regression coverage

## Validation
- `pnpm exec prettier --check packages/cli/src/commands/shared.ts packages/cli/src/commands/image.ts packages/cli/src/commands/audio.ts packages/cli/src/commands/tts.ts packages/cli/src/commands/video.ts packages/cli/src/commands/sensor.ts packages/cli/src/commands/svg.ts packages/cli/src/commands/asciipng.ts packages/cli/test/shared.test.ts packages/cli/test/bin.test.ts`
- `pnpm --filter @wittgenstein/cli test -- shared.test.ts bin.test.ts`
- `pnpm --filter @wittgenstein/cli typecheck`
- `pnpm --filter @wittgenstein/cli lint`
- `git diff --check`
- manual: `node --import tsx packages/cli/src/cli-main.ts sensor "stable ECG trace" --dry-run --seed 12abc --out /tmp/witt-seed-test.json` exits 1 with a Commander argument error

## Notes
- No training code touched.