### PR TITLE
feat(training): add resumable tokenizer run closeout tooling

### DIFF
--- a/docs/runbooks/training-operations.md
+++ b/docs/runbooks/training-operations.md
@@ -35,7 +35,8 @@ fixed wall-clock budget, and (c) leave a trustworthy receipt. Distilled from a
    checkpoint.** Loop: pick the emptiest GPUs, launch `torchrun … --resume-from
    <latest step_*.pt>`, and relaunch on non-zero exit until the deadline. Use
    `checkpoint_every` small enough (e.g. 1000) that a crash loses little. Launch
-   detached (`setsid nohup …`) so it survives an SSH disconnect.
+   detached (`setsid nohup …`) so it survives an SSH disconnect. The checked-in
+   launcher for this is `research/training/supervise_tokenizer_run.py`.
 3. **Always export these before `torchrun`:**
    - `PYTHONUNBUFFERED=1` — live logs (otherwise child stdout is block-buffered).
    - `PYTHONDONTWRITEBYTECODE=1` and clear `__pycache__` — avoid stale-pyc field shadowing.
@@ -58,6 +59,8 @@ fixed wall-clock budget, and (c) leave a trustworthy receipt. Distilled from a
   and reports codebook row-norm / dead-code stats.
 - **Reconstruction sanity**: `recon_check.py` loads the checkpoint, encode→decode
   one image, and reports L2/PSNR + before/after PNGs.
+- **Closeout pack**: `closeout_tokenizer_run.py` wraps the plot, integrity, and
+  reconstruction tools and writes a `CLOSEOUT.md` with command outputs embedded.
 - **Loss is healthy, not just decreasing**: a VQGAN total loss can be negative by
   design when an entropy anti-collapse term is in the sum — check l2 and lpips
   are falling and codebook usage is rising, rather than reading the total alone.
@@ -78,6 +81,8 @@ fixed wall-clock budget, and (c) leave a trustworthy receipt. Distilled from a
 
 - `research/training/tokenizer/train.py`, `config.py` — training entrypoint + config.
 - `research/training/_shared/manifest.py` — the receipt schema (`WITT_GIT_SHA` fallback).
-- `research/training/integrity_check.py`, `recon_check.py`, `plot_training.py` — offline audit tooling.
+- `research/training/supervise_tokenizer_run.py` — resumable wall-clock launcher.
+- `research/training/integrity_check.py`, `recon_check.py`, `plot_training.py`,
+  `closeout_tokenizer_run.py` — offline audit tooling.
 - Issues: #251 (grad accumulation), #198 (AMP), #181 (checkpoint rotation),
   #405 (reproducibility test), #270 (PatchGAN), #400 (license-clean data + DVC).

--- a/research/training/closeout_tokenizer_run.py
+++ b/research/training/closeout_tokenizer_run.py
@@ -1,0 +1,157 @@
+"""Generate tokenizer training closeout artifacts.
+
+This wraps the existing read-only audit tools:
+  - plot_training.py -> loss/codebook figures + parsed JSON
+  - integrity_check.py -> checkpoint hash/tensor/codebook audit
+  - recon_check.py -> one-image reconstruction spot-check
+
+It also writes a short CLOSEOUT.md with command outputs embedded so the result
+is reviewable without re-running every tool.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def run(cmd: list[str], cwd: Path, out_file: Path) -> int:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(cwd) + os.pathsep + env.get("PYTHONPATH", "")
+    proc = subprocess.run(
+        cmd,
+        cwd=cwd,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    out_file.write_text(proc.stdout)
+    return proc.returncode
+
+
+def latest_checkpoint(run_root: Path) -> Path:
+    candidates = sorted(run_root.glob("**/ckpts/step_*.pt"))
+    candidates.extend(sorted(run_root.glob("**/ckpts/final.pt")))
+    if not candidates:
+        raise FileNotFoundError(f"no step_*.pt or final.pt under {run_root}")
+    return max(candidates, key=lambda p: p.stat().st_mtime)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Close out a tokenizer training run.")
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--log", required=True)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--ckpt", default="")
+    parser.add_argument("--run-root", default="")
+    parser.add_argument("--data", default="", help="Image folder for recon spot-check.")
+    parser.add_argument("--title", default="")
+    args = parser.parse_args()
+
+    repo = Path(args.repo_root).resolve()
+    out = Path(args.out).resolve()
+    out.mkdir(parents=True, exist_ok=True)
+    log = Path(args.log).resolve()
+    if args.ckpt:
+        ckpt = Path(args.ckpt).resolve()
+    elif args.run_root:
+        ckpt = latest_checkpoint(Path(args.run_root).resolve())
+    else:
+        raise SystemExit("--ckpt or --run-root is required")
+
+    plot_out = out / "plots"
+    plot_out.mkdir(parents=True, exist_ok=True)
+    plot_log = out / "plot_training.txt"
+    integ_log = out / "integrity_check.txt"
+    recon_log = out / "recon_check.txt"
+
+    commands: list[tuple[str, int, Path]] = []
+    plot_cmd = [
+        sys.executable,
+        "research/training/plot_training.py",
+        "--log",
+        str(log),
+        "--out",
+        str(plot_out),
+    ]
+    if args.title:
+        plot_cmd += ["--title", args.title]
+    commands.append(("plot_training", run(plot_cmd, repo, plot_log), plot_log))
+
+    integ_cmd = [
+        sys.executable,
+        "research/training/integrity_check.py",
+        "--ckpt",
+        str(ckpt),
+    ]
+    commands.append(("integrity_check", run(integ_cmd, repo, integ_log), integ_log))
+
+    if args.data:
+        recon_dir = out / "recon"
+        recon_cmd = [
+            sys.executable,
+            "research/training/recon_check.py",
+            "--ckpt",
+            str(ckpt),
+            "--data",
+            str(Path(args.data).resolve()),
+            "--out",
+            str(recon_dir),
+        ]
+        commands.append(("recon_check", run(recon_cmd, repo, recon_log), recon_log))
+    else:
+        recon_log.write_text("[closeout] skipped: --data not provided\n")
+        commands.append(("recon_check", 0, recon_log))
+
+    md = out / "CLOSEOUT.md"
+    lines = [
+        "# Tokenizer Training Closeout",
+        "",
+        f"- generatedAt: {datetime.now(timezone.utc).isoformat()}",
+        f"- log: `{log}`",
+        f"- checkpoint: `{ckpt}`",
+        f"- outputDir: `{out}`",
+        "",
+        "## Boundary",
+        "",
+        "This is a training/audit closeout. A checkpoint trained on research-only data is not publishable unless the manifest explicitly records a permissive weights license and downstream release gates pass.",
+        "",
+        "## Command Results",
+        "",
+    ]
+    failed = False
+    for name, rc, path in commands:
+        failed = failed or rc != 0
+        lines += [
+            f"### {name}",
+            "",
+            f"- exitCode: {rc}",
+            f"- output: `{path}`",
+            "",
+            "```text",
+            path.read_text()[-8000:].rstrip(),
+            "```",
+            "",
+        ]
+    lines += [
+        "## Artifacts",
+        "",
+        f"- plots: `{plot_out}`",
+        f"- parsed series: `{plot_out / 'training_series.json'}`",
+        f"- loss plot: `{plot_out / 'loss_components.png'}`",
+        f"- codebook plot: `{plot_out / 'codebook_usage.png'}`",
+    ]
+    if args.data:
+        lines.append(f"- reconstruction spot-check: `{out / 'recon'}`")
+    md.write_text("\n".join(lines) + "\n")
+    print(f"[closeout] wrote {md}")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/training/plot_training.py
+++ b/research/training/plot_training.py
@@ -23,34 +23,38 @@ import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt  # noqa: E402
 
-LINE = re.compile(
-    r"\[step\s+(?P<step>\d+)/\d+\].*?"
-    r"l2=(?P<l2>[-\d.eE]+)\s+"
-    r"lpips=(?P<lpips>[-\d.eE]+)\s+"
-    r"commit=(?P<commit>[-\d.eE]+)\s+"
-    r"total=(?P<total>[-\d.eE]+)\s+"
-    r"codebook_usage=(?P<cb>[-\d.eE]+).*?"
-    r"imgs/s=(?P<ips>[-\d.eE]+)"
-)
+LINE = re.compile(r"\[step\s+(?P<step>\d+)/\d+\](?P<body>.*)")
+KV = re.compile(r"\b(?P<key>[A-Za-z_]\w*)=(?P<value>[-+]?\d+(?:\.\d+)?(?:[eE][-+]?\d+)?)")
+IPS = re.compile(r"imgs/s=(?P<value>[-+]?\d+(?:\.\d+)?(?:[eE][-+]?\d+)?)")
 
 
 def parse(path: str) -> dict[str, list[float]]:
-    cols: dict[str, list[float]] = {k: [] for k in
-                                    ("step", "l2", "lpips", "commit", "total", "cb", "ips")}
+    cols: dict[str, list[float | None]] = {k: [] for k in
+                                           ("step", "l2", "lpips", "commit", "total", "cb", "ips")}
     with open(path) as f:
         for ln in f:
             m = LINE.search(ln)
             if not m:
                 continue
+            row = {k: None for k in cols}
+            row["step"] = float(m.group("step"))
+            for kv in KV.finditer(m.group("body")):
+                key = "cb" if kv.group("key") == "codebook_usage" else kv.group("key")
+                if key in row:
+                    row[key] = float(kv.group("value"))
+            ips = IPS.search(m.group("body"))
+            if ips:
+                row["ips"] = float(ips.group("value"))
             for k in cols:
-                cols[k].append(float(m.group(k)))
-    return cols
+                cols[k].append(row[k])
+    return cols  # type: ignore[return-value]
 
 
 def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--log", required=True)
     ap.add_argument("--out", required=True)
+    ap.add_argument("--title", default="")
     args = ap.parse_args()
     os.makedirs(args.out, exist_ok=True)
 
@@ -65,14 +69,32 @@ def main() -> None:
 
     # Figure 1: loss components
     fig, ax = plt.subplots(figsize=(10, 6))
-    ax.plot(c["step"], c["l2"], label="l2 (recon MSE)", lw=1)
-    ax.plot(c["step"], c["lpips"], label="lpips (perceptual)", lw=1)
-    ax.plot(c["step"], c["commit"], label="commit (VQ)", lw=1)
-    ax.plot(c["step"], c["total"], label="total (incl. entropy term)", lw=1.4, color="k")
+    def series(key: str) -> tuple[list[float], list[float]]:
+        xs: list[float] = []
+        ys: list[float] = []
+        for step, value in zip(c["step"], c[key]):
+            if value is not None:
+                xs.append(step)
+                ys.append(value)
+        return xs, ys
+
+    for key, label, kwargs in (
+        ("l2", "l2 (recon MSE)", {"lw": 1}),
+        ("lpips", "lpips (perceptual)", {"lw": 1}),
+        ("commit", "commit (VQ)", {"lw": 1}),
+        ("total", "total", {"lw": 1.4, "color": "k"}),
+    ):
+        xs, ys = series(key)
+        if xs:
+            ax.plot(xs, ys, label=label, **kwargs)
     ax.axhline(0, color="grey", lw=0.5, ls="--")
     ax.set_xlabel("step")
     ax.set_ylabel("loss")
-    ax.set_title("Wittgenstein Phase-1.1 tokenizer — loss components (run 9f2c6a84, 54k steps)")
+    title = args.title or (
+        f"Wittgenstein Phase-1.1 tokenizer - loss components "
+        f"(step {c['step'][0]:.0f}..{c['step'][-1]:.0f})"
+    )
+    ax.set_title(title)
     ax.legend()
     ax.grid(alpha=0.3)
     f1 = os.path.join(args.out, "loss_components.png")
@@ -82,7 +104,8 @@ def main() -> None:
 
     # Figure 2: codebook usage trajectory
     fig, ax = plt.subplots(figsize=(10, 4.5))
-    ax.plot(c["step"], [v * 100 for v in c["cb"]], color="tab:green", lw=1)
+    cb_xs, cb_ys = series("cb")
+    ax.plot(cb_xs, [v * 100 for v in cb_ys], color="tab:green", lw=1)
     ax.set_ylim(0, 100)
     ax.set_xlabel("step")
     ax.set_ylabel("codebook usage (%)")
@@ -99,9 +122,15 @@ def main() -> None:
 
     for s in (0, 1000, 8000, 22000, 44000, c["step"][-1]):
         i = at(s)
-        print(f"[plot] step {c['step'][i]:6.0f}: l2={c['l2'][i]:.4f} "
-              f"lpips={c['lpips'][i]:.4f} commit={c['commit'][i]:.4f} "
-              f"total={c['total'][i]:.4f} cb={c['cb'][i]*100:.1f}% ips={c['ips'][i]:.1f}")
+        def fmt(key: str, scale: float = 1.0, suffix: str = "") -> str:
+            value = c[key][i]
+            if value is None:
+                return "n/a"
+            return f"{value * scale:.4f}{suffix}"
+
+        print(f"[plot] step {c['step'][i]:6.0f}: l2={fmt('l2')} "
+              f"lpips={fmt('lpips')} commit={fmt('commit')} "
+              f"total={fmt('total')} cb={fmt('cb', 100.0, '%')} ips={fmt('ips')}")
     print(f"[plot] wrote {f1}")
     print(f"[plot] wrote {f2}")
     print("[plot] DONE")

--- a/research/training/supervise_tokenizer_run.py
+++ b/research/training/supervise_tokenizer_run.py
@@ -1,0 +1,228 @@
+"""Wall-clock supervisor for long tokenizer training runs.
+
+Runs `research.training.tokenizer.train` under torchrun, resumes from the
+latest step checkpoint, and stops cleanly when the wall-clock budget expires.
+Designed for shared single-node GPU boxes where SSH sessions may disconnect.
+
+Example:
+  setsid nohup python -m research.training.supervise_tokenizer_run \
+    --repo-root /nfsdata/wxu/wittgenstein \
+    --train-data-root /nfsdata/wxu/datasets/LLaVA-Pretrain/images \
+    --out-root /nfsdata/wxu/wittgenstein/runs/run6h \
+    --resume-from /nfsdata/wxu/wittgenstein/runs/run6h/tokenizer-20260530T214518Z-9f2c6a84/ckpts/step_00054000.pt \
+    --gpus 0,2,1,3 --nproc-per-node 4 --batch-size-per-gpu 12 \
+    --max-steps 200000 --entropy-loss-ratio 0.05 --checkpoint-every 1000 \
+    --deadline-hours 18 --log /nfsdata/wxu/wittgenstein/run_resume.log &
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+STEP_RE = re.compile(r"step_(\d+)\.pt$")
+
+
+def checkpoint_step(path: Path) -> int:
+    match = STEP_RE.match(path.name)
+    if not match:
+        return -1
+    return int(match.group(1))
+
+
+def latest_step_checkpoint(out_root: Path, fallback: Path | None) -> Path | None:
+    candidates = [p for p in out_root.glob("**/ckpts/step_*.pt") if checkpoint_step(p) >= 0]
+    if fallback is not None and fallback.exists() and checkpoint_step(fallback) >= 0:
+        candidates.append(fallback)
+    if not candidates:
+        return fallback if fallback is not None and fallback.exists() else None
+    return max(candidates, key=lambda p: (checkpoint_step(p), p.stat().st_mtime))
+
+
+def git_sha(repo_root: Path) -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_root,
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except Exception:
+        return ""
+
+
+def build_train_cmd(args: argparse.Namespace, resume: Path | None) -> list[str]:
+    cmd = [
+        "torchrun",
+        "--nproc-per-node",
+        str(args.nproc_per_node),
+        "--master-port",
+        str(args.master_port),
+        "-m",
+        "research.training.tokenizer.train",
+        "--train-data-root",
+        args.train_data_root,
+        "--out-root",
+        args.out_root,
+        "--max-steps",
+        str(args.max_steps),
+        "--batch-size-per-gpu",
+        str(args.batch_size_per_gpu),
+        "--codebook-embed-dim",
+        str(args.codebook_embed_dim),
+        "--lr",
+        str(args.lr),
+        "--seed",
+        str(args.seed),
+        "--num-workers",
+        str(args.num_workers),
+        "--checkpoint-every",
+        str(args.checkpoint_every),
+        "--dataset-license",
+        args.dataset_license,
+    ]
+    if args.val_data_root:
+        cmd += ["--val-data-root", args.val_data_root]
+    if args.entropy_loss_ratio is not None:
+        cmd += ["--entropy-loss-ratio", str(args.entropy_loss_ratio)]
+    if args.gan:
+        cmd += ["--gan", "--gan-on-step", str(args.gan_on_step)]
+    else:
+        cmd += ["--no-gan"]
+    if args.no_lpips:
+        cmd += ["--no-lpips"]
+    if resume is not None:
+        cmd += ["--resume-from", str(resume)]
+    return cmd
+
+
+def terminate_process_group(proc: subprocess.Popen[bytes], log) -> int:
+    try:
+        os.killpg(proc.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return proc.poll() or 0
+    except Exception as exc:
+        print(f"[supervise] failed to SIGTERM process group: {exc}", file=log, flush=True)
+    try:
+        return proc.wait(timeout=30)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        return proc.wait()
+
+
+def run_once(args: argparse.Namespace, cmd: list[str], env: dict[str, str], remain: float, log) -> int:
+    print(f"[supervise] launching timeout={remain:.0f}s cmd={' '.join(cmd)}", file=log, flush=True)
+    proc = subprocess.Popen(
+        cmd,
+        cwd=args.repo_root,
+        env=env,
+        stdout=log,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+    try:
+        return proc.wait(timeout=remain)
+    except subprocess.TimeoutExpired:
+        print("[supervise] deadline timeout; sending SIGTERM to torchrun", file=log, flush=True)
+        terminate_process_group(proc, log)
+        return 124
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Resume and supervise tokenizer training.")
+    parser.add_argument("--repo-root", required=True)
+    parser.add_argument("--train-data-root", required=True)
+    parser.add_argument("--out-root", required=True)
+    parser.add_argument("--resume-from", default="")
+    parser.add_argument("--val-data-root", default="")
+    parser.add_argument("--log", required=True)
+    parser.add_argument("--deadline-hours", type=float, required=True)
+    parser.add_argument("--restart-delay-sec", type=float, default=30.0)
+    parser.add_argument("--gpus", default="")
+    parser.add_argument("--nproc-per-node", type=int, default=4)
+    parser.add_argument("--master-port", type=int, default=29701)
+    parser.add_argument("--max-steps", type=int, default=200_000)
+    parser.add_argument("--batch-size-per-gpu", type=int, default=12)
+    parser.add_argument("--codebook-embed-dim", type=int, default=32)
+    parser.add_argument("--entropy-loss-ratio", type=float, default=0.05)
+    parser.add_argument("--checkpoint-every", type=int, default=1000)
+    parser.add_argument("--lr", type=float, default=1e-4)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--num-workers", type=int, default=8)
+    parser.add_argument(
+        "--dataset-license",
+        choices=["research-only", "permissive"],
+        default="research-only",
+    )
+    parser.add_argument("--gan", action="store_true")
+    parser.add_argument("--gan-on-step", type=int, default=20_000)
+    parser.add_argument("--no-lpips", action="store_true")
+    args = parser.parse_args()
+
+    args.repo_root = Path(args.repo_root).resolve()
+    out_root = Path(args.out_root).resolve()
+    fallback = Path(args.resume_from).resolve() if args.resume_from else None
+    log_path = Path(args.log).resolve()
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    initial_resume = latest_step_checkpoint(out_root, fallback)
+    if args.resume_from and initial_resume is None:
+        message = (
+            f"[supervise] requested --resume-from {fallback} but no usable "
+            f"step checkpoint exists under {out_root}; refusing to start fresh"
+        )
+        with open(log_path, "a", buffering=1) as log:
+            print(message, file=log, flush=True)
+        print(message, file=sys.stderr)
+        return 2
+
+    env = os.environ.copy()
+    env.setdefault("PYTHONUNBUFFERED", "1")
+    env.setdefault("PYTHONDONTWRITEBYTECODE", "1")
+    env.setdefault("PYTORCH_ALLOC_CONF", "expandable_segments:True")
+    if args.gpus:
+        env["CUDA_VISIBLE_DEVICES"] = args.gpus
+    env.setdefault("WITT_GIT_SHA", git_sha(args.repo_root))
+    env["PYTHONPATH"] = str(args.repo_root) + os.pathsep + env.get("PYTHONPATH", "")
+
+    deadline = time.monotonic() + args.deadline_hours * 3600.0
+    attempt = 0
+    last_rc = 1
+    with open(log_path, "a", buffering=1) as log:
+        print(f"[supervise] start repo={args.repo_root} out_root={out_root}", file=log, flush=True)
+        print(f"[supervise] gpus={env.get('CUDA_VISIBLE_DEVICES', '<unset>')} git={env.get('WITT_GIT_SHA', '')}", file=log, flush=True)
+        while time.monotonic() < deadline:
+            attempt += 1
+            remain = max(1.0, deadline - time.monotonic())
+            resume = latest_step_checkpoint(out_root, fallback)
+            print(
+                f"[supervise] attempt={attempt} remain={remain:.0f}s resume={resume or 'none'}",
+                file=log,
+                flush=True,
+            )
+            cmd = build_train_cmd(args, resume)
+            last_rc = run_once(args, cmd, env, remain, log)
+            latest = latest_step_checkpoint(out_root, fallback)
+            print(f"[supervise] attempt={attempt} exited rc={last_rc} latest={latest or 'none'}", file=log, flush=True)
+            if last_rc == 0:
+                print("[supervise] training command completed successfully", file=log, flush=True)
+                return 0
+            if time.monotonic() >= deadline:
+                break
+            time.sleep(min(args.restart_delay_sec, max(0.0, deadline - time.monotonic())))
+        latest = latest_step_checkpoint(out_root, fallback)
+        print(f"[supervise] deadline reached. FINAL latest checkpoint: {latest or 'none'}", file=log, flush=True)
+    return 124 if last_rc == 124 else last_rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/training/test_resume_closeout_tools.py
+++ b/research/training/test_resume_closeout_tools.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import argparse
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+from research.training.closeout_tokenizer_run import latest_checkpoint
+from research.training.supervise_tokenizer_run import (
+    build_train_cmd,
+    checkpoint_step,
+    latest_step_checkpoint,
+)
+from research.training.tokenizer.resume import resume_start_step
+
+
+class TokenizerResumeCloseoutToolTests(unittest.TestCase):
+    def test_checkpoint_step_parses_only_step_checkpoints(self) -> None:
+        self.assertEqual(checkpoint_step(Path("step_00054000.pt")), 54000)
+        self.assertEqual(checkpoint_step(Path("final.pt")), -1)
+        self.assertEqual(checkpoint_step(Path("step_latest.pt")), -1)
+
+    def test_supervisor_selects_highest_step_over_mtime(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            ckpts = Path(tmp) / "run" / "ckpts"
+            ckpts.mkdir(parents=True)
+            older_high_step = ckpts / "step_00002000.pt"
+            newer_low_step = ckpts / "step_00001000.pt"
+            older_high_step.write_text("high", encoding="utf-8")
+            time.sleep(0.01)
+            newer_low_step.write_text("low", encoding="utf-8")
+
+            self.assertEqual(latest_step_checkpoint(Path(tmp), None), older_high_step)
+
+    def test_supervisor_includes_resume_checkpoint_in_train_command(self) -> None:
+        args = argparse.Namespace(
+            nproc_per_node=4,
+            master_port=29701,
+            train_data_root="/data/train",
+            out_root="/runs",
+            max_steps=200_000,
+            batch_size_per_gpu=12,
+            codebook_embed_dim=32,
+            lr=1e-4,
+            seed=7,
+            num_workers=8,
+            checkpoint_every=1000,
+            dataset_license="research-only",
+            val_data_root="",
+            entropy_loss_ratio=0.05,
+            gan=False,
+            gan_on_step=20_000,
+            no_lpips=True,
+        )
+        cmd = build_train_cmd(args, Path("/runs/ckpts/step_00002000.pt"))
+
+        self.assertIn("--resume-from", cmd)
+        self.assertIn("/runs/ckpts/step_00002000.pt", cmd)
+        self.assertIn("--no-lpips", cmd)
+        self.assertIn("--no-gan", cmd)
+
+    def test_closeout_latest_checkpoint_considers_final_checkpoint(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            ckpts = Path(tmp) / "run" / "ckpts"
+            ckpts.mkdir(parents=True)
+            step = ckpts / "step_00002000.pt"
+            final = ckpts / "final.pt"
+            step.write_text("step", encoding="utf-8")
+            time.sleep(0.01)
+            final.write_text("final", encoding="utf-8")
+
+            self.assertEqual(latest_checkpoint(Path(tmp)), final)
+
+    def test_resume_start_step_does_not_repeat_periodic_checkpoint_step(self) -> None:
+        self.assertEqual(resume_start_step(2000, Path("step_00002000.pt")), 2001)
+        self.assertEqual(resume_start_step(2000, Path("final.pt")), 2000)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/research/training/tokenizer/config.py
+++ b/research/training/tokenizer/config.py
@@ -81,6 +81,7 @@ class TrainConfig:
 
     # Logging / output
     out_root: str = ""           # required; ends up as research/training/_shared/runs/<run-id>/
+    resume_from: str = ""        # optional checkpoint .pt path; loads model weights + step
     aim_repo: str = ""           # optional aim tracker repo; "" = disabled
     seed: int = 0
 

--- a/research/training/tokenizer/resume.py
+++ b/research/training/tokenizer/resume.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def resume_start_step(checkpoint_step: int, checkpoint_path: Path) -> int:
+    """Return the first global step to run after loading a checkpoint.
+
+    Periodic `step_*.pt` checkpoints are written immediately after that step's
+    optimizer update, before the loop increments. Final checkpoints are written
+    after the loop exits, so their recorded step is already the next stepCount.
+    """
+    if checkpoint_path.name.startswith("step_"):
+        return checkpoint_step + 1
+    return checkpoint_step

--- a/research/training/tokenizer/train.py
+++ b/research/training/tokenizer/train.py
@@ -91,6 +91,7 @@ from research.training.tokenizer.model import (  # noqa: E402
     latent_grid,
     param_count,
 )
+from research.training.tokenizer.resume import resume_start_step  # noqa: E402
 
 
 # ---------- DDP plumbing ----------
@@ -165,6 +166,17 @@ def warmup_then_constant(step: int, warmup: int, base_lr: float) -> float:
     return base_lr
 
 
+def _unwrap(module):
+    return module.module if hasattr(module, "module") else module
+
+
+def _optimizer_to_device(optimizer, device: torch.device) -> None:
+    for state in optimizer.state.values():
+        for key, value in state.items():
+            if torch.is_tensor(value):
+                state[key] = value.to(device)
+
+
 # ---------- Train loop ----------
 
 
@@ -216,9 +228,6 @@ def train(cfg: TrainConfig) -> dict:
             f"K={cfg.tokenizer.codebook_size} D={cfg.tokenizer.codebook_embed_dim}"
         )
 
-    if world > 1:
-        model = _ddp_wrap(model, device, local_rank, find_unused_parameters=False)
-
     # ---- Loss ----
     lpips_mod = None
     if cfg.lpips_enabled and not cfg.smoke:
@@ -247,15 +256,55 @@ def train(cfg: TrainConfig) -> dict:
             lr=cfg.disc_lr,
             betas=(cfg.optim.beta1, cfg.optim.beta2),
         )
-        discriminator = (
-            _ddp_wrap(disc_core, device, local_rank)
-            if world > 1
-            else disc_core
-        )
+        discriminator = disc_core
         if is_main(rank):
             dn = sum(p.numel() for p in disc_core.parameters())
             print(f"[gan] PatchGAN discriminator params={dn:,} gan_on_step={gan_on_step} "
                   f"gan_weight={cfg.gan_weight}")
+
+    # ---- Optimizer ----
+    optim = torch.optim.AdamW(
+        model.parameters(),
+        lr=cfg.optim.lr,
+        betas=(cfg.optim.beta1, cfg.optim.beta2),
+        weight_decay=cfg.optim.weight_decay,
+    )
+
+    resumed_step = 0
+    resume_from = Path(cfg.resume_from) if cfg.resume_from else None
+    if resume_from is not None:
+        if not resume_from.exists():
+            raise FileNotFoundError(f"--resume-from checkpoint not found: {resume_from}")
+        ckpt = torch.load(resume_from, map_location="cpu", weights_only=True)
+        model.load_state_dict(ckpt["model"])
+        checkpoint_step = int(ckpt.get("step", 0))
+        resumed_step = resume_start_step(checkpoint_step, resume_from)
+        if "optimizer" in ckpt:
+            optim.load_state_dict(ckpt["optimizer"])
+            _optimizer_to_device(optim, device)
+        if discriminator is not None and "discriminator" in ckpt:
+            _unwrap(discriminator).load_state_dict(ckpt["discriminator"])
+        if discriminator is not None and d_optim is not None and "disc_optimizer" in ckpt:
+            d_optim.load_state_dict(ckpt["disc_optimizer"])
+            _optimizer_to_device(d_optim, device)
+        if is_main(rank):
+            restored = ["model", "step"]
+            if "optimizer" in ckpt:
+                restored.append("optimizer")
+            if discriminator is not None and "discriminator" in ckpt:
+                restored.append("discriminator")
+            if discriminator is not None and "discriminator" not in ckpt:
+                print("[resume] checkpoint has no discriminator state; discriminator starts fresh", flush=True)
+            print(
+                f"[resume] loaded {resume_from} checkpoint_step={checkpoint_step} "
+                f"next_step={resumed_step} ({', '.join(restored)})",
+                flush=True,
+            )
+
+    if world > 1:
+        model = _ddp_wrap(model, device, local_rank, find_unused_parameters=False)
+        if discriminator is not None:
+            discriminator = _ddp_wrap(discriminator, device, local_rank)
 
     loss_fn = TokenizerLoss(
         weights=LossWeights(gan=cfg.gan_weight),
@@ -263,14 +312,6 @@ def train(cfg: TrainConfig) -> dict:
         discriminator=discriminator,
         gan_on_step=gan_on_step,
     ).to(device)
-
-    # ---- Optimizer ----
-    optim = torch.optim.AdamW(
-        (model.module if world > 1 else model).parameters(),
-        lr=cfg.optim.lr,
-        betas=(cfg.optim.beta1, cfg.optim.beta2),
-        weight_decay=cfg.optim.weight_decay,
-    )
 
     # ---- Output paths ----
     # In DDP, only rank 0 invents the run_id; broadcast so all ranks agree
@@ -323,8 +364,10 @@ def train(cfg: TrainConfig) -> dict:
 
     # ---- Train loop ----
     t0 = time.perf_counter()
-    step = 0
+    step = resumed_step
     model.train()
+    if world > 1 and sampler is not None:
+        sampler.set_epoch(int(step // max(1, len(train_loader))))
     epoch_iter = iter(train_loader)
     last_log_t = t0
 
@@ -440,6 +483,7 @@ def train(cfg: TrainConfig) -> dict:
                 dataset_fp,
                 config_ref,
                 discriminator=discriminator,
+                d_optim=d_optim,
             )
 
         step += 1
@@ -470,6 +514,7 @@ def train(cfg: TrainConfig) -> dict:
             dataset_fp,
             config_ref,
             discriminator=discriminator,
+            d_optim=d_optim,
             eval_snapshots=eval_snapshots,
             final=True,
         )
@@ -628,16 +673,17 @@ def _write_checkpoint(
     dataset_fp,
     config_ref,
     discriminator=None,
+    d_optim=None,
     eval_snapshots=None,
     final=False,
 ):
     ckpt_path = run_dir / "ckpts" / (f"final.pt" if final else f"step_{step:08d}.pt")
-    state = (model.module if hasattr(model, "module") else model).state_dict()
-    payload = {"model": state, "step": step}
+    state = _unwrap(model).state_dict()
+    payload = {"model": state, "step": step, "optimizer": optim.state_dict()}
     if discriminator is not None:
-        payload["discriminator"] = (
-            discriminator.module if hasattr(discriminator, "module") else discriminator
-        ).state_dict()
+        payload["discriminator"] = _unwrap(discriminator).state_dict()
+    if d_optim is not None:
+        payload["disc_optimizer"] = d_optim.state_dict()
     torch.save(payload, ckpt_path)
     # Smoke / synthetic data has no license encumbrance. For real data, the
     # operator must declare the corpus license; default research-only keeps an
@@ -680,10 +726,16 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     p.add_argument("--batch-size-per-gpu", type=int, default=128)
     p.add_argument("--image-size", type=int, default=256)
     p.add_argument("--codebook-embed-dim", type=int, default=32)
+    p.add_argument("--entropy-loss-ratio", type=float, default=None,
+                   help="Codebook entropy-loss weight (>0 fights codebook collapse).")
     p.add_argument("--lr", type=float, default=1e-4)
     p.add_argument("--seed", type=int, default=0)
     p.add_argument("--smoke", action="store_true", help="Run smoke config (5 steps, synthetic)")
     p.add_argument("--num-workers", type=int, default=8)
+    p.add_argument("--checkpoint-every", type=int, default=None,
+                   help="Write a checkpoint + manifest every N steps.")
+    p.add_argument("--no-lpips", dest="lpips_enabled", default=None, action="store_false",
+                   help="Disable LPIPS perceptual loss (default: enabled).")
     p.add_argument("--val-data-root", default="", help="Validation image folder for end-of-run eval")
     p.add_argument(
         "--dataset-license",
@@ -699,6 +751,8 @@ def _build_arg_parser() -> argparse.ArgumentParser:
                            help="Disable the GAN term (reconstruction-only).")
     p.add_argument("--gan-on-step", type=int, default=None,
                    help="Step at which the GAN term turns on (warmup recon-only before).")
+    p.add_argument("--resume-from", default="",
+                   help="Checkpoint .pt to resume model weights + step from.")
     return p
 
 
@@ -706,6 +760,9 @@ def main():
     args = _build_arg_parser().parse_args()
     if args.smoke:
         cfg = smoke_config()
+        cfg.resume_from = args.resume_from
+        if args.checkpoint_every is not None:
+            cfg.checkpoint_every = args.checkpoint_every
     else:
         cfg = TrainConfig(
             train_data_root=args.train_data_root,
@@ -717,9 +774,16 @@ def main():
             seed=args.seed,
             num_workers=args.num_workers,
             dataset_license=args.dataset_license,
+            resume_from=args.resume_from,
         )
         cfg.tokenizer = TokenizerConfig(codebook_embed_dim=args.codebook_embed_dim, image_size=args.image_size)
         cfg.optim = OptimConfig(lr=args.lr)
+        if args.entropy_loss_ratio is not None:
+            cfg.tokenizer.entropy_loss_ratio = args.entropy_loss_ratio
+        if args.checkpoint_every is not None:
+            cfg.checkpoint_every = args.checkpoint_every
+        if args.lpips_enabled is not None:
+            cfg.lpips_enabled = args.lpips_enabled
         if args.gan_enabled is not None:
             cfg.gan_enabled = args.gan_enabled
         if args.gan_on_step is not None:


### PR DESCRIPTION
## Summary

- add a wall-clock tokenizer supervisor that relaunches `torchrun` from the latest `step_*.pt`, records the git SHA, and refuses to silently start fresh when an explicit resume checkpoint is unusable
- add a tokenizer closeout pack wrapper for plots, integrity checks, reconstruction spot-check output, and embedded command logs
- make tokenizer checkpoints resumable with optimizer/discriminator optimizer state, no repeated periodic-checkpoint step, and device-safe optimizer-state restore
- make training-log plotting tolerant of partial metric rows and add stdlib tests for resume/closeout selection logic

## Scope boundary

This is an operator/lab closeout slice for #396 and the #400 receipt lane. It does not claim that a publishable tokenizer has been trained, that the corpus is license-clean, or that the owner-reviewed ImageNet/CC12M/COCO DVC snapshots are complete.

## Validation

- `python3 -m unittest research.training.test_resume_closeout_tools research.training._shared.test_manifest research.training._shared.test_experiment_tracking research.training._shared.test_data_versioning research.training._shared.test_sweep_manifest research.training._shared.test_sweep_cli -v`
- `python3 -m compileall research/training/closeout_tokenizer_run.py research/training/plot_training.py research/training/supervise_tokenizer_run.py research/training/test_resume_closeout_tools.py research/training/tokenizer/config.py research/training/tokenizer/resume.py research/training/tokenizer/train.py`
- synthetic `plot_training.py` smoke with missing metric fields, checking JSON + PNG outputs
- `pnpm format:check`
- `pnpm lint:publish-surface`
- `git diff --check upstream/main..HEAD`

Not run locally: torch/GPU tokenizer smoke or real lab resume run; local Python lacks `torch`, and this PR intentionally leaves expensive training / checkpoint quality claims to the lab gate.

Closes no issue; updates the #396/#400 execution surface only.