### PR TITLE
fix(cli): enforce full node engine floor

### DIFF
--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -19,6 +19,9 @@ import { runtimeTierReadiness } from "../tiers.js";
 
 type DoctorCheck = RuntimeProbeReceipt;
 
+const NODE_ENGINE_MINIMUM = [20, 19, 0] as const;
+const HYPERFRAMES_CLI_NODE_MINIMUM = [22, 0, 0] as const;
+
 interface DoctorFileCheck {
   status: "ok" | "missing" | "invalid" | "skipped";
   path?: string;
@@ -72,14 +75,14 @@ export function registerDoctorCommand(program: Command): void {
         cwd: workspaceRoot,
         ...(options.config ? { configPath: options.config } : {}),
       });
-      const nodeMajor = Number.parseInt(process.versions.node.split(".")[0] ?? "0", 10);
+      const nodeSatisfied = isNodeVersionAtLeast(process.versions.node, NODE_ENGINE_MINIMUM);
 
       console.log(
         JSON.stringify(
           {
-            ok: nodeMajor >= 20,
+            ok: nodeSatisfied,
             nodeVersion: process.version,
-            nodeSatisfied: nodeMajor >= 20,
+            nodeSatisfied,
             hasApiKey: Boolean(process.env[config.llm.apiKeyEnv]),
             llmProvider: config.llm.provider,
             llmModel: config.llm.model,
@@ -138,8 +141,7 @@ function checkVideoRenderDependencies(): VideoRenderDoctor {
 }
 
 function checkNodeForHyperframesCli(): DoctorCheck {
-  const major = Number.parseInt(process.versions.node.split(".")[0] ?? "0", 10);
-  if (major >= 22) {
+  if (isNodeVersionAtLeast(process.versions.node, HYPERFRAMES_CLI_NODE_MINIMUM)) {
     return createRuntimeProbeReceipt({
       status: "ok",
       runtime: "node",
@@ -155,6 +157,42 @@ function checkNodeForHyperframesCli(): DoctorCheck {
     message:
       "HyperFrames CLI currently requires Node.js >=22. Use the distilled internal backend on Node 20, or run the npx backend under Node 22+.",
   });
+}
+
+export function isNodeVersionAtLeast(
+  version: string,
+  minimum: readonly [number, number, number],
+): boolean {
+  const parsed = parseNodeVersion(version);
+  if (!parsed) {
+    return false;
+  }
+
+  const [major, minor, patch] = parsed;
+  const [minimumMajor, minimumMinor, minimumPatch] = minimum;
+
+  if (major !== minimumMajor) {
+    return major > minimumMajor;
+  }
+  if (minor !== minimumMinor) {
+    return minor > minimumMinor;
+  }
+
+  return patch >= minimumPatch;
+}
+
+function parseNodeVersion(version: string): readonly [number, number, number] | null {
+  const match = /^v?(\d+)\.(\d+)\.(\d+)/.exec(version);
+  if (!match) {
+    return null;
+  }
+
+  const parsed = match.slice(1).map((part) => Number(part));
+  if (parsed.some((part) => !Number.isSafeInteger(part))) {
+    return null;
+  }
+
+  return parsed as [number, number, number];
 }
 
 function readVideoBackend(): "distilled-internal" | "npx-cli" {

--- a/packages/cli/test/doctor.test.ts
+++ b/packages/cli/test/doctor.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
+import { isNodeVersionAtLeast } from "../src/commands/doctor.js";
 
 const testDir = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolve(testDir, "..");
@@ -18,6 +19,14 @@ afterEach(() => {
 });
 
 describe("doctor tier readiness", () => {
+  it("checks the full semver floor for Node runtime gates", () => {
+    expect(isNodeVersionAtLeast("v20.18.9", [20, 19, 0])).toBe(false);
+    expect(isNodeVersionAtLeast("20.19.0", [20, 19, 0])).toBe(true);
+    expect(isNodeVersionAtLeast("v20.19.1", [20, 19, 0])).toBe(true);
+    expect(isNodeVersionAtLeast("v21.0.0", [20, 19, 0])).toBe(true);
+    expect(isNodeVersionAtLeast("not-a-node-version", [20, 19, 0])).toBe(false);
+  });
+
   it("prints the current tier readiness table", () => {
     const doctor = runDoctor();
 

--- a/scripts/verify-env.ts
+++ b/scripts/verify-env.ts
@@ -8,15 +8,42 @@ export interface EnvironmentReport {
   hasPackageJson: boolean;
 }
 
-export async function verifyEnvironment(cwd = process.cwd()): Promise<EnvironmentReport> {
-  const nodeMajor = Number.parseInt(process.versions.node.split(".")[0] ?? "0", 10);
+const NODE_ENGINE_MINIMUM = [20, 19, 0] as const;
 
+export async function verifyEnvironment(cwd = process.cwd()): Promise<EnvironmentReport> {
   return {
     nodeVersion: process.version,
-    nodeSatisfied: nodeMajor >= 20,
+    nodeSatisfied: isNodeVersionAtLeast(process.versions.node, NODE_ENGINE_MINIMUM),
     hasPnpmLockfile: await exists(resolve(cwd, "pnpm-lock.yaml")),
     hasPackageJson: await exists(resolve(cwd, "package.json")),
   };
+}
+
+function isNodeVersionAtLeast(
+  version: string,
+  minimum: readonly [number, number, number],
+): boolean {
+  const match = /^v?(\d+)\.(\d+)\.(\d+)/.exec(version);
+  if (!match) {
+    return false;
+  }
+
+  const parsed = match.slice(1).map((part) => Number(part));
+  if (parsed.some((part) => !Number.isSafeInteger(part))) {
+    return false;
+  }
+
+  const [major, minor, patch] = parsed;
+  const [minimumMajor, minimumMinor, minimumPatch] = minimum;
+
+  if (major !== minimumMajor) {
+    return major > minimumMajor;
+  }
+  if (minor !== minimumMinor) {
+    return minor > minimumMinor;
+  }
+
+  return patch >= minimumPatch;
 }
 
 async function exists(filePath: string): Promise<boolean> {


### PR DESCRIPTION
## Summary
- make `wittgenstein doctor` check the full Node engine floor (`>=20.19.0`) instead of only major version >=20
- use the same semver helper for the HyperFrames Node >=22 gate
- align the bootstrap environment report with the repo engine floor
- add boundary coverage for Node 20.18.9 vs 20.19.0

## Validation
- pnpm exec prettier --check packages/cli/src/commands/doctor.ts packages/cli/test/doctor.test.ts scripts/verify-env.ts
- pnpm exec eslint packages/cli/src/commands/doctor.ts packages/cli/test/doctor.test.ts scripts/verify-env.ts
- pnpm --filter @wittgenstein/cli test -- doctor.test.ts
- pnpm --filter @wittgenstein/cli typecheck
- pnpm tsx scripts/bootstrap.ts --json
- git diff --check
