### PR TITLE
fix(cli): reject malformed numeric options

### DIFF
--- a/packages/cli/src/commands/animate-html.ts
+++ b/packages/cli/src/commands/animate-html.ts
@@ -2,7 +2,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import type { Command } from "commander";
 import { buildPlayableSlideshowHtml } from "@wittgenstein/codec-video";
-import { resolveExecutionRoot } from "./shared.js";
+import { parsePositiveNumberOption, resolveExecutionRoot } from "./shared.js";
 
 function collectSvgPath(value: string, previous: string[] | undefined): string[] {
   return [...(previous ?? []), value];
@@ -10,7 +10,7 @@ function collectSvgPath(value: string, previous: string[] | undefined): string[]
 
 export interface AnimateHtmlCommandOptions {
   out?: string;
-  durationSec?: string;
+  durationSec?: number;
   title?: string;
   once?: boolean;
   svg?: string[];
@@ -32,8 +32,18 @@ export function registerAnimateHtmlCommand(program: Command): void {
       "Write a self-contained HTML file: SVG slides animate in the browser via CSS (looping), no HyperFrames CLI.",
     )
     .requiredOption("--out <path>", "output .html path")
-    .option("--svg <path>", "SVG file as one slide (repeatable, order preserved)", collectSvgPath, [])
-    .option("--duration-sec <number>", "total seconds split evenly across slides", "6")
+    .option(
+      "--svg <path>",
+      "SVG file as one slide (repeatable, order preserved)",
+      collectSvgPath,
+      [],
+    )
+    .option(
+      "--duration-sec <number>",
+      "total seconds split evenly across slides",
+      parsePositiveNumberOption,
+      6,
+    )
     .option("--title <text>", "document title")
     .option("--once", "play the timeline once instead of looping")
     .action(async (options: AnimateHtmlCommandOptions) => {
@@ -49,8 +59,7 @@ export function registerAnimateHtmlCommand(program: Command): void {
         inlineSvgs.push(await readFile(abs, "utf8"));
       }
 
-      const totalSec = Number.parseFloat(options.durationSec ?? "6");
-      const durationsSec = resolveSlideSeconds(inlineSvgs.length, Number.isFinite(totalSec) ? totalSec : undefined);
+      const durationsSec = resolveSlideSeconds(inlineSvgs.length, options.durationSec);
 
       const html = buildPlayableSlideshowHtml({
         svgs: inlineSvgs,

--- a/packages/cli/src/commands/asciipng.ts
+++ b/packages/cli/src/commands/asciipng.ts
@@ -2,15 +2,16 @@ import type { Command } from "commander";
 import {
   runCodecCommand,
   parseOptionalSeed,
+  parsePositiveIntegerOption,
   parseSeedOption,
   type CommandRuntimeOptions,
 } from "./shared.js";
 import { ensureMinimaxApiKeyInteractive } from "./minimax-key.js";
 
 export interface AsciipngCommandOptions extends CommandRuntimeOptions {
-  columns?: string;
-  rows?: string;
-  cell?: string;
+  columns?: number;
+  rows?: number;
+  cell?: number;
   source?: string;
   minimaxModel?: string;
 }
@@ -24,9 +25,9 @@ export function registerAsciipngCommand(program: Command): void {
     )
     .option("--out <path>", "output path (default under artifacts/runs/…)")
     .option("--seed <number>", "seed", parseSeedOption)
-    .option("--columns <n>", "grid width in characters", "60")
-    .option("--rows <n>", "grid height in characters", "30")
-    .option("--cell <n>", "pixel size per character cell", "4")
+    .option("--columns <n>", "grid width in characters", parsePositiveIntegerOption, 60)
+    .option("--rows <n>", "grid height in characters", parsePositiveIntegerOption, 30)
+    .option("--cell <n>", "pixel size per character cell", parsePositiveIntegerOption, 4)
     .option(
       "--source <local|minimax>",
       "local: deterministic pseudo-glyph; minimax: call text chat, normalize lines, rasterize",
@@ -42,9 +43,6 @@ export function registerAsciipngCommand(program: Command): void {
     )
     .option("--config <path>", "config path")
     .action(async (prompt: string, options: AsciipngCommandOptions) => {
-      const columns = Number.parseInt(options.columns ?? "60", 10);
-      const rows = Number.parseInt(options.rows ?? "30", 10);
-      const cell = Number.parseInt(options.cell ?? "4", 10);
       const source = options.source === "minimax" ? "minimax" : "local";
 
       if (source === "minimax" && !options.dryRun) {
@@ -55,9 +53,9 @@ export function registerAsciipngCommand(program: Command): void {
         {
           modality: "asciipng",
           prompt,
-          columns: Number.isFinite(columns) ? columns : 60,
-          rows: Number.isFinite(rows) ? rows : 30,
-          cell: Number.isFinite(cell) ? cell : 4,
+          columns: options.columns ?? 60,
+          rows: options.rows ?? 30,
+          cell: options.cell ?? 4,
           source,
           ...(options.minimaxModel ? { minimaxModel: options.minimaxModel } : {}),
           out: options.out,

--- a/packages/cli/src/commands/audio.ts
+++ b/packages/cli/src/commands/audio.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 import {
   runCodecCommand,
   parseOptionalSeed,
+  parsePositiveNumberOption,
   parseSeedOption,
   type CommandRuntimeOptions,
 } from "./shared.js";
@@ -13,7 +14,7 @@ export function registerAudioCommand(program: Command): void {
     .description("Run the audio codec")
     .option("--route <route>", "Deprecated compatibility hint: speech | soundscape | music")
     .option("--ambient <ambient>", "auto | silence | rain | wind | city | forest | electronic")
-    .option("--duration-sec <number>", "requested duration in seconds")
+    .option("--duration-sec <number>", "requested duration in seconds", parsePositiveNumberOption)
     .option("--out <path>", "output path")
     .option("--seed <number>", "seed", parseSeedOption)
     .option("--dry-run", "skip the remote model call and exercise the manifest spine")
@@ -24,7 +25,7 @@ export function registerAudioCommand(program: Command): void {
         options: CommandRuntimeOptions & {
           route?: "speech" | "soundscape" | "music";
           ambient?: string;
-          durationSec?: string;
+          durationSec?: number;
         },
       ) => {
         await runCodecCommand(
@@ -35,7 +36,7 @@ export function registerAudioCommand(program: Command): void {
             seed: parseOptionalSeed(options.seed),
             route: options.route,
             ambient: options.ambient,
-            durationSec: options.durationSec ? Number.parseFloat(options.durationSec) : undefined,
+            durationSec: options.durationSec,
           },
           "wittgenstein audio",
           process.argv.slice(2),

--- a/packages/cli/src/commands/sensor.ts
+++ b/packages/cli/src/commands/sensor.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 import {
   runCodecCommand,
   parseOptionalSeed,
+  parsePositiveNumberOption,
   parseSeedOption,
   type CommandRuntimeOptions,
 } from "./shared.js";
@@ -12,8 +13,8 @@ export function registerSensorCommand(program: Command): void {
     .argument("<prompt>", "user prompt")
     .description("Run the sensor codec")
     .option("--signal <signal>", "ecg | temperature | gyro")
-    .option("--sample-rate-hz <number>", "requested sample rate")
-    .option("--duration-sec <number>", "requested duration in seconds")
+    .option("--sample-rate-hz <number>", "requested sample rate", parsePositiveNumberOption)
+    .option("--duration-sec <number>", "requested duration in seconds", parsePositiveNumberOption)
     .option("--out <path>", "output path")
     .option("--seed <number>", "seed", parseSeedOption)
     .option("--dry-run", "skip the remote model call and exercise the manifest spine")
@@ -23,8 +24,8 @@ export function registerSensorCommand(program: Command): void {
         prompt: string,
         options: CommandRuntimeOptions & {
           signal?: string;
-          sampleRateHz?: string;
-          durationSec?: string;
+          sampleRateHz?: number;
+          durationSec?: number;
         },
       ) => {
         await runCodecCommand(
@@ -34,10 +35,8 @@ export function registerSensorCommand(program: Command): void {
             out: options.out,
             seed: parseOptionalSeed(options.seed),
             signal: options.signal,
-            sampleRateHz: options.sampleRateHz
-              ? Number.parseFloat(options.sampleRateHz)
-              : undefined,
-            durationSec: options.durationSec ? Number.parseFloat(options.durationSec) : undefined,
+            sampleRateHz: options.sampleRateHz,
+            durationSec: options.durationSec,
           },
           "wittgenstein sensor",
           process.argv.slice(2),

--- a/packages/cli/src/commands/shared.ts
+++ b/packages/cli/src/commands/shared.ts
@@ -84,6 +84,32 @@ export function parseSeedOption(seed: string): number {
   return parsed;
 }
 
+export function parsePositiveNumberOption(value: string): number {
+  if (!/^(?:\d+|\d*\.\d+)$/.test(value)) {
+    throw new InvalidArgumentError("Value must be a positive number.");
+  }
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new InvalidArgumentError("Value must be a positive number.");
+  }
+
+  return parsed;
+}
+
+export function parsePositiveIntegerOption(value: string): number {
+  if (!/^\d+$/.test(value)) {
+    throw new InvalidArgumentError("Value must be a positive integer.");
+  }
+
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new InvalidArgumentError("Value must be a positive safe integer.");
+  }
+
+  return parsed;
+}
+
 export function parseOptionalSeed(seed: number | undefined): number | null | undefined {
   if (seed === undefined) {
     return undefined;

--- a/packages/cli/src/commands/tts.ts
+++ b/packages/cli/src/commands/tts.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 import {
   runCodecCommand,
   parseOptionalSeed,
+  parsePositiveNumberOption,
   parseSeedOption,
   type CommandRuntimeOptions,
 } from "./shared.js";
@@ -12,7 +13,7 @@ export function registerTtsCommand(program: Command): void {
     .argument("<prompt>", "prompt for a spoken output")
     .description("Run the speech/TTS route of the audio codec")
     .option("--ambient <ambient>", "auto | silence | rain | wind | city | forest | electronic")
-    .option("--duration-sec <number>", "requested duration in seconds")
+    .option("--duration-sec <number>", "requested duration in seconds", parsePositiveNumberOption)
     .option("--out <path>", "output path")
     .option("--seed <number>", "seed", parseSeedOption)
     .option("--dry-run", "skip the remote model call and exercise the manifest spine")
@@ -22,7 +23,7 @@ export function registerTtsCommand(program: Command): void {
         prompt: string,
         options: CommandRuntimeOptions & {
           ambient?: string;
-          durationSec?: string;
+          durationSec?: number;
         },
       ) => {
         await runCodecCommand(
@@ -33,7 +34,7 @@ export function registerTtsCommand(program: Command): void {
             seed: parseOptionalSeed(options.seed),
             route: "speech",
             ambient: options.ambient,
-            durationSec: options.durationSec ? Number.parseFloat(options.durationSec) : undefined,
+            durationSec: options.durationSec,
           },
           "wittgenstein tts",
           process.argv.slice(2),

--- a/packages/cli/src/commands/video.ts
+++ b/packages/cli/src/commands/video.ts
@@ -4,6 +4,7 @@ import type { Command } from "commander";
 import {
   runCodecCommand,
   parseOptionalSeed,
+  parsePositiveNumberOption,
   parseSeedOption,
   resolveExecutionRoot,
   type CommandRuntimeOptions,
@@ -14,7 +15,7 @@ function collectSvgPath(value: string, previous: string[] | undefined): string[]
 }
 
 export interface VideoCommandOptions extends CommandRuntimeOptions {
-  durationSec?: string;
+  durationSec?: number;
   svg?: string[];
 }
 
@@ -25,7 +26,7 @@ export function registerVideoCommand(program: Command): void {
     .description(
       "Run the video codec. With `--svg` (repeatable), embeds those SVG files as timed slides and skips the LLM.",
     )
-    .option("--duration-sec <number>", "requested duration in seconds")
+    .option("--duration-sec <number>", "requested duration in seconds", parsePositiveNumberOption)
     .option("--out <path>", "output path")
     .option("--seed <number>", "seed", parseSeedOption)
     .option(
@@ -51,7 +52,7 @@ export function registerVideoCommand(program: Command): void {
           prompt,
           out: options.out,
           seed: parseOptionalSeed(options.seed),
-          durationSec: options.durationSec ? Number.parseFloat(options.durationSec) : undefined,
+          durationSec: options.durationSec,
           ...(inlineSvgs.length > 0 ? { inlineSvgs } : {}),
         },
         "wittgenstein video",

--- a/packages/cli/test/bin.test.ts
+++ b/packages/cli/test/bin.test.ts
@@ -33,4 +33,45 @@ describe("@wittgenstein/cli bin", () => {
       "error: option '--seed <number>' argument '12abc' is invalid. Seed must be an integer.",
     );
   });
+
+  it("rejects malformed positive numeric options before running a codec", () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        "./bin/wittgenstein.js",
+        "sensor",
+        "stable ECG trace",
+        "--dry-run",
+        "--duration-sec",
+        "12abc",
+      ],
+      {
+        cwd: packageRoot,
+        encoding: "utf8",
+      },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain(
+      "error: option '--duration-sec <number>' argument '12abc' is invalid. Value must be a positive number.",
+    );
+  });
+
+  it("rejects malformed positive integer options before running a codec", () => {
+    const result = spawnSync(
+      process.execPath,
+      ["./bin/wittgenstein.js", "asciipng", "hello", "--columns", "10xyz"],
+      {
+        cwd: packageRoot,
+        encoding: "utf8",
+      },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain(
+      "error: option '--columns <n>' argument '10xyz' is invalid. Value must be a positive integer.",
+    );
+  });
 });

--- a/packages/cli/test/shared.test.ts
+++ b/packages/cli/test/shared.test.ts
@@ -3,6 +3,8 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   parseOptionalSeed,
+  parsePositiveIntegerOption,
+  parsePositiveNumberOption,
   parseSeedOption,
   resolveExecutionRoot,
 } from "../src/commands/shared.js";
@@ -38,6 +40,38 @@ describe("parseSeedOption", () => {
 
   it("rejects numbers outside JavaScript's safe integer range", () => {
     expect(() => parseSeedOption("9007199254740992")).toThrow("Seed must be a safe integer.");
+  });
+});
+
+describe("parsePositiveNumberOption", () => {
+  it("parses integer and decimal positive numbers", () => {
+    expect(parsePositiveNumberOption("7")).toBe(7);
+    expect(parsePositiveNumberOption("1.25")).toBe(1.25);
+    expect(parsePositiveNumberOption(".5")).toBe(0.5);
+  });
+
+  it("rejects truncated, zero, negative, and non-numeric values", () => {
+    expect(() => parsePositiveNumberOption("12abc")).toThrow("Value must be a positive number.");
+    expect(() => parsePositiveNumberOption("0")).toThrow("Value must be a positive number.");
+    expect(() => parsePositiveNumberOption("-1")).toThrow("Value must be a positive number.");
+    expect(() => parsePositiveNumberOption("nope")).toThrow("Value must be a positive number.");
+  });
+});
+
+describe("parsePositiveIntegerOption", () => {
+  it("parses positive integers", () => {
+    expect(parsePositiveIntegerOption("1")).toBe(1);
+    expect(parsePositiveIntegerOption("120")).toBe(120);
+  });
+
+  it("rejects truncated, decimal, zero, negative, and unsafe integer values", () => {
+    expect(() => parsePositiveIntegerOption("10xyz")).toThrow("Value must be a positive integer.");
+    expect(() => parsePositiveIntegerOption("1.5")).toThrow("Value must be a positive integer.");
+    expect(() => parsePositiveIntegerOption("0")).toThrow("Value must be a positive safe integer.");
+    expect(() => parsePositiveIntegerOption("-1")).toThrow("Value must be a positive integer.");
+    expect(() => parsePositiveIntegerOption("9007199254740992")).toThrow(
+      "Value must be a positive safe integer.",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- add strict shared parsers for positive numeric and positive integer CLI options
- wire duration, sample-rate, and ASCII-PNG sizing flags through Commander parsers instead of parseFloat/parseInt fallbacks
- add helper and bin-level regressions for malformed values

## Validation
- pnpm exec prettier --check packages/cli/src/commands/shared.ts packages/cli/src/commands/animate-html.ts packages/cli/src/commands/asciipng.ts packages/cli/src/commands/audio.ts packages/cli/src/commands/tts.ts packages/cli/src/commands/video.ts packages/cli/src/commands/sensor.ts packages/cli/test/shared.test.ts packages/cli/test/bin.test.ts
- pnpm --filter @wittgenstein/cli test -- shared.test.ts bin.test.ts
- pnpm --filter @wittgenstein/cli typecheck
- pnpm --filter @wittgenstein/cli lint
- git diff --check
- manual: sensor bad --sample-rate-hz now exits 1 before codec execution
- manual: asciipng bad --columns now exits 1 before codec execution
