### PR TITLE
feat(training): add data sweep receipt floor

### DIFF
--- a/.dvc/.gitignore
+++ b/.dvc/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/tmp

--- a/.dvc/config
+++ b/.dvc/config
@@ -1,0 +1,4 @@
+[core]
+    remote = local-smoke
+[remote "local-smoke"]
+    url = research/training/data/.dvc-cache

--- a/.dvcignore
+++ b/.dvcignore
@@ -1,0 +1,5 @@
+# DVC itself should not scan generated run artifacts or package caches.
+artifacts/runs/
+artifacts/benchmarks/
+node_modules/
+research/training/_shared/runs/

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ artifacts/m1b-audit/*
 # Local CPU/GPU training smoke outputs; receipts/checkpoints are committed only
 # when deliberately copied into an artifact bundle.
 research/training/_shared/runs/
+research/training/data/snapshots/*.dataset.json
 
 # Local image-adapter training outputs (keep raw data private / large)
 data/image_adapter/train/*.jsonl

--- a/bench/gpu/smoke-sweep.yaml
+++ b/bench/gpu/smoke-sweep.yaml
@@ -1,0 +1,40 @@
+{
+  "sweepId": "phase1-smoke",
+  "tracker": "https://github.com/p-to-q/wittgenstein/issues/400",
+  "rows": [
+    {
+      "rowId": "tokenizer-stdlib-smoke",
+      "subprogram": "tokenizer",
+      "datasetSnapshot": {
+        "outPath": "artifacts/benchmarks/training-data-snapshots/synthetic-smoke.dataset.json",
+        "snapshotId": "synthetic-smoke-2026q2",
+        "dvcPath": "research/training/data/snapshots/synthetic-smoke.dvc",
+        "name": "synthetic-manifest-smoke",
+        "split": "smoke",
+        "role": "smoke",
+        "license": "permissive",
+        "sampleCount": 1,
+        "remoteName": "local-smoke",
+        "repoRevLock": "smoke-local"
+      },
+      "command": ["python3", "-m", "research.training._shared.smoke_manifest"]
+    },
+    {
+      "rowId": "tokenizer-training-smoke",
+      "subprogram": "tokenizer",
+      "datasetSnapshot": {
+        "outPath": "artifacts/benchmarks/training-data-snapshots/synthetic-smoke.dataset.json",
+        "snapshotId": "synthetic-smoke-2026q2",
+        "dvcPath": "research/training/data/snapshots/synthetic-smoke.dvc",
+        "name": "synthetic-manifest-smoke",
+        "split": "smoke",
+        "role": "smoke",
+        "license": "permissive",
+        "sampleCount": 1,
+        "remoteName": "local-smoke",
+        "repoRevLock": "smoke-local"
+      },
+      "command": ["python3", "-m", "research.training.tokenizer.smoke_test"]
+    }
+  ]
+}

--- a/bench/gpu/sweep.py
+++ b/bench/gpu/sweep.py
@@ -1,0 +1,318 @@
+"""Maintainer-run Phase 1 training sweep harness.
+
+This is the #400 receipt floor, not managed GPU CI. It reads a JSON-subset
+YAML spec, dispatches each row command locally, and writes one sweep manifest
+that indexes DVC dataset snapshots, training-run manifests, and tracker
+receipts.
+
+Run the stdlib smoke:
+    python3 bench/gpu/sweep.py --spec bench/gpu/smoke-sweep.yaml
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from research.training._shared.data_versioning import (  # noqa: E402
+    TrainingDvcRemote,
+    build_dataset_snapshot_from_dvc,
+    write_training_dataset_snapshot,
+)
+from research.training._shared.sweep_manifest import (  # noqa: E402
+    TRAINING_SWEEP_MANIFEST_SCHEMA_VERSION,
+    TrainingSweepManifest,
+    TrainingSweepRow,
+    TrainingSweepSource,
+    blocked_sweep_row,
+    build_passed_sweep_row,
+    failed_sweep_row,
+    summarize_sweep_rows,
+    write_training_sweep_manifest,
+)
+from research.training._shared.manifest import sha256_file, utc_now_iso  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run a Wittgenstein training sweep spec.")
+    parser.add_argument("--spec", type=Path, default=REPO_ROOT / "bench" / "gpu" / "smoke-sweep.yaml")
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path("artifacts") / "benchmarks" / "training-sweep.json",
+        help="Sweep manifest output path.",
+    )
+    parser.add_argument(
+        "--run-root",
+        type=Path,
+        default=Path("artifacts") / "benchmarks" / "training-sweep-runs",
+        help="Local run-output root passed to stdlib smoke commands.",
+    )
+    parser.add_argument(
+        "--keep-going",
+        action="store_true",
+        help="Continue after a failed row and record the failure in the sweep manifest.",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Return nonzero when any row fails. By default the harness writes the receipt and exits 0.",
+    )
+    args = parser.parse_args()
+
+    spec_path = _resolve(args.spec)
+    spec = _load_yamlish(spec_path)
+    rows = spec.get("rows")
+    if not isinstance(rows, list) or not rows:
+        raise SystemExit("sweep spec must contain a nonempty rows list")
+
+    emitted_rows: list[TrainingSweepRow] = []
+    for raw_row in rows:
+        if not isinstance(raw_row, dict):
+            raise SystemExit("each sweep row must be an object")
+        row_id = _required_str(raw_row, "rowId")
+        subprogram = _required_str(raw_row, "subprogram")
+        command = _required_string_list(raw_row, "command")
+        dataset_snapshot_path = _write_dataset_snapshot(raw_row)
+        row_run_root = _resolve(args.run_root) / row_id
+        dispatch_command = _dispatch_command(command, row_run_root, row_id)
+        try:
+            result = subprocess.run(
+                dispatch_command,
+                cwd=str(REPO_ROOT),
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            summary = _parse_row_receipts(result.stdout, row_id)
+            emitted_rows.append(
+                build_passed_sweep_row(
+                    row_id=row_id,
+                    subprogram=subprogram,
+                    command=dispatch_command,
+                    dataset_snapshot_path=dataset_snapshot_path,
+                    training_manifest_path=_resolve(Path(summary["manifestPath"])),
+                    experiment_receipt_path=_resolve(Path(summary["experimentReceiptPath"])),
+                    metrics=[{"name": "loss", "value": 0.0, "unit": "loss", "higherIsBetter": False}],
+                )
+            )
+            emitted_rows[-1] = _relativize_row_paths(emitted_rows[-1])
+        except Exception as exc:
+            message = _error_message(exc)
+            blocked_code = _blocked_row_error_code(message)
+            row_factory = blocked_sweep_row if blocked_code else failed_sweep_row
+            emitted_rows.append(
+                row_factory(
+                    row_id=row_id,
+                    subprogram=subprogram,
+                    command=dispatch_command,
+                    dataset_snapshot_path=dataset_snapshot_path,
+                    code=blocked_code or type(exc).__name__,
+                    message=message,
+                )
+            )
+            emitted_rows[-1] = _relativize_row_paths(emitted_rows[-1])
+            if not args.keep_going and args.strict:
+                break
+
+    manifest = TrainingSweepManifest(
+        schemaVersion=TRAINING_SWEEP_MANIFEST_SCHEMA_VERSION,
+        sweepId=_required_str(spec, "sweepId"),
+        generatedAt=utc_now_iso(),
+        tracker=spec.get("tracker"),
+        source=TrainingSweepSource(specPath=_display_path(spec_path).as_posix(), specSha256=sha256_file(spec_path)),
+        rows=emitted_rows,
+        summary=summarize_sweep_rows(emitted_rows),
+    )
+    write_training_sweep_manifest(manifest, _resolve(args.out))
+    ok = manifest.summary.failed == 0 and manifest.summary.blocked == 0
+    print(json.dumps({"ok": ok, "manifestPath": str(_resolve(args.out))}, indent=2))
+    return 1 if args.strict and not ok else 0
+
+
+def _write_dataset_snapshot(raw_row: dict[str, Any]) -> Path:
+    raw_snapshot = raw_row.get("datasetSnapshot")
+    if not isinstance(raw_snapshot, dict):
+        raise ValueError("row.datasetSnapshot must be an object")
+    out_path = _resolve(Path(_required_str(raw_snapshot, "outPath")))
+    remote_name = raw_snapshot.get("remoteName")
+    remote_url = raw_snapshot.get("remoteUrl")
+    snapshot = build_dataset_snapshot_from_dvc(
+        snapshot_id=_required_str(raw_snapshot, "snapshotId"),
+        dvc_path=_resolve(Path(_required_str(raw_snapshot, "dvcPath"))),
+        dataset_name=_required_str(raw_snapshot, "name"),
+        split=_required_str(raw_snapshot, "split"),
+        role=_required_str(raw_snapshot, "role"),
+        license=_required_str(raw_snapshot, "license"),
+        uri=raw_snapshot.get("uri"),
+        sample_count=raw_snapshot.get("sampleCount"),
+        dead_link_rate=raw_snapshot.get("deadLinkRate"),
+        remote=(
+            TrainingDvcRemote(name=remote_name, url=remote_url)
+            if isinstance(remote_name, str) and remote_name
+            else None
+        ),
+        repo_rev_lock=raw_snapshot.get("repoRevLock"),
+        repo_root=REPO_ROOT,
+    )
+    write_training_dataset_snapshot(snapshot, out_path)
+    return out_path
+
+
+def _dispatch_command(command: list[str], run_root: Path, row_id: str) -> list[str]:
+    if command[:3] == ["python3", "-m", "research.training._shared.smoke_manifest"]:
+        run_root_arg = _display_path(_resolve(run_root)).as_posix()
+        return [
+            *command,
+            "--out-root",
+            run_root_arg,
+            "--run-id",
+            row_id,
+        ]
+    return command
+
+
+def _relativize_row_paths(row: TrainingSweepRow) -> TrainingSweepRow:
+    return TrainingSweepRow(
+        rowId=row.rowId,
+        subprogram=row.subprogram,
+        status=row.status,
+        dataset=_relativize_path_fields(row.dataset, {"snapshotPath"}),
+        command=[_display_arg(part) for part in row.command],
+        config=(
+            _relativize_path_fields(row.config, {"path"}) if row.config is not None else None
+        ),
+        trainingRun=(
+            _relativize_path_fields(row.trainingRun, {"manifestPath"})
+            if row.trainingRun is not None
+            else None
+        ),
+        experiment=(
+            _relativize_path_fields(row.experiment, {"receiptPath"})
+            if row.experiment is not None
+            else None
+        ),
+        metrics=row.metrics,
+        error=row.error,
+    )
+
+
+def _relativize_path_fields(payload: dict[str, str], path_fields: set[str]) -> dict[str, str]:
+    updated = dict(payload)
+    for key in path_fields:
+        value = updated.get(key)
+        if value:
+            updated[key] = _display_path(Path(value)).as_posix()
+    return updated
+
+
+def _display_arg(arg: str) -> str:
+    return _display_path(Path(arg)).as_posix() if arg.startswith(str(REPO_ROOT)) else arg
+
+
+def _parse_row_receipts(stdout: str, row_id: str) -> dict[str, Any]:
+    start = stdout.find("{")
+    end = stdout.rfind("}")
+    if start == -1 or end == -1 or end < start:
+        raise ValueError("row command did not print a JSON summary")
+    payload = json.loads(stdout[start : end + 1])
+    if "run_dir" in payload and "manifestPath" not in payload:
+        run_dir = Path(payload["run_dir"])
+        manifest_path = run_dir / "ckpts" / "final.manifest.json"
+        checkpoint_path = run_dir / "ckpts" / "final.pt"
+        payload = {
+            **payload,
+            "manifestPath": str(manifest_path),
+            "checkpointPath": str(checkpoint_path),
+            "experimentReceiptPath": str(run_dir / "experiment.json"),
+        }
+    for key in ("manifestPath", "checkpointPath", "experimentReceiptPath"):
+        if not isinstance(payload.get(key), str) or not payload[key]:
+            raise ValueError(f"row {row_id} summary missing {key}")
+    return payload
+
+
+def _load_yamlish(path: Path) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8")
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        try:
+            import yaml  # type: ignore
+
+            payload = yaml.safe_load(text)
+        except ImportError as exc:
+            raise RuntimeError(
+                f"{path} is not JSON-subset YAML; install PyYAML in the training env for full YAML"
+            ) from exc
+    if not isinstance(payload, dict):
+        raise ValueError("sweep spec must be a mapping")
+    return payload
+
+
+def _resolve(path: Path) -> Path:
+    return path if path.is_absolute() else REPO_ROOT / path
+
+
+def _display_path(path: Path) -> Path:
+    resolved = path.resolve() if path.is_absolute() else (REPO_ROOT / path).resolve()
+    try:
+        return resolved.relative_to(REPO_ROOT)
+    except ValueError:
+        return path
+
+
+def _required_str(payload: dict[str, Any], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{key} must be a nonempty string")
+    return value
+
+
+def _required_string_list(payload: dict[str, Any], key: str) -> list[str]:
+    value = payload.get(key)
+    if not isinstance(value, list) or not value:
+        raise ValueError(f"{key} must be a nonempty list")
+    for index, item in enumerate(value):
+        if not isinstance(item, str) or not item:
+            raise ValueError(f"{key}[{index}] must be a nonempty string")
+    return value
+
+
+def _error_message(exc: Exception) -> str:
+    if isinstance(exc, subprocess.CalledProcessError):
+        stderr = (exc.stderr or "").strip()
+        stdout = (exc.stdout or "").strip()
+        return stderr or stdout or str(exc)
+    return str(exc)
+
+
+def _blocked_row_error_code(message: str) -> str | None:
+    lowered = message.lower()
+    missing_modules = {
+        "torch": "MISSING_TORCH",
+        "torchvision": "MISSING_TORCHVISION",
+        "dvc": "MISSING_DVC",
+    }
+    for module, code in missing_modules.items():
+        if f"no module named '{module}'" in lowered or f'no module named "{module}"' in lowered:
+            return code
+    if "requires torch in the lab environment" in lowered:
+        return "MISSING_TORCH"
+    if "no gpu available" in lowered or "cuda is not available" in lowered:
+        return "NO_GPU"
+    if "dvc" in lowered and any(marker in lowered for marker in ("remote", "credential", "pull")):
+        return "DVC_REMOTE_UNAVAILABLE"
+    return None
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/contributing/training-setup.md
+++ b/docs/contributing/training-setup.md
@@ -83,18 +83,32 @@ The three manifest surfaces are intentionally separate:
 Datasets will be pinned with [DVC](https://dvc.org/) so a training receipt
 points to an exact data SHA, not a moving HF dataset id.
 
-The DVC remote does not exist yet. It is tracked by
-[#400](https://github.com/p-to-q/wittgenstein/issues/400), which owns the
-dataset snapshots, remote-storage choice, and sweep-manifest shape for
-Phase 1 training. Once #400 lands, configure the remote before running:
+The repo includes the #400 executable smoke floor:
+
+- `.dvc/config` with a local-smoke remote only
+- `research/training/data/snapshots/synthetic-smoke.dvc`
+- `docs/training/data.md` for the dataset-snapshot and refresh policy
+- `bench/gpu/sweep.py` for maintainer-run sweep receipts
+
+The smoke file itself is checked in; no DVC pull is required for the stdlib
+smoke sweep. The real lab remote does not exist yet. ImageNet / CC12M / COCO
+pointers, remote-storage choice, and credentials still need model-owner review
+through [#400](https://github.com/p-to-q/wittgenstein/issues/400) and #435. Once
+the lab remote exists, configure it before running real training:
 
 ```bash
 cd research/training
 dvc pull
 ```
 
-Until that remote exists, `dvc pull` is a placeholder command, not an
-operational checkout step.
+Until that remote exists, `dvc pull` is not an operational ImageNet / CC12M /
+COCO setup step.
+
+Run the smoke sweep without GPU or DVC installed:
+
+```bash
+python3 bench/gpu/sweep.py --spec bench/gpu/smoke-sweep.yaml
+```
 
 ## CI guards
 

--- a/docs/training/data.md
+++ b/docs/training/data.md
@@ -1,0 +1,74 @@
+# Training Data Versioning
+
+Issue [#400](https://github.com/p-to-q/wittgenstein/issues/400) owns the
+Phase 1 data-versioning and GPU-sweep receipt surface. The current repo
+provides the executable contract floor; lab owners still need to publish the
+real ImageNet / CC12M / COCO snapshots and remote credentials.
+
+## Receipt Shape
+
+Dataset access is DVC-shaped, but DVC checksums are not the canonical
+Wittgenstein dataset identity. Each dataset snapshot writes a sibling receipt:
+
+- `schemaVersion: "witt.training.dataset-snapshot/v0.1"`
+- dataset name, split, role, URI, license posture, sample count, and optional
+  CC12M dead-link rate
+- DVC pointer path, `repoRevLock`, optional remote name/URL, and DVC
+  `outs[]` fields (`path`, `size`, `md5` / `etag` / `checksum`)
+- a Wittgenstein `sha256` over the normalized dataset + DVC receipt payload
+
+Training runs continue to emit `witt.training.run-manifest/v0.1`; sweep rows
+point at the dataset snapshot receipt and the training-run manifest. The
+training manifest stays strict and does not absorb DVC's full pointer payload.
+
+## Smoke Snapshot
+
+The checked-in smoke pointer is deliberately tiny:
+
+```text
+research/training/data/snapshots/synthetic-smoke.dvc
+research/training/data/smoke/synthetic-manifest-smoke.txt
+```
+
+It proves the contract without requiring DVC, S3/R2 credentials, ImageNet, or
+GPU access. Generate the smoke dataset snapshot and sweep manifest under
+`artifacts/benchmarks/` with:
+
+```bash
+python3 bench/gpu/sweep.py --spec bench/gpu/smoke-sweep.yaml
+```
+
+The command writes generated receipts under `artifacts/benchmarks/`, which are
+ignored like other benchmark output.
+
+## Real Snapshot Policy
+
+Before starting publishable Phase 1 training, a model owner must add DVC
+pointers for:
+
+- ImageNet train and val
+- CC12M filtered snapshot, named by quarter such as `cc12m-2026q2`, with
+  `deadLinkRate`
+- COCO 2017 train and val for eval and caption-conditioned rows
+
+Each pointer must resolve through the chosen lab remote (S3 or Cloudflare R2)
+and the generated dataset snapshot receipt must record `repoRevLock`. The
+remote URL can be documented without credentials; credentials stay outside the
+repo.
+
+## Refresh Policy
+
+ImageNet and COCO snapshots should be treated as stable unless the lab remote is
+rebuilt. CC12M is URL-backed and decays over time, so each refresh gets a new
+snapshot id (`cc12m-YYYYqN`) and records the observed dead-link rate. Do not
+silently replace an existing CC12M pointer with a fresher crawl.
+
+## Owner Review
+
+#435 still needs explicit owner review for:
+
+- remote storage choice and retention policy
+- dataset license posture and publishability implications
+- whether DVC `md5` / `etag` fields are sufficient source evidence for each
+  remote
+- the final managed-vs-maintainer-run GPU sweep policy

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -4,6 +4,7 @@ export * from "./modality.js";
 export * from "./manifest.js";
 export * from "./training-manifest.js";
 export * from "./training-experiment.js";
+export * from "./sweep-manifest.js";
 export * from "./trackers.js";
 export * as codecV2 from "./codec/v2/index.js";
 export * as llm from "./llm/index.js";

--- a/packages/schemas/src/sweep-manifest.ts
+++ b/packages/schemas/src/sweep-manifest.ts
@@ -1,0 +1,188 @@
+import { z } from "zod";
+import {
+  TrainingRunConfigReferenceSchema,
+  TrainingRunEvalMetricSchema,
+  TrainingRunManifestReferenceSchema,
+  TrainingSubprogramSchema,
+} from "./training-manifest.js";
+import { TrainingExperimentReferenceSchema } from "./training-experiment.js";
+
+const Sha256Schema = z.string().regex(/^[a-f0-9]{64}$/);
+const TimestampSchema = z.string().datetime({ offset: true });
+
+export const TrainingDatasetSnapshotSchemaVersion = "witt.training.dataset-snapshot/v0.1" as const;
+export const TrainingSweepManifestSchemaVersion = "witt.training.sweep-manifest/v0.1" as const;
+
+export const TrainingDatasetRoleSchema = z.enum(["train", "validation", "eval", "smoke"]);
+export const TrainingDatasetLicenseSchema = z.enum([
+  "permissive",
+  "research-only",
+  "restricted",
+  "unknown",
+]);
+
+export const TrainingDvcOutputSchema = z
+  .object({
+    path: z.string().min(1),
+    size: z.number().int().nonnegative().optional(),
+    md5: z.string().min(1).optional(),
+    etag: z.string().min(1).optional(),
+    checksum: z.string().min(1).optional(),
+    hash: z.string().min(1).optional(),
+  })
+  .strict()
+  .superRefine((output, ctx) => {
+    if (!output.md5 && !output.etag && !output.checksum) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["checksum"],
+        message: "DVC outputs must carry at least one checksum field.",
+      });
+    }
+  });
+
+export const TrainingDvcRemoteSchema = z
+  .object({
+    name: z.string().min(1),
+    url: z.string().min(1).optional(),
+  })
+  .strict();
+
+export const TrainingDatasetSnapshotSchema = z
+  .object({
+    schemaVersion: z.literal(TrainingDatasetSnapshotSchemaVersion),
+    snapshotId: z.string().min(1),
+    generatedAt: TimestampSchema,
+    dataset: z
+      .object({
+        name: z.string().min(1),
+        split: z.string().min(1),
+        role: TrainingDatasetRoleSchema,
+        uri: z.string().min(1).optional(),
+        license: TrainingDatasetLicenseSchema,
+        sampleCount: z.number().int().nonnegative().optional(),
+        deadLinkRate: z.number().finite().min(0).max(1).optional(),
+      })
+      .strict(),
+    dvc: z
+      .object({
+        path: z.string().min(1),
+        repoRevLock: z.string().min(1),
+        remote: TrainingDvcRemoteSchema.optional(),
+        outs: z.array(TrainingDvcOutputSchema).min(1),
+      })
+      .strict(),
+    sha256: Sha256Schema,
+  })
+  .strict();
+
+export const TrainingSweepRowStatusSchema = z.enum([
+  "planned",
+  "running",
+  "passed",
+  "failed",
+  "skipped",
+  "blocked",
+]);
+
+export const TrainingSweepDatasetReferenceSchema = z
+  .object({
+    snapshotId: z.string().min(1),
+    snapshotPath: z.string().min(1),
+    snapshotSha256: Sha256Schema,
+    datasetSha256: Sha256Schema,
+  })
+  .strict();
+
+export const TrainingSweepErrorSchema = z
+  .object({
+    code: z.string().min(1),
+    message: z.string().min(1),
+  })
+  .strict();
+
+export const TrainingSweepRowSchema = z
+  .object({
+    rowId: z.string().min(1),
+    subprogram: TrainingSubprogramSchema,
+    status: TrainingSweepRowStatusSchema,
+    dataset: TrainingSweepDatasetReferenceSchema,
+    command: z.array(z.string().min(1)).min(1),
+    config: TrainingRunConfigReferenceSchema.optional(),
+    trainingRun: TrainingRunManifestReferenceSchema.optional(),
+    experiment: TrainingExperimentReferenceSchema.optional(),
+    metrics: z.array(TrainingRunEvalMetricSchema).optional(),
+    error: TrainingSweepErrorSchema.optional(),
+  })
+  .strict()
+  .superRefine((row, ctx) => {
+    if (row.status === "passed" && !row.trainingRun) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["trainingRun"],
+        message: "passed sweep rows must reference a training-run manifest.",
+      });
+    }
+    if ((row.status === "failed" || row.status === "blocked") && !row.error) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["error"],
+        message: "failed or blocked sweep rows must carry a structured error.",
+      });
+    }
+  });
+
+export const TrainingSweepSummarySchema = z
+  .object({
+    total: z.number().int().nonnegative(),
+    passed: z.number().int().nonnegative(),
+    failed: z.number().int().nonnegative(),
+    skipped: z.number().int().nonnegative(),
+    blocked: z.number().int().nonnegative(),
+  })
+  .strict();
+
+export const TrainingSweepManifestSchema = z
+  .object({
+    schemaVersion: z.literal(TrainingSweepManifestSchemaVersion),
+    sweepId: z.string().min(1),
+    generatedAt: TimestampSchema,
+    tracker: z.string().url().optional(),
+    source: z
+      .object({
+        specPath: z.string().min(1),
+        specSha256: Sha256Schema,
+      })
+      .strict(),
+    rows: z.array(TrainingSweepRowSchema).min(1),
+    summary: TrainingSweepSummarySchema,
+  })
+  .strict()
+  .superRefine((manifest, ctx) => {
+    const counts = {
+      total: manifest.rows.length,
+      passed: manifest.rows.filter((row) => row.status === "passed").length,
+      failed: manifest.rows.filter((row) => row.status === "failed").length,
+      skipped: manifest.rows.filter((row) => row.status === "skipped").length,
+      blocked: manifest.rows.filter((row) => row.status === "blocked").length,
+    };
+    for (const [key, expected] of Object.entries(counts)) {
+      const actual = manifest.summary[key as keyof typeof counts];
+      if (actual !== expected) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["summary", key],
+          message: `summary.${key} must equal the number of matching sweep rows.`,
+        });
+      }
+    }
+  });
+
+export type TrainingDatasetRole = z.infer<typeof TrainingDatasetRoleSchema>;
+export type TrainingDatasetLicense = z.infer<typeof TrainingDatasetLicenseSchema>;
+export type TrainingDvcOutput = z.infer<typeof TrainingDvcOutputSchema>;
+export type TrainingDatasetSnapshot = z.infer<typeof TrainingDatasetSnapshotSchema>;
+export type TrainingSweepRowStatus = z.infer<typeof TrainingSweepRowStatusSchema>;
+export type TrainingSweepDatasetReference = z.infer<typeof TrainingSweepDatasetReferenceSchema>;
+export type TrainingSweepRow = z.infer<typeof TrainingSweepRowSchema>;
+export type TrainingSweepManifest = z.infer<typeof TrainingSweepManifestSchema>;

--- a/packages/schemas/src/trackers.ts
+++ b/packages/schemas/src/trackers.ts
@@ -47,6 +47,8 @@ export const TRACKERS = {
   decoderDeliveryDecision: issueUrl(402),
   /** `wittgenstein install <tier>` CLI + doctor tier readiness. */
   installTierCli: issueUrl(403),
+  /** DVC dataset snapshots + maintainer-run GPU sweep receipts. */
+  trainingDataSweepInfra: issueUrl(400),
 } as const;
 
 /**

--- a/packages/schemas/test/fixtures/training-dataset-snapshot.json
+++ b/packages/schemas/test/fixtures/training-dataset-snapshot.json
@@ -1,0 +1,29 @@
+{
+  "schemaVersion": "witt.training.dataset-snapshot/v0.1",
+  "snapshotId": "synthetic-smoke-2026q2",
+  "generatedAt": "2026-05-31T12:00:00Z",
+  "dataset": {
+    "name": "synthetic-manifest-smoke",
+    "split": "smoke",
+    "role": "smoke",
+    "uri": "dvc://research/training/data/snapshots/synthetic-smoke.dataset.json",
+    "license": "permissive",
+    "sampleCount": 1
+  },
+  "dvc": {
+    "path": "research/training/data/snapshots/synthetic-smoke.dvc",
+    "repoRevLock": "smoke-local",
+    "remote": {
+      "name": "local-smoke"
+    },
+    "outs": [
+      {
+        "path": "research/training/data/smoke/synthetic-manifest-smoke.txt",
+        "size": 46,
+        "md5": "4a8685c927c10ccec30a7f8d9d16d7b7",
+        "hash": "md5"
+      }
+    ]
+  },
+  "sha256": "1111111111111111111111111111111111111111111111111111111111111111"
+}

--- a/packages/schemas/test/fixtures/training-sweep-manifest.json
+++ b/packages/schemas/test/fixtures/training-sweep-manifest.json
@@ -1,0 +1,57 @@
+{
+  "schemaVersion": "witt.training.sweep-manifest/v0.1",
+  "sweepId": "phase1-smoke",
+  "generatedAt": "2026-05-31T12:05:00Z",
+  "tracker": "https://github.com/p-to-q/wittgenstein/issues/400",
+  "source": {
+    "specPath": "bench/gpu/smoke-sweep.yaml",
+    "specSha256": "2222222222222222222222222222222222222222222222222222222222222222"
+  },
+  "rows": [
+    {
+      "rowId": "tokenizer-stdlib-smoke",
+      "subprogram": "tokenizer",
+      "status": "passed",
+      "dataset": {
+        "snapshotId": "synthetic-smoke-2026q2",
+        "snapshotPath": "research/training/data/snapshots/synthetic-smoke.dataset.json",
+        "snapshotSha256": "3333333333333333333333333333333333333333333333333333333333333333",
+        "datasetSha256": "1111111111111111111111111111111111111111111111111111111111111111"
+      },
+      "command": ["python3", "-m", "research.training._shared.smoke_manifest"],
+      "config": {
+        "path": "research/training/_shared/runs/smoke/tokenizer-stdlib-smoke/config.json",
+        "sha256": "4444444444444444444444444444444444444444444444444444444444444444"
+      },
+      "trainingRun": {
+        "runId": "tokenizer-stdlib-smoke",
+        "manifestPath": "research/training/_shared/runs/smoke/tokenizer-stdlib-smoke/manifest.json",
+        "manifestSha256": "5555555555555555555555555555555555555555555555555555555555555555",
+        "checkpointSha256": "6666666666666666666666666666666666666666666666666666666666666666"
+      },
+      "experiment": {
+        "tracker": "jsonl",
+        "uri": "file:///tmp/wittgenstein/experiment-metrics.jsonl",
+        "runId": "jsonl-tokenizer-stdlib-smoke",
+        "receiptPath": "research/training/_shared/runs/smoke/tokenizer-stdlib-smoke/experiment.json",
+        "receiptSha256": "7777777777777777777777777777777777777777777777777777777777777777",
+        "metricsSha256": "8888888888888888888888888888888888888888888888888888888888888888"
+      },
+      "metrics": [
+        {
+          "name": "loss",
+          "value": 0,
+          "unit": "loss",
+          "higherIsBetter": false
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "total": 1,
+    "passed": 1,
+    "failed": 0,
+    "skipped": 0,
+    "blocked": 0
+  }
+}

--- a/packages/schemas/test/sweep-manifest.test.ts
+++ b/packages/schemas/test/sweep-manifest.test.ts
@@ -1,0 +1,99 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  TrainingDatasetSnapshotSchema,
+  TrainingDatasetSnapshotSchemaVersion,
+  TrainingSweepManifestSchema,
+  TrainingSweepManifestSchemaVersion,
+  type TrainingDatasetSnapshot,
+  type TrainingSweepManifest,
+} from "../src/index.js";
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const datasetFixturePath = join(testDir, "fixtures", "training-dataset-snapshot.json");
+const sweepFixturePath = join(testDir, "fixtures", "training-sweep-manifest.json");
+
+describe("Training dataset and sweep receipts", () => {
+  it("round-trips a DVC-backed dataset snapshot fixture", () => {
+    const fixture = readDatasetSnapshotFixture();
+
+    const parsed = TrainingDatasetSnapshotSchema.parse(fixture);
+
+    expect(parsed).toEqual(fixture);
+    expect(parsed.schemaVersion).toBe(TrainingDatasetSnapshotSchemaVersion);
+    expect(parsed.dvc.outs[0]?.md5).toBeTruthy();
+  });
+
+  it("rejects DVC outputs without a checksum-like field", () => {
+    const fixture = readDatasetSnapshotFixture();
+
+    const parsed = TrainingDatasetSnapshotSchema.safeParse({
+      ...fixture,
+      dvc: {
+        ...fixture.dvc,
+        outs: [
+          {
+            path: "dataset",
+            size: 1,
+          },
+        ],
+      },
+    });
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error?.issues.map((issue) => issue.path.join("."))).toContain(
+      "dvc.outs.0.checksum",
+    );
+  });
+
+  it("round-trips a sweep manifest fixture", () => {
+    const fixture = readSweepFixture();
+
+    const parsed = TrainingSweepManifestSchema.parse(fixture);
+
+    expect(parsed).toEqual(fixture);
+    expect(parsed.schemaVersion).toBe(TrainingSweepManifestSchemaVersion);
+    expect(parsed.rows[0]?.trainingRun?.runId).toBe("tokenizer-stdlib-smoke");
+  });
+
+  it("rejects summary counts that drift from row statuses", () => {
+    const fixture = readSweepFixture();
+
+    const parsed = TrainingSweepManifestSchema.safeParse({
+      ...fixture,
+      summary: {
+        ...fixture.summary,
+        passed: 0,
+      },
+    });
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error?.issues.map((issue) => issue.path.join("."))).toContain("summary.passed");
+  });
+
+  it("requires passed rows to point at training-run evidence", () => {
+    const fixture = readSweepFixture();
+    const row = { ...fixture.rows[0] };
+    delete row.trainingRun;
+
+    const parsed = TrainingSweepManifestSchema.safeParse({
+      ...fixture,
+      rows: [row],
+    });
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error?.issues.map((issue) => issue.path.join("."))).toContain(
+      "rows.0.trainingRun",
+    );
+  });
+});
+
+function readDatasetSnapshotFixture(): TrainingDatasetSnapshot {
+  return JSON.parse(readFileSync(datasetFixturePath, "utf8")) as TrainingDatasetSnapshot;
+}
+
+function readSweepFixture(): TrainingSweepManifest {
+  return JSON.parse(readFileSync(sweepFixturePath, "utf8")) as TrainingSweepManifest;
+}

--- a/packages/schemas/test/trackers.test.ts
+++ b/packages/schemas/test/trackers.test.ts
@@ -44,6 +44,9 @@ describe("@wittgenstein/schemas — trackers (#487 item 2)", () => {
       "https://github.com/p-to-q/wittgenstein/issues/402",
     );
     expect(TRACKERS.installTierCli).toBe("https://github.com/p-to-q/wittgenstein/issues/403");
+    expect(TRACKERS.trainingDataSweepInfra).toBe(
+      "https://github.com/p-to-q/wittgenstein/issues/400",
+    );
     expect(CLOSED_TRACKERS.adr0020Implementation).toBe(
       "https://github.com/p-to-q/wittgenstein/issues/376",
     );

--- a/research/training/README.md
+++ b/research/training/README.md
@@ -24,6 +24,7 @@ See the operating doctrine:
 - [docs/research/2026-05-13-wittgenstein-research-program.md](../../docs/research/2026-05-13-wittgenstein-research-program.md) — three-track framing (engineering / research / hacker)
 - [docs/research/2026-05-13-delivery-and-componentization.md](../../docs/research/2026-05-13-delivery-and-componentization.md) — tier doctrine + why training stays outside the publish surface
 - [docs/training/experiment-tracking.md](../../docs/training/experiment-tracking.md) — #399 tracker receipt contract and shared-Aim boundary
+- [docs/training/data.md](../../docs/training/data.md) — #400 dataset snapshot + sweep receipt contract
 - [docs/research/2026-05-13-m1b-prep-research.md](../../docs/research/2026-05-13-m1b-prep-research.md) — Phase-0 literature floor (LlamaGen, Open-MAGVIT2, TiTok, VAR)
 - [docs/research/2026-05-31-training-stack-re-audit-closeout.md](../../docs/research/2026-05-31-training-stack-re-audit-closeout.md) — #441 closeout: schema-aligned receipt floor + GPU wait lines
 - [docs/research/2026-05-27-pre-training-readiness.md](../../docs/research/2026-05-27-pre-training-readiness.md) — engineering-readiness audit run right before specialist kickoff (Tier-0 self-check, latent bugs found + fixed, open handoff issues)
@@ -108,6 +109,20 @@ This is the receipt floor for #435 / #441. It does not claim that tokenizer,
 adapter, or LLM-head training has run; it only proves that future training
 programs can emit the required manifest and tracker-receipt shape before GPU
 work starts.
+
+## Data snapshot + sweep smoke
+
+The #400 data/sweep floor has a local synthetic DVC pointer and a maintainer-run
+sweep manifest writer:
+
+```bash
+python3 bench/gpu/sweep.py --spec bench/gpu/smoke-sweep.yaml
+```
+
+The command writes generated receipts under `artifacts/benchmarks/` and indexes
+the smoke dataset snapshot, training manifest, checkpoint, and JSONL tracker
+receipt. It is not managed GPU CI and does not claim ImageNet / CC12M / COCO are
+available.
 
 ## M1B audit receipts
 

--- a/research/training/_shared/data_versioning.py
+++ b/research/training/_shared/data_versioning.py
@@ -1,0 +1,344 @@
+"""DVC-backed dataset snapshot receipts for training runs.
+
+The DVC pointer is the data-access primitive; this module emits the
+Wittgenstein receipt that training manifests and sweep rows can reference.
+It intentionally keeps DVC md5/etag/checksum fields separate from the
+canonical Wittgenstein sha256 identity.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from .manifest import SHA256_RE, capture_git_sha, sha256_bytes, sha256_file, utc_now_iso
+
+
+TRAINING_DATASET_SNAPSHOT_SCHEMA_VERSION = "witt.training.dataset-snapshot/v0.1"
+DATASET_ROLES = {"train", "validation", "eval", "smoke"}
+DATASET_LICENSES = {"permissive", "research-only", "restricted", "unknown"}
+
+
+@dataclass(frozen=True)
+class TrainingDvcOutput:
+    path: str
+    size: int | None = None
+    md5: str | None = None
+    etag: str | None = None
+    checksum: str | None = None
+    hash: str | None = None
+
+
+@dataclass(frozen=True)
+class TrainingDvcRemote:
+    name: str
+    url: str | None = None
+
+
+@dataclass(frozen=True)
+class TrainingDatasetDescriptor:
+    name: str
+    split: str
+    role: str
+    uri: str | None
+    license: str
+    sampleCount: int | None = None
+    deadLinkRate: float | None = None
+
+
+@dataclass(frozen=True)
+class TrainingDvcReference:
+    path: str
+    repoRevLock: str
+    outs: list[TrainingDvcOutput]
+    remote: TrainingDvcRemote | None = None
+
+
+@dataclass(frozen=True)
+class TrainingDatasetSnapshot:
+    schemaVersion: str
+    snapshotId: str
+    generatedAt: str
+    dataset: TrainingDatasetDescriptor
+    dvc: TrainingDvcReference
+    sha256: str
+
+
+def load_dvc_pointer(path: Path) -> list[TrainingDvcOutput]:
+    """Load a DVC pointer file.
+
+    Tests use JSON-subset YAML so the smoke path stays stdlib-only. Real DVC
+    files can be parsed when PyYAML or ruamel.yaml is present in the training
+    environment.
+    """
+
+    payload = _load_yamlish(path)
+    outs = payload.get("outs")
+    if not isinstance(outs, list) or not outs:
+        raise ValueError(f"DVC pointer must contain a nonempty outs list: {path}")
+    parsed: list[TrainingDvcOutput] = []
+    for index, raw in enumerate(outs):
+        if not isinstance(raw, dict):
+            raise ValueError(f"DVC output {index} must be an object")
+        raw_path = raw.get("path")
+        if not isinstance(raw_path, str) or not raw_path:
+            raise ValueError(f"DVC output {index} must carry a nonempty path")
+        size = raw.get("size")
+        if size is not None and (isinstance(size, bool) or not isinstance(size, int) or size < 0):
+            raise ValueError(f"DVC output {index} size must be a nonnegative integer")
+        parsed.append(
+            TrainingDvcOutput(
+                path=raw_path,
+                size=size,
+                md5=_optional_string(raw.get("md5")),
+                etag=_optional_string(raw.get("etag")),
+                checksum=_optional_string(raw.get("checksum")),
+                hash=_optional_string(raw.get("hash")),
+            )
+        )
+    return parsed
+
+
+def build_dataset_snapshot_from_dvc(
+    *,
+    snapshot_id: str,
+    dvc_path: Path,
+    dataset_name: str,
+    split: str,
+    role: str,
+    license: str,
+    uri: str | None = None,
+    sample_count: int | None = None,
+    dead_link_rate: float | None = None,
+    remote: TrainingDvcRemote | None = None,
+    repo_rev_lock: str | None = None,
+    repo_root: Path | None = None,
+) -> TrainingDatasetSnapshot:
+    outs = load_dvc_pointer(dvc_path)
+    display_dvc_path = dvc_path
+    if repo_root is not None:
+        try:
+            display_dvc_path = dvc_path.resolve().relative_to(repo_root.resolve())
+        except ValueError:
+            display_dvc_path = dvc_path
+    descriptor = TrainingDatasetDescriptor(
+        name=dataset_name,
+        split=split,
+        role=role,
+        uri=uri,
+        license=license,
+        sampleCount=sample_count,
+        deadLinkRate=dead_link_rate,
+    )
+    dvc_ref = TrainingDvcReference(
+        path=display_dvc_path.as_posix(),
+        repoRevLock=repo_rev_lock or capture_git_sha(repo_root),
+        remote=remote,
+        outs=outs,
+    )
+    payload = {
+        "dataset": _drop_none(asdict(descriptor)),
+        "dvc": _drop_none(asdict(dvc_ref)),
+    }
+    if "remote" in payload["dvc"]:
+        payload["dvc"]["remote"] = _drop_none(payload["dvc"]["remote"])
+    payload["dvc"]["outs"] = [_drop_none(out) for out in payload["dvc"]["outs"]]
+    digest = sha256_bytes(json.dumps(payload, sort_keys=True).encode("utf-8"))
+    snapshot = TrainingDatasetSnapshot(
+        schemaVersion=TRAINING_DATASET_SNAPSHOT_SCHEMA_VERSION,
+        snapshotId=snapshot_id,
+        generatedAt=utc_now_iso(),
+        dataset=descriptor,
+        dvc=dvc_ref,
+        sha256=digest,
+    )
+    assert_training_dataset_snapshot_shape(snapshot)
+    return snapshot
+
+
+def dataset_snapshot_to_dict(
+    snapshot: TrainingDatasetSnapshot | dict[str, Any],
+) -> dict[str, Any]:
+    payload = asdict(snapshot) if isinstance(snapshot, TrainingDatasetSnapshot) else dict(snapshot)
+    payload["dataset"] = _drop_none(payload["dataset"])
+    payload["dvc"] = _drop_none(payload["dvc"])
+    if "remote" in payload["dvc"]:
+        payload["dvc"]["remote"] = _drop_none(payload["dvc"]["remote"])
+    payload["dvc"]["outs"] = [_drop_none(out) for out in payload["dvc"]["outs"]]
+    return payload
+
+
+def assert_training_dataset_snapshot_shape(
+    snapshot: TrainingDatasetSnapshot | dict[str, Any],
+) -> None:
+    payload = dataset_snapshot_to_dict(snapshot)
+    _assert_keys(
+        payload,
+        {"schemaVersion", "snapshotId", "generatedAt", "dataset", "dvc", "sha256"},
+        set(),
+        "datasetSnapshot",
+    )
+    if payload["schemaVersion"] != TRAINING_DATASET_SNAPSHOT_SCHEMA_VERSION:
+        raise ValueError("schemaVersion must be witt.training.dataset-snapshot/v0.1")
+    _require_nonempty_string(payload["snapshotId"], "snapshotId")
+    _require_nonempty_string(payload["generatedAt"], "generatedAt")
+    _require_sha256(payload["sha256"], "sha256")
+    _validate_dataset_descriptor(payload["dataset"])
+    _validate_dvc_reference(payload["dvc"])
+
+
+def write_training_dataset_snapshot(snapshot: TrainingDatasetSnapshot, out_path: Path) -> None:
+    assert_training_dataset_snapshot_shape(snapshot)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = out_path.with_suffix(out_path.suffix + f".tmp-{os.getpid()}-{int(time.time())}")
+    tmp.write_text(
+        json.dumps(dataset_snapshot_to_dict(snapshot), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    tmp.replace(out_path)
+
+
+def dataset_snapshot_reference(snapshot_path: Path) -> dict[str, str]:
+    payload = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    assert_training_dataset_snapshot_shape(payload)
+    return {
+        "snapshotId": payload["snapshotId"],
+        "snapshotPath": snapshot_path.as_posix(),
+        "snapshotSha256": sha256_file(snapshot_path),
+        "datasetSha256": payload["sha256"],
+    }
+
+
+def _load_yamlish(path: Path) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8")
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        try:
+            import yaml  # type: ignore
+
+            payload = yaml.safe_load(text)
+        except ImportError:
+            try:
+                from ruamel.yaml import YAML  # type: ignore
+
+                payload = YAML(typ="safe").load(text)
+            except ImportError as exc:
+                raise RuntimeError(
+                    f"{path} is not JSON-subset YAML; install PyYAML or run inside the DVC training environment"
+                ) from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"YAML/JSON payload must be an object: {path}")
+    return payload
+
+
+def _drop_none(payload: dict[str, Any]) -> dict[str, Any]:
+    return {k: v for k, v in payload.items() if v is not None}
+
+
+def _optional_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value:
+        raise ValueError("optional DVC string fields must be nonempty strings")
+    return value
+
+
+def _assert_keys(
+    payload: dict[str, Any],
+    required: set[str],
+    optional: set[str],
+    label: str,
+) -> None:
+    actual = set(payload)
+    missing = required - actual
+    extra = actual - required - optional
+    if missing:
+        raise ValueError(f"{label} missing required keys: {sorted(missing)}")
+    if extra:
+        raise ValueError(f"{label} has unrecognized keys: {sorted(extra)}")
+
+
+def _require_nonempty_string(value: Any, label: str) -> None:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{label} must be a nonempty string")
+
+
+def _require_sha256(value: Any, label: str) -> None:
+    if not isinstance(value, str) or not SHA256_RE.match(value):
+        raise ValueError(f"{label} must be a 64-char lowercase sha256 hex string")
+
+
+def _validate_dataset_descriptor(payload: Any) -> None:
+    if not isinstance(payload, dict):
+        raise ValueError("dataset must be an object")
+    _assert_keys(
+        payload,
+        {"name", "split", "role", "license"},
+        {"uri", "sampleCount", "deadLinkRate"},
+        "dataset",
+    )
+    _require_nonempty_string(payload["name"], "dataset.name")
+    _require_nonempty_string(payload["split"], "dataset.split")
+    if payload["role"] not in DATASET_ROLES:
+        raise ValueError(f"dataset.role must be one of {sorted(DATASET_ROLES)}")
+    if payload["license"] not in DATASET_LICENSES:
+        raise ValueError(f"dataset.license must be one of {sorted(DATASET_LICENSES)}")
+    if "uri" in payload:
+        _require_nonempty_string(payload["uri"], "dataset.uri")
+    if "sampleCount" in payload:
+        value = payload["sampleCount"]
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise ValueError("dataset.sampleCount must be a nonnegative integer")
+    if "deadLinkRate" in payload:
+        value = payload["deadLinkRate"]
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, (int, float))
+            or not math.isfinite(float(value))
+            or value < 0
+            or value > 1
+        ):
+            raise ValueError("dataset.deadLinkRate must be between 0 and 1")
+
+
+def _validate_dvc_reference(payload: Any) -> None:
+    if not isinstance(payload, dict):
+        raise ValueError("dvc must be an object")
+    _assert_keys(payload, {"path", "repoRevLock", "outs"}, {"remote"}, "dvc")
+    _require_nonempty_string(payload["path"], "dvc.path")
+    _require_nonempty_string(payload["repoRevLock"], "dvc.repoRevLock")
+    outs = payload["outs"]
+    if not isinstance(outs, list) or not outs:
+        raise ValueError("dvc.outs must be a nonempty list")
+    for index, out in enumerate(outs):
+        _validate_dvc_output(out, f"dvc.outs[{index}]")
+    if "remote" in payload:
+        remote = payload["remote"]
+        if not isinstance(remote, dict):
+            raise ValueError("dvc.remote must be an object")
+        _assert_keys(remote, {"name"}, {"url"}, "dvc.remote")
+        _require_nonempty_string(remote["name"], "dvc.remote.name")
+        if "url" in remote:
+            _require_nonempty_string(remote["url"], "dvc.remote.url")
+
+
+def _validate_dvc_output(payload: Any, label: str) -> None:
+    if not isinstance(payload, dict):
+        raise ValueError(f"{label} must be an object")
+    _assert_keys(payload, {"path"}, {"size", "md5", "etag", "checksum", "hash"}, label)
+    _require_nonempty_string(payload["path"], f"{label}.path")
+    if "size" in payload:
+        value = payload["size"]
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise ValueError(f"{label}.size must be a nonnegative integer")
+    if not (payload.get("md5") or payload.get("etag") or payload.get("checksum")):
+        raise ValueError(f"{label} must carry at least one checksum field")
+    for key in ("md5", "etag", "checksum", "hash"):
+        if key in payload:
+            _require_nonempty_string(payload[key], f"{label}.{key}")

--- a/research/training/_shared/sweep_manifest.py
+++ b/research/training/_shared/sweep_manifest.py
@@ -1,0 +1,426 @@
+"""Training sweep manifest receipts.
+
+A sweep row is intentionally a receipt index, not a scheduler API. It points at
+DVC-pinned dataset snapshots, training manifests, and tracker receipts that
+already carry the evidence.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from .data_versioning import dataset_snapshot_reference
+from .experiment_tracking import (
+    TRACKERS,
+    assert_training_experiment_receipt_shape,
+)
+from .manifest import (
+    SHA256_RE,
+    SUBPROGRAMS,
+    assert_training_run_manifest_shape,
+    sha256_file,
+    utc_now_iso,
+)
+
+
+TRAINING_SWEEP_MANIFEST_SCHEMA_VERSION = "witt.training.sweep-manifest/v0.1"
+SWEEP_ROW_STATUSES = {"planned", "running", "passed", "failed", "skipped", "blocked"}
+
+
+@dataclass(frozen=True)
+class TrainingSweepError:
+    code: str
+    message: str
+
+
+@dataclass(frozen=True)
+class TrainingSweepRow:
+    rowId: str
+    subprogram: str
+    status: str
+    dataset: dict[str, str]
+    command: list[str]
+    config: dict[str, str] | None = None
+    trainingRun: dict[str, str] | None = None
+    experiment: dict[str, str] | None = None
+    metrics: list[dict[str, Any]] | None = None
+    error: TrainingSweepError | None = None
+
+
+@dataclass(frozen=True)
+class TrainingSweepSource:
+    specPath: str
+    specSha256: str
+
+
+@dataclass(frozen=True)
+class TrainingSweepSummary:
+    total: int
+    passed: int
+    failed: int
+    skipped: int
+    blocked: int
+
+
+@dataclass(frozen=True)
+class TrainingSweepManifest:
+    schemaVersion: str
+    sweepId: str
+    generatedAt: str
+    source: TrainingSweepSource
+    rows: list[TrainingSweepRow]
+    summary: TrainingSweepSummary
+    tracker: str | None = None
+
+
+def build_passed_sweep_row(
+    *,
+    row_id: str,
+    subprogram: str,
+    command: list[str],
+    dataset_snapshot_path: Path,
+    training_manifest_path: Path,
+    experiment_receipt_path: Path | None = None,
+    metrics: list[dict[str, Any]] | None = None,
+) -> TrainingSweepRow:
+    manifest_payload = json.loads(training_manifest_path.read_text(encoding="utf-8"))
+    assert_training_run_manifest_shape(manifest_payload)
+    checkpoint_sha = manifest_payload["checkpoint"]["sha256"]
+    row = TrainingSweepRow(
+        rowId=row_id,
+        subprogram=subprogram,
+        status="passed",
+        dataset=dataset_snapshot_reference(dataset_snapshot_path),
+        command=command,
+        config=manifest_payload.get("trainingConfig"),
+        trainingRun={
+            "runId": manifest_payload["runId"],
+            "manifestPath": training_manifest_path.as_posix(),
+            "manifestSha256": sha256_file(training_manifest_path),
+            "checkpointSha256": checkpoint_sha,
+        },
+        experiment=(
+            experiment_reference(experiment_receipt_path) if experiment_receipt_path else None
+        ),
+        metrics=metrics or None,
+    )
+    assert_training_sweep_row_shape(row)
+    return row
+
+
+def experiment_reference(receipt_path: Path) -> dict[str, str]:
+    payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert_training_experiment_receipt_shape(payload)
+    return {
+        "tracker": payload["tracker"],
+        "uri": payload["uri"],
+        "runId": payload["runId"],
+        "receiptPath": receipt_path.as_posix(),
+        "receiptSha256": sha256_file(receipt_path),
+        "metricsSha256": payload["metricsLog"]["sha256"],
+    }
+
+
+def summarize_sweep_rows(rows: list[TrainingSweepRow]) -> TrainingSweepSummary:
+    return TrainingSweepSummary(
+        total=len(rows),
+        passed=sum(1 for row in rows if row.status == "passed"),
+        failed=sum(1 for row in rows if row.status == "failed"),
+        skipped=sum(1 for row in rows if row.status == "skipped"),
+        blocked=sum(1 for row in rows if row.status == "blocked"),
+    )
+
+
+def sweep_manifest_to_dict(manifest: TrainingSweepManifest | dict[str, Any]) -> dict[str, Any]:
+    payload = asdict(manifest) if isinstance(manifest, TrainingSweepManifest) else dict(manifest)
+    if payload.get("tracker") is None:
+        payload.pop("tracker", None)
+    payload["rows"] = [sweep_row_to_dict(row) for row in payload["rows"]]
+    payload["summary"] = asdict(payload["summary"]) if isinstance(payload["summary"], TrainingSweepSummary) else payload["summary"]
+    payload["source"] = asdict(payload["source"]) if isinstance(payload["source"], TrainingSweepSource) else payload["source"]
+    return payload
+
+
+def sweep_row_to_dict(row: TrainingSweepRow | dict[str, Any]) -> dict[str, Any]:
+    payload = asdict(row) if isinstance(row, TrainingSweepRow) else dict(row)
+    payload = {k: v for k, v in payload.items() if v is not None}
+    if "error" in payload and isinstance(payload["error"], TrainingSweepError):
+        payload["error"] = asdict(payload["error"])
+    return payload
+
+
+def assert_training_sweep_manifest_shape(manifest: TrainingSweepManifest | dict[str, Any]) -> None:
+    payload = sweep_manifest_to_dict(manifest)
+    _assert_keys(
+        payload,
+        {"schemaVersion", "sweepId", "generatedAt", "source", "rows", "summary"},
+        {"tracker"},
+        "sweepManifest",
+    )
+    if payload["schemaVersion"] != TRAINING_SWEEP_MANIFEST_SCHEMA_VERSION:
+        raise ValueError("schemaVersion must be witt.training.sweep-manifest/v0.1")
+    _require_nonempty_string(payload["sweepId"], "sweepId")
+    _require_nonempty_string(payload["generatedAt"], "generatedAt")
+    if "tracker" in payload:
+        _require_url(payload["tracker"], "tracker")
+    _validate_source(payload["source"])
+    rows = payload["rows"]
+    if not isinstance(rows, list) or not rows:
+        raise ValueError("rows must be a nonempty list")
+    for index, row in enumerate(rows):
+        assert_training_sweep_row_shape(row, label=f"rows[{index}]")
+    _validate_summary(payload["summary"], rows)
+
+
+def assert_training_sweep_row_shape(
+    row: TrainingSweepRow | dict[str, Any],
+    *,
+    label: str = "row",
+) -> None:
+    payload = sweep_row_to_dict(row)
+    _assert_keys(
+        payload,
+        {"rowId", "subprogram", "status", "dataset", "command"},
+        {"config", "trainingRun", "experiment", "metrics", "error"},
+        label,
+    )
+    _require_nonempty_string(payload["rowId"], f"{label}.rowId")
+    if payload["subprogram"] not in SUBPROGRAMS:
+        raise ValueError(f"{label}.subprogram must be one of {sorted(SUBPROGRAMS)}")
+    if payload["status"] not in SWEEP_ROW_STATUSES:
+        raise ValueError(f"{label}.status must be one of {sorted(SWEEP_ROW_STATUSES)}")
+    _validate_dataset_reference(payload["dataset"], f"{label}.dataset")
+    command = payload["command"]
+    if not isinstance(command, list) or not command:
+        raise ValueError(f"{label}.command must be a nonempty list")
+    for index, part in enumerate(command):
+        _require_nonempty_string(part, f"{label}.command[{index}]")
+    if "config" in payload:
+        _validate_config_reference(payload["config"], f"{label}.config")
+    if "trainingRun" in payload:
+        _validate_training_run_reference(payload["trainingRun"], f"{label}.trainingRun")
+    if "experiment" in payload:
+        _validate_experiment_reference(payload["experiment"], f"{label}.experiment")
+    if "metrics" in payload:
+        metrics = payload["metrics"]
+        if not isinstance(metrics, list):
+            raise ValueError(f"{label}.metrics must be a list")
+        for index, metric in enumerate(metrics):
+            _validate_metric(metric, f"{label}.metrics[{index}]")
+    if "error" in payload:
+        _validate_error(payload["error"], f"{label}.error")
+    if payload["status"] == "passed" and "trainingRun" not in payload:
+        raise ValueError(f"{label}.trainingRun is required when status is passed")
+    if payload["status"] in {"failed", "blocked"} and "error" not in payload:
+        raise ValueError(f"{label}.error is required when status is {payload['status']}")
+
+
+def write_training_sweep_manifest(manifest: TrainingSweepManifest, out_path: Path) -> None:
+    assert_training_sweep_manifest_shape(manifest)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = out_path.with_suffix(out_path.suffix + f".tmp-{os.getpid()}-{int(time.time())}")
+    tmp.write_text(
+        json.dumps(sweep_manifest_to_dict(manifest), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    tmp.replace(out_path)
+
+
+def failed_sweep_row(
+    *,
+    row_id: str,
+    subprogram: str,
+    command: list[str],
+    dataset_snapshot_path: Path,
+    code: str,
+    message: str,
+) -> TrainingSweepRow:
+    return TrainingSweepRow(
+        rowId=row_id,
+        subprogram=subprogram,
+        status="failed",
+        dataset=dataset_snapshot_reference(dataset_snapshot_path),
+        command=command,
+        error=TrainingSweepError(code=code, message=message),
+    )
+
+
+def blocked_sweep_row(
+    *,
+    row_id: str,
+    subprogram: str,
+    command: list[str],
+    dataset_snapshot_path: Path,
+    code: str,
+    message: str,
+) -> TrainingSweepRow:
+    return TrainingSweepRow(
+        rowId=row_id,
+        subprogram=subprogram,
+        status="blocked",
+        dataset=dataset_snapshot_reference(dataset_snapshot_path),
+        command=command,
+        error=TrainingSweepError(code=code, message=message),
+    )
+
+
+def new_sweep_manifest(
+    *,
+    sweep_id: str,
+    spec_path: Path,
+    rows: list[TrainingSweepRow],
+    tracker: str | None = None,
+) -> TrainingSweepManifest:
+    manifest = TrainingSweepManifest(
+        schemaVersion=TRAINING_SWEEP_MANIFEST_SCHEMA_VERSION,
+        sweepId=sweep_id,
+        generatedAt=utc_now_iso(),
+        tracker=tracker,
+        source=TrainingSweepSource(specPath=spec_path.as_posix(), specSha256=sha256_file(spec_path)),
+        rows=rows,
+        summary=summarize_sweep_rows(rows),
+    )
+    assert_training_sweep_manifest_shape(manifest)
+    return manifest
+
+
+def _assert_keys(
+    payload: dict[str, Any],
+    required: set[str],
+    optional: set[str],
+    label: str,
+) -> None:
+    actual = set(payload)
+    missing = required - actual
+    extra = actual - required - optional
+    if missing:
+        raise ValueError(f"{label} missing required keys: {sorted(missing)}")
+    if extra:
+        raise ValueError(f"{label} has unrecognized keys: {sorted(extra)}")
+
+
+def _require_nonempty_string(value: Any, label: str) -> None:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{label} must be a nonempty string")
+
+
+def _require_sha256(value: Any, label: str) -> None:
+    if not isinstance(value, str) or not SHA256_RE.match(value):
+        raise ValueError(f"{label} must be a 64-char lowercase sha256 hex string")
+
+
+def _require_url(value: Any, label: str) -> None:
+    _require_nonempty_string(value, label)
+    if "://" not in value:
+        raise ValueError(f"{label} must be an absolute URL")
+
+
+def _validate_source(payload: Any) -> None:
+    if not isinstance(payload, dict):
+        raise ValueError("source must be an object")
+    _assert_keys(payload, {"specPath", "specSha256"}, set(), "source")
+    _require_nonempty_string(payload["specPath"], "source.specPath")
+    _require_sha256(payload["specSha256"], "source.specSha256")
+
+
+def _validate_dataset_reference(payload: Any, label: str) -> None:
+    if not isinstance(payload, dict):
+        raise ValueError(f"{label} must be an object")
+    _assert_keys(
+        payload,
+        {"snapshotId", "snapshotPath", "snapshotSha256", "datasetSha256"},
+        set(),
+        label,
+    )
+    _require_nonempty_string(payload["snapshotId"], f"{label}.snapshotId")
+    _require_nonempty_string(payload["snapshotPath"], f"{label}.snapshotPath")
+    _require_sha256(payload["snapshotSha256"], f"{label}.snapshotSha256")
+    _require_sha256(payload["datasetSha256"], f"{label}.datasetSha256")
+
+
+def _validate_config_reference(payload: Any, label: str) -> None:
+    if not isinstance(payload, dict):
+        raise ValueError(f"{label} must be an object")
+    _assert_keys(payload, {"path", "sha256"}, set(), label)
+    _require_nonempty_string(payload["path"], f"{label}.path")
+    _require_sha256(payload["sha256"], f"{label}.sha256")
+
+
+def _validate_training_run_reference(payload: Any, label: str) -> None:
+    if not isinstance(payload, dict):
+        raise ValueError(f"{label} must be an object")
+    _assert_keys(
+        payload,
+        {"runId", "manifestPath", "manifestSha256", "checkpointSha256"},
+        set(),
+        label,
+    )
+    _require_nonempty_string(payload["runId"], f"{label}.runId")
+    _require_nonempty_string(payload["manifestPath"], f"{label}.manifestPath")
+    _require_sha256(payload["manifestSha256"], f"{label}.manifestSha256")
+    _require_sha256(payload["checkpointSha256"], f"{label}.checkpointSha256")
+
+
+def _validate_experiment_reference(payload: Any, label: str) -> None:
+    if not isinstance(payload, dict):
+        raise ValueError(f"{label} must be an object")
+    _assert_keys(
+        payload,
+        {"tracker", "uri", "runId", "receiptPath", "receiptSha256", "metricsSha256"},
+        set(),
+        label,
+    )
+    if payload["tracker"] not in TRACKERS:
+        raise ValueError(f"{label}.tracker must be one of {sorted(TRACKERS)}")
+    _require_url(payload["uri"], f"{label}.uri")
+    _require_nonempty_string(payload["runId"], f"{label}.runId")
+    _require_nonempty_string(payload["receiptPath"], f"{label}.receiptPath")
+    _require_sha256(payload["receiptSha256"], f"{label}.receiptSha256")
+    _require_sha256(payload["metricsSha256"], f"{label}.metricsSha256")
+
+
+def _validate_metric(payload: Any, label: str) -> None:
+    if not isinstance(payload, dict):
+        raise ValueError(f"{label} must be an object")
+    _assert_keys(payload, {"name", "value"}, {"unit", "higherIsBetter"}, label)
+    _require_nonempty_string(payload["name"], f"{label}.name")
+    value = payload["value"]
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value):
+        raise ValueError(f"{label}.value must be a finite number")
+    if "unit" in payload:
+        _require_nonempty_string(payload["unit"], f"{label}.unit")
+    if "higherIsBetter" in payload and not isinstance(payload["higherIsBetter"], bool):
+        raise ValueError(f"{label}.higherIsBetter must be boolean")
+
+
+def _validate_error(payload: Any, label: str) -> None:
+    if not isinstance(payload, dict):
+        raise ValueError(f"{label} must be an object")
+    _assert_keys(payload, {"code", "message"}, set(), label)
+    _require_nonempty_string(payload["code"], f"{label}.code")
+    _require_nonempty_string(payload["message"], f"{label}.message")
+
+
+def _validate_summary(payload: Any, rows: list[dict[str, Any]]) -> None:
+    if not isinstance(payload, dict):
+        raise ValueError("summary must be an object")
+    _assert_keys(payload, {"total", "passed", "failed", "skipped", "blocked"}, set(), "summary")
+    expected = {
+        "total": len(rows),
+        "passed": sum(1 for row in rows if row["status"] == "passed"),
+        "failed": sum(1 for row in rows if row["status"] == "failed"),
+        "skipped": sum(1 for row in rows if row["status"] == "skipped"),
+        "blocked": sum(1 for row in rows if row["status"] == "blocked"),
+    }
+    for key, value in expected.items():
+        actual = payload[key]
+        if isinstance(actual, bool) or not isinstance(actual, int) or actual < 0:
+            raise ValueError(f"summary.{key} must be a nonnegative integer")
+        if actual != value:
+            raise ValueError(f"summary.{key} must equal {value}")

--- a/research/training/_shared/test_data_versioning.py
+++ b/research/training/_shared/test_data_versioning.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from .data_versioning import (
+    TrainingDvcRemote,
+    assert_training_dataset_snapshot_shape,
+    build_dataset_snapshot_from_dvc,
+    dataset_snapshot_reference,
+    load_dvc_pointer,
+    write_training_dataset_snapshot,
+)
+
+
+class TrainingDataVersioningTests(unittest.TestCase):
+    def test_builds_dataset_snapshot_from_json_subset_dvc_pointer(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            dvc_path = Path(tmp) / "synthetic-smoke.dvc"
+            dvc_path.write_text(
+                json.dumps(
+                    {
+                        "outs": [
+                            {
+                                "path": "../smoke/synthetic-manifest-smoke.txt",
+                                "size": 46,
+                                "md5": "4a8685c927c10ccec30a7f8d9d16d7b7",
+                                "hash": "md5",
+                            }
+                        ]
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            snapshot = build_dataset_snapshot_from_dvc(
+                snapshot_id="synthetic-smoke-2026q2",
+                dvc_path=dvc_path,
+                dataset_name="synthetic-manifest-smoke",
+                split="smoke",
+                role="smoke",
+                license="permissive",
+                sample_count=1,
+                remote=TrainingDvcRemote(name="local-smoke"),
+                repo_rev_lock="smoke-local",
+                repo_root=Path(tmp),
+            )
+            out_path = Path(tmp) / "synthetic-smoke.dataset.json"
+            write_training_dataset_snapshot(snapshot, out_path)
+            payload = json.loads(out_path.read_text(encoding="utf-8"))
+            ref = dataset_snapshot_reference(out_path)
+
+        assert_training_dataset_snapshot_shape(payload)
+        self.assertEqual(payload["schemaVersion"], "witt.training.dataset-snapshot/v0.1")
+        self.assertEqual(payload["dataset"]["role"], "smoke")
+        self.assertEqual(payload["dvc"]["outs"][0]["md5"], "4a8685c927c10ccec30a7f8d9d16d7b7")
+        self.assertEqual(payload["dvc"]["path"], "synthetic-smoke.dvc")
+        self.assertEqual(ref["snapshotId"], "synthetic-smoke-2026q2")
+        self.assertEqual(ref["datasetSha256"], payload["sha256"])
+
+    def test_rejects_dvc_outputs_without_checksum(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            dvc_path = Path(tmp) / "missing-checksum.dvc"
+            dvc_path.write_text(
+                json.dumps({"outs": [{"path": "dataset", "size": 1}]}) + "\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "checksum field"):
+                build_dataset_snapshot_from_dvc(
+                    snapshot_id="bad",
+                    dvc_path=dvc_path,
+                    dataset_name="bad",
+                    split="train",
+                    role="train",
+                    license="unknown",
+                    repo_rev_lock="smoke-local",
+                )
+
+    def test_loads_dvc_pointer_without_importing_dvc(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            dvc_path = Path(tmp) / "pointer.dvc"
+            dvc_path.write_text(
+                '{"outs":[{"path":"dataset","etag":"etag-value","size":10}]}\n',
+                encoding="utf-8",
+            )
+
+            outs = load_dvc_pointer(dvc_path)
+
+        self.assertEqual(len(outs), 1)
+        self.assertEqual(outs[0].etag, "etag-value")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/research/training/_shared/test_sweep_cli.py
+++ b/research/training/_shared/test_sweep_cli.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from .sweep_manifest import assert_training_sweep_manifest_shape
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+class TrainingSweepCliTests(unittest.TestCase):
+    def test_smoke_sweep_cli_writes_portable_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_root = Path(tmp)
+            snapshot_path = tmp_root / "synthetic-smoke.dataset.json"
+            spec_path = tmp_root / "sweep.json"
+            out_path = tmp_root / "sweep-manifest.json"
+            run_root = tmp_root / "runs"
+            spec_path.write_text(
+                json.dumps(
+                    {
+                        "sweepId": "phase1-smoke-test",
+                        "tracker": "https://github.com/p-to-q/wittgenstein/issues/400",
+                        "rows": [
+                            {
+                                "rowId": "tokenizer-stdlib-smoke",
+                                "subprogram": "tokenizer",
+                                "datasetSnapshot": {
+                                    "outPath": str(snapshot_path),
+                                    "snapshotId": "synthetic-smoke-test",
+                                    "dvcPath": "research/training/data/snapshots/synthetic-smoke.dvc",
+                                    "name": "synthetic-manifest-smoke",
+                                    "split": "smoke",
+                                    "role": "smoke",
+                                    "license": "permissive",
+                                    "sampleCount": 1,
+                                    "remoteName": "local-smoke",
+                                    "repoRevLock": "smoke-local",
+                                },
+                                "command": [
+                                    "python3",
+                                    "-m",
+                                    "research.training._shared.smoke_manifest",
+                                ],
+                            }
+                        ],
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "bench/gpu/sweep.py",
+                    "--spec",
+                    str(spec_path),
+                    "--out",
+                    str(out_path),
+                    "--run-root",
+                    str(run_root),
+                ],
+                cwd=str(REPO_ROOT),
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            payload = json.loads(out_path.read_text(encoding="utf-8"))
+            stdout = json.loads(result.stdout)
+
+        assert_training_sweep_manifest_shape(payload)
+        self.assertTrue(stdout["ok"])
+        self.assertEqual(payload["summary"]["passed"], 1)
+        self.assertEqual(payload["summary"]["failed"], 0)
+        self.assertEqual(payload["rows"][0]["status"], "passed")
+        repo_prefix = str(REPO_ROOT)
+        self.assertFalse(payload["source"]["specPath"].startswith(repo_prefix))
+        self.assertFalse(payload["rows"][0]["trainingRun"]["manifestPath"].startswith(repo_prefix))
+        self.assertFalse(payload["rows"][0]["experiment"]["receiptPath"].startswith(repo_prefix))
+
+    def test_sweep_cli_marks_missing_torch_as_blocked_not_failed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_root = Path(tmp)
+            snapshot_path = tmp_root / "synthetic-smoke.dataset.json"
+            spec_path = tmp_root / "sweep.json"
+            out_path = tmp_root / "sweep-manifest.json"
+            spec_path.write_text(
+                json.dumps(
+                    {
+                        "sweepId": "phase1-blocked-test",
+                        "tracker": "https://github.com/p-to-q/wittgenstein/issues/400",
+                        "rows": [
+                            {
+                                "rowId": "tokenizer-missing-torch",
+                                "subprogram": "tokenizer",
+                                "datasetSnapshot": {
+                                    "outPath": str(snapshot_path),
+                                    "snapshotId": "synthetic-smoke-test",
+                                    "dvcPath": "research/training/data/snapshots/synthetic-smoke.dvc",
+                                    "name": "synthetic-manifest-smoke",
+                                    "split": "smoke",
+                                    "role": "smoke",
+                                    "license": "permissive",
+                                    "sampleCount": 1,
+                                    "remoteName": "local-smoke",
+                                    "repoRevLock": "smoke-local",
+                                },
+                                "command": [
+                                    sys.executable,
+                                    "-c",
+                                    "import sys; sys.stderr.write(\"ModuleNotFoundError: No module named 'torch'\\n\"); raise SystemExit(1)",
+                                ],
+                            }
+                        ],
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "bench/gpu/sweep.py",
+                    "--spec",
+                    str(spec_path),
+                    "--out",
+                    str(out_path),
+                ],
+                cwd=str(REPO_ROOT),
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            payload = json.loads(out_path.read_text(encoding="utf-8"))
+            stdout = json.loads(result.stdout)
+
+        assert_training_sweep_manifest_shape(payload)
+        self.assertFalse(stdout["ok"])
+        self.assertEqual(payload["summary"], {"total": 1, "passed": 0, "failed": 0, "skipped": 0, "blocked": 1})
+        self.assertEqual(payload["rows"][0]["status"], "blocked")
+        self.assertEqual(payload["rows"][0]["error"]["code"], "MISSING_TORCH")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/research/training/_shared/test_sweep_manifest.py
+++ b/research/training/_shared/test_sweep_manifest.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from .data_versioning import (
+    TrainingDvcRemote,
+    build_dataset_snapshot_from_dvc,
+    write_training_dataset_snapshot,
+)
+from .manifest import sha256_file
+from .smoke_manifest import build_smoke_manifest
+from .sweep_manifest import (
+    assert_training_sweep_manifest_shape,
+    build_passed_sweep_row,
+    new_sweep_manifest,
+    write_training_sweep_manifest,
+)
+
+
+class TrainingSweepManifestTests(unittest.TestCase):
+    def test_builds_passed_sweep_manifest_from_smoke_receipts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            dvc_path = root / "synthetic-smoke.dvc"
+            dvc_path.write_text(
+                json.dumps(
+                    {
+                        "outs": [
+                            {
+                                "path": "../smoke/synthetic-manifest-smoke.txt",
+                                "size": 46,
+                                "md5": "4a8685c927c10ccec30a7f8d9d16d7b7",
+                            }
+                        ]
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            snapshot_path = root / "synthetic-smoke.dataset.json"
+            write_training_dataset_snapshot(
+                build_dataset_snapshot_from_dvc(
+                    snapshot_id="synthetic-smoke-2026q2",
+                    dvc_path=dvc_path,
+                    dataset_name="synthetic-manifest-smoke",
+                    split="smoke",
+                    role="smoke",
+                    license="permissive",
+                    sample_count=1,
+                    remote=TrainingDvcRemote(name="local-smoke"),
+                    repo_rev_lock="smoke-local",
+                ),
+                snapshot_path,
+            )
+            summary = build_smoke_manifest(root / "runs", run_id="tokenizer-stdlib-smoke")
+            checkpoint_sha256 = sha256_file(Path(summary["checkpointPath"]))
+            spec_path = root / "sweep.json"
+            spec_path.write_text("{}\n", encoding="utf-8")
+            row = build_passed_sweep_row(
+                row_id="tokenizer-stdlib-smoke",
+                subprogram="tokenizer",
+                command=["python3", "-m", "research.training._shared.smoke_manifest"],
+                dataset_snapshot_path=snapshot_path,
+                training_manifest_path=Path(summary["manifestPath"]),
+                experiment_receipt_path=Path(summary["experimentReceiptPath"]),
+                metrics=[{"name": "loss", "value": 0.0, "unit": "loss", "higherIsBetter": False}],
+            )
+            manifest = new_sweep_manifest(
+                sweep_id="phase1-smoke",
+                spec_path=spec_path,
+                rows=[row],
+                tracker="https://github.com/p-to-q/wittgenstein/issues/400",
+            )
+            out_path = root / "sweep-manifest.json"
+            write_training_sweep_manifest(manifest, out_path)
+            payload = json.loads(out_path.read_text(encoding="utf-8"))
+
+        assert_training_sweep_manifest_shape(payload)
+        self.assertEqual(payload["summary"], {"total": 1, "passed": 1, "failed": 0, "skipped": 0, "blocked": 0})
+        self.assertEqual(payload["rows"][0]["trainingRun"]["checkpointSha256"], checkpoint_sha256)
+
+    def test_rejects_mismatched_summary_counts(self) -> None:
+        with self.assertRaisesRegex(ValueError, "summary.passed"):
+            assert_training_sweep_manifest_shape(
+                {
+                    "schemaVersion": "witt.training.sweep-manifest/v0.1",
+                    "sweepId": "bad",
+                    "generatedAt": "2026-05-31T00:00:00Z",
+                    "source": {"specPath": "spec.json", "specSha256": "0" * 64},
+                    "rows": [
+                        {
+                            "rowId": "blocked-row",
+                            "subprogram": "tokenizer",
+                            "status": "blocked",
+                            "dataset": {
+                                "snapshotId": "snapshot",
+                                "snapshotPath": "snapshot.json",
+                                "snapshotSha256": "1" * 64,
+                                "datasetSha256": "2" * 64,
+                            },
+                            "command": ["python3"],
+                            "error": {"code": "NO_GPU", "message": "No GPU available."},
+                        }
+                    ],
+                    "summary": {"total": 1, "passed": 1, "failed": 0, "skipped": 0, "blocked": 0},
+                }
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/research/training/data/smoke/synthetic-manifest-smoke.txt
+++ b/research/training/data/smoke/synthetic-manifest-smoke.txt
@@ -1,0 +1,1 @@
+wittgenstein synthetic training dataset smoke

--- a/research/training/data/snapshots/synthetic-smoke.dvc
+++ b/research/training/data/snapshots/synthetic-smoke.dvc
@@ -1,0 +1,10 @@
+{
+  "outs": [
+    {
+      "path": "../smoke/synthetic-manifest-smoke.txt",
+      "size": 46,
+      "md5": "4a8685c927c10ccec30a7f8d9d16d7b7",
+      "hash": "md5"
+    }
+  ]
+}

--- a/research/training/tokenizer/README.md
+++ b/research/training/tokenizer/README.md
@@ -167,8 +167,10 @@ produced it.
 - **Aim/W&B tracker integration** — tracker links belong in the training config
   or an issue-owned tracker receipt; they are not freeform top-level manifest
   fields.
-- **DVC dataset pin** — train script reads dataset SHA from a DVC
-  `.dvc` file rather than the cheap file-enumeration fingerprint.
+- **DVC dataset pin** — train script records the dataset SHA in the
+  training manifest; #400 now provides the smoke DVC pointer and sweep receipt
+  shape, while real ImageNet / CC12M / COCO pointers still need model-owner
+  review before full training.
 - **FSDP2 sharding** — only needed if larger tokenizer variants are
   trained. The current 72M model fits comfortably on one A800.
 


### PR DESCRIPTION
## What
- Add the #400 training dataset snapshot + sweep manifest schemas and Python receipt helpers.
- Add a stdlib smoke DVC pointer and maintainer-run `bench/gpu/sweep.py` harness that writes receipts under `artifacts/benchmarks/`.
- Document that this is the executable smoke floor only; real ImageNet / CC12M / COCO pointers, lab remote choice, and credentials still need owner review (#400 / #435).

## Validation
- `pnpm --filter @wittgenstein/schemas typecheck`
- `pnpm --filter @wittgenstein/schemas lint`
- `pnpm --filter @wittgenstein/schemas test`
- `python3 -m unittest research.training._shared.test_manifest research.training._shared.test_experiment_tracking research.training._shared.test_data_versioning research.training._shared.test_sweep_manifest research.training._shared.test_sweep_cli`
- `python3 -m json.tool bench/gpu/smoke-sweep.yaml`
- `python3 bench/gpu/sweep.py --spec bench/gpu/smoke-sweep.yaml --out /tmp/witt-sweep-final.json --run-root /tmp/witt-sweep-final-runs` (current local env: 1 passed stdlib row, 1 blocked `MISSING_TORCH` row)
- `pnpm prettier --check docs/contributing/training-setup.md docs/training/data.md research/training/README.md research/training/tokenizer/README.md packages/schemas/src/sweep-manifest.ts packages/schemas/test/sweep-manifest.test.ts packages/schemas/test/trackers.test.ts packages/schemas/test/fixtures/training-dataset-snapshot.json packages/schemas/test/fixtures/training-sweep-manifest.json`
- `git diff --cached --check` / `git diff --check`

## Remaining risks
- Does not create the real lab DVC remote or publish real dataset pointers; those remain #400 / #435 owner-review work.
- The training row is allowed to record `MISSING_TORCH` as blocked on non-lab machines; managed GPU CI policy is still not decided.